### PR TITLE
Enhance the Blocks Upgrader Code

### DIFF
--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -85,6 +85,7 @@
 	<path id="libsForBlocklyeditorTests.path">
 		<fileset dir="${run.lib.dir}" includes="*.jar" />
 		<pathelement location="${build.dir}/common/CommonTestUtils.jar" />
+                <pathelement location="${build.dir}/components/CommonConstants.jar" />
 		<pathelement location="${lib.dir}/junit/junit-4.8.2.jar" />
 	</path>
 

--- a/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
+++ b/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
@@ -20,6 +20,8 @@
 
 var formJson = "";
 var componentTypes = {};
+var YOUNG_ANDROID_VERSION;
+var BLOCKS_LANGUAGE_VERSION;
 
 function start() {
 
@@ -118,8 +120,8 @@ function start() {
   // [lyn, 2015/01/02] Needed by the upgrader in versioning.js
   // Is there a way to get the actual current version number?
 
-  window.parent.BlocklyPanel_getBlocksLanguageVersion = function () { return 18; }
-
+  window.parent.BlocklyPanel_getBlocksLanguageVersion = function () { return BLOCKS_LANGUAGE_VERSION; }
+  window.parent.BlocklyPanel_getYaVersion = function() { return YOUNG_ANDROID_VERSION; }
 
   // ----- End the Mock locale operations
 
@@ -195,6 +197,11 @@ function handleLoadForm(event) {
         }
     };
     reader.readAsText(files[0]);
+}
+
+function processVersion(bl, yav) {
+    BLOCKS_LANGUAGE_VERSION = bl;
+    YOUNG_ANDROID_VERSION = yav;
 }
 
 function processBlocks(formJsonString, blocks){ // [lyn, 2015/01/01] Modified to handled upgrader changes

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -31,13 +31,13 @@ Blockly.Versioning.loggingFlag = true;
 
 Blockly.Versioning.setLogging = function (bool) {
   Blockly.Versioning.loggingFlag = bool;
-}
+};
 
 Blockly.Versioning.log = function log(string) { // Display feedback on upgrade if Blockly.Versioning.loggingFlag is on.
   if (Blockly.Versioning.loggingFlag) {
     console.log("Blockly.Versioning: " + string);
   }
-}
+};
 
 /**
  * [lyn, 2014/11/04] Simplified version of Halloween AI2 upgrading architecture.
@@ -82,16 +82,16 @@ Blockly.Versioning.upgrade = function (preUpgradeFormJsonString, blocksContent) 
     if (componentType == "Form") {
       componentType = "Screen"; // Treat Form as if it were Screen
     }
-    Blockly.Versioning.log("In Blockly.Versioning.upgrade, upgradeComponentType("  + componentType + ","
-        + preUpgradeVersion + ","  + systemVersion + "," + rep + ")");
+    Blockly.Versioning.log("In Blockly.Versioning.upgrade, upgradeComponentType("  + componentType + "," +
+        preUpgradeVersion + ","  + systemVersion + "," + rep + ")");
     if (preUpgradeVersion > systemVersion) {
       // What to do in this case? Currently, throw an exception, but might want to do something else:
-      throw "Unexpected situation in Blockly.Versioning.upgrade: preUpgradeVersion of " + componentType
-          +  " = " + preUpgradeVersion + " > systemVersion = " + systemVersion;
+      throw "Unexpected situation in Blockly.Versioning.upgrade: preUpgradeVersion of " + componentType +
+          " = " + preUpgradeVersion + " > systemVersion = " + systemVersion;
     } else if (preUpgradeVersion < systemVersion) {
       // Need to upgrade this component
-      Blockly.Versioning.log("upgrading component type " + componentType + " from version "
-          + preUpgradeVersion + " to version " + systemVersion);
+      Blockly.Versioning.log("upgrading component type " + componentType + " from version " +
+          preUpgradeVersion + " to version " + systemVersion);
       var upgradeMap = Blockly.Versioning.AllUpgradeMaps[componentType];
       if (! upgradeMap) {
         throw "Blockly.Versioning.upgrade: no upgrade map for component type " + componentType;
@@ -99,12 +99,12 @@ Blockly.Versioning.upgrade = function (preUpgradeFormJsonString, blocksContent) 
       for (var version = preUpgradeVersion + 1; version <= systemVersion; version++) {
         var versionUpgrader = upgradeMap[version];
         if (! versionUpgrader) {
-          throw "Blockly.Versioning.upgrade: no upgrader to upgrade component type " + componentType
-              + " to version " + version;
+          throw "Blockly.Versioning.upgrade: no upgrader to upgrade component type " + componentType +
+              " to version " + version;
         }
         // Perform upgrade
-        Blockly.Versioning.log("applying upgrader for upgrading component type " + componentType
-            + " from version " + (version-1) + " to version " + version);
+        Blockly.Versioning.log("applying upgrader for upgrading component type " + componentType +
+            " from version " + (version-1) + " to version " + version);
         // Apply upgrader, possibly mutating rep and changing its dynamic type.
         rep = Blockly.Versioning.applyUpgrader(versionUpgrader, rep);
       }
@@ -116,18 +116,24 @@ Blockly.Versioning.upgrade = function (preUpgradeFormJsonString, blocksContent) 
   // Upgrade language based on language version
 
   var systemLanguageVersion = window.parent.BlocklyPanel_getBlocksLanguageVersion();
+  var systemYoungAndroidVersion = window.parent.BlocklyPanel_getYaVersion();
   var versionTags = dom.getElementsByTagName('yacodeblocks');
+
   // if there is no version in the file, then this is an early ai2 project, prior to
   // 10/21/13, when the blocks internal xml structure was overhauled
   // with descriptive mutator tags. blocksOverhaul translates the blocks
 
   var preUpgradeLanguageVersion;
-  if (versionTags.length==0) {
+  if (versionTags.length===0) {
     Blockly.Versioning.v17_blocksOverhaul(dom);
     preUpgradeLanguageVersion = 17;  // default for oldest ai2
   }
   else {
-    preUpgradeLanguageVersion = parseInt(versionTags[0].getAttribute('language-version'))
+    if (systemYoungAndroidVersion == parseInt(versionTags[0].getAttribute('ya-version'), 10)) {
+      Blockly.Versioning.ensureWorkspace(dom);
+      return;
+    }
+    preUpgradeLanguageVersion = parseInt(versionTags[0].getAttribute('language-version'), 10);
   }
 
   var blocksRep = dom; // Initial blocks rep is dom

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/BlocklyEvalTest.java
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/BlocklyEvalTest.java
@@ -6,6 +6,7 @@ package com.google.appinventor.blocklyeditor;
 import java.io.IOException;
 import com.google.appinventor.blocklyeditor.BlocklyTestUtils;
 import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.components.common.YaVersion;
 import junit.framework.TestCase;
 
 /**
@@ -25,7 +26,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/backgroundColorTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/backgroundColorTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -41,7 +43,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/moleMashTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/moleMashTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -57,7 +60,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/paintPotTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/paintPotTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -73,7 +77,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/helloPurrTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/helloPurrTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -89,7 +94,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/makeQuizTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/makeQuizTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -105,7 +111,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/pictureCycleTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/pictureCycleTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -121,7 +128,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/sensorTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/sensorTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -137,7 +145,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/clockTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/clockTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -153,7 +162,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/camcorderTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/camcorderTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -169,7 +179,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/copyCatTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/copyCatTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -185,7 +196,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/productLookupTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/productLookupTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -201,7 +213,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/factorialTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/factorialTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {
@@ -217,7 +230,8 @@ public class BlocklyEvalTest extends TestCase {
 
     String[] params =
       { "phantomjs",
-        testpath + "/tests/com/google/appinventor/blocklyeditor/underscoreTest.js" };
+        testpath + "/tests/com/google/appinventor/blocklyeditor/underscoreTest.js",
+        Integer.toString(YaVersion.BLOCKS_LANGUAGE_VERSION), Integer.toString(YaVersion.YOUNG_ANDROID_VERSION) };
     String result = "";
 
     try {

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/backgroundColorTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/backgroundColorTest.js
@@ -4,6 +4,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var formJson = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/backgroundColor/Screen1.scm');
@@ -41,6 +43,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+    processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -49,7 +52,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/camcorderTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/camcorderTest.js
@@ -7,7 +7,8 @@ var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/block
 var formJson = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/camcorder/Screen1.scm');
 formJson = formJson.substring(9, formJson.length-2); // Cut off Leading $JSON
 var blocks = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/camcorder/Screen1.bky');
-
+var system = require('system');
+var args = system.args;
 // PhantomJS page object to open and load an URL
 var page = require('webpage').create();
 // Some debugging from PhantomJS
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -43,8 +45,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
 
         return doTheyMatch(expected, newblocks);
 
-
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/clockTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/clockTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/clock/clockExpected.yail');
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -44,7 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/copyCatTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/copyCatTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/copyCat/copyCatExpected.yail');
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -44,7 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/factorialTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/factorialTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/factorial/factorialExpected.yail');
@@ -37,6 +38,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -45,7 +47,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/helloPurrTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/helloPurrTest.js
@@ -4,7 +4,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/helloPurr/helloPurrExpected.yail');
@@ -40,6 +41,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+      processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -48,7 +50,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/makeQuizTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/makeQuizTest.js
@@ -4,7 +4,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/makeQuiz/makeQuizExpected.yail');
@@ -40,6 +41,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+      processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -48,7 +50,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/moleMashTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/moleMashTest.js
@@ -4,7 +4,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/moleMash/MoleMashExpected.yail');
@@ -40,6 +41,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+      processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -48,7 +50,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/paintPotTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/paintPotTest.js
@@ -4,7 +4,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/paintPot/PaintPotExpected.yail');
@@ -41,6 +42,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+    processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -49,7 +51,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/pictureCycleTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/pictureCycleTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/pictureCycle/pictureCycleExpected.yail');
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -44,7 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/productLookupTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/productLookupTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/productLookup/productLookupExpected.yail');
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -44,7 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/sensorTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/sensorTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/sensor/sensorExpected.yail');
@@ -36,6 +37,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -44,7 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/underscoreTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/underscoreTest.js
@@ -1,6 +1,7 @@
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/underscore/underscoreExpected.yail');
@@ -37,6 +38,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         var expected = arguments[0];
 
         // Functions in yail_testing_index.html
+        processVersion(arguments[3], arguments[4]);
         processForm(arguments[1]);
         processBlocks(arguments[1], arguments[2]); // [lyn, 2015/01/01] Changed to handle upgrader
 
@@ -45,7 +47,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
         return doTheyMatch(expected, newblocks);
 
 
-    }, expected, formJson, blocks);
+    }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
     //This is the actual result of the test
     console.log(passed);

--- a/appinventor/blocklyeditor/tests/yailGeneratorTest.template
+++ b/appinventor/blocklyeditor/tests/yailGeneratorTest.template
@@ -9,7 +9,8 @@
 
 var fs = require('fs'); //Always required to read from files
 var path = fs.absolute('.');
-
+var system = require('system');
+var args = system.args;
 
 //Read files from filesystem
 var expected = fs.read(path + '/blocklyeditor/tests/com/google/appinventor/blocklyeditor/data/<FOLDERNAME>/<EXPECTED_YAIL_FILE>');
@@ -45,6 +46,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     var expected = arguments[0];
 
     // Functions in yail_testing_index.html
+    processVersion(arguments[3], arguments[4]);
     processForm(arguments[1]);
     processBlocks(arguments[2]);
 
@@ -53,7 +55,7 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
     return doTheyMatch(expected, newblocks);
 
 
-  }, expected, formJson, blocks);
+  }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
   //This is the actual result of the test
   console.log(passed);

--- a/appinventor/build-common.xml
+++ b/appinventor/build-common.xml
@@ -146,7 +146,7 @@
        compiles all the specified tests, builds them into a library,
        runs them with junit, and then generates a report. It sets
        haltonfailure to no so that the tests will continue to run even
-       after a failure, and so that a report wil be generated.
+       after a failure, and so that a report will be generated.
 
        Depends on having the following properties and paths defined:
 


### PR DESCRIPTION
Add a test for YOUNG_ANDROID_VERSION and bypass upgrade code if
loading project has same value as the system. Some minor style fixups
in versioning.js. Also updated BlocklyEvalTests so that the blocks
language and young android version do not have to be hardcoded into
the units tests. They are read from YaVersion.java at runtime.

Change-Id: I593a652a36373573125a3b2e28d9c842455e0499