### PR TITLE
Add The necessary datastore-index file for the Gallery

### DIFF
--- a/appinventor/appengine/war/WEB-INF/datastore-indexes.xml
+++ b/appinventor/appengine/war/WEB-INF/datastore-indexes.xml
@@ -1,0 +1,22 @@
+<!-- Indices written at Wed, 4 Mar 2015 11:07:49 EST -->
+
+<datastore-indexes>
+
+    <!-- Used 6 times in query history -->
+    <datastore-index kind="GalleryAppData" ancestor="false" source="manual">
+        <property name="active" direction="asc"/>
+        <property name="numDownloads" direction="desc"/>
+    </datastore-index>
+
+    <!-- Used 6 times in query history -->
+    <datastore-index kind="GalleryAppData" ancestor="false" source="manual">
+        <property name="active" direction="asc"/>
+        <property name="dateModified" direction="desc"/>
+    </datastore-index>
+
+    <datastore-index kind="GalleryAppReportData" ancestor="false" source="manual">
+      <property name="resolved" direction="asc"/>
+      <property name="dateCreated" direction="desc"/>
+    </datastore-index>
+
+</datastore-indexes>


### PR DESCRIPTION
The Gallery App requires a few datastore indexes. This configuration
file provides them.

Change-Id: Ib4b411551200870e06ea0a04237debd473a8c2c2