### PR TITLE
Add ability to disable an account

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1812,6 +1812,33 @@ public class Ode implements EntryPoint {
   }
 
   /**
+   * This dialog is showned if an account is disabled. It is
+   * completely modal with no escape. The provided URL is displayed in
+   * an iframe, so it can be tailored to each person whose account is
+   * disabled.
+   *
+   * @param Url the Url to display in the dialog box.
+   */
+
+  public void disabledAccountDialog(String Url) {
+    // Create the UI elements of the DialogBox
+    final DialogBox dialogBox = new DialogBox(false, true); // DialogBox(autohide, modal)
+    dialogBox.setStylePrimaryName("ode-DialogBox");
+    dialogBox.setText(MESSAGES.accountDisabledMessage());
+    dialogBox.setHeight("700px");
+    dialogBox.setWidth("700px");
+    dialogBox.setGlassEnabled(true);
+    dialogBox.setAnimationEnabled(true);
+    dialogBox.center();
+    VerticalPanel DialogBoxContents = new VerticalPanel();
+    HTML message = new HTML("<iframe src=\"" + Url + "\" style=\"border: 0; width: 680px; height: 660px;\"></iframe>");
+    message.setStyleName("DialogBox-message");
+    DialogBoxContents.add(message);
+    dialogBox.setWidget(DialogBoxContents);
+    dialogBox.show();
+  }
+
+  /**
    * Is it OK to connect a device/emulator. Returns true if so false
    * otherwise.
    *

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5281,6 +5281,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String finalDialogText();
 
+  @DefaultMessage("Your Account is Disabled")
+  @Description("")
+  String accountDisabledMessage();
+
   @DefaultMessage("<p><b>Your Session is now ended, you may close this window</b></p>")
   @Description("")
   String finalDialogMessage();

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/user/GeneralSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/user/GeneralSettings.java
@@ -29,10 +29,19 @@ public final class GeneralSettings extends Settings {
         "0", EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this, SettingsConstants.USER_TEMPLATE_URLS,"",
         EditableProperty.TYPE_INVISIBLE));
+    addProperty(new EditableProperty(this, SettingsConstants.DISABLED_USER_URL, "",
+        EditableProperty.TYPE_INVISIBLE));
   }
 
   @Override
   protected void updateAfterDecoding() {
-    Ode.getInstance().openPreviousProject();
+    String disabledUrl = getPropertyValue(SettingsConstants.DISABLED_USER_URL);
+    if (disabledUrl != null && !disabledUrl.equals("")) {
+      // Account is disabled, show dialog box and stop further processing
+      // i.e., do not open previous project.
+      Ode.getInstance().disabledAccountDialog(disabledUrl);
+    } else {
+      Ode.getInstance().openPreviousProject();
+    }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
@@ -20,6 +20,11 @@ public class SettingsConstants {
   public static final String USER_GENERAL_SETTINGS = "GeneralSettings";
   public static final String GENERAL_SETTINGS_CURRENT_PROJECT_ID = "CurrentProjectId";
   public static final String USER_TEMPLATE_URLS = "TemplateUrls";
+  // If DISABLED_USER_URL is non-empty, then it is the URL to display in a frame
+  // inside of a modal dialog, displayed at login, with no exit. This is used to
+  // disable someone's account. The URL can be user specific in order to deliver
+  // a particular message to a particular user.
+  public static final String DISABLED_USER_URL = "DisabledUserUrl";
 
   public static final String SPLASH_SETTINGS = "SplashSettings";
 


### PR DESCRIPTION
Accounts are disabled by setting a URL in their general settings. This
URL is then displayed in an iframe when they login and App Inventor is
not available to them.

Change-Id: Iebf1c268358608d29a8e000935d0b9e4458f77f3