### PR TITLE
add a getter of ContactPicker for getting contactUri

### DIFF
--- a/appinventor/aiplayapp/youngandroidproject/project.properties
+++ b/appinventor/aiplayapp/youngandroidproject/project.properties
@@ -7,12 +7,12 @@ icon=AI2Companion-Icon.png
 # The Version code is an integer. Each new version of an App uploaded
 # to the Play Store must have a version greater then the version in
 # the store
-versioncode=223
+versioncode=224
 # The Version Name is displayed to the user and can contain numbers
 # and letters. It generally should be congruent to the Version Code
 # Terms used by AI2:
 # Version code XYZ turns into X.YZ. ai2 indicates a Companion for AI2
 # and an optional "zx1" indicates it has internal Zebra Crossing (QR
 # Code) scanning builtin.
-versionname=2.23ai2zx1
+versionname=2.24
 useslocation=False

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -3684,6 +3684,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String LongClickEvents();
 
+  @DefaultMessage("RequestFocus")
+  @Description("")
+  String RequestFocusMethods();
+
   @DefaultMessage("LostFocus")
   @Description("")
   String LostFocusEvents();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -4685,6 +4685,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String ClearLocationsMethods();
 
+  @DefaultMessage("ClearCaches")
+  @Description("")
+  String ClearCachesMethods();
+
   @DefaultMessage("GoBack")
   @Description("")
   String GoBackMethods();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2682,6 +2682,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String ShowFilterBarProperties();
   
+  @DefaultMessage("TextSize")
+  @Description("")
+  String TextSizeProperties();
+
   @DefaultMessage("NotifierLength")
   @Description("")
   String NotifierLengthProperties();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2841,6 +2841,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("EmailAddress")
   @Description("")
   String EmailAddressProperties();
+  
+  @DefaultMessage("TextContactUri")
+  @Description("")
+  String TextContactUriProperties();
 
   @DefaultMessage("EmailAddressList")
   @Description("")

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2853,7 +2853,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("TextContactUri")
   @Description("")
   String TextContactUriProperties();
-
+  
   @DefaultMessage("EmailAddressList")
   @Description("")
   String EmailAddressListProperties();
