### PR TITLE
fix for duplicate Warning for disabled blocks

### DIFF
--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -269,7 +269,7 @@ Blockly.WarningHandler.determineDuplicateComponentEventHandlers = function(){
     if (topBlock.type == "component_event") {
       topBlock.IAmADuplicate = false; // default value for this field; may be changed to true below
       var typeName = topBlock.typeName;
-      var propertyName = typeName + ":" + topBlock.eventName + ":" + topBlock.instanceName;
+      var propertyName = typeName + ":" + topBlock.eventName + ":" + topBlock.instanceName + ":" + topBlock.disabled;
       /* [lyn, 01/04/2013] Notion of singleton component is not well-defined. Must think more about this!
          If adopt singleton component notion, will need the following code:
             // if (! Blockly.WarningHandler.isSingletonComponentType(typeName)) {


### PR DESCRIPTION
Currently, all event handler blocks are marked as duplicate blocks (and show a warning) if there are two or more blocks of the same type. This happens even if one or more of the blocks are disabled. e.g. if you have one disabled block and one enabled block of the same type, you won't be able to build your application.

This fix separates the duplicate checking for disabled and enabled blocks of the same type. Now, errors are only shown for enabled blocks if there are 1 or more enabled blocks of the same type. Multiple disabled blocks of the same type will show a warning, but will not have an impact building the application.

 
![screenshot 2015-03-23 14 56 13](https://cloud.githubusercontent.com/assets/2532363/6791523/c84651ee-d16c-11e4-83d9-ef98a70c5341.png)
