### PR TITLE
Removed symlink for ComponentsTranslation.java

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -354,6 +354,7 @@
     <mkdir dir="${build.war.dir}/WEB-INF/classes"/>
     <ai.javac encoding="utf-8"
               destdir="${build.war.dir}/WEB-INF/classes"
+              srcdir="${src.dir};${build.dir}/components/ComponentTranslation/src"
               source="1.5" target="1.5" nowarn="true"
               debug="true" debuglevel="lines,vars,source">
       <include name="${appinventor.pkg}/client/**/*.java" />
@@ -405,6 +406,7 @@
     <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler">
       <classpath>
         <pathelement location="src"/>
+        <pathelement location="${build.dir}/components/ComponentTranslation/src"/>
         <pathelement location="${build.war.dir}/WEB-INF/classes"/>
         <pathelement location="${local.build.dir}/AiRebindLib.jar" />
         <pathelement location="${build.dir}/common/BlocksEditorHttpConstants-gwt.jar" />

--- a/appinventor/appengine/src/com/google/appinventor/client/ComponentsTranslation.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/ComponentsTranslation.java
@@ -1,1 +1,0 @@
-../../../../../build/src/com/google/appinventor/client/ComponentsTranslation.java

--- a/appinventor/components/build.xml
+++ b/appinventor/components/build.xml
@@ -373,7 +373,7 @@
             apt-target="${ComponentTranslation-class.dir}/ComponentsTranslation.java"/>
 
     <copy file="${ComponentTranslation-class.dir}/ComponentsTranslation.java"
-          todir="${appinventor.dir}/appengine/build/src/com/google/appinventor/client/" />
+          todir="${public.build.dir}/ComponentTranslation/src/com/google/appinventor/client/" />
 
   </target>
 


### PR DESCRIPTION
Modified appinventor/components/build.xml target ComponentTranslation so ComponentsTranslation.java

is generated into appinventor/build/components/ComponentTranslation/src/com/google/appinventor/client. This
fixes a problem where "ant clean" in the components subdirectory did not clean up the generated file
ComponentsTranslation.java.

Removed the symlink appinventor/appengine/src/com/google/appinventor/client/ComponentsTranslation.java

Modified appinventor/appengine/build.xml target AiClientLib to include
appinventor/build/components/ComponentTranslation/src in the srcdir, in addition to ${src.dir}.
Modified appinventor/appengine/build.xml target YaClientApp to include a pathelement for
appinventor/build/components/ComponentTranslation/src.

I have only tested this on linux.

@jisqyv @josmas @kkashi01 