### PR TITLE
Arrange for Companion to report its package name.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AppInvHTTPD.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AppInvHTTPD.java
@@ -210,7 +210,8 @@ public class AppInvHTTPD extends NanoHTTPD {
     } else if (uri.equals("/_getversion")) {
       Response res;
       try {
-        PackageInfo pInfo = form.getPackageManager().getPackageInfo(form.getPackageName(), 0);
+        String packageName = form.getPackageName();
+        PackageInfo pInfo = form.getPackageManager().getPackageInfo(packageName, 0);
         String installer;
         if (SdkLevel.getLevel() >= SdkLevel.LEVEL_ECLAIR) {
           installer = EclairUtil.getInstallerPackageName("edu.mit.appinventor.aicompanion3", form);
@@ -224,7 +225,8 @@ public class AppInvHTTPD extends NanoHTTPD {
         if (installer == null)
           installer = "Not Known";
         res = new Response(HTTP_OK, MIME_JSON, "{\"version\" : \"" + versionName +
-          "\", \"fingerprint\" : \"" + Build.FINGERPRINT + "\"," + " \"installer\" : \"" + installer + "\"}");
+          "\", \"fingerprint\" : \"" + Build.FINGERPRINT + "\"," +
+          " \"installer\" : \"" + installer + "\", \"package\" : \"" + packageName + "\" }");
       } catch (NameNotFoundException n) {
         n.printStackTrace();
         res = new Response(HTTP_OK, MIME_JSON, "{\"verison\" : \"Unknown\"");


### PR DESCRIPTION
Arrange for Companion to report its package name, this permits the
service to determine if the correct companion is being used. This is
of particular value to people compiling their own version of App
Inventor and want to make sure their end-users are using the
corresponding Companion. The code to check the package name in the
service is not yet written, this change is just on the Companion side
to report its package name along with its version.

Change-Id: If1b9624ab60830b336bac8122eb8dbb9fb34a167
