### PR TITLE
Signal an error on unbound lexical variables

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -248,7 +248,12 @@
 (define-syntax lexical-value
   (syntax-rules ()
     ((_ var-name)
-     var-name)))
+     (if (instance? var-name <java.lang.Package>)
+         (signal-runtime-error
+          (string-append "The variable " (get-display-representation `var-name)
+                         " is not bound in the current context")
+          "Unbound Variable")
+         var-name))))
 
 ;;; Lexical Set Variable
 ;;; (set-lexical! var 10)


### PR DESCRIPTION
Work around an issue in kawa/dalvik where unbound variables were being
displayed as a package instead of being signaled as an error.

Change-Id: Ia4ac53b607a2fb935c8339e7d523b1f8043b4f2d