### PR TITLE
BuildServer: pre-dex the runtime libraries

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -226,6 +226,8 @@
       <arg value="--isForStemCellApp" />
       <arg value="--outputDir" />
       <arg value="${public.build.dir}" />
+      <arg value="--dexCacheDir" />
+      <arg value="${public.build.dir}/dexCache" />
     </java>
   </target>
 
@@ -275,6 +277,8 @@
       <arg value="--isForWirelessRepl" />
       <arg value="--outputDir" />
       <arg value="${public.build.dir}" />
+      <arg value="--dexCacheDir" />
+      <arg value="${public.build.dir}/dexCache" />
     </java>
   </target>
 
@@ -302,6 +306,8 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <arg value="--dexCacheDir" />
+      <arg value="${public.build.dir}/dexCache" />
     </java>
   </target>
 
@@ -324,6 +330,8 @@
       <arg value="${user.name}" />
       <arg value="--outputDir" />
       <arg value="${output.dir}" />
+      <arg value="--dexCacheDir" />
+      <arg value="${public.build.dir}/dexCache" />
     </java>
   </target>
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -86,6 +86,9 @@ public class BuildServer {
     @Option(name = "--debug",
       usage = "Turn on debugging, which enables the non-async calls of the buildserver.")
     boolean debug = false;
+    @Option(name = "--dexCacheDir",
+            usage = "the directory to cache the pre-dexed libraries")
+    String dexCacheDir = null;
 
   }
 
