### PR TITLE
Update Splash Screen Management

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -70,6 +70,7 @@ import com.google.appinventor.shared.rpc.project.GalleryService;
 import com.google.appinventor.shared.rpc.project.GalleryServiceAsync;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidSourceNode;
 import com.google.appinventor.shared.rpc.user.Config;
+import com.google.appinventor.shared.rpc.user.SplashConfig;
 import com.google.appinventor.shared.rpc.user.User;
 import com.google.appinventor.shared.rpc.user.UserInfoService;
 import com.google.appinventor.shared.rpc.user.UserInfoServiceAsync;
@@ -95,6 +96,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.rpc.StatusCodeException;
 import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.DeckPanel;
 import com.google.gwt.user.client.ui.DialogBox;
@@ -246,6 +248,8 @@ public class Ode implements EntryPoint {
   private boolean windowClosing;
 
   private boolean screensLocked;
+
+  private SplashConfig splashConfig; // Splash Screen Configuration
 
   /**
    * Returns global instance of Ode.
@@ -637,6 +641,8 @@ public class Ode implements EntryPoint {
           ErrorReporter.reportError(MESSAGES.serverUnavailable());
           return;
         }
+
+        splashConfig = result.getSplashConfig();
 
         if (result.getRendezvousServer() != null) {
           setRendezvousServer(result.getRendezvousServer());
@@ -1361,49 +1367,90 @@ public class Ode implements EntryPoint {
    * that informs the user how to start learning about using App Inventor
    * or create a new project.
    * @param showDialog Convenience variable to show the created DialogBox.
-   * @return The created and optionally displayed Dialog box.
    */
-  public DialogBox createWelcomeDialog(boolean showDialog) {
+  private void createWelcomeDialog(boolean showDialog) {
+    if (!shouldShowWelcomeDialog()) {
+      openProjectsTab();
+      return;
+    }
     // Create the UI elements of the DialogBox
     final DialogBox dialogBox = new DialogBox(false, true); // DialogBox(autohide, modal)
     dialogBox.setStylePrimaryName("ode-DialogBox");
     dialogBox.setText(MESSAGES.createWelcomeDialogText());
-    dialogBox.setHeight("400px");
-    dialogBox.setWidth("400px");
+    dialogBox.setHeight(splashConfig.height + "px");
+    dialogBox.setWidth(splashConfig.width + "px");
     dialogBox.setGlassEnabled(true);
     dialogBox.setAnimationEnabled(true);
     dialogBox.center();
     VerticalPanel DialogBoxContents = new VerticalPanel();
-    HTML message = new HTML(MESSAGES.createWelcomeDialogMessage());
+    HTML message = new HTML(splashConfig.content);
     message.setStyleName("DialogBox-message");
-    SimplePanel holder = new SimplePanel();
+    FlowPanel holder = new FlowPanel();
     Button ok = new Button(MESSAGES.createWelcomeDialogButton());
+    final CheckBox noshow = new CheckBox(MESSAGES.doNotShow());
     ok.addClickListener(new ClickListener() {
         public void onClick(Widget sender) {
           dialogBox.hide();
-          getProjectService().getProjects(new AsyncCallback<long[]>() {
-              @Override
-              public void onSuccess(long [] projectIds) {
-                if (projectIds.length == 0 && !templateLoadingFlag) {
-                  createNoProjectsDialog(true);
-                }
-              }
-
-              @Override
-              public void onFailure(Throwable projectIds) {
-                OdeLog.elog("Could not get project list");
-              }
-            });
+          if (noshow.getValue()) { // User checked the box
+            userSettings.getSettings(SettingsConstants.SPLASH_SETTINGS).
+              changePropertyValue(SettingsConstants.SPLASH_SETTINGS_VERSION,
+                "" + splashConfig.version);
+            userSettings.saveSettings(null);
+          }
+          openProjectsTab();
         }
       });
     holder.add(ok);
+    holder.add(noshow);
     DialogBoxContents.add(message);
     DialogBoxContents.add(holder);
     dialogBox.setWidget(DialogBoxContents);
     if (showDialog) {
       dialogBox.show();
     }
-    return dialogBox;
+  }
+
+  /**
+   * Load and open the projects tab.
+   */
+  private void openProjectsTab() {
+    getProjectService().getProjects(new AsyncCallback<long[]>() {
+        @Override
+          public void onSuccess(long [] projectIds) {
+          if (projectIds.length == 0 && !templateLoadingFlag) {
+            createNoProjectsDialog(true);
+          }
+        }
+
+        @Override
+          public void onFailure(Throwable projectIds) {
+          OdeLog.elog("Could not get project list");
+        }
+      });
+  }
+
+  /*
+   * Check the user's setting to get the version of the Splash
+   * Screen that they have seen. If they have seen this version (or greater)
+   * then return false so they do not see it again. Return true to show it
+   */
+  private boolean shouldShowWelcomeDialog() {
+    if (splashConfig.version == 0) {   // Never show splash if version is 0
+      return false;             // Check first to avoid others unnecessary calls
+    }
+    String value = userSettings.getSettings(SettingsConstants.SPLASH_SETTINGS).
+      getPropertyValue(SettingsConstants.SPLASH_SETTINGS_VERSION);
+    int uversion;
+    if (value == null) {        // Nothing stored
+      uversion = 0;
+    } else {
+      uversion = Integer.parseInt(value);
+    }
+    if (uversion >= splashConfig.version) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   /**
@@ -1475,19 +1522,7 @@ public class Ode implements EntryPoint {
     if (AppInventorFeatures.showSplashScreen()) {
       createWelcomeDialog(true);
     } else {
-      getProjectService().getProjects(new AsyncCallback<long[]>() {
-          @Override
-            public void onSuccess(long [] projectIds) {
-            if (projectIds.length == 0 && !templateLoadingFlag) {
-              createNoProjectsDialog(true);
-            }
-          }
-
-          @Override
-            public void onFailure(Throwable projectIds) {
-            OdeLog.elog("Could not get project list");
-          }
-        });
+      openProjectsTab();
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5202,6 +5202,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String createWelcomeDialogButton();
 
+  @DefaultMessage("Do Not Show Again")
+  @Description("")
+  String doNotShow();
+
   @DefaultMessage("<h2>Please fill out a short voluntary survey so that we can learn more about our users and improve MIT App Inventor.</h2>")
   @Description("")
   String showSurveySplashMessage();

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/user/SplashSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/user/SplashSettings.java
@@ -29,6 +29,8 @@ public final class SplashSettings extends Settings {
         "0", EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this, SettingsConstants.SPLASH_SETTINGS_DECLINED,
         "", EditableProperty.TYPE_INVISIBLE));
+    addProperty(new EditableProperty(this, SettingsConstants.SPLASH_SETTINGS_VERSION,
+        "0", EditableProperty.TYPE_INVISIBLE));
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -43,6 +43,10 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
       config.setRendezvousServer(rendezvousFlag.get());
     }
     config.setUser(user);
+
+    // Fetch the current splash screen version
+    config.setSplashConfig(storageIo.getSplashConfig());
+
     // Check to see if we need to upgrade this user's project to GCS
     storageIo.checkUpgrade(userInfoProvider.getUserId());
     return config;

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -34,6 +34,7 @@ import com.google.appinventor.server.storage.StoredData.FileData;
 import com.google.appinventor.server.storage.StoredData.MotdData;
 import com.google.appinventor.server.storage.StoredData.NonceData;
 import com.google.appinventor.server.storage.StoredData.ProjectData;
+import com.google.appinventor.server.storage.StoredData.SplashData;
 import com.google.appinventor.server.storage.StoredData.UserData;
 import com.google.appinventor.server.storage.StoredData.UserFileData;
 import com.google.appinventor.server.storage.StoredData.UserProjectData;
@@ -48,6 +49,7 @@ import com.google.appinventor.shared.rpc.project.RawFile;
 import com.google.appinventor.shared.rpc.project.TextFile;
 import com.google.appinventor.shared.rpc.project.UserProject;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+import com.google.appinventor.shared.rpc.user.SplashConfig;
 import com.google.appinventor.shared.rpc.user.User;
 import com.google.appinventor.shared.storage.StorageUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -106,6 +108,7 @@ public class ObjectifyStorageIo implements  StorageIo {
   private static final String DEFAULT_ENCODING = "UTF-8";
 
   private static final long MOTD_ID = 1;
+  private static final long SPLASHDATA_ID = 1;
 
   // TODO(user): need a way to modify this. Also, what is really a good value?
   private static final int MAX_JOB_RETRIES = 10;
@@ -175,6 +178,7 @@ public class ObjectifyStorageIo implements  StorageIo {
     ObjectifyService.register(FeedbackData.class);
     ObjectifyService.register(NonceData.class);
     ObjectifyService.register(CorruptionRecord.class);
+    ObjectifyService.register(SplashData.class);
 
     // Learn GCS Bucket from App Configuration or App Engine Default
     String gcsBucket = Flag.createFlag("gcs.bucket", "").get();
@@ -2537,6 +2541,34 @@ public class ObjectifyStorageIo implements  StorageIo {
     userData.upgradedGCS = useGcs;
     datastore.put(userData);
     datastore.getTxn().commit();
+  }
+
+  public SplashConfig getSplashConfig() {
+    final Result<SplashConfig> result = new Result<SplashConfig>();
+    try {
+      runJobWithRetries(new JobRetryHelper() {
+          @Override
+          public void run(Objectify datastore) {
+            // Fixed key because only one record
+            SplashData sd = datastore.find(SplashData.class, SPLASHDATA_ID);
+            if (sd == null) {   // If we don't have Splash Data, create it
+              SplashData firstSd = new SplashData(); // We do this so cacheing works
+              firstSd.id = SPLASHDATA_ID;
+              firstSd.version = 0;                   // on future calls
+              firstSd.content = "<b>Welcome to MIT App Inventor</b>";
+              firstSd.width = 350;
+              firstSd.height = 100;
+              datastore.put(firstSd);
+              result.t = new SplashConfig(0, firstSd.width, firstSd.height, firstSd.content);
+            } else {
+              result.t = new SplashConfig(sd.version, sd.width, sd.height, sd.content);
+            }
+          }
+        }, false);             // No transaction, Objectify will cache
+    } catch (ObjectifyException e) {
+      throw CrashReport.createAndLogError(LOG, null, null, e);
+    }
+    return result.t;
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -13,6 +13,7 @@ import com.google.appinventor.shared.rpc.project.Project;
 import com.google.appinventor.shared.rpc.project.ProjectSourceZip;
 import com.google.appinventor.shared.rpc.project.UserProject;
 import com.google.appinventor.shared.rpc.user.User;
+import com.google.appinventor.shared.rpc.user.SplashConfig;
 
 import java.io.IOException;
 import java.util.Date;
@@ -578,4 +579,7 @@ public interface StorageIo {
 
   // Called by the task queue to actually upgrade user's projects
   void doUpgrade(String userId);
+
+  // Retrieve the current Splash Screen Version
+  SplashConfig getSplashConfig();
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
@@ -259,6 +259,7 @@ public class StoredData {
     public String message;
   }
 
+  @Cached(expirationSeconds=60)
   @Unindexed
   static final class SplashData {
     @Id Long id;

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
@@ -258,4 +258,14 @@ public class StoredData {
     public String fileId;
     public String message;
   }
+
+  @Unindexed
+  static final class SplashData {
+    @Id Long id;
+    public int version;
+    public String content;
+    public int height;
+    public int width;
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
@@ -19,6 +19,8 @@ public class Config implements IsSerializable, Serializable {
 
   private String rendezvousServer = null;
 
+  private SplashConfig splashConfig;
+
   public Config() {
   }
 
@@ -36,6 +38,14 @@ public class Config implements IsSerializable, Serializable {
 
   public void setRendezvousServer(String value) {
     this.rendezvousServer = value;
+  }
+
+  public SplashConfig getSplashConfig() {
+    return this.splashConfig;
+  }
+
+  public void setSplashConfig(SplashConfig config) {
+    this.splashConfig = config;
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/SplashConfig.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/SplashConfig.java
@@ -1,0 +1,34 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2009-2011 Google, All Rights reserved
+// Copyright 2011-2012 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.shared.rpc.user;
+
+import com.google.gwt.user.client.rpc.IsSerializable;
+import java.io.Serializable;
+
+/**
+ * Data Transfer Object representing user data.
+ *
+ */
+public class SplashConfig implements IsSerializable, Serializable {
+  // Unique identifier for the user
+
+    // Needed to make the GWT Compiler happy
+    protected SplashConfig() {
+    }
+
+    public SplashConfig(int version, int width, int height, String content) {
+      this.version = version;
+      this.width = width;
+      this.height = height;
+      this.content = content;
+    }
+
+    public int version;
+    public int height;
+    public int width;
+    public String content;
+}

--- a/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
@@ -25,6 +25,8 @@ public class SettingsConstants {
 
   public static final String SPLASH_SETTINGS_SHOWSURVEY = "ShowSurvey";
   public static final String SPLASH_SETTINGS_DECLINED = "DeclinedSurvey";
+  public static final String SPLASH_SETTINGS_VERSION = "SplashVersion";
+
   /**
    *  YoungAndroid settings.
    */

--- a/appinventor/common/src/com/google/appinventor/common/version/AppInventorFeatures.java
+++ b/appinventor/common/src/com/google/appinventor/common/version/AppInventorFeatures.java
@@ -49,15 +49,30 @@ public final class AppInventorFeatures {
   }
 
   /**
-   * If set to return true, a splash screen will be shown on every login. The
-   * Contents are defined in {@link com.google.appinventor.client.Ode#createWelcomeDialog}
-   * You should set the "message" variable there to an iframe that points to your
-   * content. The default size of the splash box is 400x400 (which you can change).
+   * If set to return true we may show a splash screen. Each splash
+   * screen has a version stored in the datastore in the SplashData
+   * kind. If it doesn't exist, it is initialized to 0. If 0, no
+   * splash screen is shown. If it is non-zero it is compared to the
+   * users's SplashSettings value. If the users's is less then the
+   * current SplashData.version, they are shown the splash screen.
+   * Along with the splash screen a "Continue" button is displayed
+   * along with a checkbox labeled "Do Not Show Again".  If they check
+   * this box then their SplashSettings value is set to the current
+   * version and they do not see that splash screen again. We provide
+   * a python script for the System Admin to use to set or "bump" the
+   * system splash screen version. Presumably you use this when you
+   * update the splash screen and want to show the new version to
+   * people, including people who had previously checked the "Do Not
+   * Show Again" box.
    *
-   * @return true to display a splash screen
+   * Because a system splash version of 0 means "Do not ever show the
+   * splash screen" we can leave this feature on. Sites that do not
+   * wish to show a splash screen just leave it set to zero.
+   *
+   * @return true to (maybe) show a splash screen.
    */
   public static boolean showSplashScreen() {
-    return false;
+    return true;
   }
 
   /**

--- a/appinventor/misc/splashscreen/splashmanager.py
+++ b/appinventor/misc/splashscreen/splashmanager.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+#
+# Simple tool for managing the Splash Screen in MIT App Inventor using
+# the Remote API Service
+#
+# @author Jeffrey I. Schiller <jis@mit.edu>
+
+import os
+import sys
+import getpass
+from getopt import getopt, GetoptError
+
+os.environ['SERVER_SOFTWARE'] = 'MIT SplashScreen Manager 1.0' # Googlism
+
+
+def auth_func():
+  return (raw_input('Email: '), getpass.getpass('Password: '))
+
+def main():
+    getlibdir()
+    from google.appengine.ext import db
+    from google.appengine.ext.remote_api import remote_api_stub
+    from google.appengine.tools import appengine_rpc
+
+    class SplashData(db.Model):
+        version = db.IntegerProperty()
+        content = db.TextProperty()
+        width = db.IntegerProperty()
+        height = db.IntegerProperty()
+
+    filename = None
+    host = 'localhost'
+    getversion = False
+    bumpversion = False
+    setversion = None
+    width = None
+    height = None
+    try:
+        opts = getopt(sys.argv[1:], 'sbgf:w:h:H:', ['set','bump','getversion','file=','width=','height=','host='])
+    except GetoptError:
+        sys.stderr.write('Usage: splashmanager.py [-f splashfile -w width -h height] [-H host] \n')
+        sys.exit(1)
+    for opt in opts[0]:
+        if opt == []:
+            continue
+        if len(opt) < 2:
+            sys.stderr.write('Usage: splashmanager.py [-f splashfile -w width -h height] [-H host] \n')
+            sys.exit(1)
+        if opt[0] in ('--file', '-f'):
+            filename = opt[1]
+            whitelistname = opt[1]
+        elif opt[0] in ('-H','--host'):
+            host = opt[1]
+        elif opt[0] in ('-g','--getversion'):
+            getversion = True
+        elif opt[0] in ('--bump','-b'):
+            bumpversion = True
+        elif opt[0] in ('-w','--width'):
+            width = opt[1]
+        elif opt[0] in ('-h','--host'):
+            height = opt[1]
+        elif opt[0] in ('-s','--set'):
+            setversion = opt[1]
+
+    if setversion and bumpversion:
+        sys.stderr.write('Error: -s and -b are incompatible, use one or the other.\n')
+        sys.stderr.write('Usage: splashmanager.py [-f splashfile -w width -h height] [-H host] \n')
+        sys.exit(1)
+
+    print 'Connecting to %s' % host
+    if host == 'localhost':
+        host = host + ':8888'
+        secure = False
+    else:
+        secure = True
+
+    remote_api_stub.ConfigureRemoteApi(None, '/remote_api', auth_func,
+                                       servername=host,
+                                       save_cookies=True, secure=secure,
+                                       rpc_server_factory=appengine_rpc.HttpRpcServer)
+    remote_api_stub.MaybeInvokeAuthentication()
+
+    update = False
+    sd = SplashData.all().fetch(1)[0]
+    if getversion:
+        print 'Splash Version: %d' % sd.version
+    if setversion:
+        sd.version = setversion
+        update = True
+    if filename:
+        if width == None or height == None:
+            sys.stderr.write('Must specify width and height while you provide a file.\n')
+            sys.exit(1)
+        data = open(filename).read()
+        sd.content = data
+        sd.width = int(width)
+        sd.height = int(height)
+        update = True
+    if bumpversion:
+        sd.version = sd.version + 1
+        update = True
+    if update:
+        sd.put()
+
+def getlibdir():
+    '''Find the googl_appengine library directory'''
+    from os.path import expanduser
+    import ConfigParser
+    doupdate = False
+    config = ConfigParser.RawConfigParser()
+    configfile = expanduser('~/.appinv_splashmanager')
+    config.read(configfile)
+    libdir = '/usr/local/google_appengine' # Default
+    if config.has_section('splashmanager'):
+        try:
+            libdir = config.get('splashmanager', 'googlelibdir')
+        except ConfigParser.NoOptionError:
+            config.set('splashmanager', 'googlelibdir', libdir)
+            doupdate = True
+    else:
+        config.add_section('splashmanager')
+        doupdate = True
+    if doupdate:
+        f = open(configfile, 'w')
+        config.write(f)
+        f.close()
+    sys.path.insert(0, libdir)
+    sys.path.insert(1, libdir + '/lib/fancy_urllib')
+    try:
+        from google.appengine.ext import db
+    except ImportError:
+        newpath = raw_input('Google Python App Engine SDK Path [%s]: ' % libdir)
+        if newpath == '':
+            newpath = libdir
+        libdir = newpath
+        config.set('splashmanager', 'googlelibdir', libdir)
+        f = open(configfile, 'w')
+        config.write(f)
+        f.close()
+        print 'Location of Google Library Directory Saved, exiting, try again...'
+        sys.exit(0)
+
+# The stuff below is to permit the prompt for the library dir to
+# use filename completion....
+
+class Completer(object):
+
+    def _listdir(self, root):
+        "List directory 'root' appending the path separator to subdirs."
+        res = []
+        for name in os.listdir(root):
+            path = os.path.join(root, name)
+            if os.path.isdir(path):
+                name += os.sep
+            res.append(name)
+        return res
+
+    def _complete_path(self, path=None):
+        "Perform completion of filesystem path."
+        if not path:
+            return self._listdir('.')
+        dirname, rest = os.path.split(path)
+        tmp = dirname if dirname else '.'
+        res = [os.path.join(dirname, p)
+                for p in self._listdir(tmp) if p.startswith(rest)]
+        # more than one match, or single match which does not exist (typo)
+        if len(res) > 1 or not os.path.exists(path):
+            return res
+        # resolved to a single directory, so return list of files below it
+        if os.path.isdir(path):
+            return [os.path.join(path, p) for p in self._listdir(path)]
+        # exact file match terminates this completion
+        return [path + ' ']
+
+    def complete_filename(self, args):
+        "Completions for the 'extra' command."
+        if not args:
+            return self._complete_path('.')
+        # treat the last arg as a path and complete it
+        return self._complete_path(args[-1])
+
+    def complete(self, text, state):
+        "Generic readline completion entry point."
+        buffer = readline.get_line_buffer()
+        line = buffer.split()
+        return (self.complete_filename(line) + [None])[state]
+
+comp = Completer()
+
+try:
+    import readline
+except ImportError:
+    print "Module readline not available."
+else:
+    import rlcompleter
+    readline.set_completer_delims(' \t\n;')
+    readline.parse_and_bind("tab: complete")
+    readline.set_completer(comp.complete)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Move the configuration of the Splash Screen into the Data Store. The
contents and size of the splash screen is fetched from the datastore
at runtime. The content can either be local, or a reference to an
iframe on another site.

Add an internal version number to the splash screen.  Provide a "Do
Not Show Again" Checkbox so that end-users can dismiss the splash
screen until the version is incremented.

Provide a python script "splashmanager.py" (in
appinventor/misc/splashscreen) to permit site administrators to update
the splash configuration. It requires the App Engine python SDK to be
installed.

Change-Id: I8b162fac35a1b3f2d0d78f1be6069f2d46c0f717