### PR TITLE
Add pointer to XML documentation in reference -> other

### DIFF
--- a/appinventor/docs/reference/index.html
+++ b/appinventor/docs/reference/index.html
@@ -67,26 +67,17 @@
                 <li> <a href="http://appinventor.mit.edu/explore/ai2/support/blocks/procedures.html"> Procedures blocks </a> </li>
               </ul>
               <h2> Concepts </h2>
-              <ul>
-                <li> <a href="other/activitystarter.html"> Using the Activity
-                    Starter </a> </li>
-                <li> <a href="other/appstoplay.html"> Uploading Your Apps to
-                    Google Play </a> </li>
-                <li> <a href="other/tinywebdb.html"> Creating a Custom
-                    TinyWebDB Service </a> </li>
-                <li> <a href="other/testing.html"> Live Development, Testing,
-                    and Debugging </a> </li>
-                <li> <a href="other/displaylist.html"> Displaying a List </a>
-                </li>
-                <li> <a href="other/locationsensor.html"> Using the Location
-                    Sensor </a> </li>
-                <li> <a href="other/sizes.html"> Specifying Sizes of Components
-                  </a> </li>
-                <li> <a href="other/sizes.html"> </a> <a href="other/sizes.html">
-                  </a> <a href="other/media.html"> Accessing Images and Sounds
-                  </a> </li>
-                <li> <a href="other/bluetooth.html"> Bluetooth </a> - <i>
-                    Coming Soon! </i> </li>
+            <ul>
+                <li> <a href="other/activitystarter.html"> Using the Activity Starter </a> </li>
+                <li> <a href="other/appstoplay.html"> Uploading Your Apps to Google Play </a> </li>
+                <li> <a href="other/tinywebdb.html"> Creating a Custom TinyWebDB Service </a> </li>
+                <li> <a href="other/testing.html"> Live Development, Testing and Debugging </a> </li>
+                <li> <a href="other/displaylist.html"> Displaying Lists </a> </li>
+                <li> <a href="other/locationsensor.html"> Using the Location Sensor </a> </li>
+                <li> <a href="other/sizes.html"> Specifying Sizes of Components </a> </li>
+                <li> <a href="other/media.html"> Accessing Images and Sounds </a> </li>
+                <li> <a href="other/xml.html"> Working with XML and Web Services</a> </li>
+                <li> <a href="other/bluetooth.html"> Bluetooth </a> - <i> Coming Soon! </i> </li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
@jisqyv @afmckinney 
Updated the reference/other page to include a link to the XML documentation (which should already  be there)
