### PR TITLE
Gracefully handle half created projects

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
@@ -241,7 +241,13 @@ public class ProjectServiceImpl extends OdeRemoteServiceServlet implements Proje
     List<Long> projectIds = storageIo.getProjects(userId);
     List<UserProject> projectInfos = Lists.newArrayListWithExpectedSize(projectIds.size());
     for (Long projectId : projectIds) {
-      projectInfos.add(makeUserProject(userId, projectId));
+      UserProject up = makeUserProject(userId, projectId);
+      if (up != null) {
+        projectInfos.add(up);
+      } else {
+        LOG.log(Level.WARNING, "ProjectId " + projectId +
+          " is missing at the lower level.");
+      }
     }
     return projectInfos;
   }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -875,7 +875,7 @@ public class ObjectifyStorageIo implements  StorageIo {
       throw CrashReport.createAndLogError(LOG, null,
           collectUserProjectErrorInfo(userId, projectId), e);
     }
-    if (projectData == null) {
+    if (projectData.t == null) {
       return null;
     } else {
       return new UserProject(projectId, projectData.t.name,


### PR DESCRIPTION
Ignore half created projects when building the project list at
login. Before this change a half created (or half deleted project)
would result in an NPF which would prevent the user from logging in.

Change-Id: Iafdc0c6ec1a3cf4a31c9a534455116f9d268be74