### PR TITLE
Enable to rename components with non-English characters

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -147,6 +147,9 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
 
     private void handleOkClick() {
       String newName = newNameTextBox.getText();
+      // Remove leading and trailing whitespace
+      // Replace nonempty sequences of internal spaces by underscores
+      newName = newName.trim().replaceAll("[\\s\\xa0]+", "_");
       if (newName.equals(getName())) {
         hide();
       } else if (validate(newName)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -61,15 +61,16 @@ public final class TextValidators {
   }
 
   /**
-   * Checks whether the argument is a legal component identifier, specifically,
-   * no empty or whitespace is allowed.
+   * Checks whether the argument is a legal component identifier; please check 
+   * Blockly.LexicalVariable.checkIdentifier for the regex reference
    *
    * @param text the proposed identifier
    * @return {@code true} if the argument is a legal identifier, {@code false}
    *         otherwise
    */
   public static boolean isValidComponentIdentifier(String text) {
-	return text.matches("^\\S+$");
+	return text.matches("^[^-0-9!&%^/>=<`'\"#:;\\\\^\\*\\+\\.\\(\\)\\|\\{\\}\\[\\]\\ ]" +
+			"[^-!&%^/>=<'\"#:;\\\\^\\*\\+\\.\\(\\)\\|\\{\\}\\[\\]\\ ]*$");
   }  
   
   /**

--- a/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
@@ -25,8 +25,8 @@ public class TextValidatorsTest extends TestCase {
   private final List<String> legalComponentIdentifierNames = Arrays.asList("你好吗", "按钮1", "图片2",
 		  "图_片2", "图3片_2", "botón1", "botón_2");
 
-  private final List<String> illegalComponentIdentifierNames = Arrays.asList("", " 你好吗", "你好吗 ",
-		  "按 钮", " 按 钮 ", " botón", " botón 2");
+  private final List<String> illegalComponentIdentifierNames = Arrays.asList("", "!你好吗", "2你好吗",
+		  "123按_钮", "1按2钮 ", "1botón", "!botón2");
 
   public void testIdentifierFilter(){
     for (String legalIdentifier : legalIdentifierNames) {


### PR DESCRIPTION
The current internationalization framework doesn't allow to rename
component to something other than English. I changed the
identifier regex and it allows anything but no empty or whitespace.
The regex for the project name remains unchanged.
