### PR TITLE
Simplified "make color" & "split color" blocks

### DIFF
--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -364,26 +364,24 @@ Blockly.Drawer.defaultBlockXMLStrings = {
     '</block>' +
   '</xml>' },
 
-   math_random_int : {xmlString:
+  math_random_int : {xmlString:
   '<xml>' +
     '<block type="math_random_int">' +
     '<value name="FROM"><block type="math_number"><title name="NUM">1</title></block></value>' +
     '<value name="TO"><block type="math_number"><title name="NUM">100</title></block></value>' +
     '</block>' +
   '</xml>'},
+
   color_make_color: {xmlString:
   '<xml>' +
     '<block type="color_make_color">' +
-      '<value name="COLORLIST">' +
-        '<block type="lists_create_with" inline="false">' +
-          '<mutation items="3"></mutation>' +
-          '<value name="ADD0"><block type="math_number"><title name="NUM">255</title></block></value>' +
-          '<value name="ADD1"><block type="math_number"><title name="NUM">0</title></block></value>' +
-          '<value name="ADD2"><block type="math_number"><title name="NUM">0</title></block></value>' +
-        '</block>' +
-      '</value>' +
+      '<value name="RED"><block type="math_number"><title name="NUM">255</title></block></value>' +
+      '<value name="GREEN"><block type="math_number"><title name="NUM">0</title></block></value>' +
+      '<value name="BLUE"><block type="math_number"><title name="NUM">0</title></block></value>' +
+      '<value name="OPACITY"><block type="math_number"><title name="NUM">255</title></block></value>' +
     '</block>' +
   '</xml>'},
+
   lists_create_with:{xmlString:
   '<xml>' +
     '<block type="lists_create_with">' +

--- a/appinventor/blocklyeditor/src/generators/yail/colors.js
+++ b/appinventor/blocklyeditor/src/generators/yail/colors.js
@@ -59,34 +59,42 @@ Blockly.Yail.color_yellow = function() {
 };
 
 Blockly.Yail.color_make_color = function() {
-  var blackList = "(call-yail-primitive make-yail-list (*list-for-runtime* 0 0 0)  '( any any any)  \"make a list\")";
-  var argument0 = Blockly.Yail.valueToCode(this, 'COLORLIST', Blockly.Yail.ORDER_NONE) || blackList;
-  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "make-color" + Blockly.Yail.YAIL_SPACER;
-
-  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "make-color" + Blockly.Yail.YAIL_SPACER;
-  code += Blockly.Yail.YAIL_OPEN_COMBINATION
-      + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER
-      + argument0 + Blockly.Yail.YAIL_CLOSE_COMBINATION;
-  code += Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE
-      + Blockly.Yail.YAIL_OPEN_COMBINATION + "list"
-      + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
-  code += Blockly.Yail.YAIL_DOUBLE_QUOTE + "make-color"
-      + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  var argument0 = Blockly.Yail.valueToCode(this, 'RED', Blockly.Yail.ORDER_NONE) || 1;
+  var argument1 = Blockly.Yail.valueToCode(this, 'GREEN', Blockly.Yail.ORDER_NONE) || 1;
+  var argument2 = Blockly.Yail.valueToCode(this, 'BLUE', Blockly.Yail.ORDER_NONE) || 1;
+  var argument3 = Blockly.Yail.valueToCode(this, 'OPACITY', Blockly.Yail.ORDER_NONE) || 1;
+  var code ="(call-yail-primitive make-color (*list-for-runtime* (call-yail-primitive make-yail-list (*list-for-runtime* "
+           + argument0 + Blockly.Yail.YAIL_SPACER
+           + argument1 + Blockly.Yail.YAIL_SPACER
+           + argument2 + Blockly.Yail.YAIL_SPACER
+           + argument3
+           +") '(any any any any) \"make a list\")) '(list) \"make-color\")";
   return [ code, Blockly.Yail.ORDER_ATOMIC ];
-
 };
 
 Blockly.Yail.color_split_color = function() {
-  var argument0 = Blockly.Yail.valueToCode(this, 'COLOR', Blockly.Yail.ORDER_NONE) || -1;
-  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "split-color" + Blockly.Yail.YAIL_SPACER;
-  code += Blockly.Yail.YAIL_OPEN_COMBINATION
+  var mode = this.getTitleValue('OP');
+  var tuple = Blockly.Yail.color_split_color.OPERATORS[mode];
+  var operator1 = tuple[0];
+  var operator2 = tuple[1];
+  var order = tuple[2];
+  var argument = Blockly.Yail.valueToCode(this, 'COLOR', order) || 0;
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + operator1
+      + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION
       + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER
-      + argument0 + Blockly.Yail.YAIL_CLOSE_COMBINATION;
-  code += Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE
+      + argument + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE
       + Blockly.Yail.YAIL_OPEN_COMBINATION + "number"
       + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
-  code += Blockly.Yail.YAIL_DOUBLE_QUOTE + "split-color"
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + operator2
       + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
   return [ code, Blockly.Yail.ORDER_ATOMIC ];
+};
 
+Blockly.Yail.color_split_color.OPERATORS = {
+  RED: ['split-color-red', 'split the red from the color', Blockly.Yail.ORDER_NONE],
+  GREEN: ['split-color-green', 'split the green from the color', Blockly.Yail.ORDER_NONE],
+  BLUE: ['split-color-blue', 'split the blue from the color', Blockly.Yail.ORDER_NONE],
+  OPACITY: ['split-color-opacity', 'split the opacity from the color', Blockly.Yail.ORDER_NONE]
 };

--- a/appinventor/blocklyeditor/src/language/common/colors.js
+++ b/appinventor/blocklyeditor/src/language/common/colors.js
@@ -211,33 +211,84 @@ Blockly.Language.color_dark_gray = {
   typeblock: [{ translatedName: Blockly.LANG_COLOUR_DARK_GRAY }]
 };
 
+
 Blockly.Language.color_make_color = {
-  category: "Colors",
-  helpUrl: Blockly.LANG_COLOUR_MAKE_COLOUR_HELPURL,
-  init: function() {
-    this.setColour(Blockly.COLOR_CATEGORY_HUE);
-    this.appendValueInput('COLORLIST').appendTitle("make color").setCheck(Blockly.Language.YailTypeToBlocklyType("list",Blockly.Language.INPUT));
-    this.setOutput(true, Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.OUTPUT));
-    this.setTooltip(Blockly.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
-    this.appendCollapsedInput().appendTitle(Blockly.LANG_COLOUR_MAKE_COLOUR, 'COLLAPSED_TEXT');
-  },
-  onchange: Blockly.WarningHandler.checkErrors,
-  typeblock: [{ translatedName: Blockly.LANG_COLOUR_MAKE_COLOUR }]
+    //Make RGB colour
+    category: "Colors",
+    helpUrl: Blockly.LANG_COLOUR_MAKE_COLOUR_HELPURL,
+    init: function() {
+      this.setColour(Blockly.COLOR_CATEGORY_HUE);
+      this.setOutput(true, Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.OUTPUT));
+      this.appendValueInput('RED')
+        .setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT))
+        .appendTitle('make color')
+        .appendTitle('Red')
+        .setAlign(Blockly.ALIGN_RIGHT);
+      this.appendValueInput('GREEN')
+        .setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT))
+        .appendTitle('Green')
+        .setAlign(Blockly.ALIGN_RIGHT);
+      this.appendValueInput('BLUE')
+        .setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT))
+        .appendTitle('Blue')
+        .setAlign(Blockly.ALIGN_RIGHT);
+      this.appendValueInput('OPACITY')
+        .setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT))
+        .appendTitle('Opacity')
+        .setAlign(Blockly.ALIGN_RIGHT);
+      this.setTooltip(Blockly.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+      this.appendCollapsedInput().appendTitle(Blockly.LANG_COLOUR_MAKE_COLOUR, 'COLLAPSED_TEXT');
+    },
+    onchange: Blockly.WarningHandler.checkErrors,
+    typeblock: [{ translatedName: Blockly.LANG_COLOUR_MAKE_COLOUR }]
 };
 
