### PR TITLE
Put space between project name and "Progress Bar".

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/ShowProgressBarCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/ShowProgressBarCommand.java
@@ -120,7 +120,7 @@ public class ShowProgressBarCommand extends ChainableCommand {
     ProgressBarDialogBox() {
       super(false, true);
       setStylePrimaryName("ode-DialogBox");
-      setText(projectNode.getName() + MESSAGES.ProgressBarFor());
+      setText(projectNode.getName() + " " + MESSAGES.ProgressBarFor());
 
       //click handler for the mini html buttons
       buttonHandler = new ClickHandler() {


### PR DESCRIPTION
When you build a project, it shows a progress bar with the project name, followed by "Progress Bar", with no space between the project name and the rest. This change puts the space in there.
@josmas 