### PR TITLE
background-issue-when-scrolling-a-list-picker-#368

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListPickerActivity.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListPickerActivity.java
@@ -78,6 +78,7 @@ public class ListPickerActivity extends Activity implements AdapterView.OnItemCl
       String items[] = getIntent().getStringArrayExtra(ListPicker.LIST_ACTIVITY_ARG_NAME);
       listView = new ListView(this);
       listView.setOnItemClickListener(this);
+      listView.setScrollingCacheEnabled(false);
 
       itemColor = myIntent.getIntExtra(ListPicker.LIST_ACTIVITY_ITEM_TEXT_COLOR, ListPicker.DEFAULT_ITEM_TEXT_COLOR);
       backgroundColor = myIntent.getIntExtra(ListPicker.LIST_ACTIVITY_BACKGROUND_COLOR, ListPicker.DEFAULT_ITEM_BACKGROUND_COLOR);


### PR DESCRIPTION
@halatmit #368 

The issue is due to scrolling cache is enabled in ListPickerActivity. It also occurs if the apk is compiled with AppToMarket.

This change has been tested on emulator with API 10, 15, 18, 19, 21.