@@ -3989,6 +3989,7 @@ public interface OdeMessages extends Messages {
   String ShakingEvents();
 
   //Methods
+  
   @DefaultMessage("ResolveActivity")
   @Description("")
   String ResolveActivityMethods();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -417,12 +417,12 @@ public interface OdeMessages extends Messages {
   String privacyTermsLink();
 
   // Used in TopPanel.java
-  
+
   //Project
   @DefaultMessage("Projects")
   @Description("Name of Projects tab")
   String projectsTabName();
-  
+
   @DefaultMessage("My projects")
   @Description("Name of My projects menuitem")
   String projectMenuItem();
@@ -430,15 +430,15 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Start new project")
   @Description("Label of the menu item for creating a new project")
   String newProjectMenuItem();
-  
+
   @DefaultMessage("Import project (.aia) from my computer ...")
   @Description("Name of Import Project menuitem")
   String importProjectMenuItem();
-  
+
   @DefaultMessage("Delete project")
   @Description("Name of Delete project menuitem")
   String deleteProjectMenuItem();
-  
+
   @DefaultMessage("Save project")
   @Description("Name of Save menuitem")
   String saveMenuItem();
@@ -446,7 +446,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Save project as ...")
   @Description("Name of Save as ... menuitem")
   String saveAsMenuItem();
-  
+
   @DefaultMessage("Checkpoint")
   @Description("Name of Checkpoint menuitem")
   String checkpointMenuItem();
@@ -462,7 +462,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Export all projects")
   @Description("Name of Export all Project menuitem")
   String exportAllProjectsMenuItem();
-  
+
   @DefaultMessage("Export keystore")
   @Description("Label of the button for export keystore")
   String downloadKeystoreMenuItem();
@@ -479,7 +479,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Connect")
   @Description("Label of the button leading to Connect related cascade items")
   String connectTabName();
-  
+
   @DefaultMessage("AI Companion")
   @Description("Message providing details about starting the wireless connection.")
   String AICompanionMenuItem();
@@ -528,7 +528,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Build")
   @Description("Label of the button leading to build related cascade items")
   String buildTabName();
-  
+
   @DefaultMessage("App ( provide QR code for .apk )")
   @Description("Label of item for building a project and show barcode")
   String showBarcodeMenuItem();
@@ -540,7 +540,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Generate YAIL")
   @Description("Label of the cascade item for generating YAIL for a project")
   String generateYailMenuItem();
-  
+
   //Help
   @DefaultMessage("Help")
   @Description("Label for the Help menu")
@@ -549,7 +549,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("About")
   @Description("Label of the link for About")
   String aboutMenuItem();
-  
+
   @DefaultMessage("Companion Information")
   @Description("Information about the Companion")
   String companionInformation();
@@ -573,16 +573,16 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Forums")
   @Description("Name of Forums link")
   String forumsMenuItem();
-  
+
   @DefaultMessage("Report an Issue")
   @Description("Link for Report an Issue form")
   String feedbackMenuItem();
-  
+
   //Admin
   @DefaultMessage("Admin")
   @Description("Label of the button leading to admin functionality")
   String adminTabName();
-  
+
   @DefaultMessage("Download User Source")
   @Description("Label of the button for admins to download a user's project source")
   String downloadUserSourceMenuItem();
@@ -590,16 +590,16 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Switch To Debug Panel")
   @Description("Label of the button for admins to switch to the debug panel without an explicit error")
   String switchToDebugMenuItem();
-  
+
   //Tabs
   @DefaultMessage("My Projects")
   @Description("Name of My Projects tab")
   String myProjectsTabName();
-  
+
   @DefaultMessage("Guide")
   @Description("Name of Guide link")
   String guideTabName();
-  
+
   @DefaultMessage("Report an Issue")
   @Description("Link for Report an Issue form")
   String feedbackTabName();
@@ -607,12 +607,12 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Gallery")
   @Description("Link for Gallery")
   String galleryTabName();
-  
+
   //User email dropdown
   @DefaultMessage("Sign out")
   @Description("Label of the link for signing out")
   String signOutLink();
-  
+
   //
 
   @DefaultMessage("Design")
@@ -732,35 +732,35 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Control")
   @Description("Label on built-in-Control-blocks branch of block selector tree")
   String builtinControlLabel();
-  
+
   @DefaultMessage("Logic")
   @Description("Label on built-in-Logic-blocks branch of block selector tree")
   String builtinLogicLabel();
-  
+
   @DefaultMessage("Text")
   @Description("Label on built-in-Text-blocks branch of block selector tree")
   String builtinTextLabel();
-  
+
   @DefaultMessage("Lists")
   @Description("Label on built-in-Lists-blocks branch of block selector tree")
   String builtinListsLabel();
-  
+
   @DefaultMessage("Colors")
   @Description("Label on built-in-Colors-blocks branch of block selector tree")
   String builtinColorsLabel();
-  
+
   @DefaultMessage("Variables")
   @Description("Label on built-in-Variables-blocks branch of block selector tree")
   String builtinVariablesLabel();
-  
+
   @DefaultMessage("Procedures")
   @Description("Label on built-in-Procedures-blocks branch of block selector tree")
   String builtinProceduresLabel();
-  
+
   @DefaultMessage("Any component")
   @Description("Label on any-component branch of block selector tree")
   String anyComponentLabel();
-  
+
   @DefaultMessage("Any ")
   @Description("None")
   String textAnyComponentLabel();
@@ -1919,7 +1919,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Sensors")
   @Description("")
   String sensorsComponentPallette();
-  
+
   @DefaultMessage("Social")
   @Description("")
   String socialComponentPallette();
@@ -1927,7 +1927,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Storage")
   @Description("")
   String storageComponentPallette();
-  
+
   @DefaultMessage("Form")
   @Description("")
   String FormComponentPallette();
@@ -1939,7 +1939,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Connectivity")
   @Description("")
   String connectivityComponentPallette();
-  
+
   @DefaultMessage("LEGO\u00AE MINDSTORMS\u00AE")
   @Description("")
   String legoComponentPallette();
@@ -1960,416 +1960,416 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Button")
   @Description("")
   String buttonComponentPallette();
-  
+
   @DefaultMessage("Canvas")
   @Description("")
   String canvasComponentPallette();
-  
+
   @DefaultMessage("CheckBox")
   @Description("")
   String checkBoxComponentPallette();
-  
+
   @DefaultMessage("Clock")
   @Description("")
   String clockComponentPallette();
-  
+
   @DefaultMessage("DatePicker")
   @Description("")
   String datePickerComponentPallette();
-  
+
   @DefaultMessage("Image")
   @Description("")
   String imageComponentPallette();
-  
+
   @DefaultMessage("Label")
   @Description("")
   String labelComponentPallette();
-  
+
   @DefaultMessage("ListPicker")
   @Description("")
   String listPickerComponentPallette();
-  
+
   @DefaultMessage("ListView")
   @Description("")
   String listViewComponentPallette();
-  
+
   @DefaultMessage("PasswordTextBox")
   @Description("")
   String passwordTextBoxComponentPallette();
-  
+
   @DefaultMessage("Slider")
   @Description("")
   String sliderComponentPallette();
-  
+
   @DefaultMessage("Spinner")
   @Description("")
   String spinnerComponentPallette();
-  
+
   @DefaultMessage("TextBox")
   @Description("")
   String textBoxComponentPallette();
-  
+
   @DefaultMessage("TimePicker")
   @Description("")
   String timePickerComponentPallette();
-  
+
   @DefaultMessage("TinyDB")
   @Description("")
   String tinyDBComponentPallette();
-  
+
   // Media Pallette
   @DefaultMessage("Camcorder")
   @Description("")
   String camcorderComponentPallette();
-  
+
   @DefaultMessage("Camera")
   @Description("")
   String cameraComponentPallette();
-  
+
   @DefaultMessage("ImagePicker")
   @Description("")
   String imagePickerComponentPallette();
-  
+
   @DefaultMessage("Player")
   @Description("")
   String playerComponentPallette();
-  
+
   @DefaultMessage("Sound")
   @Description("")
   String soundComponentPallette();
-  
+
   @DefaultMessage("VideoPlayer")
   @Description("")
   String videoPlayerComponentPallette();
-  
+
   @DefaultMessage("YandexTranslate")
   @Description("")
   String yandexTranslateComponentPallette();
-  
+
   // Animation
   @DefaultMessage("Ball")
   @Description("")
   String ballComponentPallette();
-  
+
   @DefaultMessage("ImageSprite")
   @Description("")
   String imageSpriteComponentPallette();
-  
+
   // Social
   @DefaultMessage("ContactPicker")
   @Description("")
   String contactPickerComponentPallette();
-  
+
   @DefaultMessage("EmailPicker")
   @Description("")
   String emailPickerComponentPallette();
-  
+
   @DefaultMessage("PhoneCall")
   @Description("")
   String phoneCallComponentPallette();
-  
+
   @DefaultMessage("PhoneNumberPicker")
   @Description("")
   String phoneNumberPickerComponentPallette();
-  
+
   @DefaultMessage("Sharing")
   @Description("")
   String sharingComponentPallette();
-  
+
   @DefaultMessage("Texting")
   @Description("")
   String textingComponentPallette();
-  
+
   @DefaultMessage("Twitter")
   @Description("")
   String twitterComponentPallette();
-  
+
   // Sensor
   @DefaultMessage("AccelerometerSensor")
   @Description("")
   String accelerometerSensorComponentPallette();
-  
+
   @DefaultMessage("BarcodeScanner")
   @Description("")
   String barcodeScannerComponentPallette();
-  
+
   @DefaultMessage("LocationSensor")
   @Description("")
   String locationSensorComponentPallette();
-  
+
   @DefaultMessage("NearField")
   @Description("")
   String nearFieldComponentPallette();
-  
+
   @DefaultMessage("OrientationSensor")
   @Description("")
   String orientationSensorComponentPallette();
- 
+
   // Screen Arrangement
   @DefaultMessage("HorizontalArrangement")
   @Description("")
   String horizontalArrangementComponentPallette();
-  
+
   @DefaultMessage("TableArrangement")
   @Description("")
   String tableArrangementComponentPallette();
-  
+
   @DefaultMessage("VerticalArrangement")
   @Description("")
   String verticalArrangementComponentPallette();
-  
+
   // Lego Mindstorms
   @DefaultMessage("NxtColorSensor")
   @Description("")
   String nxtColorSensorComponentPallette();
-  
+
   @DefaultMessage("NxtDirectCommands")
   @Description("")
   String nxtDirectCommandsComponentPallette();
-  
+
   @DefaultMessage("NxtDrive")
   @Description("")
   String nxtDriveComponentPallette();
- 
+
   @DefaultMessage("NxtLightSensor")
   @Description("")
   String nxtLightSensorComponentPallette();
-  
+
   @DefaultMessage("NxtSoundSensor")
   @Description("")
   String nxtSoundSensorComponentPallette();
-  
+
   @DefaultMessage("NxtTouchSensor")
   @Description("")
   String nxtTouchSensorComponentPallette();
-  
+
   @DefaultMessage("NxtUltrasonicSensor")
   @Description("")
   String nxtUltrasonicSensorComponentPallette();
-  
+
   // Storage
   @DefaultMessage("ActivityStarter")
   @Description("")
   String activityStarterComponentPallette();
-  
+
   @DefaultMessage("BluetoothClient")
   @Description("")
   String bluetoothClientComponentPallette();
- 
+
   @DefaultMessage("BluetoothServer")
   @Description("")
   String bluetoothServerComponentPallette();
-  
+
   @DefaultMessage("Notifier")
   @Description("")
   String notifierComponentPallette();
-  
+
   @DefaultMessage("SpeechRecognizer")
   @Description("")
   String speechRecognizerComponentPallette();
-  
+
   @DefaultMessage("TextToSpeech")
   @Description("")
   String textToSpeechComponentPallette();
-  
+
   @DefaultMessage("TinyWebDB")
   @Description("")
   String tinyWebDBComponentPallette();
-  
+
   @DefaultMessage("Web")
   @Description("")
   String webComponentPallette();
-  
+
   // Connectivity
   @DefaultMessage("File")
   @Description("")
   String fileComponentPallette();
-  
+
   @DefaultMessage("FusiontablesControl")
   @Description("")
   String fusiontablesControlComponentPallette();
-  
+
   @DefaultMessage("GameClient")
   @Description("")
   String gameClientComponentPallette();
-  
+
   @DefaultMessage("SoundRecorder")
   @Description("")
   String soundRecorderComponentPallette();
- 
+
   @DefaultMessage("Voting")
   @Description("")
   String votingComponentPallette();
-  
+
   @DefaultMessage("WebViewer")
   @Description("")
   String webViewerComponentPallette();
-  
-  // Component Properties 
+
+  // Component Properties
   @DefaultMessage("AboutScreen")
   @Description("")
   String AboutScreenProperties();
-  
+
   @DefaultMessage("AboveRangeEventEnabled")
   @Description("")
   String AboveRangeEventEnabledProperties();
-  
+
   @DefaultMessage("Action")
   @Description("")
   String ActionProperties();
-  
+
   @DefaultMessage("ActivityClass")
   @Description("")
   String ActivityClassProperties();
- 
+
   @DefaultMessage("ActivityPackage")
   @Description("")
   String ActivityPackageProperties();
-  
+
   @DefaultMessage("AlignHorizontal")
   @Description("")
   String AlignHorizontalProperties();
-  
+
   @DefaultMessage("AlignVertical")
   @Description("")
   String AlignVerticalProperties();
-  
+
   @DefaultMessage("AllowCookies")
   @Description("")
   String AllowCookiesProperties();
-  
+
   @DefaultMessage("ApiKey")
   @Description("")
   String ApiKeyProperties();
- 
+
   @DefaultMessage("BackgroundColor")
   @Description("")
   String BackgroundColorProperties();
-  
+
   @DefaultMessage("BackgroundImage")
   @Description("")
   String BackgroundImageProperties();
-  
+
   @DefaultMessage("BelowRangeEventEnabled")
   @Description("")
   String BelowRangeEventEnabledProperties();
-  
+
   @DefaultMessage("BluetoothClient")
   @Description("")
   String BluetoothClientProperties();
-  
+
   @DefaultMessage("BottomOfRange")
   @Description("")
   String BottomOfRangeProperties();
- 
+
   @DefaultMessage("CalibrateStrideLength")
   @Description("")
   String CalibrateStrideLengthProperties();
-  
+
   @DefaultMessage("CharacterEncoding")
   @Description("")
   String CharacterEncodingProperties();
-  
+
   @DefaultMessage("Checked")
   @Description("")
   String CheckedProperties();
-  
+
   @DefaultMessage("CloseScreenAnimation")
   @Description("")
   String CloseScreenAnimationProperties();
-  
+
   @DefaultMessage("ColorChangedEventEnabled")
   @Description("")
   String ColorChangedEventEnabledProperties();
- 
+
   @DefaultMessage("Columns")
   @Description("")
   String ColumnsProperties();
-  
+
   @DefaultMessage("ConsumerKey")
   @Description("")
   String ConsumerKeyProperties();
-  
+
   @DefaultMessage("ConsumerSecret")
   @Description("")
   String ConsumerSecretProperties();
-  
+
   @DefaultMessage("Country")
   @Description("")
   String CountryProperties();
-  
+
   @DefaultMessage("DataType")
   @Description("")
   String DataTypeProperties();
-  
+
   @DefaultMessage("DataUri")
   @Description("")
   String DataUriProperties();
- 
+
   @DefaultMessage("DelimiterByte")
   @Description("")
   String DelimiterByteProperties();
-  
+
   @DefaultMessage("DetectColor")
   @Description("")
   String DetectColorProperties();
-  
+
   @DefaultMessage("DistanceInterval")
   @Description("")
   String DistanceIntervalProperties();
-  
+
   @DefaultMessage("DriveMotors")
   @Description("")
   String DriveMotorsProperties();
-  
+
   @DefaultMessage("Enabled")
   @Description("")
   String EnabledProperties();
- 
+
   @DefaultMessage("ExtraKey")
   @Description("")
   String ExtraKeyProperties();
-  
+
   @DefaultMessage("ExtraValue")
   @Description("")
   String ExtraValueProperties();
-  
+
   @DefaultMessage("FollowLinks")
   @Description("")
   String FollowLinksProperties();
-  
+
   @DefaultMessage("FontBold")
   @Description("")
   String FontBoldProperties();
-  
+
   @DefaultMessage("FontItalic")
   @Description("")
   String FontItalicProperties();
-  
+
   @DefaultMessage("FontSize")
   @Description("")
   String FontSizeProperties();
- 
+
   @DefaultMessage("FontTypeface")
   @Description("")
   String FontTypefaceProperties();
-  
+
   @DefaultMessage("GameId")
   @Description("")
   String GameIdProperties();
-  
+
   @DefaultMessage("GenerateColor")
   @Description("")
   String GenerateColorProperties();
-  
+
   @DefaultMessage("GenerateLight")
   @Description("")
   String GenerateLightProperties();
-  
+
   @DefaultMessage("GoogleVoiceEnabled")
   @Description("")
   String GoogleVoiceEnabledProperties();
-  
+
   @DefaultMessage("HasMargins")
   @Description("")
   String HasMarginsProperties();
@@ -2377,39 +2377,39 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Heading")
   @Description("")
   String HeadingProperties();
- 
+
   @DefaultMessage("HighByteFirst")
   @Description("")
   String HighByteFirstProperties();
-  
+
   @DefaultMessage("Hint")
   @Description("")
   String HintProperties();
-  
+
   @DefaultMessage("HomeUrl")
   @Description("")
   String HomeUrlProperties();
-  
+
   @DefaultMessage("Icon")
   @Description("")
   String IconProperties();
-  
+
   @DefaultMessage("IgnoreSslErrors")
   @Description("")
   String IgnoreSslErrorsProperties();
- 
+
   @DefaultMessage("Image")
   @Description("")
   String ImageProperties();
- 
+
   @DefaultMessage("Interval")
   @Description("")
   String IntervalProperties();
-  
+
   @DefaultMessage("IsLooping")
   @Description("")
   String IsLoopingProperties();
-  
+
   @DefaultMessage("KeyFile")
   @Description("")
   String KeyFileProperties();
@@ -2417,91 +2417,95 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Language")
   @Description("")
   String LanguageProperties();
-  
+
   @DefaultMessage("LineWidth")
   @Description("")
   String LineWidthProperties();
-  
+
   @DefaultMessage("Message")
   @Description("")
   String MessageProperties();
-  
+
   @DefaultMessage("MinimumInterval")
   @Description("")
   String MinimumIntervalProperties();
- 
+
   @DefaultMessage("MultiLine")
   @Description("")
   String MultiLineProperties();
-  
+
   @DefaultMessage("NumbersOnly")
   @Description("")
   String NumbersOnlyProperties();
-  
+
   @DefaultMessage("OpenScreenAnimation")
   @Description("")
   String OpenScreenAnimationProperties();
-  
+
   @DefaultMessage("PaintColor")
   @Description("")
   String PaintColorProperties();
-  
+
   @DefaultMessage("PhoneNumber")
   @Description("")
   String PhoneNumberProperties();
-  
+
   @DefaultMessage("PhoneNumberList")
   @Description("")
   String PhoneNumberListProperties();
-  
+
   @DefaultMessage("Picture")
   @Description("")
   String PictureProperties();
- 
+
   @DefaultMessage("PressedEventEnabled")
   @Description("")
   String PressedEventEnabledProperties();
-  
+
   @DefaultMessage("PromptforPermission")
   @Description("")
   String PromptforPermissionProperties();
-  
+
   @DefaultMessage("Query")
   @Description("")
   String QueryProperties();
-  
+
   @DefaultMessage("Radius")
   @Description("")
   String RadiusProperties();
-  
+
   @DefaultMessage("ReadMode")
   @Description("")
   String ReadModeProperties();
-  
+
   @DefaultMessage("ReceivingEnabled")
   @Description("")
   String ReceivingEnabledProperties();
- 
+
   @DefaultMessage("ReleasedEventEnabled")
   @Description("")
   String ReleasedEventEnabledProperties();
-  
+
   @DefaultMessage("ResponseFileName")
   @Description("")
   String ResponseFileNameProperties();
-  
+
   @DefaultMessage("ResultName")
   @Description("")
   String ResultNameProperties();
-  
+
   @DefaultMessage("Rows")
   @Description("")
   String RowsProperties();
-  
+
+  @DefaultMessage("SavedRecording")
+  @Description("")
+  String SavedRecordingProperties();
+
   @DefaultMessage("SaveResponse")
   @Description("")
   String SaveResponseProperties();
-  
+
   @DefaultMessage("ScalePictureToFit")
   @Description("")
   String ScalePictureToFitProperties();
@@ -2509,15 +2513,15 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("SensorPort")
   @Description("")
   String SensorPortProperties();
-  
+
   @DefaultMessage("ScreenOrientation")
   @Description("")
   String ScreenOrientationProperties();
-  
+
   @DefaultMessage("Secure")
   @Description("")
   String SecureProperties();
- 
+
   @DefaultMessage("ServiceAccountEmail")
   @Description("")
   String ServiceAccountEmailProperties();
@@ -2525,87 +2529,87 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("ServiceURL")
   @Description("")
   String ServiceURLProperties();
-  
+
   @DefaultMessage("Scrollable")
   @Description("")
   String ScrollableProperties();
-  
+
   @DefaultMessage("Shape")
   @Description("")
   String ShapeProperties();
-  
+
   @DefaultMessage("ShowFeedback")
   @Description("")
   String ShowFeedbackProperties();
-  
+
   @DefaultMessage("show tables")
   @Description("")
   String ShowTablesProperties();
-  
+
   @DefaultMessage("Source")
   @Description("")
   String SourceProperties();
-  
+
   @DefaultMessage("Speed")
   @Description("")
   String SpeedProperties();
-  
+
   @DefaultMessage("StopBeforeDisconnect")
   @Description("")
   String StopBeforeDisconnectProperties();
- 
+
   @DefaultMessage("StopDetectionTimeout")
   @Description("")
   String StopDetectionTimeoutProperties();
-  
+
   @DefaultMessage("StrideLength")
   @Description("")
   String StrideLengthProperties();
-  
+
   @DefaultMessage("Text")
   @Description("")
   String TextProperties();
-  
+
   @DefaultMessage("TextAlignment")
   @Description("")
   String TextAlignmentProperties();
-  
+
   @DefaultMessage("TextColor")
   @Description("")
   String TextColorProperties();
- 
+
   @DefaultMessage("TimerAlwaysFires")
   @Description("")
   String TimerAlwaysFiresProperties();
-  
+
   @DefaultMessage("TimerEnabled")
   @Description("")
   String TimerEnabledProperties();
-  
+
   @DefaultMessage("TimerInterval")
   @Description("")
   String TimerIntervalProperties();
-  
+
   @DefaultMessage("Title")
   @Description("")
   String TitleProperties();
-  
+
   @DefaultMessage("TopOfRange")
   @Description("")
   String TopOfRangeProperties();
-  
+
   @DefaultMessage("Url")
   @Description("")
   String UrlProperties();
-  
+
   @DefaultMessage("UseFront")
   @Description("")
   String UseFrontProperties();
-  
+
   @DefaultMessage("UseGPS")
   @Description("")
   String UseGPSProperties();
-  
+
   @DefaultMessage("UseServiceAuthentication")
   @Description("")
   String UseServiceAuthenticationProperties();
@@ -2613,39 +2617,39 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("UsesLocationVisible")
   @Description("")
   String UsesLocationVisibleProperties();
- 
+
   @DefaultMessage("VersionCode")
   @Description("")
   String VersionCodeProperties();
-  
+
   @DefaultMessage("VersionName")
   @Description("")
   String VersionNameProperties();
-  
+
   @DefaultMessage("Visible")
   @Description("")
   String VisibleProperties();
-  
+
   @DefaultMessage("Volume")
   @Description("")
   String VolumeProperties();
-  
+
   @DefaultMessage("WheelDiameter")
   @Description("")
   String WheelDiameterProperties();
-  
+
   @DefaultMessage("WithinRangeEventEnabled")
   @Description("")
   String WithinRangeEventEnabledProperties();
- 
+
   @DefaultMessage("X")
   @Description("")
   String XProperties();
-  
+
   @DefaultMessage("Y")
   @Description("")
   String YProperties();
-  
+
   @DefaultMessage("Z")
   @Description("")
   String ZProperties();
@@ -2657,11 +2661,11 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("hidden")
   @Description("")
   String VisibilityHiddenProperties();
-  
+
   @DefaultMessage("ElementsFromString")
   @Description("")
   String ElementsFromStringProperties();
-  
+
   @DefaultMessage("Rotates")
   @Description("")
   String RotatesProperties();
@@ -2669,19 +2673,19 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Selection")
   @Description("")
   String SelectionProperties();
-  
+
   @DefaultMessage("TimeInterval")
   @Description("")
   String TimeIntervalProperties();
-  
+
   @DefaultMessage("UsesLocation")
   @Description("")
   String UsesLocationProperties();
-  
+
   @DefaultMessage("ShowFilterBar")
   @Description("")
   String ShowFilterBarProperties();
-  
+
   @DefaultMessage("TextSize")
   @Description("")
   String TextSizeProperties();
@@ -2689,79 +2693,79 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("NotifierLength")
   @Description("")
   String NotifierLengthProperties();
-  
+
   @DefaultMessage("Loop")
   @Description("")
   String LoopProperties();
-  
+
   @DefaultMessage("Pitch")
   @Description("")
   String PitchProperties();
-  
+
   @DefaultMessage("SpeechRate")
   @Description("")
   String SpeechRateProperties();
-  
+
   @DefaultMessage("Sensitivity")
   @Description("")
   String SensitivityProperties();
-  
+
   @DefaultMessage("TwitPic_API_Key")
   @Description("")
   String TwitPic_API_KeyProperties();
-  
+
   @DefaultMessage("Prompt")
   @Description("")
   String PromptProperties();
-  
+
   @DefaultMessage("ColorLeft")
   @Description("")
   String ColorLeftProperties();
-  
+
   @DefaultMessage("ColorRight")
   @Description("")
   String ColorRightProperties();
-  
+
   @DefaultMessage("MaxValue")
   @Description("")
   String MaxValueProperties();
-  
+
   @DefaultMessage("MinValue")
   @Description("")
   String MinValueProperties();
-  
+
   @DefaultMessage("ThumbPosition")
   @Description("")
   String ThumbPositionProperties();
-  
+
   @DefaultMessage("Day")
   @Description("")
   String DayProperties();
-  
+
   @DefaultMessage("Month")
   @Description("")
   String MonthProperties();
-  
+
   @DefaultMessage("MonthInText")
   @Description("")
   String MonthInTextProperties();
-  
+
   @DefaultMessage("Year")
   @Description("")
   String YearProperties();
-  
+
   @DefaultMessage("LastMessage")
   @Description("")
   String LastMessageProperties();
-  
+
   @DefaultMessage("TextToWrite")
   @Description("")
   String TextToWriteProperties();
-  
+
   @DefaultMessage("WriteType")
   @Description("")
   String WriteTypeProperties();
-  
+
   @DefaultMessage("ElapsedTime")
   @Description("")
   String ElapsedTimeProperties();
@@ -2773,15 +2777,15 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Hour")
   @Description("")
   String HourProperties();
-  
+
   @DefaultMessage("Minute")
   @Description("")
   String MinuteProperties();
-  
+
   @DefaultMessage("Distance")
   @Description("")
   String DistanceProperties();
-  
+
   @DefaultMessage("DirectMessages")
   @Description("")
   String DirectMessagesProperties();
@@ -3021,7 +3025,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("WebViewString")
   @Description("")
   String WebViewStringProperties();
-  
+
   //Params
   @DefaultMessage("xAccel")
   @Description("")
@@ -3618,7 +3622,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("textToTranslate")
   @Description("")
   String textToTranslateParams();
-  
+
   //Events
   @DefaultMessage("AccelerationChanged")
   @Description("")
@@ -4792,13 +4796,13 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("RequestTranslation")
   @Description("")
   String RequestTranslationMethods();
-  
-  
+
+
   //Mock Components
   @DefaultMessage("add items...")
   @Description("")
   String MockSpinnerAddItems();
-  
+
   //help strings
   @DefaultMessage("Non-visible component that can detect shaking and measure acceleration approximately in three dimensions using SI units (m/s<sup>2</sup>).  The components are: <ul>\n<li> <strong>xAccel</strong>: 0 when the phone is at rest on a flat      surface, positive when the phone is tilted to the right (i.e.,      its left side is raised), and negative when the phone is tilted      to the left (i.e., its right size is raised).</li>\n <li> <strong>yAccel</strong>: 0 when the phone is at rest on a flat      surface, positive when its bottom is raised, and negative when      its top is raised. </li>\n <li> <strong>zAccel</strong>: Equal to -9.8 (earth\"s gravity in meters per      second per second when the device is at rest parallel to the ground      with the display facing up,      0 when perpindicular to the ground, and +9.8 when facing down.       The value can also be affected by accelerating it with or against      gravity. </li></ul>")
   @Description("")
@@ -5055,13 +5059,13 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Use this component to translate words and sentences between different languages. This component needs Internet access, as it will request translations to the Yandex.Translate service. Specify the source and target language in the form source-target using two letter language codes. So\"en-es\" will translate from English to Spanish while \"es-ru\" will translate from Spanish to Russian. If you leave out the source language, the service will attempt to detect the source language. So providing just \"es\" will attempt to detect the source language and translate it to Spanish.<p /> This component is powered by the Yandex translation service.  See http://api.yandex.com/translate/ for more information, including the list of available languages and the meanings of the language codes and status codes. <p />Note: Translation happens asynchronously in the background. When the translation is complete, the \"GotTranslation\" event is triggered.")
   @Description("")
   String YandexTranslateHelpStringComponentPallette();
-  
-  
+
+
   //Ode.java messages
   @DefaultMessage("Welcome to App Inventor 2!")
   @Description("")
   String createNoProjectsDialogText();
-  
+
   @DefaultMessage("<p>You don\"t have any projects in App Inventor 2 yet. " +
       "To learn how to use App Inventor, click the \"Guide\" " +
       "link at the upper right of the window; or to start your first project, " +
@@ -5073,132 +5077,132 @@ public interface OdeMessages extends Messages {
       "<a href=\"http://beta.appinventor.mit.edu\" target=\"_blank\">beta.appinventor.mit.edu</a></p>\n")
   @Description("")
   String createNoProjectsDialogMessage1();
-  
+
   @DefaultMessage("Happy Inventing!")
   @Description("")
   String createNoprojectsDialogMessage2();
 
   @DefaultMessage("Welcome to App Inventor!")
   @Description("")
-  String createWelcomeDialogText(); 
-  
+  String createWelcomeDialogText();
+
   @DefaultMessage("<h2>This is the Splash Screen. Make this an iframe to your splash screen.</h2>")
   @Description("")
-  String createWelcomeDialogMessage(); 
-  
+  String createWelcomeDialogMessage();
+
   @DefaultMessage("Continue")
   @Description("")
-  String createWelcomeDialogButton(); 
-  
+  String createWelcomeDialogButton();
+
   @DefaultMessage("<h2>Please fill out a short voluntary survey so that we can learn more about our users and improve MIT App Inventor.</h2>")
   @Description("")
-  String showSurveySplashMessage(); 
-  
+  String showSurveySplashMessage();
+
   @DefaultMessage("Take Survey Now")
   @Description("")
-  String showSurveySplashButtonNow(); 
-  
+  String showSurveySplashButtonNow();
+
   @DefaultMessage("Take Survey Later")
   @Description("")
-  String showSurveySplashButtonLater(); 
-  
+  String showSurveySplashButtonLater();
+
   @DefaultMessage("Never Take Survey")
   @Description("")
-  String showSurveySplashButtonNever(); 
-  
+  String showSurveySplashButtonNever();
+
   @DefaultMessage("This Session Is Out of Date")
   @Description("")
-  String invalidSessionDialogText(); 
-  
+  String invalidSessionDialogText();
+
   @DefaultMessage("<p><font color=red>Warning:</font> This session is out of date.</p>" +
-	        "<p>This App Inventor account has been opened from another location. " +
-	        "Using a single account from more than one location at the same time " +
-	        "can damage your projects.</p>" +
-	        "<p>Choose one of the buttons below to:" +
-	        "<ul>" +
-	        "<li>End this session here.</li>" +
-	        "<li>Make this the current session and make the other sessions out of date.</li>" +
-	        "<li>Continue with both sessions.</li>" +
-	        "</ul>" +
-	        "</p>")
+                "<p>This App Inventor account has been opened from another location. " +
+                "Using a single account from more than one location at the same time " +
+                "can damage your projects.</p>" +
+                "<p>Choose one of the buttons below to:" +
+                "<ul>" +
+                "<li>End this session here.</li>" +
+                "<li>Make this the current session and make the other sessions out of date.</li>" +
+                "<li>Continue with both sessions.</li>" +
+                "</ul>" +
+                "</p>")
   @Description("")
-  String invalidSessionDialogMessage(); 
-  
+  String invalidSessionDialogMessage();
+
   @DefaultMessage("End This Session")
   @Description("")
-  String invalidSessionDialogButtonEnd(); 
-  
+  String invalidSessionDialogButtonEnd();
+
   @DefaultMessage("Make this the current session")
   @Description("")
-  String invalidSessionDialogButtonCurrent(); 
-  
+  String invalidSessionDialogButtonCurrent();
+
   @DefaultMessage("Continue with Both Sessions")
   @Description("")
-  String invalidSessionDialogButtonContinue(); 
-  
+  String invalidSessionDialogButtonContinue();
+
   @DefaultMessage("Do you want to continue with multiple sessions?")
   @Description("")
-  String bashWarningDialogText(); 
-  
+  String bashWarningDialogText();
+
   @DefaultMessage("<p><font color=red>WARNING:</font> A second App " +
-	        "Inventor session has been opened for this account. You may choose to " +
-	        "continue with both sessions, but working with App Inventor from more " +
-	        "than one session simultaneously can cause blocks to be lost in ways " +
-	        "that cannot be recovered from the App Inventor server.</p><p>" +
-	        "We recommend that people not open multiple sessions on the same " +
-	        "account. But if you do need to work in this way, then you should " +
-	        "regularly export your project to your local computer, so you will " +
-	        "have a backup copy independent of the App Inventor server. Use " +
-	        "\"Export\" from the Projects menu to export the project.</p>")
+                "Inventor session has been opened for this account. You may choose to " +
+                "continue with both sessions, but working with App Inventor from more " +
+                "than one session simultaneously can cause blocks to be lost in ways " +
+                "that cannot be recovered from the App Inventor server.</p><p>" +
+                "We recommend that people not open multiple sessions on the same " +
+                "account. But if you do need to work in this way, then you should " +
+                "regularly export your project to your local computer, so you will " +
+                "have a backup copy independent of the App Inventor server. Use " +
+                "\"Export\" from the Projects menu to export the project.</p>")
   @Description("")
