### PR TITLE
Update How App Inventor is served and cached

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -12,6 +12,24 @@
   <description>
     Appengine server and client code
   </description>
+
+  <!-- =====================================================================
+       Generate a Unique ID for this build. This is used to name blockly-all.js
+       in a unique way (blockly-${guid1}.js) so blockly is cacheable but
+       different builds get their own copy instead of a potentially out of date
+       version. This is particularly important when we do releases.
+       ===================================================================== -->
+
+  <scriptdef name="generateguid" language="javascript">
+    <attribute name="property" />
+    <![CDATA[
+             importClass( java.util.UUID );
+             project.setProperty( attributes.get( "property" ), UUID.randomUUID() );
+    ]]>
+  </scriptdef>
+  <generateguid property="guid1" />
+  <echo message="${guid1}" />
+
   <condition property="XstartOnFirstThread" value="-XstartOnFirstThread">
     <os family="mac"/>
   </condition>
@@ -46,19 +64,26 @@
           depends="init,blocklyeditor_BlocklyCompile">
     <mkdir dir="${build.war.dir}" />
     <copy todir="${build.war.dir}/">
-      <fileset dir="war"/>
+      <fileset dir="war">
+        <exclude name="blocklyframe.html"/>
+      </fileset>
       <fileset dir="src/${appinventor.pkg}">
         <!-- canvas is a special case (see MockCanvas.java) -->
         <include name="images/canvas.png" />
       </fileset>
       <fileset dir="${docs.dir}"/>
-      <fileset file="${build.dir}/blocklyeditor/blockly-all.js"/>
       <fileset dir="${lib.dir}/blockly/src">
         <include name="media/*"/>
         <include name="**/*.css"/>
         <include name="1x1.gif"/>
       </fileset>
     </copy>
+    <copy file="war/blocklyframe.html" toFile="${build.war.dir}/blocklyframe.html" overwrite="true">
+      <filterset>
+        <filter token="GUID" value="${guid1}"/>
+      </filterset>
+    </copy>
+    <copy file="${build.dir}/blocklyeditor/blockly-all.js" tofile="${build.war.dir}/blockly-${guid1}.js" />
     <copy todir="${build.war.dir}/">
       <fileset dir="${lib.dir}">
         <include name="closure-library/**/*"/>
@@ -67,10 +92,13 @@
   </target>
 
   <target name="CopyBlocklyToBuildWar"
-          description="Create blockly-all.js and add to war"
+          description="Create blockly-all.js and add to war with unique name"
           depends="init,blocklyeditor_BlocklyCompile">
-    <copy todir="${build.war.dir}/">
-      <fileset file="${build.dir}/blocklyeditor/blockly-all.js"></fileset>
+    <copy file="${build.dir}/blocklyeditor/blockly-all.js" tofile="${build.war.dir}/blockly-${guid1}.js" />
+    <copy file="war/blocklyframe.html" toFile="${build.war.dir}/blocklyframe.html" overwrite="true">
+      <filterset>
+        <filter token="GUID" value="${guid1}"/>
+      </filterset>
     </copy>
   </target>
   <!-- =====================================================================

--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -5,13 +5,14 @@
 
   <!-- Configure serving/caching of GWT files -->
   <static-files>
-    <include path="/blockly-all.js">
+    <include path="/blockly-*.js" expiration="365d">
       <http-header name="Content-Type" value="application/javascript; charset=UTF-8" />
     </include>
-    <include path="**" />
 
-    <!-- The following line requires App Engine 1.3.2 SDK -->
+    <!-- These are not cached on purpose -->
     <include path="/ode/**.nocache.*" expiration="0s" />
+    <include path="/blocklyframe.html" expiration="0s" />
+    <include path="/index.html" expiration="0s" />
 
     <include path="/ode/**.cache.*" expiration="365d" />
     <exclude path="/ode/**.gwt.rpc" />

--- a/appinventor/appengine/war/blocklyframe.html
+++ b/appinventor/appengine/war/blocklyframe.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="closure-library/closure/goog/base.js"></script>
     <link type="text/css" rel="stylesheet" href="media/blockly.css">
     <link type="text/css" rel="stylesheet" href="closure-library/closure/goog/css/dialog.css">
-    <script type="text/javascript" src="blockly-all.js"></script>
+    <script type="text/javascript" src="blockly-@GUID@.js"></script>
     <style>
       html, body {
       background-color: #fff;

--- a/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
+++ b/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
@@ -9,7 +9,7 @@
 <title> Yail Comparison Test </title>
 
 <script type="text/javascript" src="../../../../lib/closure-library/closure/goog/base.js"></script>
-<script type="text/javascript" src="../../../../appengine/build/war/blockly-all.js"></script>
+<script type="text/javascript" src="../../../../build/blocklyeditor/blockly-all.js"></script>
 <script type="text/javascript" src="../../../../build/blocklyeditor/component-types.js"></script>
 
 <script type ="text/javascript">


### PR DESCRIPTION
Improve caching behavior so that when a release is made updates are
more likely to be seen by end-users faster with less inconsistency
between the Designer and the Blocks Editor. This change also arranges
for new versions of Blockly to be seen on each build, hopefully
eliminating the need to disable caching during development.

Change-Id: Ie6e38c46db5fd4208fcc4bb2c680ebefdccc1061