### PR TITLE
Fix to prevent the user removed yandexTranslateTagline

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1358,8 +1358,8 @@ public class Form extends Activity
 
   private void showAboutApplicationNotification() {
     String title = "About This App";
-    String tagline = "<p><small><em>Invented with MIT App Inventor<br>appinventor.mit.edu</em></small>";
-    String message = aboutScreen + tagline + yandexTranslateTagline;
+    String tagline = "<p><small><em>Invented with MIT App Inventor<br>appinventor.mit.edu</em></small></p>";
+    String message = yandexTranslateTagline + aboutScreen + tagline;
     String buttonText ="Got it";
     Notifier.oneButtonAlert(this, message, title, buttonText);
   }


### PR DESCRIPTION
Prevent the user from removing the yandex Translate license statement from the about popup if they enter <!-- in the About property