### PR TITLE
MediaUtil Case-insensitive search caching

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -36,6 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Utilities for loading media.
@@ -124,7 +125,25 @@ public class MediaUtil {
     return MediaSource.ASSET;
   }
 
+  private static ConcurrentHashMap<String, String> pathCache = new ConcurrentHashMap<String, String>(2);
+
   private static String findCaseinsensitivePath(Form form, String mediaPath)
+      throws IOException{
+    if( !pathCache.containsKey(mediaPath) ){
+      pathCache.put(mediaPath, findCaseinsensitivePathWithoutCache(form, mediaPath));
+    }
+    return pathCache.get(mediaPath);
+  }
+
+  /**
+   * Don't use this directly! Use findCaseinsensitivePath. It has caching.
+   * This is the original findCaseinsensitivePath, unchanged.
+   * @param form the Form
+   * @param mediaPath the path to the media to resolve
+   * @return the correct path, adjusted for case errors
+   * @throws IOException
+   */
+  private static String findCaseinsensitivePathWithoutCache(Form form, String mediaPath)
       throws IOException{
     String[] mediaPathlist = form.getAssets().list("");
     int l = Array.getLength(mediaPathlist);
@@ -136,6 +155,7 @@ public class MediaUtil {
     }
     return null;
   }
+
 
   /**
    * find path of an asset from a mediaPath using case-insensitive comparison,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -150,10 +150,10 @@ public class MediaUtil {
       return form.getAssets().open(mediaPath);
 
     } catch (IOException e) {
-        if (findCaseinsensitivePath(form, mediaPath) == null) {
+      String path = findCaseinsensitivePath(form, mediaPath);
+      if (path == null) {
           throw e;
         } else {
-          String path = findCaseinsensitivePath(form, mediaPath);
           return form.getAssets().open(path);
         }
     }
@@ -384,10 +384,10 @@ public class MediaUtil {
       return form.getAssets().openFd(mediaPath);
 
     } catch (IOException e) {
-      if (findCaseinsensitivePath(form, mediaPath) == null){
+      String path = findCaseinsensitivePath(form, mediaPath);
+      if (path == null){
         throw e;
       } else {
-      String path = findCaseinsensitivePath(form, mediaPath);
       return form.getAssets().openFd(path);
       }
     }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -130,7 +130,11 @@ public class MediaUtil {
   private static String findCaseinsensitivePath(Form form, String mediaPath)
       throws IOException{
     if( !pathCache.containsKey(mediaPath) ){
-      pathCache.put(mediaPath, findCaseinsensitivePathWithoutCache(form, mediaPath));
+      String newPath = findCaseinsensitivePathWithoutCache(form, mediaPath);
+      if( newPath == null){
+        return null;
+      }
+      pathCache.put(mediaPath, newPath);
     }
     return pathCache.get(mediaPath);
   }
@@ -155,7 +159,6 @@ public class MediaUtil {
     }
     return null;
   }
-
 
   /**
    * find path of an asset from a mediaPath using case-insensitive comparison,


### PR DESCRIPTION
Fixes #188 

Speeds are better, even in the correct case!

(average operation times)

Before change:
Good names: 9 ms
Bad names: 704 ms

After change:
Good names: 6 ms
Bad names initial load: 202 ms
Bad names subsequent: 6ms

Cases where the path is not found are not cached. Average op time for this case is 175 ms.
(This is the null-return case from findCaseinsensitivePath)

This uses a ConcurrentHashMap, with no eviction mechanism. The hash table can grow without bound, adding an entry for each unique path that is requested. 