### PR TITLE
Added property in Slider component to all for Slider Thumb removal

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2738,6 +2738,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String ThumbPositionProperties();
 
+  @DefaultMessage("ThumbEnabled")
+  @Description("")
+  String ThumbEnabled();
+
   @DefaultMessage("Day")
   @Description("")
   String DayProperties();

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -205,6 +205,7 @@ public class TranslationComponentProperty {
     map.put("MaxValue", MESSAGES.MaxValueProperties());
     map.put("MinValue", MESSAGES.MinValueProperties());
     map.put("ThumbPosition", MESSAGES.ThumbPositionProperties());
+    map.put("ThumbEnabled", MESSAGES.ThumbEnabled());
     map.put("FontBold", MESSAGES.FontBoldProperties());
     map.put("FontItalic", MESSAGES.FontItalicProperties());
     map.put("ShowFeedback", MESSAGES.ShowFeedbackProperties());

--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationDesignerProperties.java
@@ -264,6 +264,8 @@ public class TranslationDesignerProperties {
       value = MESSAGES.MinValueProperties();
     } else if (key.equals("ThumbPosition")) {
       value = MESSAGES.ThumbPositionProperties();
+    } else if (key.equals("ThumbEnabled")) {
+      value = MESSAGES.ThumbEnabled();
     } else if (key.equals("UseFront")) {
       value = MESSAGES.UseFrontProperties();
     } else if (key.equals("Day")) {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -500,7 +500,10 @@ public final class YoungAndroidFormUpgrader {
       // Initial version. Placeholder for future upgrades
       srcCompVersion = 1;
     }
-
+    if (srcCompVersion < 2) {
+      // Added the property to allow for the removal of the Thumb Slider
+      srcCompVersion = 2;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -313,8 +313,10 @@ public class YaVersion {
   // For YOUNG_ANDROID_VERSION 119:
   // - TEXTBOX_COMPONENT_VERSION was incremented to 5
   // - WEBVIEWER_COMPONENT_VERSION was incremented to 6
+  // For YOUNG_ANDROID_VERSION 120:
+  // - SLIDER_COMPONENT_VERSION was incremented to 2
 
-  public static final int YOUNG_ANDROID_VERSION = 119;
+  public static final int YOUNG_ANDROID_VERSION = 120;
 
   // ............................... Blocks Language Version Number ...............................
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -726,7 +726,9 @@ public class YaVersion {
 
   // For SLIDER_COMPONENT_VERSION 1:
   // - Initial version.
-  public static final int SLIDER_COMPONENT_VERSION = 1;
+  // For SLIDER_COMPONENT_VERSION 2:
+  // - Added the property to allow for the removal of the Thumb Slider
+  public static final int SLIDER_COMPONENT_VERSION = 2;
 
   // For SPINNER_COMPONENT_VERSION 1:
   public static final int SPINNER_COMPONENT_VERSION = 1;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
@@ -53,6 +53,7 @@ public class Slider extends AndroidViewComponent implements SeekBar.OnSeekBarCha
   private float maxValue;
   // thumbPosition is a number between minValue and maxValue
   private float thumbPosition;
+  private boolean thumbEnabled;
 
   // the total slider width
   private LayerDrawable fullBar;
@@ -90,6 +91,7 @@ public class Slider extends AndroidViewComponent implements SeekBar.OnSeekBarCha
     minValue = Component.SLIDER_MIN_VALUE;
     maxValue = Component.SLIDER_MAX_VALUE;
     thumbPosition = Component.SLIDER_THUMB_VALUE;
+    thumbEnabled = true;
 
     seekbar.setOnSeekBarChangeListener(this);
 
@@ -138,6 +140,34 @@ public class Slider extends AndroidViewComponent implements SeekBar.OnSeekBarCha
 
     // Set the thumb position on the seekbar
     seekbar.setProgress((int) seekbarPosition);
+  }
+
+  /**
+   * Sets whether or not the slider thumb should be shown
+   *
+   * @param enabled Whether or not the slider thumb should be shown
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+    defaultValue = "True")
+  @SimpleProperty(description = "Sets whether or not to display the slider thumb.",
+     userVisible = true)
+  public void ThumbEnabled(boolean enabled) {
+    thumbEnabled = enabled;
+    int alpha = thumbEnabled ? 255 : 0;
+    seekbar.getThumb().mutate().setAlpha(alpha);
+    seekbar.setEnabled(thumbEnabled);
+  }
+
+  /**
+   * Whether or not the slider thumb is being be shown
+   *
+   * @return Whether or not the slider thumb is being be shown
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+      description = "Returns whether or not the slider thumb is being be shown",
+      userVisible = true)
+  public boolean ThumbEnabled() {
+    return thumbEnabled;
   }
 
   /**


### PR DESCRIPTION
Earlier, I wanted to see the addition of a progress bar, and recently it was brought up to me that the Slider component can easily be modified to be a progress bar. So basically, what I have here is the addition of a property to the Slider component that will remove the Thumb Slider, and you will simply be left with a progress bar. The way it works is, when the property, ThumbEnabled = true, nothing is changed. When it is false, the Thumb Slider is hidden and the ability to change the progress (from the UI) is disabled (you can still change the progress from the code/blocks). 

The reason I went with "ThumbEnabled" was because there is another property "ThumbPosition" so I figured they kind of go together.

Also, this is not a complete feature because it lacks Internationalization which I am still not 100% sure how to do. If anything else is missing, please let me know.