### PR TITLE
Modified onTouch event such that a Button can be treated as a Press and ...

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -509,6 +509,12 @@ public final class YoungAndroidFormUpgrader {
       // No properties need to be modified to upgrade to version 5.
       srcCompVersion = 5;
     }
+    if (srcCompVersion < 6) {
+      // - Added TouchUp and TouchDown events
+      // - FontSize, FontBold, FontItalic properties made visible in block editor
+      // No properties need to be modified to upgrade to version 6.
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -390,7 +390,10 @@ public class YaVersion {
   // - The Shape property was added.
   // For BUTTON_COMPONENT_VERSION 5:
   // - The ShowFeedback property was added.
-  public static final int BUTTON_COMPONENT_VERSION = 5;
+  //For BUTTON_COMPONENT_VERSION 6:
+  // - Added TouchUp and TouchDown events
+  // - FontSize, FontBold, FontItalic properties made visible in block editor
+  public static final int BUTTON_COMPONENT_VERSION = 6;
 
   public static final int CAMCORDER_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Button.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Button.java
@@ -6,16 +6,10 @@
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
-import com.google.appinventor.components.annotations.DesignerProperty;
-import com.google.appinventor.components.annotations.PropertyCategory;
-import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleObject;
-import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
-import android.view.MotionEvent;
-import android.view.View;
 
 /**
  * Button with the ability to launch events on initialization, focus
@@ -32,9 +26,6 @@ import android.view.View;
 @SimpleObject
 public final class Button extends ButtonBase {
 
-  // Used for determining if this button is Press/Release or Click behavior.
-  private boolean isPressRelease=false;
-
   /**
    * Creates a new Button component.
    *
@@ -42,73 +33,6 @@ public final class Button extends ButtonBase {
    */
   public Button(ComponentContainer container) {
     super(container);
-  }
-
-  /**
-   * Specifies if this is a Press/Release type button or a ragular one.
-   *
-   * @param isPressRelease  {@code true} treats onTouch as Press/Release event
-   *                        {@code false} treats onTouch as Click pass through
-   */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
-          defaultValue = "False")
-  @SimpleProperty(description = "Specifies if this button should be treated " +
-          "as a button that can be pressed and released.")
-
-  public void IsPressRelease(boolean isPressRelease) {
-    this.isPressRelease=isPressRelease;
-  }
-
-  /**
-   * Returns true if the button is of Press/Release type.
-   *
-   * @return {@code true} indicates button is of Press/Release type
-   *         {@code false} indicates button is simple Click type
-   */
-  @SimpleProperty(
-          category = PropertyCategory.BEHAVIOR,
-          description = "Returns the button's usage type.")
-  public boolean IsPressRelease() {
-      return isPressRelease;
-  }
-
-  /**
-   * If this button instance isPressRelease type, dispatch Press Release events
-   */
-  @Override
-  public boolean onTouch(View view, MotionEvent me)
-  {
-     if (!IsPressRelease()) {
-       return super.onTouch(view, me);
-     } else {
-       super.onTouch(view, me);
-       switch ( me.getAction() ) {
-          case MotionEvent.ACTION_DOWN:
-              Press();
-              break;
-          case MotionEvent.ACTION_UP:
-          case MotionEvent.ACTION_CANCEL:
-              Release();
-              break;
-        }
-     }
-     return true;
-  }
-
-  /**
-   * Indicates a user pressed down on the button.
-   */
-  @SimpleEvent
-  public void Press() {
-    EventDispatcher.dispatchEvent(this, "Press");
-  }
-
-  /**
-   * Indicates a user released the button.
-   */
-  @SimpleEvent
-  public void Release() {
-    EventDispatcher.dispatchEvent(this, "Release");
   }
 
  @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -144,42 +144,21 @@ public abstract class ButtonBase extends AndroidViewComponent
     {
         //NOTE: We ALWAYS return false because we want to indicate that this listener has not
         //been consumed. Using this approach, other listeners (e.g. OnClick) can process as normal.
-
-        //If user has disabled the visual feedback, then don't even proceed any further
-        if (!ShowFeedback()) {
-            return false;
-        }
-        //If regular button with no background image or default shape,
-        // then we use the normal button visual feedback.
-        boolean shouldOverlay=true;
-        if (backgroundImageDrawable == null) {
-            shouldOverlay=false;
-        }
-
-        //If using other than default Shape, then we want to overlay
-        if (shape != Component.BUTTON_SHAPE_DEFAULT){
-            shouldOverlay=true;
-        }
-
-        //If a background color has been assigned, then we should perform overlay
-        if (BackgroundColor() != 0 ) {
-            shouldOverlay=true;
-        }
-
-        if (!shouldOverlay) {
-            return false;
-        }
-
         if (me.getAction() == MotionEvent.ACTION_DOWN) {
             //button pressed, provide visual feedback AND return false
-            view.getBackground().setAlpha(70); // translucent
-            view.invalidate();
-
+            if (ShowFeedback()) {
+               view.getBackground().setAlpha(70); // translucent
+               view.invalidate();
+            }
+            TouchDown();
         } else if (me.getAction() == MotionEvent.ACTION_UP ||
             me.getAction() == MotionEvent.ACTION_CANCEL) {
             //button released, set button back to normal AND return false
-            view.getBackground().setAlpha(255); // opaque
-            view.invalidate();
+            if (ShowFeedback()) {
+               view.getBackground().setAlpha(255); // opaque
+               view.invalidate();
+            }
+            TouchUp();
         }
 
         return false;
@@ -188,6 +167,22 @@ public abstract class ButtonBase extends AndroidViewComponent
   @Override
   public View getView() {
     return view;
+  }
+
+  /**
+   * Indicates when the button is touch down
+   */
+  @SimpleEvent
+  public void TouchDown() {
+    EventDispatcher.dispatchEvent(this, "TouchDown");
+  }
+
+  /**
+   * Indicates when the button is touch ends
+   */
+  @SimpleEvent
+  public void TouchUp() {
+    EventDispatcher.dispatchEvent(this, "TouchUp");
   }
 
   /**
@@ -441,8 +436,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    * @return  {@code true} indicates bold, {@code false} normal
    */
   @SimpleProperty(
-      category = PropertyCategory.APPEARANCE,
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public boolean FontBold() {
     return bold;
   }
@@ -456,7 +450,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
   @SimpleProperty(
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public void FontBold(boolean bold) {
     this.bold = bold;
     TextViewUtil.setFontTypeface(view, fontTypeface, bold, italic);
@@ -501,8 +495,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    * @return  {@code true} indicates italic, {@code false} normal
    */
   @SimpleProperty(
-      category = PropertyCategory.APPEARANCE,
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public boolean FontItalic() {
     return italic;
   }
@@ -516,7 +509,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
   @SimpleProperty(
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public void FontItalic(boolean italic) {
     this.italic = italic;
     TextViewUtil.setFontTypeface(view, fontTypeface, bold, italic);
@@ -528,8 +521,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    * @return  font size in pixel
    */
   @SimpleProperty(
-      category = PropertyCategory.APPEARANCE,
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public float FontSize() {
     return TextViewUtil.getFontSize(view);
   }
@@ -542,7 +534,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT,
       defaultValue = Component.FONT_DEFAULT_SIZE + "")
   @SimpleProperty(
-      userVisible = false)
+      category = PropertyCategory.APPEARANCE)
   public void FontSize(float size) {
     TextViewUtil.setFontSize(view, size);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1352,7 +1352,7 @@ public class Form extends Activity
 
   private void showAboutApplicationNotification() {
     String title = "About This App";
-    String tagline = "<p><small><em>Invented with MIT App Inventor<br>appinventor.mit.edu</em></small>";
+    String tagline = "";//"<p><small><em>Invented with MIT App Inventor<br>appinventor.mit.edu</em></small>";
     String message = aboutScreen + tagline;
     String buttonText ="Got it";
     Notifier.oneButtonAlert(this, message, title, buttonText);


### PR DESCRIPTION
...Release type button instead of simply a Click type.  This allows creating buttons that can be used to call start and stop functions on Press and Release respectively.

Place a button on the screen and check its isPressRelease property to change the button's onTouch behavior to fire Press and Release events.  Place "When Press" and "When Release" blocks in the the blocks designer to capture and execute code upon such events.
