### PR TITLE
Fixes issue for adding Native Library files to APK

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -1044,6 +1044,7 @@ public final class Compiler {
         "-A", project.getAssetsDirectory().getAbsolutePath(),
         "-I", getResource(ANDROID_RUNTIME),
         "-F", tmpPackageName,
+        libsDir.getAbsolutePath()
     };
     long startAapt = System.currentTimeMillis();
     // Using System.err and System.out on purpose. Don't want to pollute build messages with
@@ -1078,10 +1079,10 @@ public final class Compiler {
         if (library.endsWith(ARMEABI_V7A_SUFFIX)) { // Remove suffix and copy.
           library = library.substring(0, library.length() - ARMEABI_V7A_SUFFIX.length());
           Files.copy(new File(getResource(RUNTIME_FILES_DIR + ARMEABI_V7A_DIRECTORY +
-              File.separator + library)), new File(armeabiV7aDir, library));
+              "/" + library)), new File(armeabiV7aDir, library));
         } else {
-          Files.copy(new File(getResource(RUNTIME_FILES_DIR + library)),
-              new File(armeabiDir, library));
+          Files.copy(new File(getResource(RUNTIME_FILES_DIR + ARMEABI_DIR_NAME +
+              "/" + library)), new File(armeabiDir, library));
         }
       }
       return true;


### PR DESCRIPTION
Currently the code for include Native Libraries does not work. This pull request fixes the issue.

<H2><b>Here is an example how to added the native libriaries</b></H2>


1)  Add you libraries to the <b>appinventor\lib</b> folder

<b>Example:</b>

```
appinventor\lib\sphero\RobotLibrary.jar
appinventor\lib\sphero\armeabi\libachievement_manager.so
appinventor\lib\sphero\armeabi-v7ai\libachievement_manager.so
```

<br>2) In the file <b>appinventor\buildserver\build.xml</b> add the native library

<b>Example:</b>

```
<copy toFile="${classes.files.dir}/RobotLibrary.jar" file="${lib.dir}/sphero/RobotLibrary.jar" />
<copy todir="${classes.files.dir}/armeabi">
    <fileset dir="${lib.dir}/sphero/armeabi" includes="*.so" />
</copy>
<copy todir="${classes.files.dir}/armeabi-v7a">
    <fileset dir="${lib.dir}/sphero/armeabi-v7a" includes="*.so" />
</copy>
```

<br>
3)  In the component file <b>appinventor\components\src\com\google\appinventor\components\runtime\mrSphero.java</b> add the <b>@UsesNativeLibraries</b> annotations as shown below

<b>Example:</b>

```
@DesignerComponent(version = 1,
    description = "Component to control Sphero",
    category = ComponentCategory.USERINTERFACE,
    nonVisible = true,
    iconName = "images/mrSphero.png")
@SimpleObject
@UsesPermissions(permissionNames = "android.permission.BLUETOOTH_ADMIN, android.permission.BLUETOOTH")
@UsesLibraries(libraries = "RobotLibrary.jar")
@UsesNativeLibraries(libraries = "libachievement_manager.so" ,
                        v7aLibraries = "libachievement_manager.so")
public class mrSphero extends AndroidNonvisibleComponent
```
