### PR TITLE
Bug Fix for Building on Windows

### DIFF
--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -47,7 +47,8 @@
 		<java failonerror="true" fork="true" jar="${lib.dir}/plovr/plovr-eba786b34df9.jar">
 			<arg line="build ploverConfig.js" />
 		</java>
-                <exec executable="../misc/utils/bomify.py">
+                <exec executable="python" failonerror="true"> 
+		  <arg line="../misc/utils/bomify.py"/> 
                   <arg value="../build/blocklyeditor/blockly-all.js" />
                 </exec>
 	</target>


### PR DESCRIPTION
Fixes a bug with building with ant on windows

Prior behavior: windows didn't know to use python to run bomify.py so building with ant would fail on line 50 of appinventor/blocklyeditor/build.xml

Post behavior: ant has a successful build
