### PR TITLE
Fix for make a list in Typeblock

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/lists.js
+++ b/appinventor/blocklyeditor/src/blocks/lists.js
@@ -53,7 +53,8 @@ Blockly.Blocks['lists_create_with'] = {
   },
   // create type blocks for both make a list (two items) and create empty list
   typeblock: [
-      { translatedName: Blockly.Msg.LANG_LISTS_CREATE_WITH_TITLE_MAKE_LIST },
+      { translatedName: Blockly.Msg.LANG_LISTS_CREATE_WITH_TITLE_MAKE_LIST,
+        mutatorAttributes: { items: 2 } },
       { translatedName: Blockly.Msg.LANG_LISTS_CREATE_EMPTY_TITLE,
         mutatorAttributes: { items: 0 } }]
 };

--- a/appinventor/lib/blockly/src/core/typeblock.js
+++ b/appinventor/lib/blockly/src/core/typeblock.js
@@ -474,7 +474,10 @@ Blockly.TypeBlock.createAutoComplete_ = function(inputText){
           }
         }
         xml = Blockly.Xml.textToDom(xmlString);
-        block = Blockly.Xml.domToBlock(Blockly.mainWorkspace, xml.firstChild);
+        var xmlBlock = xml.firstChild;
+        if (xml.children.length > 1 && goog.dom.getElement(inputText).value === 'make a list')
+          xmlBlock = xml.children[1];
+        block = Blockly.Xml.domToBlock(Blockly.mainWorkspace, xmlBlock);
 
         if (blockToCreate.dropDown.titleName && blockToCreate.dropDown.value){
           block.setTitleValue(blockToCreate.dropDown.value, blockToCreate.dropDown.titleName);


### PR DESCRIPTION
`make a list` and `create empty list` are created from the same block, providing different values at `Blockly.Drawer.defaultBlockXMLStrings.lists_create_with`

The drawer handles this by creating a block for each Children at https://github.com/mit-cml/appinventor-sources/blob/master/appinventor/blocklyeditor/src/drawer.js#L264

I've added a check in typeblock to choose one of the children depending on the text entered.

Please review @jisqyv @halatmit 