### PR TITLE
TextToSpeech: Need a "Default" choice #447

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -18,6 +18,10 @@ import com.google.gwt.i18n.client.Messages;
 public interface OdeMessages extends Messages {
   // Used in multiple files
 
+  @DefaultMessage("Default")
+  @Description("Text for property editors")
+  String defaultText();
+
   @DefaultMessage("Cancel")
   @Description("Text on \"Cancel\" button.")
   String cancelButton();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_es_ES.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_es_ES.properties
@@ -667,6 +667,7 @@ defaultFontTypeface = por defecto
 defaultRpcMessage = Cargando…
 defaultSaveAsProjectName = {0}_copiar
 defaultScreenAnimation = Por defecto
+defaultText = Por defecto
 deleteButton = Borrar
 deleteFileCommand = Borrando…
 deleteFileError = Error del servidor: no se ha podido borrar el archivo. ¡Por favor, inténtalo de nuevo más tarde!

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_it_IT.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_it_IT.properties
@@ -679,6 +679,7 @@ defaultFontTypeface = default
 defaultRpcMessage = Caricamento...
 defaultSaveAsProjectName = {0}_copia
 defaultScreenAnimation = Default
+defaultText = Default
 deleteButton = Elimina
 deleteFileCommand = Elimina...
 deleteFileError = Errore server: impossibile eliminare il file. Prego riprovare più tardi!

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_CN.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_CN.properties
@@ -206,6 +206,7 @@ defaultFontTypeface = 默认字体
 sansSerifFontTypeface = sans serif
 serifFontTypeface = serif
 monospaceFontTypeface = monospace
+defaultText = 默认
 
 # Used in editor/youngandroid/properties/YoungAndroidLengthPropertyEditor.java
 automaticCaption = 自动

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_TW.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_TW.properties
@@ -207,6 +207,7 @@ defaultFontTypeface = 預設字體
 sansSerifFontTypeface = sans serif
 serifFontTypeface = serif
 monospaceFontTypeface = monospace
+defaultText = 預設
 
 # Used in editor/youngandroid/properties/YoungAndroidLengthPropertyEditor.java
 automaticCaption = 自動

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/CountryChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/CountryChoicePropertyEditor.java
@@ -6,7 +6,7 @@
 
 package com.google.appinventor.client.widgets.properties;
 
-import com.google.appinventor.client.widgets.properties.ChoicePropertyEditor.Choice;
+import static com.google.appinventor.client.Ode.MESSAGES;
 
 /**
  * Property editor for text-to-speech countries.
@@ -16,6 +16,7 @@ public class CountryChoicePropertyEditor extends ChoicePropertyEditor {
 
   // countries supported by AppInventor's Android 2.2 emulator
   private static final Choice[] countries = new Choice[] {
+    new Choice(MESSAGES.defaultText(), ""),
     new Choice("AUS", "AUS"),
     new Choice("AUT", "AUT"),
     new Choice("BEL", "BEL"),
@@ -53,11 +54,3 @@ public class CountryChoicePropertyEditor extends ChoicePropertyEditor {
     super(countries);
   }
 }
-
-
-
-
-
-
-
-

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/LanguageChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/LanguageChoicePropertyEditor.java
@@ -6,6 +6,8 @@
 
 package com.google.appinventor.client.widgets.properties;
 
+import static com.google.appinventor.client.Ode.MESSAGES;
+
 /**
  * Property editor for text-to-speech languages.
  *
@@ -14,6 +16,7 @@ public class LanguageChoicePropertyEditor extends ChoicePropertyEditor {
 
   // languages supported by AppInventor's Android 2.2 emulator
   private static final Choice[] languages = new Choice[] {
+    new Choice(MESSAGES.defaultText(), ""),
     new Choice("de", "de"),
     new Choice("en", "en"),
     new Choice("es", "es"),

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -532,6 +532,11 @@ public final class YoungAndroidFormUpgrader {
       // the Language designer property was changed to use a ChoicePropertyEditor
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // default value was added to the Country designer property
+      // default value was added to the Language designer property
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1934,7 +1934,11 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // the Country designer property was changed to use a ChoicePropertyEditor
     // the Language designer property was changed to use a ChoicePropertyEditor
-    4: "noUpgrade"
+    4: "noUpgrade",
+
+    // default value was added to the Country designer property
+    // default value was added to the Language designer property
+    5: "noUpgrade"
 
   }, // End TextToSpeech upgraders
 
@@ -2117,4 +2121,3 @@ Blockly.Versioning.AllUpgradeMaps =
   } // End YandexTranslate upgraders
 
 }
-

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -336,8 +336,10 @@ public class YaVersion {
   // - CLOCK_COMPONENT_VERSION was incremented to 2
   // For YOUNG_ANDROID_VERSION 130:
   // - TEXTTOSPEECH_COMPONENT_VERSION was incremented to 4
+  // For YOUNG_ANDROID_VERSION 131:
+  // - TEXTTOSPEECH_COMPONENT_VERSION was incremented to 5
 
-  public static final int YOUNG_ANDROID_VERSION = 130;
+  public static final int YOUNG_ANDROID_VERSION = 131;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -396,7 +398,7 @@ public class YaVersion {
   // The is-number block was modified to include dropdowns for base10, hex, and binary
   // The number-convert blocks was added
   public static final int BLOCKS_LANGUAGE_VERSION = 19;
-  
+
   // ................................. Component Version Numbers ..................................
 
   // NOTE(lizlooney,user) - when a new component is added:
@@ -818,7 +820,10 @@ public class YaVersion {
   // For TEXTTOSPEECH_COMPONENT_VERSION 4:
   // - the Country designer property was changed to use a ChoicePropertyEditor
   // - the Language designer property was changed to use a ChoicePropertyEditor
-  public static final int TEXTTOSPEECH_COMPONENT_VERSION = 4;
+  // For TEXTTOSPEECH_COMPONENT_VERSION 5:
+  // - default value was added to the Country designer property
+  // - default value was added to the Language designer property
+  public static final int TEXTTOSPEECH_COMPONENT_VERSION = 5;
 
   // For TIMEPICKER_COMPONENT_VERSION 2:
   // After feedback from the forum, the timepicker dialog was updated

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
@@ -137,7 +137,7 @@ public interface Component {
   public static float SLIDER_MAX_VALUE = 50;
   public static float SLIDER_THUMB_VALUE = (SLIDER_MIN_VALUE + SLIDER_MAX_VALUE) / 2.0f;
 
-  static final String DEFAULT_VALUE_TEXT_TO_SPEECH_COUNTRY = "USA";
-  static final String DEFAULT_VALUE_TEXT_TO_SPEECH_LANGUAGE = "en";
+  static final String DEFAULT_VALUE_TEXT_TO_SPEECH_COUNTRY = "";
+  static final String DEFAULT_VALUE_TEXT_TO_SPEECH_LANGUAGE = "";
 
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
@@ -122,8 +122,8 @@ implements Component, OnStopListener, OnResumeListener, OnDestroyListener /*, Ac
   public TextToSpeech(ComponentContainer container) {
     super(container.$form());
     result = false;
-    Language("en");
-    Country("USA");
+    Language(Component.DEFAULT_VALUE_TEXT_TO_SPEECH_LANGUAGE);
+    Country(Component.DEFAULT_VALUE_TEXT_TO_SPEECH_COUNTRY);
     /* Determine which TTS library to use */
     boolean useExternalLibrary = SdkLevel.getLevel() < SdkLevel.LEVEL_DONUT;
     Log.v(LOG_TAG, "Using " + (useExternalLibrary ? "external" : "internal") + " TTS library.");


### PR DESCRIPTION
see #447 

Tested on emulator of API level 19
- When the default values of Country and Language are set to an empty string, once their getters are called, the device's default values are retrieved.