-  String bashWarningDialogMessage(); 
-  
+  String bashWarningDialogMessage();
+
   @DefaultMessage("Continue with Multiple Sessions")
   @Description("")
-  String bashWarningDialogButtonContinue(); 
-  
+  String bashWarningDialogButtonContinue();
+
   @DefaultMessage("Do not use multiple Sessions")
   @Description("")
-  String bashWarningDialogButtonNo(); 
-  
+  String bashWarningDialogButtonNo();
+
   @DefaultMessage("Your Session is Finished")
   @Description("")
-  String finalDialogText(); 
-  
+  String finalDialogText();
+
   @DefaultMessage("<p><b>Your Session is now ended, you may close this window</b></p>")
   @Description("")
-  String finalDialogMessage(); 
-  
+  String finalDialogMessage();
+
   @DefaultMessage("Project Read Error")
   @Description("")
-  String corruptionDialogText(); 
-  
+  String corruptionDialogText();
+
   @DefaultMessage("<p><b>We detected errors while reading in your project</b></p>" +
-	        "<p>To protect your project from damage, we have ended this session. You may close this " +
-	        "window.</p>")
+                "<p>To protect your project from damage, we have ended this session. You may close this " +
+                "window.</p>")
   @Description("")
-  String corruptionDialogMessage(); 
-  
+  String corruptionDialogMessage();
+
   @DefaultMessage("Blocks Workspace is Empty")
   @Description("")
