### PR TITLE
Upgrade user projects to GCS

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/BlobUpgradeServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/BlobUpgradeServlet.java
@@ -1,0 +1,57 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2015 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server;
+
+import com.google.appengine.api.capabilities.CapabilitiesService;
+import com.google.appengine.api.capabilities.CapabilitiesServiceFactory;
+import com.google.appengine.api.capabilities.Capability;
+import com.google.appengine.api.capabilities.CapabilityState;
+import com.google.appengine.api.capabilities.CapabilityStatus;
+import com.google.appinventor.server.flags.Flag;
+import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * BlobUpgradeServlet -- Upgrade a user's projects from Blobstore to GCS
+ *
+ * This Servlet is called from the task queue manager (part of App
+ * Engine). It is restricted to admin users only, which means that
+ * normal people cannot directly call it.  However the task queue
+ * manager operates with admin privileges, so it can always call it.
+ *
+ * This code verifies that memcache is available (we cannot upgrade
+ * projects without it) and if so, calls storageIo.doUpgrade(), which
+ * does the actual work. Because we are called from the task queue, we
+ * have up to 10 minutes to run, which should be sufficient to convert
+ * all the projects for any user.
+ *
+ */
+public class BlobUpgradeServlet extends OdeServlet {
+  // Logging support
+  private static final Logger LOG = Logger.getLogger(BlobUpgradeServlet.class.getName());
+  private static final CapabilitiesService caps = CapabilitiesServiceFactory.getCapabilitiesService();
+  private final StorageIo storageIo = StorageIoInstanceHolder.INSTANCE;
+
+  @Override
+  public void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
+
+    String userId = req.getParameter("user");
+    LOG.info("Got Request to Upgrade: " + userId);
+    CapabilityState cstat = caps.getStatus(Capability.MEMCACHE);
+    CapabilityStatus cstatus = cstat.getStatus();
+    // Only attempt upgrade if Memcache is available
+    if (cstatus == CapabilityStatus.ENABLED) {
+      storageIo.doUpgrade(userId);
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -43,6 +43,8 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
       config.setRendezvousServer(rendezvousFlag.get());
     }
     config.setUser(user);
+    // Check to see if we need to upgrade this user's project to GCS
+    storageIo.checkUpgrade(userInfoProvider.getUserId());
     return config;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -1448,7 +1448,7 @@ public class ObjectifyStorageIo implements  StorageIo {
     return uploadRawFile(projectId, fileName, userId, force, content, false);
   }
 
-  public long uploadRawFile(final long projectId, final String fileName, final String userId,
+  private long uploadRawFile(final long projectId, final String fileName, final String userId,
       final boolean force, final byte[] content, final boolean doingConversion) throws BlocksTruncatedException {
     validateGCS();
     final Result<Long> modTime = new Result<Long>();
@@ -1524,8 +1524,8 @@ public class ObjectifyStorageIo implements  StorageIo {
                 try {
                   gcsService.delete(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName));
                 } catch (IOException e) {
-                throw CrashReport.createAndLogError(LOG, null,
-                  collectProjectErrorInfo(userId, projectId, fileName), e);
+                  throw CrashReport.createAndLogError(LOG, null,
+                    collectProjectErrorInfo(userId, projectId, fileName), e);
                 }
               fd.gcsName = null;
               fd.isGCS = false;

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -2415,7 +2415,7 @@ public class ObjectifyStorageIo implements  StorageIo {
   // explains how.
 
   private void validateGCS() {
-    if (GCS_BUCKET_NAME.equals("")) {
+    if (useGcs && GCS_BUCKET_NAME.equals("")) {
       try {
         throw new RuntimeException("You need to configure the default GCS Bucket for your App. " +
           "Follow instructions in the App Engine Developer's Documentation");

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -1520,13 +1520,14 @@ public class ObjectifyStorageIo implements  StorageIo {
             fd.isBlob = true;
             fd.content = null;
             if (fd.isGCS) { // If the content was previously stored in GCS, clear it out.
-              if (fd.gcsName != null)
+              if (fd.gcsName != null) {
                 try {
                   gcsService.delete(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName));
                 } catch (IOException e) {
                   throw CrashReport.createAndLogError(LOG, null,
                     collectProjectErrorInfo(userId, projectId, fileName), e);
                 }
+              }
               fd.gcsName = null;
               fd.isGCS = false;
             }
@@ -1805,8 +1806,7 @@ public class ObjectifyStorageIo implements  StorageIo {
                 // Should we downgrade to the blobstore (for debugging)?
                 // Note: We only run if we have at least 5 seconds of runtime left in the request
                 long timeRemaining = ApiProxy.getCurrentEnvironment().getRemainingMillis();
-                if (conversionEnabled && !useGcs &&
-                  (timeRemaining > 5000)) {
+                if (conversionEnabled && !useGcs && (timeRemaining > 5000)) {
                   // Garf, Let's downgrade this file to the blobstore!
                   // This is used for debugging -- so we can retry upgrading by
                   // first downgrading!
@@ -1857,8 +1857,7 @@ public class ObjectifyStorageIo implements  StorageIo {
           // Time to consider upgrading this file if we are moving to GCS
           // Note: We only run if we have at least 5 seconds of runtime left in the request
           long timeRemaining = ApiProxy.getCurrentEnvironment().getRemainingMillis();
-          if (conversionEnabled && useGcs &&
-            (timeRemaining > 5000)) {
+          if (conversionEnabled && useGcs && (timeRemaining > 5000)) {
             // Upgrade the file to use GCS
             // Note: uploadRawFile does the work for us!
             LOG.log(Level.INFO, "Upgrading " + fileName + " with " +

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -12,12 +12,6 @@ import com.google.appengine.api.appidentity.AppIdentityServiceFailureException;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreInputStream;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.datastore.KeyFactory;
-import com.google.appengine.api.capabilities.CapabilitiesService;
-import com.google.appengine.api.capabilities.CapabilitiesServiceFactory;
-import com.google.appengine.api.capabilities.Capability;
-import com.google.appengine.api.capabilities.CapabilityState;
-import com.google.appengine.api.capabilities.CapabilityStatus;
 import com.google.appengine.api.files.AppEngineFile;
 import com.google.appengine.api.files.FileService;
 import com.google.appengine.api.files.FileServiceFactory;
@@ -125,17 +119,12 @@ public class ObjectifyStorageIo implements  StorageIo {
 
   private final boolean useGcs = Flag.createFlag("use.gcs", false).get();
 
-  private static class LockFailedException extends Exception {
-    LockFailedException(String message) {
-      super(message);
-    }
-  }
+  private final long BIG_FILE = 5*1024*1024; // > 5MB is "big" used to determine if
+                                             // we can do a file upgrade during a normal
+                                             // user request or if we should only do it
+                                             // from the taskqueue
 
-  private static class UpgradeFailedException extends Exception {
-    UpgradeFailedException(String message) {
-      super(message);
-    }
-  }
+  private final boolean conversionEnabled = true; // We are converting GCS <=> Blobstore
 
   // Use this class to define the work of a job that can be
   // retried. The "datastore" argument to run() is the Objectify
@@ -1475,108 +1464,105 @@ public class ObjectifyStorageIo implements  StorageIo {
         @Override
         public void run(Objectify datastore) throws ObjectifyException {
           Key<FileData> key = projectFileKey(projectKey(projectId), fileName);
-          boolean needsUnlock = true;
-          try {
-            fd = fetchFileDatafromMemcache(key.getString());
-          } catch (LockFailedException e) {
-            needsUnlock = false;
-            LOG.log(Level.WARNING, "Lock Failed", e);
-          }
+          fd = (FileData) memcache.get(key.getString());
           if (fd == null) {
             fd = datastore.find(projectFileKey(projectKey(projectId), fileName));
           } else {
             LOG.log(Level.INFO, "Fetched " + key.getString() + " from memcache.");
           }
-          try {
 
-            // <Screen>.yail files are missing when user converts AI1 project to AI2
-            // instead of blowing up, just create a <Screen>.yail file
-            if (fd == null && fileName.endsWith(".yail")){
-              fd = createProjectFile(datastore, projectKey(projectId), FileData.RoleEnum.SOURCE, fileName);
+          // <Screen>.yail files are missing when user converts AI1 project to AI2
+          // instead of blowing up, just create a <Screen>.yail file
+          if (fd == null && fileName.endsWith(".yail")){
+            fd = createProjectFile(datastore, projectKey(projectId), FileData.RoleEnum.SOURCE, fileName);
+          }
+
+          Preconditions.checkState(fd != null);
+
+          if ((content.length < 125) && (fileName.endsWith(".bky"))) { // Likely this is an empty blocks workspace
+            if (!force) {            // force is true if we *really* want to save it!
+              checkForBlocksTruncation(fd); // See if we had previous content and throw and exception if so
             }
+          }
 
-            Preconditions.checkState(fd != null);
-
-            if ((content.length < 125) && (fileName.endsWith(".bky"))) { // Likely this is an empty blocks workspace
-              if (!force) {            // force is true if we *really* want to save it!
-                checkForBlocksTruncation(fd); // See if we had previous content and throw and exception if so
-              }
+          if (fd.isBlob) {
+            // mark the old blobstore blob for deletion
+           oldBlobstorePath.t = fd.blobstorePath;
+          }
+          if (useGCS) {
+            fd.isGCS = true;
+            fd.gcsName = makeGCSfileName(fileName, projectId);
+            try {
+              GcsOutputChannel outputChannel =
+                gcsService.createOrReplace(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName), GcsFileOptions.getDefaultInstance());
+              outputChannel.write(ByteBuffer.wrap(content));
+              outputChannel.close();
+            } catch (IOException e) {
+              throw CrashReport.createAndLogError(LOG, null,
+                collectProjectErrorInfo(userId, projectId, fileName), e);
             }
-
-            if (fd.isBlob) {
-              // mark the old blobstore blob for deletion
-              oldBlobstorePath.t = fd.blobstorePath;
+            // If the content was previously stored in the datastore, clear it out.
+            fd.content = null;
+            fd.isBlob = false;  // in case we are converting from a blob
+            fd.blobstorePath = null;
+          } else if (useBlobstore) {
+            try {
+              fd.blobstorePath = uploadToBlobstore(content, makeBlobName(projectId, fileName));
+            } catch (BlobWriteException e) {
+              // Note that this makes the BlobWriteException fatal. The job will
+              // not be retried if we get this exception.
+              throw CrashReport.createAndLogError(LOG, null,
+                  collectProjectErrorInfo(userId, projectId, fileName), e);
             }
-            if (useGCS) {
-              fd.isGCS = true;
-              fd.gcsName = makeGCSfileName(fileName, projectId);
-              try {
-                GcsOutputChannel outputChannel =
-                  gcsService.createOrReplace(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName), GcsFileOptions.getDefaultInstance());
-                outputChannel.write(ByteBuffer.wrap(content));
-                outputChannel.close();
+            fd.isBlob = true;
+            fd.content = null;
+            if (fd.isGCS) { // If the content was previously stored in GCS, clear it out.
+              if (fd.gcsName != null)
+                try {
+                  gcsService.delete(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName));
+                } catch (IOException e) {
+                throw CrashReport.createAndLogError(LOG, null,
+                  collectProjectErrorInfo(userId, projectId, fileName), e);
+                }
+              fd.gcsName = null;
+              fd.isGCS = false;
+            }
+          } else {
+            if (fd.isGCS) {     // Was a GCS file, must have gotten smaller
+              try {             // and is now stored in the data store
+                gcsService.delete(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName));
               } catch (IOException e) {
                 throw CrashReport.createAndLogError(LOG, null,
                   collectProjectErrorInfo(userId, projectId, fileName), e);
               }
-              // If the content was previously stored in the datastore, clear it out.
-              fd.content = null;
-              fd.isBlob = false;  // in case we are converting from a blob
-              fd.blobstorePath = null;
-            } else if (useBlobstore) {
-              try {
-                fd.blobstorePath = uploadToBlobstore(content, makeBlobName(projectId, fileName));
-              } catch (BlobWriteException e) {
-                // Note that this makes the BlobWriteException fatal. The job will
-                // not be retried if we get this exception.
-                throw CrashReport.createAndLogError(LOG, null,
-                  collectProjectErrorInfo(userId, projectId, fileName), e);
-              }
-              // If the content was previously stored in the datastore or GCS, clear it out.
-              fd.isBlob = true;
               fd.isGCS = false;
               fd.gcsName = null;
-              fd.content = null;
-            } else {
-              if (fd.isGCS) {     // Was a GCS file, must have gotten smaller
-                try {             // and is now stored in the data store
-                  gcsService.delete(new GcsFilename(GCS_BUCKET_NAME, fd.gcsName));
-                } catch (IOException e) {
-                  throw CrashReport.createAndLogError(LOG, null,
-                    collectProjectErrorInfo(userId, projectId, fileName), e);
-                }
-                fd.isGCS = false;
-                fd.gcsName = null;
-              }
-              // Note, Don't have to do anything if the file was in the
-              // Blobstore and shrank because the code above (3 lines
-              // into the function) already handles removing the old
-              // contents from the Blobstore.
-              fd.isBlob = false;
-              fd.blobstorePath = null;
-              fd.content = content;
             }
-            if (considerBackup) {
-              if ((fd.lastBackup + TWENTYFOURHOURS) < System.currentTimeMillis()) {
-                try {
-                  String gcsName = makeGCSfileName(fileName + "." + formattedTime() + ".backup", projectId);
-                  GcsOutputChannel outputChannel =
-                    gcsService.createOrReplace((new GcsFilename(GCS_BUCKET_NAME, gcsName)), GcsFileOptions.getDefaultInstance());
-                  outputChannel.write(ByteBuffer.wrap(content));
-                  outputChannel.close();
-                  fd.lastBackup = System.currentTimeMillis();
-                } catch (IOException e) {
-                  throw CrashReport.createAndLogError(LOG, null,
-                    collectProjectErrorInfo(userId, projectId, fileName + "(backup)"), e);
-                }
-              }
-            }
-            datastore.put(fd);
-            memcache.put(key.getString(), fd); // Store the updated data in memcache
-          } finally {
-            if (needsUnlock)
-              unlockFileDataMemcache(key.getString());
+            // Note, Don't have to do anything if the file was in the
+            // Blobstore and shrank because the code above (3 lines
+            // into the function) already handles removing the old
+            // contents from the Blobstore.
+            fd.isBlob = false;
+            fd.blobstorePath = null;
+            fd.content = content;
           }
+          if (considerBackup) {
+            if ((fd.lastBackup + TWENTYFOURHOURS) < System.currentTimeMillis()) {
+              try {
+                String gcsName = makeGCSfileName(fileName + "." + formattedTime() + ".backup", projectId);
+                GcsOutputChannel outputChannel =
+                    gcsService.createOrReplace((new GcsFilename(GCS_BUCKET_NAME, gcsName)), GcsFileOptions.getDefaultInstance());
+                outputChannel.write(ByteBuffer.wrap(content));
+                outputChannel.close();
+                fd.lastBackup = System.currentTimeMillis();
+              } catch (IOException e) {
+                throw CrashReport.createAndLogError(LOG, null,
+                    collectProjectErrorInfo(userId, projectId, fileName + "(backup)"), e);
+              }
+            }
+          }
+          datastore.put(fd);
+          memcache.put(key.getString(), fd); // Store the updated data in memcache
           modTime.t = updateProjectModDate(datastore, projectId);
         }
 
@@ -1762,120 +1748,138 @@ public class ObjectifyStorageIo implements  StorageIo {
     }
   }
 
+
+
   @Override
   public byte[] downloadRawFile(final String userId, final long projectId, final String fileName) {
+    return downloadRawFileInternal(userId, projectId, fileName, false);
+  }
+
+  public byte[] downloadRawFileInternal(final String userId, final long projectId,
+    final String fileName, final boolean fromTaskQueue) {
     validateGCS();
     if (!getProjects(userId).contains(projectId)) {
       throw CrashReport.createAndLogError(LOG, null,
           collectUserProjectErrorInfo(userId, projectId),
           new UnauthorizedAccessException(userId, projectId, null));
     }
-    final Key<FileData> fileKey = projectFileKey(projectKey(projectId), fileName);
     final Result<byte[]> result = new Result<byte[]>();
     final Result<FileData> fd = new Result<FileData>();
-    boolean needsUnlock = true;
     try {
-      fd.t = fetchFileDatafromMemcache(fileKey.getString());
-    } catch (LockFailedException e) {
-      needsUnlock = false;
-      LOG.log(Level.WARNING, "Lock Filed", e);
-    }
-    if (fd.t != null) {
-      LOG.log(Level.INFO, "Fetch from memcache: fileKey = " + fileKey.getString());
-    }
-    try {
-      try {
-        runJobWithRetries(new JobRetryHelper() {
-            @Override
-            public void run(Objectify datastore) {
-              if (fd.t == null) {
-                fd.t = datastore.find(fileKey);
-              }
-            }
-          }, false); // Transaction not needed
-      } catch (ObjectifyException e) {
-        throw CrashReport.createAndLogError(LOG, null,
-          collectProjectErrorInfo(userId, projectId, fileName), e);
-      }
-      // read the blob/GCS File outside of the job
-      FileData fileData = fd.t;
-      if (fileData != null) {
-        if (fileData.isGCS) {     // It's in the Cloud Store
-          try {
-            int count;
-            boolean npfHappened = false;
-            boolean recovered = false;
-            for (count = 0; count < 5; count++) {
-              GcsFilename gcsFileName = new GcsFilename(GCS_BUCKET_NAME, fileData.gcsName);
-              int bytesRead = 0;
-              int fileSize = 0;
-              ByteBuffer resultBuffer;
-              try {
-                fileSize = (int) gcsService.getMetadata(gcsFileName).getLength();
-                resultBuffer = ByteBuffer.allocate(fileSize);
-                GcsInputChannel readChannel = gcsService.openReadChannel(gcsFileName, 0);
-                try {
-                  while (bytesRead < fileSize) {
-                    bytesRead += readChannel.read(resultBuffer);
-                    if (bytesRead < fileSize) {
-                      LOG.log(Level.INFO, "readChannel: bytesRead = " + bytesRead + " fileSize = " + fileSize);
-                    }
-                  }
-                  recovered = true;
-                  result.t = resultBuffer.array();
-                  break;          // We got the data, break out of the loop!
-                } finally {
-                  readChannel.close();
-                }
-              } catch (NullPointerException e) {
-                // This happens if the object in GCS is non-existent, which would happen
-                // when people uploaded a zero length object. As of this change, we now
-                // store zero length objects into GCS, but there are plenty of older objects
-                // that are missing in GCS.
-                LOG.log(Level.WARNING, "downloadrawfile: NPF recorded for " + fileData.gcsName);
-                npfHappened = true;
-                resultBuffer = ByteBuffer.allocate(0);
-                result.t = resultBuffer.array();
-              }
-            }
-
-            // report out on how things went above
-            if (npfHappened) {    // We lost at least once
-              if (recovered) {
-                LOG.log(Level.WARNING, "recovered from NPF in downloadrawfile filename = " + fileData.gcsName +
-                  " count = " + count);
-              } else {
-                LOG.log(Level.WARNING, "FATAL NPF in downloadrawfile filename = " + fileData.gcsName);
-              }
-            }
-
-          } catch (IOException e) {
-            throw CrashReport.createAndLogError(LOG, null,
-              collectProjectErrorInfo(userId, projectId, fileName), e);
-          }
-        } else if (fileData.isBlob) {
-          try {
-            result.t = getBlobstoreBytes(fileData.blobstorePath);
-          } catch (BlobReadException e) {
-            throw CrashReport.createAndLogError(LOG, null,
-              collectProjectErrorInfo(userId, projectId, fileName), e);
-          }
-        } else {
-          if (fileData.content == null) {
-            result.t = new byte[0];
-          } else {
-            result.t = fileData.content;
+      runJobWithRetries(new JobRetryHelper() {
+        @Override
+        public void run(Objectify datastore) {
+          Key<FileData> fileKey = projectFileKey(projectKey(projectId), fileName);
+          fd.t = (FileData) memcache.get(fileKey.getString());
+          if (fd.t == null) {
+            fd.t = datastore.find(fileKey);
           }
         }
+      }, false); // Transaction not needed
+    } catch (ObjectifyException e) {
+      throw CrashReport.createAndLogError(LOG, null,
+          collectProjectErrorInfo(userId, projectId, fileName), e);
+    }
+    // read the blob/GCS File outside of the job
+    FileData fileData = fd.t;
+    if (fileData != null) {
+      if (fileData.isGCS) {     // It's in the Cloud Store
+        try {
+          int count;
+          boolean npfHappened = false;
+          boolean recovered = false;
+          for (count = 0; count < 5; count++) {
+            GcsFilename gcsFileName = new GcsFilename(GCS_BUCKET_NAME, fileData.gcsName);
+            int bytesRead = 0;
+            int fileSize = 0;
+            ByteBuffer resultBuffer;
+            try {
+              fileSize = (int) gcsService.getMetadata(gcsFileName).getLength();
+              resultBuffer = ByteBuffer.allocate(fileSize);
+              GcsInputChannel readChannel = gcsService.openReadChannel(gcsFileName, 0);
+              try {
+                while (bytesRead < fileSize) {
+                  bytesRead += readChannel.read(resultBuffer);
+                  if (bytesRead < fileSize) {
+                    LOG.log(Level.INFO, "readChannel: bytesRead = " + bytesRead + " fileSize = " + fileSize);
+                  }
+                }
+                recovered = true;
+                result.t = resultBuffer.array();
+                // Should we downgrade to the blobstore (for debugging)?
+                if (conversionEnabled && !useGcs &&
+                  (result.t.length < BIG_FILE || fromTaskQueue)) {
+                  // Garf, Let's downgrade this file to the blobstore!
+                  // This is used for debugging -- so we can retry upgrading by
+                  // first downgrading!
+                  // Note: uploadRawFile will do the work!
+                  try {
+                    uploadRawFile(projectId, fileName, userId, true /* force */,
+                      result.t);
+                  } catch (BlocksTruncatedException e) {
+                    /* will never happen because force is true */
+                  }
+                }
+
+                break;          // We got the data, break out of the loop!
+              } finally {
+                readChannel.close();
+              }
+            } catch (NullPointerException e) {
+              // This happens if the object in GCS is non-existent, which would happen
+              // when people uploaded a zero length object. As of this change, we now
+              // store zero length objects into GCS, but there are plenty of older objects
+              // that are missing in GCS.
+              LOG.log(Level.WARNING, "downloadrawfile: NPF recorded for " + fileData.gcsName);
+              npfHappened = true;
+              resultBuffer = ByteBuffer.allocate(0);
+              result.t = resultBuffer.array();
+            }
+          }
+
+          // report out on how things went above
+          if (npfHappened) {    // We lost at least once
+            if (recovered) {
+              LOG.log(Level.WARNING, "recovered from NPF in downloadrawfile filename = " + fileData.gcsName +
+                " count = " + count);
+            } else {
+              LOG.log(Level.WARNING, "FATAL NPF in downloadrawfile filename = " + fileData.gcsName);
+            }
+          }
+
+        } catch (IOException e) {
+          throw CrashReport.createAndLogError(LOG, null,
+              collectProjectErrorInfo(userId, projectId, fileName), e);
+        }
+      } else if (fileData.isBlob) {
+        try {
+          result.t = getBlobstoreBytes(fileData.blobstorePath);
+          if (conversionEnabled && useGcs &&
+            ((result.t.length < BIG_FILE) || fromTaskQueue)) {
+            // Upgrade the file to use GCS
+            // Note: uploadRawFile does the work for us!
+            try {
+              uploadRawFile(projectId, fileName, userId, true /* force */,
+                result.t);
+            } catch (BlocksTruncatedException e) {
+              /* will never happen because force is true */
+            }
+          }
+        } catch (BlobReadException e) {
+          throw CrashReport.createAndLogError(LOG, null,
+              collectProjectErrorInfo(userId, projectId, fileName), e);
+        }
       } else {
-        throw CrashReport.createAndLogError(LOG, null,
+        if (fileData.content == null) {
+          result.t = new byte[0];
+        } else {
+          result.t = fileData.content;
+        }
+      }
+    } else {
+      throw CrashReport.createAndLogError(LOG, null,
           collectProjectErrorInfo(userId, projectId, fileName),
           new FileNotFoundException("No data for " + fileName));
-      }
-    } finally {
-      memcache.put(fileKey.getString(), fd.t);
-      if (needsUnlock)
-        unlockFileDataMemcache(fileKey.getString());
     }
     return result.t;
   }
@@ -2296,70 +2300,6 @@ public class ObjectifyStorageIo implements  StorageIo {
 
   }
 
-  // Convert a file from the BlobStore to GCS
-  public void upgradeFile(String stringFileKey) throws UpgradeFailedException {
-    if (!useGcs)
-      throw new UpgradeFailedException("GCS Unavailable");
-    final Key<FileData> fileKey = new Key(KeyFactory.stringToKey(stringFileKey));
-    final List<String> blobsToDelete = new ArrayList<String>();
-    boolean needsUnlock = true;
-    try {
-      try {
-        fetchFileDatafromMemcache(fileKey.getString()); // Ignore return -- want fetch from datastore
-                                                        // to ensure a transaction
-      } catch (LockFailedException e) {
-        needsUnlock = false;    // Didn't get lock, don't unlock!
-        throw new UpgradeFailedException("lock contention");
-      }
-      runJobWithRetries(new JobRetryHelper() {
-          @Override
-          public void run(Objectify datastore) throws ObjectifyException {
-            FileData fileData = datastore.find(fileKey);
-            memcache.delete(fileKey.getString()); // Make sure it isn't laying around in the cache!
-            if (fileData == null) {   // Maybe it was deleted...
-              return;
-            }
-            if (!fileData.isBlob) {   // Maybe someone beat us to it...
-              return;
-            }
-            byte [] fileContent;
-            try {
-              fileContent = getBlobstoreBytes(fileData.blobstorePath);
-            } catch (BlobReadException e) {
-              LOG.log(Level.WARNING, "BlobReadException during upgrade", e);
-              throw new ObjectifyException("BlobReadException: " + e.toString());
-            }
-            String oldBlobstorePath = fileData.blobstorePath;
-            fileData.blobstorePath = null;
-            fileData.isBlob = false;
-            fileData.isGCS = true;
-            fileData.gcsName = makeGCSfileName(fileData.fileName, fileData.projectKey.getId());
-            try {
-              GcsOutputChannel outputChannel =
-                gcsService.createOrReplace(new GcsFilename(GCS_BUCKET_NAME, fileData.gcsName),
-                  GcsFileOptions.getDefaultInstance());
-              outputChannel.write(ByteBuffer.wrap(fileContent));
-              outputChannel.close();
-            } catch (IOException e) {
-              LOG.log(Level.SEVERE, "Cannot store to GCS during upgrade", e);
-              throw new ObjectifyException("GCS Exception: " + e.toString());
-              // NOTE: This operation will be retried
-            }
-            datastore.put(fileData);
-            blobsToDelete.add(oldBlobstorePath);
-          }
-        }, true);
-    } catch (ObjectifyException e) {
-      throw CrashReport.createAndLogError(LOG, null, null, e);
-    } finally {
-      if (needsUnlock)
-        unlockFileDataMemcache(fileKey.getString());
-      for (String blobToDelete: blobsToDelete) { // There really should only be one...
-        deleteBlobstoreFile(blobToDelete);
-      }
-    }
-  }
-
   // Create a name for a blob from a project id and file name. This is mostly
   // to help with debugging and viewing the blobstore via the admin console.
   // We don't currently use these blob names anywhere else.
@@ -2540,11 +2480,12 @@ public class ObjectifyStorageIo implements  StorageIo {
   // See if this person needs to have their projects upgraded and if so
   // add a task to the task queue to take care of it
   public void checkUpgrade(String userId) {
-    if (!useGcs)                // No GCS, nothing to do
+    if (!conversionEnabled)     // Unless conversion is enabled...
       return;
     Objectify datastore = ObjectifyService.begin();
     UserData userData = datastore.find(userKey(userId));
-    if (userData.upgradedGCS)
+    if ((userData.upgradedGCS && useGcs) ||
+      (!userData.upgradedGCS && !useGcs))
       return;                   // All done.
     Queue queue = QueueFactory.getQueue("blobupgrade");
     queue.add(TaskOptions.Builder.withUrl("/convert").param("user", userId));
@@ -2552,24 +2493,24 @@ public class ObjectifyStorageIo implements  StorageIo {
   }
 
   public void doUpgrade(String userId) {
-    if (!useGcs)                // No GCS, nothing to do
+    if (!conversionEnabled)     // Unless conversion is enabled...
       return;                   // shouldn't really ever happen but...
     Objectify datastore = ObjectifyService.begin();
     UserData userData = datastore.find(userKey(userId));
-    if (userData.upgradedGCS)
+    if ((userData.upgradedGCS && useGcs) ||
+      (!userData.upgradedGCS && !useGcs))
       return;                   // All done, another task did it!
     List<Long> projectIds = getProjects(userId);
     boolean anyFailed = false;
     for (long projectId : projectIds) {
       for (FileData fd : datastore.query(FileData.class).ancestor(projectKey(projectId))) {
         if (fd.isBlob) {
-          Key<FileData> fileKey = projectFileKey(projectKey(projectId), fd.fileName);
-          try {
-            upgradeFile(fileKey.getString());
-          } catch (UpgradeFailedException e) {
-            anyFailed = true;
-            LOG.log(Level.WARNING, "Upgrade Failed for projectId = " +
-              projectId + " fileName = " + fd.fileName, e);
+          if (useGcs) {         // Let's convert by just reading it!
+            downloadRawFileInternal(userId, projectId, fd.fileName, true /* fromTaskQueue */);
+          }
+        } else if (fd.isGCS) {
+          if (!useGcs) {        // Let's downgrade by just reading it!
+            downloadRawFileInternal(userId, projectId, fd.fileName, true /* fromTaskQueue */);
           }
         }
       }
@@ -2577,59 +2518,10 @@ public class ObjectifyStorageIo implements  StorageIo {
     if (!anyFailed) {
       datastore = ObjectifyService.beginTransaction();
       userData = datastore.find(userKey(userId));
-      userData.upgradedGCS = true;
+      userData.upgradedGCS = useGcs;
       datastore.put(userData);
       datastore.getTxn().commit();
     }
-  }
-
-  // Fetch FileData from memcache. We do this using some interesting locking.
-  // When we are upgrading projects from Blobstore to GCS, there is a race going
-  // on because at the same time the user is loading their initial project.
-  // The conversion process will update the FileData of any file that was previously
-  // stored in the Blobstore. But the project load may use a cached version that
-  // doesn't reflect the update. So we have to implement a mutex lock on the
-  // FileData stored in cache while it is being actively referenced and/or updated
-  // by the upgrader code.
-  private FileData fetchFileDatafromMemcache(String cacheKey) throws LockFailedException {
-    // Make a lock object by appending '-lock' to the cacheKey
-    String lockKey = cacheKey + "-lock";
-    int count = 0;
-    boolean warned = false;
-    Long LL;
-    while (!memcache.put(lockKey, true, Expiration.byDeltaMillis(5000), SetPolicy.ADD_ONLY_IF_NOT_PRESENT)) {
-      if (!warned) {
-        warned = true;
-        LOG.log(Level.INFO, "fetchFileDatafromMemcache: lock contention lockKey = " + lockKey);
-      }
-      // We didn't get the lock
-      try {
-        Thread.sleep(10);         // Sleep 10 milliseconds and try again
-      } catch (InterruptedException e) {
-        // Nothing really to do here
-      }
-      count += 1;
-      if (count > 2) {          // Hmmm. Maybe memcache service is down, check on it
-        CapabilitiesService caps = CapabilitiesServiceFactory.getCapabilitiesService();
-        CapabilityState cstat = caps.getStatus(Capability.MEMCACHE);
-        CapabilityStatus cstatus = cstat.getStatus();
-        if (cstatus != CapabilityStatus.ENABLED)
-          throw new LockFailedException("Memcache Service Down, cannot lock");
-      }
-      if (count > 100) {        // Likely something is wrong
-        LOG.log(Level.WARNING, "fetchFileDatafromMemcache timeout! lockKey = " + lockKey);
-        throw new LockFailedException("Failed to lock: " + lockKey);
-      }
-    }
-    LOG.log(Level.INFO, "fetchFileDatafromMemcache: Got Lock! lockKey = " + lockKey);
-    // Should have the lock now.
-    return (FileData) memcache.get(cacheKey);
-  }
-
-  private void unlockFileDataMemcache(String cacheKey) {
-    String lockKey = cacheKey + "-lock";
-    LOG.log(Level.INFO, "unlockFileDataMemcache: Unlocking " + lockKey);
-    memcache.delete(lockKey);
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -576,6 +576,6 @@ public interface StorageIo {
   // if so, add task to task queue
   void checkUpgrade(String userId);
 
-  // Called by the task queue to actually upgrade a project
+  // Called by the task queue to actually upgrade user's projects
   void doUpgrade(String userId);
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -572,4 +572,10 @@ public interface StorageIo {
   // Cleanup expired nonces
   void cleanupNonces();
 
+  // Check to see if user needs projects upgraded (moved to GCS)
+  // if so, add task to task queue
+  void checkUpgrade(String userId);
+
+  // Called by the task queue to actually upgrade a project
+  void doUpgrade(String userId);
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
@@ -58,7 +58,7 @@ public class StoredData {
 
     // Path to template project passed as GET parameter
     String templatePath;
-
+    boolean upgradedGCS;
   }
 
   // Project properties

--- a/appinventor/appengine/war/WEB-INF/queue.xml
+++ b/appinventor/appengine/war/WEB-INF/queue.xml
@@ -1,0 +1,8 @@
+<queue-entries>
+  <queue>
+    <name>blobupgrade</name>
+    <rate>5/s</rate>
+    <bucket-size>5</bucket-size>
+    <max-concurrent-requests>3</max-concurrent-requests>
+  </queue>
+</queue-entries>

--- a/appinventor/appengine/war/WEB-INF/web.xml
+++ b/appinventor/appengine/war/WEB-INF/web.xml
@@ -62,6 +62,7 @@
   <security-constraint>
     <web-resource-collection>
       <url-pattern>/appstats/*</url-pattern>
+      <url-pattern>/convert/</url-pattern>
     </web-resource-collection>
     <auth-constraint>
       <role-name>admin</role-name>
@@ -69,6 +70,18 @@
   </security-constraint>
 
   <!-- Servlets -->
+
+  <!-- Blob Conversion Servlet -->
+
+  <servlet>
+    <display-name>Blob Conversion Servlet</display-name>
+    <servlet-name>BlobUpgradeServlet</servlet-name>
+    <servlet-class>com.google.appinventor.server.BlobUpgradeServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>BlobUpgradeServlet</servlet-name>
+    <url-pattern>/convert</url-pattern>
+  </servlet-mapping>
 
   <!-- Remote API -->
   <servlet>


### PR DESCRIPTION
When GCS is enabled, when a user logs in, go over all of their
projects and move any files in the blobstore to GCS. Use a task queue
to avoid the 60 second deadline limit.

Change-Id: I4e7bd56980ea3e957f235eb89d0f453753d4c5cd