### PR TITLE
Fix for initial scrollable state in Designer #203

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -198,9 +198,11 @@ public final class MockForm extends MockContainer {
     } catch (BadPropertyEditorException e) {
       OdeLog.log(MESSAGES.badAlignmentPropertyEditorForArrangement());
       return;
-    };
+    }
     enableAndDisableDropdowns();
     initialized = true;
+    // Now that the default for Scrollable is false, we need to force setting the property when creating the MockForm
+    setScrollableProperty(getPropertyValue(PROPERTY_NAME_SCROLLABLE));
   }
 
   /*


### PR DESCRIPTION
After having changed the default value of Screen.Scrollable (this was done a few months ago) now we need to force the setting of the property when creating a MockForm. Fixes #203.

Please review @jisqyv @halatmit 