### PR TITLE
New screen options: enable & disable ShowTitleBar & ShowStatusBar

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2210,6 +2210,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String AboutScreenProperties();
   
+  @DefaultMessage("ShowTitleBar")
+  @Description("")
+  String ShowTitleBarProperties();
+  
   @DefaultMessage("AboveRangeEventEnabled")
   @Description("")
   String AboveRangeEventEnabledProperties();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2214,6 +2214,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String ShowTitleBarProperties();
   
+  @DefaultMessage("ShowStatusBar")
+  @Description("")
+  String ShowStatusBarProperties();
+  
   @DefaultMessage("AboveRangeEventEnabled")
   @Description("")
   String AboveRangeEventEnabledProperties();

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -204,6 +204,7 @@ public class TranslationComponentProperty {
     map.put("Year", MESSAGES.YearProperties());
     map.put("AboutScreen", MESSAGES.AboutScreenProperties());
     map.put("ShowTitleBar", MESSAGES.ShowTitleBarProperties());
+    map.put("ShowStatusBar", MESSAGES.ShowStatusBarProperties());
     map.put("CloseScreenAnimation", MESSAGES.CloseScreenAnimationProperties());
     map.put("OpenScreenAnimation", MESSAGES.OpenScreenAnimationProperties());
     map.put("LastMessage", MESSAGES.LastMessageProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -203,6 +203,7 @@ public class TranslationComponentProperty {
     map.put("MonthInText", MESSAGES.MonthInTextProperties());
     map.put("Year", MESSAGES.YearProperties());
     map.put("AboutScreen", MESSAGES.AboutScreenProperties());
+    map.put("ShowTitleBar", MESSAGES.ShowTitleBarProperties());
     map.put("CloseScreenAnimation", MESSAGES.CloseScreenAnimationProperties());
     map.put("OpenScreenAnimation", MESSAGES.OpenScreenAnimationProperties());
     map.put("LastMessage", MESSAGES.LastMessageProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
@@ -16,6 +16,8 @@ public class TranslationDesignerProperties {
     // Properties
     if (key.equals("AboutScreen")) {
       value = MESSAGES.AboutScreenProperties();
+    } else if (key.equals("ShowTitleBar")) {
+      value = MESSAGES.ShowTitleBarProperties();
     } else if (key.equals("AboveRangeEventEnabled")) {
       value = MESSAGES.AboveRangeEventEnabledProperties();
     } else if (key.equals("Action")) {
@@ -272,8 +274,8 @@ public class TranslationDesignerProperties {
       value = MESSAGES.MonthInTextProperties();
     } else if (key.equals("Year")) {
       value = MESSAGES.YearProperties();
-    } else if (key.equals("AboutScreen")) {
-      value = MESSAGES.AboutScreenProperties();
+    } else if (key.equals("FullScreen")) {
+      value = MESSAGES.FullScreenProperties();
     } else if (key.equals("CloseScreenAnimation")) {
       value = MESSAGES.CloseScreenAnimationProperties();
     } else if (key.equals("OpenScreenAnimation")) {

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
@@ -16,8 +16,6 @@ public class TranslationDesignerProperties {
     // Properties
     if (key.equals("AboutScreen")) {
       value = MESSAGES.AboutScreenProperties();
-    } else if (key.equals("ShowTitleBar")) {
-      value = MESSAGES.ShowTitleBarProperties();
     } else if (key.equals("AboveRangeEventEnabled")) {
       value = MESSAGES.AboveRangeEventEnabledProperties();
     } else if (key.equals("Action")) {
@@ -174,6 +172,10 @@ public class TranslationDesignerProperties {
       value = MESSAGES.ServiceURLProperties();
     } else if (key.equals("Shape")) {
       value = MESSAGES.ShapeProperties();
+    } else if (key.equals("ShowTitleBar")) {
+      value = MESSAGES.ShowTitleBarProperties();
+    } else if (key.equals("ShowStatusBar")) {
+      value = MESSAGES.ShowStatusBarProperties();
     } else if (key.equals("ShowFeedback")) {
       value = MESSAGES.ShowFeedbackProperties();
     } else if (key.equals("show tables")) {
@@ -274,8 +276,6 @@ public class TranslationDesignerProperties {
       value = MESSAGES.MonthInTextProperties();
     } else if (key.equals("Year")) {
       value = MESSAGES.YearProperties();
-    } else if (key.equals("FullScreen")) {
-      value = MESSAGES.FullScreenProperties();
     } else if (key.equals("CloseScreenAnimation")) {
       value = MESSAGES.CloseScreenAnimationProperties();
     } else if (key.equals("OpenScreenAnimation")) {

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -287,8 +287,10 @@ public class YaVersion {
   // - LISTVIEW_COMPONENT_VERSION was incremented to 3.
   // For YOUNG_ANDROID_VERSION 107:
   // - WEBVIEWER_COMPONENT_VERSION was incremented to 5
+  // For YOUNG_ANDROID_VERSION 108:
+  // - FORM_COMPONENT_VERSION was incremented to 14.
 
-  public static final int YOUNG_ANDROID_VERSION = 107;
+  public static final int YOUNG_ANDROID_VERSION = 108;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -530,7 +532,9 @@ public class YaVersion {
   // - AboutScreen property was added
   // For FORM_COMPONENT_VERSION 13:
   // - The Screen.Scrollable property was set to False by default
-  public static final int FORM_COMPONENT_VERSION = 13;
+  // For FORM_COMPONENT_VERSION 14:
+  // - The Screen.ShowStatusBar & Screen.ShowTitleBar were added.
+  public static final int FORM_COMPONENT_VERSION = 14;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:
   // - The Fusiontables API was migrated from SQL to V1

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -751,7 +751,7 @@ public class Form extends Activity
    * @return  showTitleBar boolean
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-		    description = "Visibility of the title bar.")
+      description = "Visibility of the title bar.")
   public boolean ShowTitleBar() {
     return showTitleBar;
   }
@@ -761,9 +761,8 @@ public class Form extends Activity
    *
    * @param visibility boolean
    */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN)
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-		    description = "We can show/hide the title bar.")
+      description = "We can show/hide the title bar.")
   public void ShowTitleBar(boolean visibility) {
     if (visibility != showTitleBar) {
       View v = (View)findViewById(android.R.id.title).getParent();
@@ -782,7 +781,7 @@ public class Form extends Activity
    * @return  showTitleBar boolean
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-		    description = "Full Screen status")
+      description = "Full Screen status")
   public boolean FullScreen() {
     return fullScreen;
   }
@@ -792,20 +791,19 @@ public class Form extends Activity
    *
    * @param visibility boolean
    */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN)
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-		    description = "We can enable/disable full screen.")
+      description = "We can enable/disable full screen.")
   public void FullScreen(boolean enabled) {
-	if (enabled != fullScreen) {
-	  if (enabled) {
-	    getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-	   	getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-	   } else {
-		getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-		getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-	   }    
-	  fullScreen = enabled;		
-	}
+    if (enabled != fullScreen) {
+      if (enabled) {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+      } else {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+      }    
+      fullScreen = enabled;		
+    }
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -118,7 +118,7 @@ public class Form extends Activity
   // "about this application" menu item is selected.
   private String aboutScreen;
   private boolean showTitleBar = true;
-  private boolean fullScreen = false;
+  private boolean showStatusBar = true;
 
   private String backgroundImagePath = "";
   private Drawable backgroundDrawable;
@@ -751,7 +751,7 @@ public class Form extends Activity
    * @return  showTitleBar boolean
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "Visibility of the title bar.")
+      description = "Title bar visibility")
   public boolean ShowTitleBar() {
     return showTitleBar;
   }
@@ -761,6 +761,8 @@ public class Form extends Activity
    *
    * @param visibility boolean
    */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "True")
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       description = "We can show/hide the title bar.")
   public void ShowTitleBar(boolean visibility) {
@@ -776,33 +778,35 @@ public class Form extends Activity
   }
   
   /**
-   * FullScreen property getter method.
+   * ShowStatusBar property getter method.
    *
-   * @return  showTitleBar boolean
+   * @return  showStatusBar boolean
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "Full Screen status")
-  public boolean FullScreen() {
-    return fullScreen;
+      description = "Status bar visibility")
+  public boolean ShowStatusBar() {
+    return showStatusBar;
   }
 
   /**
-   * FullScreen property setter method.
+   * ShowStatusBar property setter method.
    *
    * @param visibility boolean
    */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "True")
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "We can enable/disable full screen.")
-  public void FullScreen(boolean enabled) {
-    if (enabled != fullScreen) {
-      if (enabled) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-      } else {
+      description = "We can enable/disable status bar.")
+  public void ShowStatusBar(boolean visibility) {
+    if (visibility != showStatusBar) {
+      if (visibility) {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+      } else {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
       }    
-      fullScreen = enabled;		
+      showStatusBar = visibility;		
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -34,7 +34,9 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MenuItem.OnMenuItemClickListener;
+import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ScrollView;
@@ -115,6 +117,8 @@ public class Form extends Activity
   // Information string the app creator can set.  It will be shown when
   // "about this application" menu item is selected.
   private String aboutScreen;
+  private boolean showTitleBar = true;
+  private boolean fullScreen = false;
 
   private String backgroundImagePath = "";
   private Drawable backgroundDrawable;
@@ -739,6 +743,69 @@ public class Form extends Activity
   @SimpleProperty
   public void AboutScreen(String aboutScreen) {
     this.aboutScreen = aboutScreen;
+  }
+  
+  /**
+   * ShowTitleBar property getter method.
+   *
+   * @return  showTitleBar boolean
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+		    description = "Visibility of the title bar.")
+  public boolean ShowTitleBar() {
+    return showTitleBar;
+  }
+
+  /**
+   * ShowTitleBar property setter method.
+   *
+   * @param visibility boolean
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN)
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+		    description = "We can show/hide the title bar.")
+  public void ShowTitleBar(boolean visibility) {
+    if (visibility != showTitleBar) {
+      View v = (View)findViewById(android.R.id.title).getParent();
+      if (visibility) {
+        v.setVisibility(View.VISIBLE);
+      } else {
+        v.setVisibility(View.GONE);
+      }    
+      showTitleBar = visibility;		
+    }
+  }
+  
+  /**
+   * FullScreen property getter method.
+   *
+   * @return  showTitleBar boolean
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+		    description = "Full Screen status")
+  public boolean FullScreen() {
+    return fullScreen;
+  }
+
+  /**
+   * FullScreen property setter method.
+   *
+   * @param visibility boolean
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN)
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+		    description = "We can enable/disable full screen.")
+  public void FullScreen(boolean enabled) {
+	if (enabled != fullScreen) {
+	  if (enabled) {
+	    getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+	   	getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+	   } else {
+		getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+		getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+	   }    
+	  fullScreen = enabled;		
+	}
   }
 
   /**


### PR DESCRIPTION
I added new options in the screen, which allow App Inventor users to enable/disable ShowTitleBar & ShowStatusBar. These methods are in the form of the getter and setter methods in the block editor and also in the designer property list. But there won't be any change in the designer viewer if you decide to change them. Future work, make the changes reflected on the designer viewer. 