### PR TITLE
Adds code to mark blocks as bad when deprecated:

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -294,8 +294,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         paramList.add(new ParameterDefinition(param.get("name").asString().getString(), param
             .get("type").asString().getString()));
       }
-      component.add(new EventDefinition(event.get("name").asString().getString(), event
-          .get("description").asString().getString(), paramList));
+      component.add(
+          new EventDefinition(
+              event.get("name").asString().getString(),
+              event.get("description").asString().getString(),
+              new Boolean(event.get("deprecated").asString().getString()),
+              paramList));
     }
   }
 
@@ -314,8 +318,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         paramList.add(new ParameterDefinition(param.get("name").asString().getString(), param
             .get("type").asString().getString()));
       }
-      component.add(new MethodDefinition(method.get("name").asString().getString(), method
-          .get("description").asString().getString(), paramList));
+      component.add(
+          new MethodDefinition(
+              method.get("name").asString().getString(),
+              method.get("description").asString().getString(),
+              new Boolean(method.get("deprecated").asString().getString()),
+              paramList));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
@@ -120,13 +120,15 @@ public interface ComponentDatabaseInterface {
   public static class EventDefinition {
     private final String name;
     private final String description;
+    private final boolean deprecated;
     // "params": [{ "name": "xAccel", "type": "number"},*]
     private final List<ParameterDefinition> params;
 
-    public EventDefinition(String name, String description,
+    public EventDefinition(String name, String description, boolean deprecated,
         List<ParameterDefinition> params) {
       this.name = name;
       this.description = description;
+      this.deprecated = deprecated;
       this.params = params;
     }
 
@@ -137,6 +139,8 @@ public interface ComponentDatabaseInterface {
     public String getDescription() {
       return description;
     }
+
+    public boolean getDeprecated() { return deprecated; }
 
     public List<ParameterDefinition> getParam() {
       return params;
@@ -150,13 +154,15 @@ public interface ComponentDatabaseInterface {
   public static class MethodDefinition {
     private final String name;
     private final String description;
+    private final boolean deprecated;
     // "params": [{ "name": "xAccel", "type": "number"},*]
     private List<ParameterDefinition> params;
 
-    public MethodDefinition(String name, String description,
+    public MethodDefinition(String name, String description, boolean deprecated,
         List<ParameterDefinition> params) {
       this.name = name;
       this.description = description;
+      this.deprecated = deprecated;
       this.params = params;
     }
 
@@ -167,6 +173,8 @@ public interface ComponentDatabaseInterface {
     public String getDescription() {
       return description;
     }
+
+    public boolean getDeprecated() { return deprecated; }
 
     public List<ParameterDefinition> getParam() {
       return params;

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -86,6 +86,11 @@ Blockly.Blocks.component_event = {
     // [lyn, 12/23/2013] Move this out of domToMutation into top-level component_event
     // this.onchange = Blockly.WarningHandler.checkErrors;
 
+    if (this.getEventTypeObject().deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
+      this.badBlock();
+      this.setDisabled(true);
+    }
+
   },
   // [lyn, 10/24/13] Allow switching between horizontal and vertical display of arguments
   // Also must create flydown params and DO input if they don't exist.
@@ -322,6 +327,10 @@ Blockly.Blocks.component_method = {
       this.setNextStatement(true);
     }
     this.errors = [{name:"checkIsInDefinition"}];
+    if (this.getMethodTypeObject().deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
+      this.badBlock();
+      this.setDisabled(true);
+    }
   },
   // Rename the block's instanceName, type, and reset its title
   rename : function(oldname, newname) {

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -179,12 +179,14 @@ Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
   //create event blocks
   var eventObjects = Blockly.ComponentTypes[typeName].componentInfo.events;
   for(var i=0;i<eventObjects.length;i++) {
+    if (eventObjects[i].deprecated === "true") continue;
     mutatorAttributes = {component_type: typeName, instance_name: instanceName, event_name : eventObjects[i].name};
     xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_event",mutatorAttributes));
   }
   //create non-generic method blocks
   var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
   for(var i=0;i<methodObjects.length;i++) {
+    if (methodObjects[i].deprecated === "true") continue;
     mutatorAttributes = {component_type: typeName, instance_name: instanceName, method_name: methodObjects[i].name, is_generic:"false"};
     xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
   }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -107,20 +107,16 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("],\n  \"events\": [");
     separator = "";
     for (Event event : component.events.values()) {
-      if (event.userVisible) {
-        sb.append(separator);
-        outputBlockEvent(event.name, event, sb);
-        separator = ",\n    ";
-      }
+      sb.append(separator);
+      outputBlockEvent(event.name, event, sb, !event.userVisible);
+      separator = ",\n    ";
     }
     sb.append("],\n  \"methods\": [");
     separator = "";
     for (Method method : component.methods.values()) {
-      if (method.userVisible) {
-        sb.append(separator);
-        outputBlockMethod(method.name, method, sb);
-        separator = ",\n    ";
-      }
+      sb.append(separator);
+      outputBlockMethod(method.name, method, sb, !method.userVisible);
+      separator = ",\n    ";
     }
     sb.append("]}\n");
   }
@@ -147,21 +143,25 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("\"}");
   }
   
-  private void outputBlockEvent(String eventName, Event event, StringBuilder sb) {
+  private void outputBlockEvent(String eventName, Event event, StringBuilder sb,
+                                boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(eventName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(event.description));
+    sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(event.parameters, sb);
     sb.append("}\n");
   }
   
-  private void outputBlockMethod(String methodName, Method method, StringBuilder sb) {
+  private void outputBlockMethod(String methodName, Method method, StringBuilder sb,
+                                 boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(methodName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(method.description));
+    sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(method.parameters, sb);
     if (method.getReturnType() != null) {

--- a/appinventor/lib/blockly/src/core/block.js
+++ b/appinventor/lib/blockly/src/core/block.js
@@ -346,6 +346,14 @@ Blockly.Block.prototype.unselect = function() {
 };
 
 /**
+ * Mark this block as Bad.  Highlight it visually in Red.
+ */
+Blockly.Block.prototype.badBlock = function() {
+  goog.asserts.assertObject(this.svg_, 'Block is not rendered.');
+  this.svg_.addBadBlock();
+};
+
+/**
  * Dispose of this block.
  * @param {boolean} healStack If true, then try to heal any gap by connecting
  *     the next statement with the previous statement.  Otherwise, dispose of

--- a/appinventor/lib/blockly/src/core/block_svg.js
+++ b/appinventor/lib/blockly/src/core/block_svg.js
@@ -461,6 +461,16 @@ Blockly.BlockSvg.prototype.removeSelect = function() {
 };
 
 /**
+ * Mark this block as bad.  Highlight it visually in red.
+ */
+Blockly.BlockSvg.prototype.addBadBlock = function() {
+  Blockly.addClass_(/** @type {!Element} */ (this.svgGroup_),
+      'badBlock');
+  // Move the selected block to the top of the stack.
+  this.svgGroup_.parentNode.appendChild(this.svgGroup_);
+};
+
+/**
  * Adds the dragging class to this block.
  * Also disables the highlights/shadows to improve performance.
  */

--- a/appinventor/lib/blockly/src/core/css.js
+++ b/appinventor/lib/blockly/src/core/css.js
@@ -113,6 +113,15 @@ Blockly.Css.CONTENT = [
   '  display: none;',
   '}',
 
+  '.badBlock>.blocklyPath {',
+  '  stroke-width: 3px;',
+  '  stroke: #f00;',
+  '}',
+
+  '.badBlockl>.blocklyPathLight {',
+  '  display: none;',
+  '}',
+
   '.blocklyDragging>.blocklyPath,',
   '.blocklyDragging>.blocklyPathLight {',
   '  fill-opacity: .8;',


### PR DESCRIPTION
  - Modification of the annotation processor to include deprecated (userVisible
    = false) methods and events in simple_components.json with a deprecated
    property.
  - Modification of the creation of components in mainWorkspace to mark
    deprecated blocks as bad blocks.
  - Creation of a badBlock function to mark blocks as bad (highlight them in red
    and disable them).
  - Modification of the loading of blocks in Drawer.js to skip deprecated blocks
    in flyouts.

Review please: @jisqyv @afmckinney @halatmit @fturbak 