### PR TITLE
Do not attempt to rename the “type” of a block.

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -340,9 +340,6 @@ Blockly.Blocks.component_method = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText('call ' + this.instanceName + '.' + this.methodType.name);
       this.componentDropDown.setValue(this.instanceName);
-      if (this.type.indexOf(oldname) != -1) {
-        this.type = this.type.replace(oldname, newname);
-      }
     }
   },
   getMethodTypeObject : function() {
@@ -565,9 +562,6 @@ Blockly.Blocks.component_set_get = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText(this.instanceName + '.');
       this.componentDropDown.setValue(this.instanceName);
-      if (this.type.indexOf(oldname) != -1) {
-        this.type = this.type.replace(oldname, newname);
-      }
     }
   },
   typeblock : function(){
@@ -679,9 +673,6 @@ Blockly.Blocks.component_component_block = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText(this.instanceName);
       this.componentDropDown.setValue(this.instanceName);
-      if (this.type.indexOf(oldname) != -1) {
-        this.type = this.type.replace(oldname, newname);
-      }
     }
   },
 


### PR DESCRIPTION
Do not attempt to rename the type of a block when it’s name is
changed. Doing so can corrupt projects is the oldname of a block is a
substring of a type name (say component_set_get). If you create a
component named “et”. Make sure it has blocks in the workspace and
then rename it to “st” the project will become corrupted because
occurances of the string “component_set_get” will turn into
“component_sst_get.”

Change-Id: I2dbcb308a6f81f67a2ebdef645e70c4dfee93f7a