### PR TITLE
Add methods to resize the tabs to fit the browser window

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -245,10 +245,12 @@ public class DesignToolbar extends Toolbar {
       projectEditor.selectFileEditor(screen.formEditor);
       toggleEditor(false);
       Ode.getInstance().getTopToolbar().updateFileMenuButtons(1);
+      Ode.getInstance().SwitchToFormEditor();
     } else {  // must be View.BLOCKS
       projectEditor.selectFileEditor(screen.blocksEditor);
       toggleEditor(true);
       Ode.getInstance().getTopToolbar().updateFileMenuButtons(1);
+      Ode.getInstance().SwitchToBlocksEditor();
     }
     // Inform the Blockly Panel which project/screen (aka form) we are working on
     BlocklyPanel.setCurrentForm(projectId + "_" + newScreenName);

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -95,7 +95,7 @@ public class SourceStructureExplorer extends Composite {
 
     // Put a ScrollPanel around the tree.
     ScrollPanel scrollPanel = new ScrollPanel(tree);
-    scrollPanel.setWidth("200px");  // wide enough to avoid a horizontal scrollbar most of the time
+    scrollPanel.setWidth("110%");  // wide enough to avoid a horizontal scrollbar most of the time
     scrollPanel.setHeight("480px"); // approximately the same height as the viewer
 
     HorizontalPanel buttonPanel = new HorizontalPanel();


### PR DESCRIPTION
### Description

Currently, most tabs on the AI2 design page such as Palette and Properties are not allowed to be resized to fit the browser window. It may cause some troubles when users try to narrow the browser window to do something else like reading an toturial at the same time.

I made some modification to make the size of the tabs adjust automatically when the size of browser window is changed.
### Screen Shots:
- FormEditorScreen_Before
  ![4](https://f.cloud.github.com/assets/6442245/2178097/6415b990-9657-11e3-960f-65668d7bd782.png)
- FormEditorScreen_After
  ![3](https://f.cloud.github.com/assets/6442245/2178099/6c14eb48-9657-11e3-8dd6-c711da3359b3.png)
- BlocksEditorScreen_Before
  ![6](https://f.cloud.github.com/assets/6442245/2178103/91750800-9657-11e3-84c4-b32548a247fc.png)
- BlocksEditorScreen_After
  ![5](https://f.cloud.github.com/assets/6442245/2178112/e2ad93fe-9657-11e3-8551-c6a84cd1cadc.png)
