### PR TITLE
Bug fix for git issue #208.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/File.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/File.java
@@ -240,6 +240,20 @@ public class File extends AndroidNonvisibleComponent implements Component {
     });
   }
 
+  /**  
+   * Replace Windows-style CRLF with Unix LF as String. This
+   * allows end-user to treat Windows text files same as Unix or Mac. In future, 
+   * allowing user to choose to normalize new lines might also be nice - in case someone really 
+   * wants to detect Windows-style line separators, or save a file which was read (and expect 
+   * no changes in size or checksum).
+   * @param string to convert
+   */
+
+  private String normalizeNewLines(String s) {
+    return s.replaceAll("\r\n", "\n");
+  }
+
+
   /**
    * Asynchronously reads from the given file. Calls the main event thread
    * when the function has completed reading from the file.
@@ -258,7 +272,15 @@ public class File extends AndroidNonvisibleComponent implements Component {
       while ((length = input.read(buffer, offset, BUFFER_LENGTH)) > 0) {
         output.write(buffer, 0, length);
       }
-      final String text = output.toString();
+      
+      // Now that we have the file as a String, 
+      // normalize any line separators to avoid compatibility between Windows and Mac
+      // text files. Users can expect \n to mean a line separator regardless of how
+      // file was created. Currently only doing this for files opened locally - not files we pull
+      // from other places like URLs. 
+
+      final String text = normalizeNewLines(output.toString());
+
       activity.runOnUiThread(new Runnable() {
         @Override
         public void run() {


### PR DESCRIPTION
I'd like someone to review changes for:

File ReadFrom: Normalize end of line characters to make dealing with text files uniform across platforms.

It's a straightforward change, but still a bit concerned that:

1. People may want to detect Windows files (and find they no longer can, because we've obscured any differences)
2. Someone reading in a file, then writing it out, can expect a change in size or checksum if it contained CRLF when opened.
3. Someone reading in a file from different source, like URL, may expect same functionality. (They won't get it with this fix).

Please note that **AI Companion must be upgraded** for this change to take effect.

