### PR TITLE
Default to use GCS

### DIFF
--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -53,7 +53,7 @@
     <!-- Name of storage bucket in Google Cloud Store -->
     <property name="gcs.bucket" value="" />
     <!-- Whether or not to use GCS for storage -->
-    <property name="use.gcs" value="false" />
+    <property name="use.gcs" value="true" />
 
     <!-- Name of gallery bucket in Google Cloud Store -->
     <property name="gallery.bucket" value="" />


### PR DESCRIPTION
Now use GCS by default. Use the App Engine Application’s default GCS
bucket if one is not specified in the appengine-web.xml configuration
file.

With this change, people can now deploy new instances to App Engine
and GCS will be used by default and the instance should run without
issue after the “files” API is deprecated.

Change-Id: Ic7fd03e918d837894bfe14cd6963068a05abf797