### PR TITLE
Typeblocking Bugfix

### DIFF
--- a/appinventor/lib/blockly/src/core/typeblock.js
+++ b/appinventor/lib/blockly/src/core/typeblock.js
@@ -563,13 +563,13 @@ Blockly.TypeBlock.connectIfPossible = function(blockSelected, createdBlock) {
         //If it's not, no connections should be made  
         } else return;
       } 
-    } 
     else {
       //try the parent for other connections
       Blockly.TypeBlock.connectIfPossible(blockSelected.parentBlock_, createdBlock);
       //recursive call: creates the inner functions again, but should not be much
       //overhead; if it is, optimise!   
     }
+  }
 };
 
 //--------------------------------------


### PR DESCRIPTION
This bugfix corrected a typeblocking bug, where if a statement block was selected, a typed statement would not connect directly below the selected block.

Version of App Inventor with fix: http://vkb-mit.appspot.com/
