### PR TITLE
Fixed misleading "onepotato" example

### DIFF
--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -632,7 +632,7 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = 'Divides text into pieces using the text \'at\' as the dividing points and produces a list of the results.  \n'
         + 'Splitting "one,two,three,four" at "," (comma) returns the list "(one two three four)". \n'
-        + 'Splitting "one-potato,two-potato,three-potato,four" at "-potato", returns the list "(one two three four)".';
+        + 'Splitting "one-potato,two-potato,three-potato,four" at "-potato,", returns the list "(one two three four)".';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#split';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY = 'Divides the given text into a list, using any of the items in the list \'at\' as the \n'
         + 'dividing point, and returns a list of the results. \n'

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -626,7 +626,7 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitat';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_FIRST_OF_ANY = 'Divides the given text into a two-item list, using the first location of any item \n'
         + 'in the list \'at\' as the dividing point. \n\n'
-        + 'Splitting "I love apples bananas apples grapes" by the list "(ba,ap)" returns \n'
+        + 'Splitting "I love apples bananas apples grapes" by the list "(ba ap)" returns \n'
         + 'a list of two items, the first being "I love" and the second being \n'
         + '"ples bananas apples grapes."';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';

--- a/appinventor/blocklyeditor/src/msg/es_es/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/es_es/_messages.js
@@ -595,8 +595,8 @@ Blockly.Msg.es_es.switch_language_to_spanish_es = {
         + 'porque es el punto de corte.';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitat';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_FIRST_OF_ANY = 'Divide el texto especificado en una lista de dos elementos, utilizando la primera posición de un elemento \n'
-        + 'en la lista \'at\' como punto de corte. \n\n'
-        + 'Recortar “Me gustan las manzanas plátanos manzanas uvas”  "I love apples bananas apples grapes" por la lista "(ma,pl)" devuelve \n'
+        + 'en la lista \'en\' como punto de corte. \n\n'
+        + 'Recortar “Me gustan las manzanas plátanos manzanas uvas” por la lista "(pl ma)" devuelve \n'
         + 'una lista de dos elementos, siendo el primero "Me gustan las" y el segundo \n'
         + '"nzanas plátanos manzanas uvas."';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';

--- a/appinventor/blocklyeditor/src/msg/es_es/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/es_es/_messages.js
@@ -602,7 +602,7 @@ Blockly.Msg.es_es.switch_language_to_spanish_es = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = 'Divide el texto en partes utilizando el texto \'at\' como puntos de corte y genera una lista con los resultados.  \n'
         + 'Recortar "uno,dos,tres,cuatro" en "," (coma) devuelve la lista "(uno dos tres cuatro)". \n'
-        + 'Recortar "uno-patata,dos-patata,tres-patata,cuatro" en "-patata", devuelve la lista"(uno dos tres cuatro)".'
+        + 'Recortar "uno-patata,dos-patata,tres-patata,cuatro" en "-patata,", devuelve la lista"(uno dos tres cuatro)".'
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#split';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY = 'Divide el texto especificado en una lista, utilizando cualquiera de los elementos de la lista \'at\' como \n'
         + 'punto de corte, y devuelve una lista con los resultados. \n'

--- a/appinventor/blocklyeditor/src/msg/it_it/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/it_it/_messages.js
@@ -626,7 +626,7 @@ Blockly.Msg.it_it.switch_language_to_italian = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = 'Divide il testo un più pezzi usando il testo \'ogni\' come punto di divisione e produce una lista con i risultati. \n'
         + 'Dividendo "uno,due,tre,quattro" ogni "," (virgola) risulterà una lista “(uno due tre quattro)”. \n'
-        + 'Dividendo "una-patata,due-patate,tre-patate,quattro" ogni "-patata", verrà prodotta la lista “(uno due tre quattro)”.'
+        + 'Dividendo "una-patata,due-patate,tre-patate,quattro" ogni "-patata,", verrà prodotta la lista “(uno due tre quattro)”.'
 
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#split';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY = 'Divide il testo in una lista, usando ogni elemento della lista \'lista\' come \n'

--- a/appinventor/blocklyeditor/src/msg/it_it/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/it_it/_messages.js
@@ -619,10 +619,10 @@ Blockly.Msg.it_it.switch_language_to_italian = {
 
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitat';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_FIRST_OF_ANY = 'Divide il testo in due elementi di una lista, usando la prima ricorrenza di ogni elemento \n'
-        + 'nella lista \'lista\' come punto di divisione. \n\n'
-        + 'Dividendo "Io amo le mele banane angurie arance." con la lista “(ba,me)” risulterà \n'
+        + 'nella lista \'a\' come punto di divisione. \n\n'
+        + 'Dividendo "Io amo le mele banane angurie arance." con la lista “(ba me)” risulterà \n'
         + 'una lista di due elementi, come primo "Io amo le" e come secondo \n'
-        + '"nane angurie arance."';
+        + '"le banane angurie arance."';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = 'Divide il testo un più pezzi usando il testo \'ogni\' come punto di divisione e produce una lista con i risultati. \n'
         + 'Dividendo "uno,due,tre,quattro" ogni "," (virgola) risulterà una lista “(uno due tre quattro)”. \n'

--- a/appinventor/blocklyeditor/src/msg/zh_cn/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/zh_cn/_messages.js
@@ -603,13 +603,13 @@ Blockly.Msg.zh_cn.switch_language_to_chinese_cn = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitat';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_FIRST_OF_ANY = '以列表中的任意项作为分隔符，\n'
     + '在首次出现分隔符的位置将给定文本分解为一个两项列表。\n\n'
-    + '如以"(稥,苹)"作为分隔符分解"我喜欢苹果香蕉苹果葡萄"，\n'
+    + '如以"(稥 苹)"作为分隔符分解"我喜欢苹果香蕉苹果葡萄"，\n'
     + '将返回一个两项列表，其第一项为"我喜欢"，第二项为\n'
     + '"果香蕉苹果葡萄"';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = '以指定文本作为分隔符，将字符串分解为不同片段，并生成一个列表作为返回结果。\n'
     + ' 如以","(逗号)分解"一,二,三,四"，将返回列表"(一 二 三 四)"，\n'
-    + ' 而以"-土豆"作为分隔符分解字符串"一-土豆,二-土豆,三-土豆,四"，则返回列表"(一 二 三 四)"。'
+    + ' 而以"-土豆"作为分隔符分解字符串"一-土豆,二-土豆,三-土豆,四"，则返回列表"(一 ,二 ,三 ,四)"。'
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#split';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY  = '以分隔符列表中的任意一项作为分隔符，将给定文本分解为列表，\n'
     + '并将列表作为处理结果返回。\n'

--- a/appinventor/blocklyeditor/src/msg/zh_tw/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/zh_tw/_messages.js
@@ -604,13 +604,13 @@ Blockly.Msg.zh_tw.switch_language_to_chinese_tw = {
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitat';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_FIRST_OF_ANY = '以清單中的任意項作為分隔符號，\n'
     + '在首次出現分隔符號的位置將給定文字分解為一個兩項清單。\n\n'
-    + '如以"(稥,蘋)"作為分隔符號分解"我喜歡蘋果香蕉蘋果葡萄"，\n'
+    + '如以"(稥 蘋)"作為分隔符號分解"我喜歡蘋果香蕉蘋果葡萄"，\n'
     + '將傳回一個兩項清單，其第一項為"我喜歡"，第二項為\n'
     + '"果香蕉蘋果葡萄"';
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT_AT_FIRST_OF_ANY = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#splitatfirstofany';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT = '以指定文字作為分隔符號，將字元串分解為不同片段，並產生一個清單作為傳回結果。\n'
     + ' 如以","(逗號)分解"一,二,三,四"，將傳回清單"(一 二 三 四)"，\n'
-    + ' 而以"-土豆"作為分隔符號分解字元串"一-土豆,二-土豆,三-土豆,四"，則傳回清單"(一 二 三 四)"。'
+    + ' 而以"-土豆"作為分隔符號分解字元串"一-土豆,二-土豆,三-土豆,四"，則傳回清單"(一 ,二 ,三 ,四)"。'
     Blockly.Msg.LANG_TEXT_SPLIT_HELPURL_SPLIT = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#split';
     Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY  = '以分隔符號清單中的任意一項作為分隔符號，將給定文字分解為清單，\n'
     + '並將清單作為處理結果傳回。\n'


### PR DESCRIPTION
Tooltip for text split fixed.

and other fixes to tooltips for relating to that block in english, spanish, and italian. (see commit log)

fixes #322 (pending chinese languages being checked)

Change-Id: I2df5c783d8b8a00e00928e69b587f14ff326ee57