+
 Blockly.Language.color_split_color = {
-  category: "Colors",
-  helpUrl: Blockly.LANG_COLOUR_SPLIT_COLOUR_HELPURL,
-  init: function() {
-    this.setColour(Blockly.COLOR_CATEGORY_HUE);
-    this.appendValueInput('COLOR').appendTitle("split color").setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT));
-    this.setOutput(true, Blockly.Language.YailTypeToBlocklyType("list",Blockly.Language.OUTPUT));
-    this.setTooltip(Blockly.LANG_COLOUR_SPLIT_COLOUR_TOOLTIP);
-    this.appendCollapsedInput().appendTitle(Blockly.LANG_COLOUR_SPLIT_COLOUR, 'COLLAPSED_TEXT');
-  },
-  onchange: Blockly.WarningHandler.checkErrors,
-  typeblock: [{ translatedName: Blockly.LANG_COLOUR_SPLIT_COLOUR }]
+    category: "Colors",
+    helpUrl: Blockly.LANG_COLOUR_SPLIT_COLOUR_HELPURL,
+    init: function() {
+      this.setColour(Blockly.COLOR_CATEGORY_HUE);
+      this.appendValueInput('COLOR').setCheck(Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.INPUT)).appendTitle('split color').appendTitle(new Blockly.FieldDropdown(this.OPERATORS), 'OP');
+      this.setOutput(true, Blockly.Language.YailTypeToBlocklyType("number",Blockly.Language.OUTPUT));
+   // Assign 'this' to a variable for use in the closures below.
+      var thisBlock = this;
+      this.setTooltip(Blockly.LANG_COLOUR_SPLIT_COLOUR_TOOLTIP);
+      this.appendCollapsedInput().appendTitle(this.getTitleValue('OP'), 'COLLAPSED_TEXT');
+    },
+    onchange: Blockly.WarningHandler.checkErrors,
+    typeblock: [{
+      dropDown: {
+        titleName: 'OP',
+        value: 'RED'
+      }
+    },{
+      dropDown: {
+        titleName: 'OP',
+        value: 'GREEN'
+      }
+    },{
+      dropDown: {
+        titleName: 'OP',
+        value: 'BLUE'
+      }
+    },{
+      dropDown: {
+        titleName: 'OP',
+        value: 'OPACITY'
+      }
+    }],
+    prepareCollapsedText: function(){
+      var titleFromOperator = Blockly.FieldDropdown.lookupOperator(this.OPERATORS, this.getTitleValue('OP'));
+      this.getTitle_('COLLAPSED_TEXT').setText(titleFromOperator, 'COLLAPSED_TEXT');
+    }
 };
