### PR TITLE
Adds two guard clauses for events in mutators and flyouts

### DIFF
--- a/appinventor/lib/blockly/src/core/flyout.js
+++ b/appinventor/lib/blockly/src/core/flyout.js
@@ -614,6 +614,7 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
  * @private
  */
 Blockly.Flyout.prototype.filterForCapacity_ = function() {
+  if (!this.targetWorkspace_) return;
   var remainingCapacity = this.targetWorkspace_.remainingCapacity();
   var blocks = this.workspace_.getTopBlocks(false);
   for (var i = 0, block; block = blocks[i]; i++) {

--- a/appinventor/lib/blockly/src/core/mutator.js
+++ b/appinventor/lib/blockly/src/core/mutator.js
@@ -263,6 +263,7 @@ Blockly.Mutator.prototype.setVisible = function(visible) {
  * @private
  */
 Blockly.Mutator.prototype.workspaceChanged_ = function() {
+  if (!this.workspace_) return;
   if (Blockly.Block.dragMode_ == 0) {
     var blocks = this.workspace_.getTopBlocks(false);
     var MARGIN = 20;


### PR DESCRIPTION
- When a block in a mutator window is deselected, it triggers a workspace
  changed event that will run after the workspace has been disposed of. These
  two guard clauses are early returns if the target workspace is null.

We don't really use filterForCapacity_ so we could modify the signature of the init function in flyuot.js to inject a boolean that will control if the function is registered or not. But that would deviate us (more) from Blockly core.
In any case, that would only fix one of the TypeErrors.
