### PR TITLE
Fix for typeblocking in safari

### DIFF
--- a/appinventor/lib/blockly/src/core/typeblock.js
+++ b/appinventor/lib/blockly/src/core/typeblock.js
@@ -475,8 +475,8 @@ Blockly.TypeBlock.createAutoComplete_ = function(inputText){
         }
         xml = Blockly.Xml.textToDom(xmlString);
         var xmlBlock = xml.firstChild;
-        if (xml.children.length > 1 && goog.dom.getElement(inputText).value === 'make a list')
-          xmlBlock = xml.children[1];
+        if (xml.childNodes.length > 1 && goog.dom.getElement(inputText).value === 'make a list')
+          xmlBlock = xml.childNodes[1];
         block = Blockly.Xml.domToBlock(Blockly.mainWorkspace, xmlBlock);
 
         if (blockToCreate.dropDown.titleName && blockToCreate.dropDown.value){


### PR DESCRIPTION
Typeblocks in Safari does not work

Safari returns a 'Node' as opposed to an 'Element' so .childNodes should be used instead of .children