-  String blocksTruncatedDialogText(); 
-  
+  String blocksTruncatedDialogText();
+
   @DefaultMessage("<p>It appears that <b>" + "%1" +
-	        "</b> has had all blocks removed. Either you removed them intentionally, or this is " +
-	        "the result of a bug in our system.</p><p>" +
-	        "<ul><li>Select \"OK, save the empty screen\" to continue to save the empty screen</li>" +
-	        "<li>Select \"No, Don\"t Save\" below to restore the previously saved version</li></ul></p>")
+                "</b> has had all blocks removed. Either you removed them intentionally, or this is " +
+                "the result of a bug in our system.</p><p>" +
+                "<ul><li>Select \"OK, save the empty screen\" to continue to save the empty screen</li>" +
+                "<li>Select \"No, Don\"t Save\" below to restore the previously saved version</li></ul></p>")
   @Description("")
-  String blocksTruncatedDialogMessage(); 
-  
+  String blocksTruncatedDialogMessage();
+
   @DefaultMessage("OK, save the empty screen")
   @Description("")
-  String blocksTruncatedDialogButtonSave(); 
-  
+  String blocksTruncatedDialogButtonSave();
+
   @DefaultMessage("No, Don\"t Save")
   @Description("")
   String blocksTruncatedDialogButtonNoSave();
