### PR TITLE
scan newly added picture into a default media contents provider ISSUE#433

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
@@ -152,6 +152,7 @@ public class Camera extends AndroidNonvisibleComponent
     if (requestCode == this.requestCode && resultCode == Activity.RESULT_OK) {
       File image = new File(imageFile.getPath());
       if (image.length() != 0) {
+        scanFileToAdd(image);
         AfterPicture(imageFile.toString());
       } else {
         deleteFile(imageFile);  // delete empty file
@@ -172,6 +173,19 @@ public class Camera extends AndroidNonvisibleComponent
       deleteFile(imageFile);
     }
   }
+
+  /**
+   * Scan the newly added picture to be displayed in a default media content provider 
+   * in a device (e.g. Gallery, Google Photo, etc..) 
+   * 
+   * @param image the picture taken by Camera component 
+   */
+  private void scanFileToAdd(File image) {
+	    Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+	    Uri contentUri = Uri.fromFile(image);
+	    mediaScanIntent.setData(contentUri);
+	    container.$context().getApplicationContext().sendBroadcast(mediaScanIntent);
+}
 
   private void deleteFile(Uri fileUri) {
     File fileToDelete = new File(fileUri.getPath());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -175,7 +175,7 @@ public class ImagePicker extends Picker implements ActivityResultListener {
       inStream.close();
       outStream.close();
       Log.i(LOG_TAG, "Image was copied to " + selectionSavedImage);
-      // this can be uncommented to show the alert, but tha alert
+      // this can be uncommented to show the alert, but the alert
       // is pretty annoying
       // new (container.$form()).ShowAlert("Image was copied to " + selectedImage);
 


### PR DESCRIPTION
Added a method scanFileToAdd to allows a default media contents
provider(e.g. Gallery, Google Photos) to display the newly added
pictures. 

This will allow users to select pictures taken by Camera component by using ImagePicker (Issue #433).

Instance is available here: http://ai2-issue433.appspot.com/