### PR TITLE
Speed Up Blockly on Firefox

### DIFF
--- a/appinventor/lib/blockly/src/core/utils.js
+++ b/appinventor/lib/blockly/src/core/utils.js
@@ -82,7 +82,7 @@ Blockly.removeClass_ = function(element, className) {
  */
 Blockly.bindEvent_ = function(node, name, thisObject, func) {
   var wrapFunc = function(e) {
-    func.apply(thisObject, arguments);
+    func.call(thisObject, e);
   };
   node.addEventListener(name, wrapFunc, false);
   var bindData = [[node, name, wrapFunc]];


### PR DESCRIPTION
This small fix comes from Neil. see:

 https://github.com/google/blockly/commit/f79b42ab70e2c6eda7beb6777cec76db654332a4

Change-Id: I2559fe33fb261243e5a4c985bddfda59ff103a3a