### PR TITLE
buildserver tests to run clean with Windows generate .apk change

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -955,7 +955,7 @@ public final class Compiler {
             file);
         resources.put(resourcePath, file);
       }
-      return file.getAbsolutePath();
+      return file.getAbsolutePath().replace(File.separatorChar, '/');
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
@@ -8,6 +8,7 @@ package com.google.appinventor.buildserver;
 import com.google.appinventor.common.testutils.TestUtils;
 import com.google.appinventor.components.runtime.errors.YailRuntimeError;
 
+import java.io.File;
 import gnu.math.DFloNum;
 import gnu.math.IntNum;
 import junit.framework.Assert;
@@ -45,7 +46,7 @@ public class YailEvalTest extends TestCase {
   public void setUp() throws Exception {
     scheme = new Scheme();
     String yailRuntimeLibrary = Compiler.getResource(Compiler.YAIL_RUNTIME);
-    String yailSchemeTests = YAIL_SCHEME_TESTS;
+    String yailSchemeTests = YAIL_SCHEME_TESTS.replace(File.separatorChar, '/');
     try {
       scheme.eval("(load \"" + yailRuntimeLibrary + "\")");
       scheme.eval("(load \"" + yailSchemeTests + "\")");


### PR DESCRIPTION
added change so tests of the buildserver on Windows will pass all the tests.

Tested on Linux and Windows.

Based on code that has been running in ai4a for a year.