-  
+
   @DefaultMessage("Please wait " + "%1" + " seconds...")
   @Description("")
   String blocksTruncatedDialogButtonHTML();
@@ -5226,7 +5230,7 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Español")
   @Description("")
   String SwitchToSpanish();
-  
+
   @DefaultMessage("Progress Bar")
   @Description("")
   String ProgressBarFor();

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentMethods.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentMethods.java
@@ -227,6 +227,7 @@ public class TranslationComponentMethods {
     map.put("CanGoBack", MESSAGES.CanGoBackMethods());
     map.put("CanGoForward", MESSAGES.CanGoForwardMethods());
     map.put("ClearLocations", MESSAGES.ClearLocationsMethods());
+    map.put("ClearCaches", MESSAGES.ClearCachesMethods());
     map.put("GoBack", MESSAGES.GoBackMethods());
     map.put("GoForward", MESSAGES.GoForwardMethods());
     map.put("GoHome", MESSAGES.GoHomeMethods());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentMethods.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentMethods.java
@@ -216,6 +216,7 @@ public class TranslationComponentMethods {
     map.put("BuildPostData", MESSAGES.BuildPostDataMethods());
     map.put("ClearCookies", MESSAGES.ClearCookiesMethods());
     map.put("Get", MESSAGES.GetMethods());
+    map.put("RequestFocus", MESSAGES.RequestFocusMethods());
     map.put("HtmlTextDecode", MESSAGES.HtmlTextDecodeMethods());
     map.put("JsonTextDecode", MESSAGES.JsonTextDecodeMethods());
     map.put("XmlTextDecode", MESSAGES.XmlTextDecodeMethods());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -185,6 +185,7 @@ public class TranslationComponentProperty {
     map.put("Y", MESSAGES.YProperties());
     map.put("Z", MESSAGES.ZProperties());
     map.put("ShowFilterBar", MESSAGES.ShowFilterBarProperties());
+    map.put("TextSize", MESSAGES.TextSizeProperties());
     map.put("NotifierLength", MESSAGES.NotifierLengthProperties());
     map.put("Loop", MESSAGES.LoopProperties());
     map.put("Pitch", MESSAGES.PitchProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -50,6 +50,7 @@ public class TranslationComponentProperty {
     map.put("BallotOptions", MESSAGES.BallotOptionsProperties());
     map.put("BallotQuestion", MESSAGES.BallotQuestionProperties());
     map.put("EmailAddress", MESSAGES.EmailAddressProperties());
+    map.put("TextContactUri", MESSAGES.TextContactUriProperties());
     map.put("EmailAddressList", MESSAGES.EmailAddressListProperties());
     map.put("Elements", MESSAGES.ElementsProperties());
     map.put("Followers", MESSAGES.FollowersProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -20,7 +20,14 @@ public class TranslationComponentProperty {
   }
 
   public static String getName(String key) {
-    return myMap.get(key);
+    String value = myMap.get(key);
+    if (key == null) {
+      // This will help implementors debug if the forget to add an entry
+      // when defining a new property
+      return "**Missing key in TranslationComponentProperty**";
+    } else {
+      return value;
+    }
   }
 
   /**
@@ -157,6 +164,7 @@ public class TranslationComponentProperty {
     map.put("ResultName", MESSAGES.ResultNameProperties());
     map.put("Rotates", MESSAGES.RotatesProperties());
     map.put("SaveResponse", MESSAGES.SaveResponseProperties());
+    map.put("SavedRecording", MESSAGES.SavedRecordingProperties());
     map.put("ScalePictureToFit", MESSAGES.ScalePictureToFitProperties());
     map.put("ScreenOrientation", MESSAGES.ScreenOrientationProperties());
     map.put("Scrollable", MESSAGES.ScrollableProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -295,8 +295,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         paramList.add(new ParameterDefinition(param.get("name").asString().getString(), param
             .get("type").asString().getString()));
       }
-      component.add(new EventDefinition(event.get("name").asString().getString(), event
-          .get("description").asString().getString(), paramList));
+      component.add(
+          new EventDefinition(
+              event.get("name").asString().getString(),
+              event.get("description").asString().getString(),
+              new Boolean(event.get("deprecated").asString().getString()),
+              paramList));
     }
   }
 
@@ -315,8 +319,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         paramList.add(new ParameterDefinition(param.get("name").asString().getString(), param
             .get("type").asString().getString()));
       }
-      component.add(new MethodDefinition(method.get("name").asString().getString(), method
-          .get("description").asString().getString(), paramList));
+      component.add(
+          new MethodDefinition(
+              method.get("name").asString().getString(),
+              method.get("description").asString().getString(),
+              new Boolean(method.get("deprecated").asString().getString()),
+              paramList));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -912,6 +912,10 @@ public final class YoungAndroidFormUpgrader {
       // Added the TextColor property
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // Added the TextSize property
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -290,6 +290,9 @@ public final class YoungAndroidFormUpgrader {
       } else if (componentType.equals("Sound")) {
         srcCompVersion = upgradeSoundProperties(componentProperties, srcCompVersion);
 
+      } else if (componentType.equals("SoundRecorder")) {
+        srcCompVersion = upgradeSoundRecorderProperties(componentProperties, srcCompVersion);
+
       } else if (componentType.equals("TimePicker")) {
         srcCompVersion = upgradeTimePickerProperties(componentProperties, srcCompVersion);
 
@@ -1031,6 +1034,17 @@ public final class YoungAndroidFormUpgrader {
     }
     return srcCompVersion;
   }
+
+  private static int upgradeSoundRecorderProperties(Map<String, JSONValue> componentProperties,
+      int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // The SoundRecorder.RecordFile property was added.
+      // No properties need to be modified to upgrade to version 2.
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
 
   private static int upgradeTimePickerProperties(Map<String, JSONValue> componentProperties,
       int srcCompVersion) {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1184,6 +1184,10 @@ public final class YoungAndroidFormUpgrader {
       // Properties related to this component have now been upgraded to version 4.
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // RequestFocus method was added
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -1213,7 +1217,7 @@ public final class YoungAndroidFormUpgrader {
 
   private static int upgradeWebViewerProperties(Map<String, JSONValue> componentProperties,
                                                 int srcCompVersion) {
-    if (srcCompVersion < 5) {
+    if (srcCompVersion < 6) {
       // The CanGoForward and CanGoBack methods were added.
       // No properties need to be modified to upgrade to version 2.
       // UsesLocation property added.
@@ -1221,7 +1225,8 @@ public final class YoungAndroidFormUpgrader {
       // WebViewString added
       // No properties need to be modified to upgrade to version 4.
       // IgnoreSslError property added (version 5)
-      srcCompVersion = 5;
+      // ClearCaches method was added (version 6)
+      srcCompVersion = 6;
     }
     return srcCompVersion;
   }

--- a/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
@@ -121,13 +121,15 @@ public interface ComponentDatabaseInterface {
   public static class EventDefinition {
     private final String name;
     private final String description;
+    private final boolean deprecated;
     // "params": [{ "name": "xAccel", "type": "number"},*]
     private final List<ParameterDefinition> params;
 
-    public EventDefinition(String name, String description,
+    public EventDefinition(String name, String description, boolean deprecated,
         List<ParameterDefinition> params) {
       this.name = name;
       this.description = description;
+      this.deprecated = deprecated;
       this.params = params;
     }
 
@@ -138,6 +140,8 @@ public interface ComponentDatabaseInterface {
     public String getDescription() {
       return description;
     }
+
+    public boolean getDeprecated() { return deprecated; }
 
     public List<ParameterDefinition> getParam() {
       return params;
@@ -151,13 +155,15 @@ public interface ComponentDatabaseInterface {
   public static class MethodDefinition {
     private final String name;
     private final String description;
+    private final boolean deprecated;
     // "params": [{ "name": "xAccel", "type": "number"},*]
     private List<ParameterDefinition> params;
 
-    public MethodDefinition(String name, String description,
+    public MethodDefinition(String name, String description, boolean deprecated,
         List<ParameterDefinition> params) {
       this.name = name;
       this.description = description;
+      this.deprecated = deprecated;
       this.params = params;
     }
 
@@ -168,6 +174,8 @@ public interface ComponentDatabaseInterface {
     public String getDescription() {
       return description;
     }
+
+    public boolean getDeprecated() { return deprecated; }
 
     public List<ParameterDefinition> getParam() {
       return params;

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -87,6 +87,11 @@ Blockly.Blocks.component_event = {
     // [lyn, 12/23/2013] Move this out of domToMutation into top-level component_event
     // this.onchange = Blockly.WarningHandler.checkErrors;
 
+    if (this.getEventTypeObject().deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
+      this.badBlock();
+      this.setDisabled(true);
+    }
+
   },
   // [lyn, 10/24/13] Allow switching between horizontal and vertical display of arguments
   // Also must create flydown params and DO input if they don't exist.
@@ -323,6 +328,10 @@ Blockly.Blocks.component_method = {
       this.setNextStatement(true);
     }
     this.errors = [{name:"checkIsInDefinition"}];
+    if (this.getMethodTypeObject().deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
+      this.badBlock();
+      this.setDisabled(true);
+    }
   },
   // Rename the block's instanceName, type, and reset its title
   rename : function(oldname, newname) {

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -180,12 +180,14 @@ Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
   //create event blocks
   var eventObjects = Blockly.ComponentTypes[typeName].componentInfo.events;
   for(var i=0;i<eventObjects.length;i++) {
+    if (eventObjects[i].deprecated === "true") continue;
     mutatorAttributes = {component_type: typeName, instance_name: instanceName, event_name : eventObjects[i].name};
     xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_event",mutatorAttributes));
   }
   //create non-generic method blocks
   var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
   for(var i=0;i<methodObjects.length;i++) {
+    if (methodObjects[i].deprecated === "true") continue;
     mutatorAttributes = {component_type: typeName, instance_name: instanceName, method_name: methodObjects[i].name, is_generic:"false"};
     xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
   }

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -455,6 +455,6 @@ Blockly.Drawer.defaultBlockXMLStrings = {
          Blockly.Drawer.mutatorAttributesToXMLString(mutatorAttributes) +
          '<value name="ARG3"><block type="logic_boolean"><title name="BOOL">TRUE</title></block></value>' +
          '</block>' +
-         '</xml>';}},
+         '</xml>';}}
   ]
 };

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -376,9 +376,9 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_MATH_SINGLE_HELPURL_ABS = 'http://appinventor.mit.edu/explore/ai2/support/blocks/math#abs';
     Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_NEG = 'Return the negation of a number.';
     Blockly.Msg.LANG_MATH_SINGLE_HELPURL_NEG = 'http://appinventor.mit.edu/explore/ai2/support/blocks/math#neg';
-    Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_LN = 'Return the natural logarithm of a number.';
+    Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_LN = 'Return the natural logarithm of a number, i.e. the logarithm to the base e (2.71828...)';
     Blockly.Msg.LANG_MATH_SINGLE_HELPURL_LN ='http://appinventor.mit.edu/explore/ai2/support/blocks/math#log';
-    Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_EXP = 'Return e to the power of a number.';
+    Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_EXP = 'Return e (2.71828...) to the power of a number.';
     Blockly.Msg.LANG_MATH_SINGLE_HELPURL_EXP ='http://appinventor.mit.edu/explore/ai2/support/blocks/math#e';
     /*Blockly.Msg.LANG_MATH_SINGLE_TOOLTIP_POW10 = 'Return 10 to the power of a number.';*/
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1811,7 +1811,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "SoundRecorder": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+    // AI2: The Sound.SavedRecording property was added.
+    // No blocks need to be modified to upgrade to version 2.
+    2: "noUpgrade"
 
   }, // End SoundRecorder upgraders
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1857,7 +1857,10 @@ Blockly.Versioning.AllUpgradeMaps =
     // No blocks need to be modified to upgrade to version 4, although old
     // block need to have MultiLine explicitly set to true, since the new default
     // is false (see YoungAndroidFormUpgrade).
-    4: "noUpgrade"
+    4: "noUpgrade",
+
+    // AI2: Added RequestFocus method
+    5: "noUpgrade"
 
   }, // End TextBox upgraders
 
@@ -2047,7 +2050,10 @@ Blockly.Versioning.AllUpgradeMaps =
     4: "noUpgrade",
 
     // AI2: IgnoreSslError property added
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // AI2: Added ClearCaches method
+    6: "noUpgrade"
 
   }, // End WebViewer upgraders
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1495,7 +1495,10 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2:
     // - Added BackgroundColor Property
     // - Added TextColor Property
-    3: "noUpgrade"
+    3: "noUpgrade",
+    // AI2:
+    // - Added TextSize Property
+    4: "noUpgrade"
 
   }, // End ListView upgraders
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1164,7 +1164,7 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI2: No blocks need to be modified to upgrade to version 10
     // The default value of TextAlignment was changed from Normal (left) to Center
-    10: "noUpgrade",
+    10: "noUpgrade"
 
   }, // End Canvas upgraders
 
@@ -1510,13 +1510,6 @@ Blockly.Versioning.AllUpgradeMaps =
 
   }, // End LocationSensor upgraders
 
