### PR TITLE
Updated deprecated calls to GWT CheckBox

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/BooleanPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/BooleanPropertyEditor.java
@@ -43,13 +43,13 @@ public class BooleanPropertyEditor extends PropertyEditor implements ValueChange
   // Updates the property value shown in the editor
   @Override
   protected void updateValue() {
-    checkbox.setChecked(property.getValue().equals(trueValue));
+    checkbox.setValue(property.getValue().equals(trueValue));
   }
 
   // ValueChangeHandler implementation
 
   @Override
   public void onValueChange(ValueChangeEvent<Boolean> event) {
-    property.setValue(checkbox.isChecked() ? trueValue : falseValue);
+    property.setValue(checkbox.getValue() ? trueValue : falseValue);
   }
 }


### PR DESCRIPTION
Replacements are type-consistent drop-ins:
isChecked -> getValue
setChecked -> setValue

Fixes #175 
Change-Id: If727b574d181e95461bb6e270d5dc0ec879428ae