+
+Blockly.Language.color_split_color.OPERATORS =
+[['red', 'RED'],
+ ['green', 'GREEN'],
+ ['blue', 'BLUE'],
+ ['opacity', 'OPACITY']];
 
 
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -2092,26 +2092,33 @@ list, use the make-yail-list constructor with no arguments.
      (bitwise-arithmetic-shift-left (bitwise-and blue *max-color-component*)
                                     *color-blue-position*))))
 
-(define (split-color color)
+(define (split-color-red color)
   (let ((intcolor (make-exact-yail-integer color)))
-  (kawa-list->yail-list
-   (list
     ;; red
     (bitwise-and (bitwise-arithmetic-shift-right intcolor
                                                  *color-red-position*)
-                 *max-color-component*)
+                 *max-color-component*)))
+
+(define (split-color-green color)
+  (let ((intcolor (make-exact-yail-integer color)))
     ;; green
     (bitwise-and (bitwise-arithmetic-shift-right intcolor
                                                  *color-green-position*)
-                 *max-color-component*)
+                 *max-color-component*)))
+
+(define (split-color-blue color)
+  (let ((intcolor (make-exact-yail-integer color)))
     ;; blue
     (bitwise-and (bitwise-arithmetic-shift-right intcolor
                                                  *color-blue-position*)
-                 *max-color-component*)
+                 *max-color-component*)))
+
+(define (split-color-opacity color)
+  (let ((intcolor (make-exact-yail-integer color)))
     ;; alpha
     (bitwise-and (bitwise-arithmetic-shift-right intcolor
                                                  *color-alpha-position*)
-                 *max-color-component*)))))
+                 *max-color-component*)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This enhancement to the "make color" & "split color" blocks simplifies the to blocks for the user. It does not change the function of the 2 blocks in anyway.

For full details about the enhancement: https://docs.google.com/document/d/1bG39GMz5xN2amUywPiutie3PSJyEnYaifegAc-nLzHM/edit?usp=sharing

To test the enhancement:http://mad-robot-dev.appspot.com/
Download the MrAI companion app:  http://sourceforge.net/projects/themadrobot/files/App-inventor-resource/Mad-Robots-AI/MrAI%20Companion.apk/download

Sample project: http://sourceforge.net/projects/themadrobot/files/App-inventor-resource/Mad-Robots-AI/DEMO_ColourPicker.aia/download
