### PR TITLE
fixes build for Java 8 by loading nashorn compatibility

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -23,6 +23,7 @@
   <scriptdef name="generateguid" language="javascript">
     <attribute name="property" />
     <![CDATA[
+             load("nashorn:mozilla_compat.js");
              importClass( java.util.UUID );
              project.setProperty( attributes.get( "property" ), UUID.randomUUID() );
     ]]>

--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -23,7 +23,12 @@
   <scriptdef name="generateguid" language="javascript">
     <attribute name="property" />
     <![CDATA[
-             load("nashorn:mozilla_compat.js");
+             try {
+               load("nashorn:mozilla_compat.js");
+             }
+             catch (exception) {
+               // Ignore the exception as the compat mode is only needed for Java 8
+             }
              importClass( java.util.UUID );
              project.setProperty( attributes.get( "property" ), UUID.randomUUID() );
     ]]>


### PR DESCRIPTION
Building on Java 8 needs nashorn/rhino compatibility after the changes to caching made in https://github.com/mit-cml/appinventor-sources/commit/78605a252f28d6f41fa950b1ec1fd9cc275ada0e