### PR TITLE
fixed prop panel renaming issue

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -313,6 +313,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
   public void onComponentRenamed(MockComponent component, String oldName) {
     if (loadComplete) {
       onFormStructureChange();
+      updatePropertiesPanel(component);
     } else {
       OdeLog.elog("onComponentRenamed called when loadComplete is false");
     }


### PR DESCRIPTION
Fix for trac ticket #621. Component name at top of properties panel now updates when component is renamed.