-  "LocationSensor": {
-
-    // AI2: The TimeInterval and DistanceInterval properties were added.
-    2: "noUpgrade"
-
-  }, // End LocationSensor upgraders
-
   "NearField": {
 
     //This is initial version. Placeholder for future upgrades
@@ -1659,7 +1652,7 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI1: The Shape property was added.
     // No blocks need to be modified to upgrade to version 4.
-    4: "noUpgrade",
+    4: "noUpgrade"
 
   }, // End PhoneNumberPicker upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -308,8 +308,10 @@ public class YaVersion {
   // - LISTPICKER_COMPONENT_VERSION was incremented to 9.
   // For YOUNG_ANDROID_VERSION 117:
   // - LISTVIEW_COMPONENT_VERSION was incremented to 4.
+  // For YOUNG_ANDROID_VERSION 118:
+  // - SOUND_RECORDER_COMPONENT_VERSION was incremented to 2.
 
-  public static final int YOUNG_ANDROID_VERSION = 117;
+  public static final int YOUNG_ANDROID_VERSION = 118;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -377,8 +379,9 @@ public class YaVersion {
   // 2. Increment the version number for that component below
   // 3. Add code in com.google.appinventor.client.youngandroid.YoungAndroidFormUpgrader#
   //    upgradeComponentProperties to upgrade the .scm file contents
-  // 4. Add code in openblocks.yacodeblocks.BlockSaveFile#upgradeComponentBlocks to
-  //    upgrade the .blk file contents (not used in AI 2)
+  // *** OBSOLETE 4. Add code in openblocks.yacodeblocks.BlockSaveFile#upgradeComponentBlocks to
+  // *** OBSOLETE upgrade the .blk file contents (not used in AI 2)
+  // 4. For AI2, update the table in blocklyeditor/src/versioning.js
 
 
   // Note added after internationalization (8/25/2014)
@@ -731,7 +734,9 @@ public class YaVersion {
   // - The Sound.SoundError event was marked userVisible false and is no longer used.
   public static final int SOUND_COMPONENT_VERSION = 3;
 
-  public static final int SOUND_RECORDER_COMPONENT_VERSION = 1;
+  // For SOUND_RECORDER_COMPONENT_VERSION 2:
+  // - The SavedRecording property was added.
+  public static final int SOUND_RECORDER_COMPONENT_VERSION = 2;
 
   public static final int SPEECHRECOGNIZER_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -310,8 +310,11 @@ public class YaVersion {
   // - LISTVIEW_COMPONENT_VERSION was incremented to 4.
   // For YOUNG_ANDROID_VERSION 118:
   // - SOUND_RECORDER_COMPONENT_VERSION was incremented to 2.
+  // For YOUNG_ANDROID_VERSION 119:
+  // - TEXTBOX_COMPONENT_VERSION was incremented to 5
+  // - WEBVIEWER_COMPONENT_VERSION was incremented to 6
 
-  public static final int YOUNG_ANDROID_VERSION = 118;
+  public static final int YOUNG_ANDROID_VERSION = 119;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -749,7 +752,9 @@ public class YaVersion {
   // For TEXTBOX_COMPONENT_VERSION 4:
   // - The HideKeyboard method was added.
   // - The MultiLine property was added.
-  public static final int TEXTBOX_COMPONENT_VERSION = 4;
+  // For TEXTBOX_COMPONENT_VERSION 5:
+  // - RequestFocus method was added
+  public static final int TEXTBOX_COMPONENT_VERSION = 5;
 
   // For TEXTING_COMPONENT_VERSION 2:
   // Texting over Wifi was implemented using Google Voice
@@ -844,7 +849,9 @@ public class YaVersion {
   // - Add WebViewString
   // For WEBVIEWER_COMPONENT_VERSION 5:
   // - IgnoreSslError property added
-  public static final int WEBVIEWER_COMPONENT_VERSION = 5;
+  // For WEBVIEWER_COMPONENT_VERSION 6:
+  // - ClearCaches method was added
+  public static final int WEBVIEWER_COMPONENT_VERSION = 6;
 
 
   // For YANDEX_COMPONENT_VERSION 1:

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -880,10 +880,10 @@ public class YaVersion {
   // key as the Companion it is replacing, as the Package Manager
   // is invoked from the running Companion.
 
-  public static final String PREFERRED_COMPANION = "2.23ai2zx1";
+  public static final String PREFERRED_COMPANION = "2.24";
   public static final String COMPANION_UPDATE_URL = "";
   public static final String COMPANION_UPDATE_URL1 = "";
-  public static final String [] ACCEPTABLE_COMPANIONS = { "2.22ai2", "2.22ai2zx1", "2.23ai2", "2.23ai2zx1", };
+  public static final String [] ACCEPTABLE_COMPANIONS = { "2.23ai2", "2.23ai2zx1", "2.24"};
 
   // Splash Screen Values
   public static final int SPLASH_SURVEY = 1;

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -306,8 +306,10 @@ public class YaVersion {
   // - CANVAS_COMPONENT_VERSION was incremented to 10.
   // For YOUNG_ANDROID_VERSION 116:
   // - LISTPICKER_COMPONENT_VERSION was incremented to 9.
+  // For YOUNG_ANDROID_VERSION 117:
+  // - LISTVIEW_COMPONENT_VERSION was incremented to 4.
 
-  public static final int YOUNG_ANDROID_VERSION = 116;
+  public static final int YOUNG_ANDROID_VERSION = 117;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -639,7 +641,9 @@ public class YaVersion {
   // For LISTVIEW_COMPONENT_VERSION 3:
   // - Added BackgroundColor Property
   // - Added TextColor Property
-  public static final int LISTVIEW_COMPONENT_VERSION = 3;
+  // For LISTVIEW_COMPONENT_VERSION 4:
+  // - Added TextSize Property
+  public static final int LISTVIEW_COMPONENT_VERSION = 4;
 
   // For LOCATIONSENSOR_COMPONENT_VERSION 2:
   // - The TimeInterval and DistanceInterval properties were added.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
@@ -8,6 +8,7 @@ package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.PropertyCategory;
+import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
@@ -19,6 +20,8 @@ import com.google.appinventor.components.runtime.util.SdkLevel;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.Contacts;
@@ -177,6 +180,20 @@ public class ContactPicker extends Picker implements ActivityResultListener {
     return ensureNotNull(phoneNumberList);
   }
 
+  /**
+   *  return nothing, just call another activity which is view contact
+   */
+  @SimpleFunction(description = "view a contact through its URI")
+  public void ViewContact(String uri) {
+    if(textConactUri != null){
+    	Intent intent = new Intent(Intent.ACTION_VIEW,Uri.parse(uri));
+    	if (intent.resolveActivity(this.activityContext.getPackageManager()) != null) {
+            this.activityContext.startActivity(intent);
+        }
+    }
+  }
+  
+  
   @Override
   protected Intent getIntent() {
     return new Intent(Intent.ACTION_PICK, intentUri);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
@@ -41,6 +41,7 @@ import java.util.List;
     "the chosen contact: <ul>\n" +
     "<li> <code>ContactName</code>: the contact's name </li>\n "  +
     "<li> <code>EmailAddress</code>: the contact's primary email address </li>\n " +
+    "<li> <code>TextContactUri</code>: the contact's URI in string </li>\n"+
     "<li> <code>EmailAddressList</code>: a list of the contact's email addresses </li>\n " +
     "<li> <code>PhoneNumber</code>: the contact's primary phone number (on Later Android Verisons)</li>\n " +
     "<li> <code>PhoneNumberList</code>: a list of the contact's phone numbers (on Later Android Versions)</li>\n " +
@@ -74,6 +75,7 @@ public class ContactPicker extends Picker implements ActivityResultListener {
 
   protected String contactName;
   protected String emailAddress;
+  protected String textConactUri;
   protected String contactPictureUri;
   protected String phoneNumber;
 
@@ -137,7 +139,17 @@ public class ContactPicker extends Picker implements ActivityResultListener {
     //    }
     return ensureNotNull(emailAddress);
   }
-
+  
+  /**
+   * TextContactUri property getter method.
+   * @Author: Yifan(Evan) Li
+   */
+  @SimpleProperty(
+      category = PropertyCategory.BEHAVIOR)
+  public String TextContactUri() {
+    return ensureNotNull(textConactUri);
+  }
+  
   /**
    * EmailAddressList property getter method.
    */
@@ -206,13 +218,16 @@ public class ContactPicker extends Picker implements ActivityResultListener {
             DATA_PROJECTION = HoneycombUtil.getDataProjection();
             dataCursor = HoneycombUtil.getDataCursor(id, activityContext, DATA_PROJECTION);
             postHoneycombGetContactEmailAndPhone(dataCursor);
+            
+            //explicit set TextContactUri
+            textConactUri = contactUri.toString();
           } else {
             contactCursor = activityContext.getContentResolver().query(contactUri,
                 PROJECTION, null, null, null);
             preHoneycombGetContactInfo(contactCursor, contactUri);
           }
           Log.i("ContactPicker",
-                "Contact name = " + contactName + ", email address = " + emailAddress +
+                "Contact name = " + contactName + ", email address = " + emailAddress + ",contact Uri = " + textConactUri + 
                 ", phone number = " + phoneNumber + ", contactPhotoUri = " +  contactPictureUri);
         } catch (Exception e) {
           // There was an exception in trying to extract the cursor from the activity context.
@@ -241,6 +256,7 @@ public class ContactPicker extends Picker implements ActivityResultListener {
       contactName = guardCursorGetString(contactCursor, NAME_INDEX);
       String emailId = guardCursorGetString(contactCursor, EMAIL_INDEX);
       emailAddress = getEmailAddress(emailId);
+      textConactUri = contactUri.toString();
       contactPictureUri = contactUri.toString();
       emailAddressList = emailAddress.equals("") ? new ArrayList() : Arrays.asList(emailAddress);
     }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -11,6 +11,7 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextWatcher;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.AbsoluteSizeSpan;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -72,6 +73,9 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   private int textColor;
   private static final int DEFAULT_TEXT_COLOR = Component.COLOR_WHITE;
 
+  private int textSize;
+  private static final int DEFAULT_TEXT_SIZE = 22;
+
   /**
    * Creates a new ListView component.
    * @param container  container that the component will be placed in
@@ -127,6 +131,8 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
 
     textColor = DEFAULT_TEXT_COLOR;
     TextColor(textColor);
+    textSize = DEFAULT_TEXT_SIZE;
+    TextSize(textSize);
     ElementsFromString("");
 
     listViewLayout.addView(txtSearchBox);
@@ -253,6 +259,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       // need to allocate new objects?
       Spannable chars = new SpannableString(itemString);
       chars.setSpan(new ForegroundColorSpan(textColor),0,chars.length(),0);
+      chars.setSpan(new AbsoluteSizeSpan(textSize),0,chars.length(),0);
       objects[i - 1] = chars;
     }
     return objects;
@@ -404,6 +411,34 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   @SimpleProperty
   public void TextColor(int argb) {
       textColor = argb;
+      setAdapterData();
+  }
+
+  /**
+   * Returns the listview's text font Size
+   *
+   * @return text size as an float
+   */
+  @SimpleProperty(
+      description = "The text size of the listview items.",
+      category = PropertyCategory.APPEARANCE)
+  public int TextSize() {
+    return textSize;
+  }
+
+  /**
+   * Specifies the ListView item's text font size
+   *
+   * @param integer value for font size
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
+      defaultValue = DEFAULT_TEXT_SIZE + "")
+  @SimpleProperty
+  public void TextSize(int fontSize) {
+      if(fontSize>1000)
+        textSize = 999;
+      else
+        textSize = fontSize;
       setAdapterData();
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
@@ -7,15 +7,18 @@
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
+import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
-
 import android.media.MediaRecorder;
 import android.media.MediaRecorder.OnErrorListener;
 import android.media.MediaRecorder.OnInfoListener;
@@ -41,15 +44,28 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
 
   private static final String TAG = "SoundRecorder";
 
+  // the path to the savedRecording
+  // if it is the null string, the recorder will generate a path
+  // note that this is also initialized to "" in the designer
+  private String savedRecording = "";
+
+
   /**
    * This class encapsulates the required state during recording.
    */
   private class RecordingController {
     final MediaRecorder recorder;
-    final String file;
 
-    RecordingController() throws IOException {
-      file = FileUtil.getRecordingFile("3gp").getAbsolutePath();
+    // file is the same as savedRecording, but we'll keep it local to the
+    // RecordingController for future flexibility
+     final String file;
+
+    RecordingController(String savedRecording) throws IOException {
+      // pick a pathname if none was specified
+      file = (savedRecording.equals("")) ?
+          FileUtil.getRecordingFile("3gp").getAbsolutePath() :
+            savedRecording;
+
       recorder = new MediaRecorder();
       recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
       recorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP);
@@ -62,9 +78,19 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
       recorder.setOnInfoListener(SoundRecorder.this);
     }
 
-    void start() {
+    void start() throws IllegalStateException {
       Log.i(TAG, "starting");
+      try {
       recorder.start();
+      } catch (IllegalStateException e) {
+        // This is the error produced when there are two recorders running.
+        // There might be other causes, but we don't know them.
+        // Using Log.e will log a stack trace, so we can investigate
+        Log.e(TAG, "got IllegalStateException. Are there two recorders running?", e);
+        // Pass back a message detail for dispatchErrorOccurred to
+        // show at user level
+        throw (new IllegalStateException("Is there another recording running?"));
+      }
     }
 
     void stop() {
@@ -86,6 +112,33 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
     super(container.$form());
   }
 
+
+  /**
+   * Returns the path to the saved recording
+   *
+   * @return  savedRecording path to recording
+   */
+  @SimpleProperty(
+      description = "Specifies the path to the file where the recording is stored. " +
+          "If this proprety is the empty string, then starting a recording will create a file in " +
+          "an appropriate location.",
+          category = PropertyCategory.BEHAVIOR)
+  public String SavedRecording() {
+    return savedRecording;
+  }
+
+  /**
+   * Specifies the path to the saved recording displayed by the label.
+   *
+   * @param pathName  path to saved recording
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
+      defaultValue = "")
+  @SimpleProperty
+  public void SavedRecording(String pathName) {
+    savedRecording = pathName;
+  }
+
   /**
    * Starts recording.
    */
@@ -102,7 +155,7 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
       return;
     }
     try {
-      controller = new RecordingController();
+      controller = new RecordingController(savedRecording);
     } catch (Throwable t) {
       form.dispatchErrorOccurredEvent(
           this, "Start", ErrorMessages.ERROR_SOUND_RECORDER_CANNOT_CREATE, t.getMessage());
@@ -111,7 +164,9 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
     try {
       controller.start();
     } catch (Throwable t) {
-      controller.stop();
+      // I'm commenting the next line out because stop can throw an error, and
+      // it's not clear to me how to handle that.
+      // controller.stop();
       controller = null;
       form.dispatchErrorOccurredEvent(
           this, "Start", ErrorMessages.ERROR_SOUND_RECORDER_CANNOT_CREATE, t.getMessage());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBox.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBox.java
@@ -154,6 +154,15 @@ public final class TextBox extends TextBoxBase {
   }
 
   /**
+   * Request focus to current textbox.
+   */
+  @SimpleFunction(
+    description = "Sets the textbox active.")
+  public void RequestFocus() {
+    view.requestFocus();
+  }
+
+  /**
    * Multi line property getter method.
    *
    * @return {@code true} indicates that the textbox accepts multiple lines

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -429,6 +429,18 @@ public final class WebViewer extends AndroidViewComponent {
   }
 
   /**
+   * Clear the webview cache, both ram and disk. This is useful
+   * when using the webviewer to poll a page that may not be sending
+   * appropriate cache control headers. This is particularly useful
+   * when using the webviwer to look at a Fusion Table.
+   */
+
+  @SimpleFunction(description = "Clear WebView caches.")
+  public void ClearCaches() {
+    webview.clearCache(true);
+  }
+
+  /**
    * Allows the setting of properties to be monitored from the javascript
    * in the WebView
    */

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -108,20 +108,16 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("],\n  \"events\": [");
     separator = "";
     for (Event event : component.events.values()) {
-      if (event.userVisible) {
-        sb.append(separator);
-        outputBlockEvent(event.name, event, sb);
-        separator = ",\n    ";
-      }
+      sb.append(separator);
+      outputBlockEvent(event.name, event, sb, !event.userVisible);
+      separator = ",\n    ";
     }
     sb.append("],\n  \"methods\": [");
     separator = "";
     for (Method method : component.methods.values()) {
-      if (method.userVisible) {
-        sb.append(separator);
-        outputBlockMethod(method.name, method, sb);
-        separator = ",\n    ";
-      }
+      sb.append(separator);
+      outputBlockMethod(method.name, method, sb, !method.userVisible);
+      separator = ",\n    ";
     }
     sb.append("]}\n");
   }
@@ -148,21 +144,25 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("\"}");
   }
   
-  private void outputBlockEvent(String eventName, Event event, StringBuilder sb) {
+  private void outputBlockEvent(String eventName, Event event, StringBuilder sb,
+                                boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(eventName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(event.description));
+    sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(event.parameters, sb);
     sb.append("}\n");
   }
   
-  private void outputBlockMethod(String methodName, Method method, StringBuilder sb) {
+  private void outputBlockMethod(String methodName, Method method, StringBuilder sb,
+                                 boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(methodName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(method.description));
+    sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(method.parameters, sb);
     if (method.getReturnType() != null) {

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -1247,6 +1247,8 @@ none
   <dd>Returns true if the WebViewer can go back in the history list.</dd>
   <dt><code>boolean CanGoForward()</code></dt>
   <dd>Returns true if the WebViewer can go forward in the history list.</dd>
+  <dt><code>ClearCaches()</code></dt>
+  <dd>Clear the WebViewer caches</dd>
   <dt><code>ClearLocations()</code></dt>
   <dd>Clear stored location permissions.</dd>
   <dt><code>GoBack()</code></dt>

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -1147,6 +1147,8 @@ none
                       Single
                       line text boxes close the keyboard when the users presses
                       the Done key. </dd>
+                    <dt><code>RequestFocus()</code></dt>
+                    <dd>Sets the textbox active.</dd>
                   </dl>
 
                   <h2 id="TimePicker">TimePicker</h2>

--- a/appinventor/lib/blockly/src/core/block.js
+++ b/appinventor/lib/blockly/src/core/block.js
@@ -346,6 +346,22 @@ Blockly.Block.prototype.unselect = function() {
 };
 
 /**
+ * Mark this block as Bad.  Highlight it visually in Red.
+ */
+Blockly.Block.prototype.badBlock = function() {
+  goog.asserts.assertObject(this.svg_, 'Block is not rendered.');
+  this.svg_.addBadBlock();
+};
+
+/**
+ * Check to see if this block is bad.
+ */
+Blockly.Block.prototype.isBadBlock = function() {
+  goog.asserts.assertObject(this.svg_, 'Block is not rendered.');
+  return this.svg_.isBadBlock();
+};
+
+/**
  * Dispose of this block.
  * @param {boolean} healStack If true, then try to heal any gap by connecting
  *     the next statement with the previous statement.  Otherwise, dispose of
@@ -730,7 +746,7 @@ Blockly.Block.prototype.showContextMenu_ = function(e) {
   var block = this;
   var options = [];
 
-  if (this.isDeletable() && this.isMovable() && !block.isInFlyout) {
+  if (!this.isBadBlock() && this.isDeletable() && this.isMovable() && !block.isInFlyout) {
     // Option to duplicate this block.
     var duplicateOption = {
       text: Blockly.Msg.DUPLICATE_BLOCK,

--- a/appinventor/lib/blockly/src/core/block_svg.js
+++ b/appinventor/lib/blockly/src/core/block_svg.js
@@ -461,6 +461,24 @@ Blockly.BlockSvg.prototype.removeSelect = function() {
 };
 
 /**
+ * Mark this block as bad.  Highlight it visually in red.
+ */
+Blockly.BlockSvg.prototype.addBadBlock = function() {
+  Blockly.addClass_(/** @type {!Element} */ (this.svgGroup_),
+      'badBlock');
+  // Move the selected block to the top of the stack.
+  this.svgGroup_.parentNode.appendChild(this.svgGroup_);
+};
+
+/**
+ * Check to see if the block is marked as bad.
+ */
+Blockly.BlockSvg.prototype.isBadBlock = function() {
+  return Blockly.haveClass_(/** @type {!Element} */ (this.svgGroup_),
+    'badBlock');
+}
+
+/**
  * Adds the dragging class to this block.
  * Also disables the highlights/shadows to improve performance.
  */

--- a/appinventor/lib/blockly/src/core/css.js
+++ b/appinventor/lib/blockly/src/core/css.js
@@ -114,6 +114,15 @@ Blockly.Css.CONTENT = [
   '  display: none;',
   '}',
 
+  '.badBlock>.blocklyPath {',
+  '  stroke-width: 3px;',
+  '  stroke: #f00;',
+  '}',
+
+  '.badBlockl>.blocklyPathLight {',
+  '  display: none;',
+  '}',
+
   '.blocklyDragging>.blocklyPath,',
   '.blocklyDragging>.blocklyPathLight {',
   '  fill-opacity: .8;',

--- a/appinventor/lib/blockly/src/core/typeblock.js
+++ b/appinventor/lib/blockly/src/core/typeblock.js
@@ -459,18 +459,22 @@ Blockly.TypeBlock.createAutoComplete_ = function(inputText){
         blockToCreateName = blockToCreate.canonicName;
         // components have mutator attributes we need to deal with. We can also add these for special blocks
         //   e.g., this is done for create empty list
-        var xmlString;
-        if(xmlString = Blockly.Drawer.getDefaultXMLString(blockToCreate.canonicName, blockToCreate.mutatorAttributes)) {
-          var xml = Blockly.Xml.textToDom(xmlString);
-          block = Blockly.Xml.domToBlock(Blockly.mainWorkspace, xml.firstChild);
-        } else {
-          block = new Blockly.Block.obtain(Blockly.mainWorkspace, blockToCreateName);
-          block.initSvg(); //Need to init the block before doing anything else
-          if (block.type && (block.type == "procedures_callnoreturn" || block.type == "procedures_callreturn")) {
-            //Need to make sure Procedure Block inputs are updated
-            Blockly.FieldProcedure.onChange.call(block.getField_("PROCNAME"), blockToCreate.dropDown.value);
+        var xmlString = Blockly.Drawer.getDefaultXMLString(blockToCreate.canonicName, blockToCreate.mutatorAttributes);
+        var xml;
+        if (xmlString === null) {
+          var blockType = blockToCreate.canonicName;
+          if (blockType == 'procedures_callnoreturn' || blockType == 'procedures_callreturn') {
+            xmlString = Blockly.Drawer.procedureCallersXMLString(blockType == 'procedures_callreturn');
+          } else {
+            xmlString = '<xml><block type="' + blockType + '">';
+            if(blockToCreate.mutatorAttributes) {
+              xmlString += Blockly.Drawer.mutatorAttributesToXMLString(blockToCreate.mutatorAttributes);
+            }
+            xmlString += '</block></xml>';
           }
         }
+        xml = Blockly.Xml.textToDom(xmlString);
+        block = Blockly.Xml.domToBlock(Blockly.mainWorkspace, xml.firstChild);
 
         if (blockToCreate.dropDown.titleName && blockToCreate.dropDown.value){
           block.setTitleValue(blockToCreate.dropDown.value, blockToCreate.dropDown.titleName);

--- a/appinventor/lib/blockly/src/core/utils.js
+++ b/appinventor/lib/blockly/src/core/utils.js
@@ -82,7 +82,7 @@ Blockly.removeClass_ = function(element, className) {
  */
 Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var wrapFunc = function(e) {
-    func.apply(thisObject, arguments);
+    func.call(thisObject, e);
   };
   node.addEventListener(name, wrapFunc, false);
   var bindData = [[node, name, wrapFunc]];

--- a/appinventor/lib/blockly/src/core/utils.js
+++ b/appinventor/lib/blockly/src/core/utils.js
@@ -47,6 +47,23 @@ Blockly.addClass_ = function(element, className) {
 };
 
 /**
+ * Check to see if a specific class is already assigned to
+ * a block.
+ * @param {!Element} element DOM element to check on.
+ * @param {string} className to check
+ * @return {boolean} true if class is present
+ * @private
+ */
+Blockly.haveClass_ = function(element, className) {
+  var classes = element.getAttribute('class') || '';
+  if ((' ' + classes + ' ').indexOf(' ' + className + ' ') == -1) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+/**
  * Remove a CSS class from a element.
  * Similar to Closure's goog.dom.classes.remove, except it handles SVG elements.
  * @param {!Element} element DOM element to remove class from.


### PR DESCRIPTION
I propose this getter because of the issue below:
I was creating a android system intent "contact" based app. The contactPicker which is provided by AppInventor is working fine. Howvever, I want to click a button and view a specific contact. To achieve that, I need to use Activity Starter to do an action which is: android.intent.action.VIEW. This activity will need a input: DataUri.

Here is the problem. I cannot find out what is the DataUri for a contact so I cannot do the call to view a contact.

Thus, since we already have this contactPicker and inside the code I learned that we actually have the contactUri but we somehow haven't expose it. I propose to make a getter for this ContactUri. And then we could view the contact in the program. 
Here are the screen shots of my test:
1.png->2.png->3.png
The new block in ContactClicker: 4.png

1.png
![1](https://cloud.githubusercontent.com/assets/3294244/5991062/0efa60be-a9a2-11e4-80c8-60cd2c505815.png)
2.png
![2](https://cloud.githubusercontent.com/assets/3294244/5991063/122878de-a9a2-11e4-8acf-6070ff7e35dc.png)
3.png
![3](https://cloud.githubusercontent.com/assets/3294244/5991064/142dd30e-a9a2-11e4-968f-c12187f30f0b.png)
4.png
![4](https://cloud.githubusercontent.com/assets/3294244/5991065/17075f14-a9a2-11e4-85cb-fe02bb9203e0.png)

ant tests also built successfully.

By Yifan(Evan) Li (thueeliyifan@gmail.com)