@@ -489,7 +492,7 @@ public class BuildServer {
     // is happening, so we should be careful about that.
     outputDir.deleteOnExit();
     Result buildResult = projectBuilder.build(userName, new ZipFile(zipFile), outputDir, false, false,
-      commandLineOptions.childProcessRamMb);
+      commandLineOptions.childProcessRamMb, commandLineOptions.dexCacheDir);
     String buildOutput = buildResult.getOutput();
     LOG.info("Build output: " + buildOutput);
     String buildError = buildResult.getError();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -175,6 +175,7 @@ public final class Compiler {
   private Set<String> nativeLibrariesNeeded; // Set of component native libraries
   private Set<String> assetsNeeded; // Set of component assets
   private File libsDir; // The directory that will contain any native libraries for packaging
+  private String dexCacheDir;
 
   /*
    * Generate the set of Android permissions needed by this project.
@@ -484,12 +485,12 @@ public final class Compiler {
   public static boolean compile(Project project, Set<String> componentTypes,
                                 PrintStream out, PrintStream err, PrintStream userErrors,
                                 boolean isForRepl, boolean isForWireless, String keystoreFilePath,
-                                int childProcessRam) throws IOException, JSONException {
+                                int childProcessRam, String dexCacheDir) throws IOException, JSONException {
     long start = System.currentTimeMillis();
 
     // Create a new compiler instance for the compilation
     Compiler compiler = new Compiler(project, componentTypes, out, err, userErrors, isForRepl, isForWireless,
-                                     childProcessRam);
+                                     childProcessRam, dexCacheDir);
 
     // Get names of component-required libraries and assets.
     compiler.generateLibraryNames();
@@ -562,6 +563,12 @@ public final class Compiler {
     // Android guy suggested an alternate approach of shipping the kawa runtime .dex file as
     // data with the application and then creating a new DexClassLoader using that .dex file
     // and with the original app class loader as the parent of the new one.
+    // TODONE(zhuowei): Now using the new Android DX tool to merge dex files
+    // Needs to specify a writable cache dir on the command line that persists after shutdown
+    // Each pre-dexed file is identified via its MD5 hash (since the standard Android SDK's
+    // method of identifying via a hash of the path won't work when files
+    // are copied into temporary storage) and processed via a hacked up version of 
+    // Android SDK's Dex Ant task
     File tmpDir = createDirectory(buildDir, "tmp");
     String dexedClasses = tmpDir.getAbsolutePath() + File.separator + "classes.dex";
     if (!compiler.runDx(classesDir, dexedClasses)) {
@@ -690,7 +697,7 @@ public final class Compiler {
   @VisibleForTesting
   Compiler(Project project, Set<String> componentTypes, PrintStream out, PrintStream err,
            PrintStream userErrors, boolean isForRepl, boolean isForWireless,
-           int childProcessMaxRam) {
+           int childProcessMaxRam, String dexCacheDir) {
     this.project = project;
     this.componentTypes = componentTypes;
     this.out = out;
@@ -699,6 +706,7 @@ public final class Compiler {
     this.isForRepl = isForRepl;
     this.isForWireless = isForWireless;
     this.childProcessRamMb = childProcessMaxRam;
+    this.dexCacheDir = dexCacheDir;
   }
 
   /*
@@ -954,40 +962,36 @@ public final class Compiler {
   }
 
   private boolean runDx(File classesDir, String dexedClasses) {
-    int mx = childProcessRamMb - 200;
-
-    List<String> commandLineList = new ArrayList<String>();
-    commandLineList.add(System.getProperty("java.home") + "/bin/java");
-    commandLineList.add("-mx" + mx + "M");
-    commandLineList.add("-jar");
-    commandLineList.add(getResource(DX_JAR));
-    commandLineList.add("--dex");
-    commandLineList.add("--positions=lines");
-    commandLineList.add("--output=" + dexedClasses);
-    commandLineList.add(classesDir.getAbsolutePath());
-    commandLineList.add(getResource(SIMPLE_ANDROID_RUNTIME_JAR));
-    commandLineList.add(getResource(KAWA_RUNTIME));
-    commandLineList.add(getResource(ACRA_RUNTIME));
+    List<File> inputList = new ArrayList<File>();
+    inputList.add(classesDir); //this is a directory, and won't be cached into the dex cache
+    inputList.add(new File(getResource(SIMPLE_ANDROID_RUNTIME_JAR)));
+    inputList.add(new File(getResource(KAWA_RUNTIME)));
+    inputList.add(new File(getResource(ACRA_RUNTIME)));
 
     // Add libraries to command line arguments
     System.out.println("Libraries needed command line n = " + librariesNeeded.size());
     for (String library : librariesNeeded) {
-      commandLineList.add(getResource(RUNTIME_FILES_DIR + library));
+      inputList.add(new File(getResource(RUNTIME_FILES_DIR + library)));
     }
 
-    System.out.println("Libraries command line = " + commandLineList);
+    DexExecTask dexTask = new DexExecTask();
+    dexTask.setExecutable(getResource(DX_JAR));
+    dexTask.setOutput(dexedClasses);
+    dexTask.setChildProcessRamMb(childProcessRamMb);
+    if (dexCacheDir == null) {
+      dexTask.setDisableDexMerger(true);
+    } else {
+      createDirectory(new File(dexCacheDir));
+      dexTask.setDexedLibs(dexCacheDir);
+    }
 
-    // Convert command line to an array
-    String[] dxCommandLine = new String[commandLineList.size()];
-    commandLineList.toArray(dxCommandLine);
-
-   long startDx = System.currentTimeMillis();
+    long startDx = System.currentTimeMillis();
     // Using System.err and System.out on purpose. Don't want to pollute build messages with
     // tools output
     boolean dxSuccess;
     synchronized (SYNC_KAWA_OR_DX) {
       setProgress(50);
-      dxSuccess = Execution.execute(null, dxCommandLine, System.out, System.err);
+      dxSuccess = dexTask.execute(inputList);
       setProgress(75);
     }
     if (!dxSuccess) {

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.appinventor.buildserver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+/**
+ * Dex task, modified from the Android SDK to run in BuildServer.
+ * Custom task to execute dx while handling dependencies.
+ */
+public class DexExecTask  {
+
+    private String mExecutable;
+    private String mOutput;
+    private String mDexedLibs;
+    private boolean mVerbose = false;
+    private boolean mNoLocals = false;
+    private int mChildProcessRamMb = 1024;
+    private boolean mDisableDexMerger = false;
+    private static Map<String, String> alreadyChecked = new HashMap<String, String>();
+
+
+    /**
+     * Sets the value of the "executable" attribute.
+     * @param executable the value.
+     */
+    public void setExecutable(String executable) {
+        mExecutable = executable;
+    }
+
+    /**
+     * Sets the value of the "verbose" attribute.
+     * @param verbose the value.
+     */
+    public void setVerbose(boolean verbose) {
+        mVerbose = verbose;
+    }
+
+    /**
+     * Sets the value of the "output" attribute.
+     * @param output the value.
+     */
+    public void setOutput(String output) {
+        mOutput = output;
+    }
+
+    public void setDexedLibs(String dexedLibs) {
+        mDexedLibs = dexedLibs;
+    }
+
+    /**
+     * Sets the value of the "nolocals" attribute.
+     * @param verbose the value.
+     */
+    public void setNoLocals(boolean nolocals) {
+        mNoLocals = nolocals;
+    }
+
+    public void setChildProcessRamMb(int mb) {
+        mChildProcessRamMb = mb;
+    }
+
+    public void setDisableDexMerger(boolean disable) {
+        mDisableDexMerger = disable;
+    }
+
+    private boolean preDexLibraries(List<File> inputs) {
+        if (mDisableDexMerger || inputs.size() == 1) {
+            // only one input, no need to put a pre-dexed version, even if this path is
+            // just a jar file (case for proguard'ed builds)
+            return true;
+        }
+
+        final int count = inputs.size();
+        boolean allSuccessful = true;
+        for (int i = 0 ; i < count; i++) {
+            File input = inputs.get(i);
+            if (input.isFile()) {
+                // check if this libs needs to be pre-dexed
+                String fileName = getDexFileName(input);
+                File dexedLib = new File(mDexedLibs, fileName);
+                String dexedLibPath = dexedLib.getAbsolutePath();
+
+                if (dexedLib.isFile() == false/*||
+                        dexedLib.lastModified() < input.lastModified()*/) {
+
+                    System.out.println(
+                            String.format("Pre-Dexing %1$s -> %2$s",
+                                    input.getAbsolutePath(), fileName));
+
+                    if (dexedLib.isFile()) {
+                        dexedLib.delete();
+                    }
+
+                    boolean dexSuccess = runDx(input, dexedLibPath, false /*showInput*/);
+                    allSuccessful = allSuccessful && dexSuccess;
+                } else {
+                    System.out.println(
+                            String.format("Using Pre-Dexed %1$s <- %2$s",
+                                    fileName, input.getAbsolutePath()));
+                }
+
+                // replace the input with the pre-dex libs.
+                inputs.set(i, dexedLib);
+            }
+        }
+        return allSuccessful;
+    }
+
+    private String getDexFileName(File inputFile) {
+        // get the filename
+        String name = inputFile.getName();
+        // remove the extension
+        int pos = name.lastIndexOf('.');
+        if (pos != -1) {
+            name = name.substring(0, pos);
+        }
+
+        String hashed = getHashFor(inputFile);
+
+        return "dex-cached-" + hashed + ".jar";
+    }
+
+    private String getHashFor(File inputFile) {
+        String retval = alreadyChecked.get(inputFile.getAbsolutePath());
+        if (retval != null) return retval;
+        // add a hash of the original file path
+        try {
+            HashFunction hashFunction = Hashing.md5();
+            HashCode hashCode = hashFunction.hashBytes(Files.readAllBytes(inputFile.toPath()));
+            retval = hashCode.toString();
+            alreadyChecked.put(inputFile.getAbsolutePath(), retval);
+            return retval;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "ERROR";
+        }
+    }
+
+    public boolean execute(List<File> paths) {
+        // pre dex libraries if needed
+        boolean successPredex = preDexLibraries(paths);
+        if (!successPredex) return false;
+
+        System.out.println(String.format(
+                "Converting compiled files and external libraries into %1$s...", mOutput));
+
+        return runDx(paths, mOutput, mVerbose /*showInputs*/);
+    }
+
+    private boolean runDx(File input, String output, boolean showInputs) {
+        return runDx(Collections.singleton(input), output, showInputs);
+    }
+
+    private boolean runDx(Collection<File> inputs, String output, boolean showInputs) {
+        int mx = mChildProcessRamMb - 200;
+
+        List<String> commandLineList = new ArrayList<String>();
+        commandLineList.add(System.getProperty("java.home") + "/bin/java");
+        commandLineList.add("-mx" + mx + "M");
+        commandLineList.add("-jar");
+        commandLineList.add(mExecutable);
+
+        commandLineList.add("--dex");
+        commandLineList.add("--positions=lines");
+
+        if (mNoLocals) {
+            commandLineList.add("--no-locals");
+        }
+
+        if (mVerbose) {
+            commandLineList.add("--verbose");
+        }
+
+        commandLineList.add("--output=" + output);
+
+        for (File input : inputs) {
+            String absPath = input.getAbsolutePath();
+            if (showInputs) {
+                System.out.println("Input: " + absPath);
+            }
+            commandLineList.add(absPath);
+        }
+
+        // Convert command line to an array
+        String[] dxCommandLine = new String[commandLineList.size()];
+        commandLineList.toArray(dxCommandLine);
+
+        boolean dxSuccess = Execution.execute(null, dxCommandLine, System.out, System.err);
+        return dxSuccess;
+
+    }
+
+    protected String getExecTaskName() {
+        return "dx";
+    }
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
@@ -44,6 +44,10 @@ public final class Main {
     @Option(name = "--childProcessRamMb",
             usage = "Maximum ram that can be used by a child processes, in MB.")
     int childProcessRamMb = 2048;
+
+    @Option(name = "--dexCacheDir",
+            usage = "the directory to cache the pre-dexed libraries")
+    String dexCacheDir = null;
   }
 
   private static CommandLineOptions commandLineOptions = new CommandLineOptions();
@@ -83,7 +87,8 @@ public final class Main {
                                          commandLineOptions.outputDir,
                                          commandLineOptions.isForStemCellApp,
                                          commandLineOptions.isForWireless,
-                                         commandLineOptions.childProcessRamMb);
+                                         commandLineOptions.childProcessRamMb,
+                                         commandLineOptions.dexCacheDir);
     System.exit(result.getResult());
   }
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -112,7 +112,7 @@ public final class ProjectBuilder {
   }
 
     Result build(String userName, ZipFile inputZip, File outputDir, boolean isForRepl, boolean isForWireless,
-               int childProcessRam) {
+               int childProcessRam, String dexCachePath) {
     try {
       // Download project files into a temporary directory
       File projectRoot = createNewTempDir();
@@ -162,7 +162,7 @@ public final class ProjectBuilder {
         // Invoke YoungAndroid compiler
         boolean success =
             Compiler.compile(project, componentTypes, console, console, userErrors, isForRepl, isForWireless,
-                             keyStorePath, childProcessRam);
+                             keyStorePath, childProcessRam, dexCachePath);
         console.close();
         userErrors.close();
 

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
@@ -20,12 +20,12 @@ public class CompilerTest extends TestCase {
   public void testGeneratePermissions() throws Exception {
     Set<String> noComponents = Sets.newHashSet();
     Compiler compiler = new Compiler(null, noComponents, System.out, System.err, System.err, false, false,
-                                     2048);
+                                     2048, null);
     assertTrue("Permissions for no components not empty. (It should be empty!)",
         compiler.generatePermissions().isEmpty());
 
     Set<String> componentTypes = Sets.newHashSet("LocationSensor");
-    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, false, 2048);
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, false, 2048, null);
     Set<String> permissions = compiler.generatePermissions();
     assertEquals(4, permissions.size());
     assertTrue(permissions.contains(


### PR DESCRIPTION
I replaced the current dex launching method with a heavily modified version of the Android SDK's Dex ant task. Now, if you pass in a directory that dex files can be cached into, dexing time and memory usage goes down dramatically after the first launch.

On my crappy 6-year old laptop with 1GB of RAM, OpenJDK 32 (Client VM) running Ubuntu 12.04, and with a Pentium M processor 1.20GHz, I get:

Without pre-dexing, running ant PlayApp

```
BUILD SUCCESSFUL
Total time: 3 minutes 59 seconds

real    4m0.929s
user    1m49.631s
sys 0m6.796s
```

With pre-dexing (All dex files in cache except project classes):

```
BUILD SUCCESSFUL
Total time: 1 minute 2 seconds

real    1m4.228s
user    0m44.087s
sys 0m3.376s
```
