### PR TITLE
Fixed problem with designer-only properties not labeled in the designer ...

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2279,6 +2279,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String ApiKeyProperties();
 
+  @DefaultMessage("AppName")
+  @Description("")
+  String AppNameProperties();
+
   @DefaultMessage("AvailableCountries")
   @Description("")
   String AvailableCountriesProperties();

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
@@ -25,7 +25,7 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
     sb.append("\n\n/* Properties */\n\n");
     for (Property prop : component.properties.values()) {
       String propertyName = prop.name;
-      if (prop.isUserVisible()) {
+      if (prop.isUserVisible() || component.designerProperties.containsKey(propertyName)) {
         sb.append("    map.put(\"PROPERTY-" + propertyName + "\", MESSAGES." + propertyName + "Properties());\n");
       }
     }


### PR DESCRIPTION
...Properties panel.

For example, Screen1 has designer-only properties AppName, Icon, VersionCode, VersionName.

@jisqyv 

PS - Thanks for doing the work on the automatically creating the translation maps! It makes adding components/properties/methods/events a lot easier.

![screen shot 2015-04-15 at 11 01 52 pm](https://cloud.githubusercontent.com/assets/397725/7174947/cdd296ae-e3c3-11e4-889a-14428c67b679.png)
