### PR TITLE
TimePicker and DatePicker: Instant getter, Date and Time setter with Instant

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2493,6 +2493,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Icon")
   @Description("")
   String IconProperties();
+  
+  @DefaultMessage("Instant")
+  @Description("")
+  String InstantProperties();
 
   @DefaultMessage("IgnoreSslErrors")
   @Description("")
@@ -4297,6 +4301,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String HourMethods();
 
+//  @DefaultMessage("Instant")
+  //@Description("")
+  //String InstantMethods();
+  
   @DefaultMessage("MakeInstant")
   @Description("")
   String MakeInstantMethods();
@@ -5430,6 +5438,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String SetDateToDisplayMethods();
 
+  @DefaultMessage("SetDateToDisplayFromInstant")
+  @Description("")
+  String SetDateToDisplayFromInstantMethods();
+
   @DefaultMessage("IncomingCallAnswered")
   @Description("")
   String IncomingCallAnsweredEvents();
@@ -5461,6 +5473,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("SetTimeToDisplay")
   @Description("")
   String SetTimeToDisplayMethods();
+
+  @DefaultMessage("SetTimeToDisplayFromInstant")
+  @Description("")
+  String SetTimeToDisplayFromInstantMethods();
 
   @DefaultMessage("XMLTextDecode")
   @Description("")

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -4301,10 +4301,6 @@ public interface OdeMessages extends Messages {
   @Description("")
   String HourMethods();
 
-//  @DefaultMessage("Instant")
-  //@Description("")
-  //String InstantMethods();
-  
   @DefaultMessage("MakeInstant")
   @Description("")
   String MakeInstantMethods();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_es_ES.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_es_ES.properties
@@ -229,6 +229,7 @@ InitializeEvents = Inicializar
 InstanceIdChangedEvents = CambioEnIdDeInstancia
 InstanceIdProperties = IdDeInstancia
 InstantInTimeParams = instanteEnTiempo
+InstantProperties = instante
 IntervalProperties = Intervalo
 InviteMethods = Invitar
 InvitedEvents = Invitado

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_it_IT.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_it_IT.properties
@@ -779,6 +779,7 @@ inputNewUrlCaption = Inserisci un Url...
 installURLMethods = IndirizzoInstallazione
 instanceIdParams = IdIstanza
 instantParams = istante
+instantProperties = istante
 internalError = Si è verificato un errore interno.
 internalErrorClickOkDebuggingView = Si è verificato un errore interno. Clicca su "ok" per maggiori informazioni.
 internalErrorReportBug = Si è verificato un errore interno. Vuoi segnalare il bug?

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_CN.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_CN.properties
@@ -449,6 +449,7 @@ HintProperties = 提示
 HomeUrlProperties = 首页地址
 IconProperties = 图标
 ImageProperties = 图像
+InstantProperties = 时刻
 IntervalProperties = 间隔
 IsLoopingProperties = 循环状态
 KeyFileProperties = 密钥文件

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_TW.properties
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages_zh_TW.properties
@@ -574,6 +574,7 @@ HasAltitudeProperties = 海拔資料狀態
 HasLongitudeLatitudeProperties = 經緯度資料狀態
 HeightProperties = 高度
 InstanceIdProperties = 對象編號
+InstantProperties = 時刻
 InvitedInstancesProperties = 已邀請對象
 IsAcceptingProperties = 接收狀態
 IsConnectedProperties = 連線狀態

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -684,6 +684,11 @@ public final class YoungAndroidFormUpgrader {
       // No properties need to be modified to upgrade to version 2.
       srcCompVersion = 2;
     }
+    if (srcCompVersion < 3) {
+      // SetDateToDisplayFromInstant, and Instant property are added.
+      // No properties need to be modified to upgrade to version 3.
+      srcCompVersion = 3;
+    }
     return srcCompVersion;
   }
 
@@ -1100,6 +1105,11 @@ public final class YoungAndroidFormUpgrader {
       // The SetTimeToDisplay and LaunchPicker methods were added.
       // No properties need to be modified to upgrade to version 2.
       srcCompVersion = 2;
+    }
+    if (srcCompVersion < 3) {
+      // SetTimeToDisplayFromInstant, and Instant property are added.
+      // No properties need to be modified to upgrade to version 3.       
+      srcCompVersion = 3;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1231,7 +1231,10 @@ Blockly.Versioning.AllUpgradeMaps =
     // The SetDateToDisplay and LaunchPicker methods were added to
     // give the user more control of what time is displayed in the
     // datepicker dialog.
-    2: "noUpgrade"
+    2: "noUpgrade",
+    
+    // AI2: SetDateToDisplayFromInstant method and Instant property are added.
+    3: "noUpgrade"
 
   }, // End DatePicker upgraders
 
@@ -1945,9 +1948,12 @@ Blockly.Versioning.AllUpgradeMaps =
     // The SetTimeToDisplay and LaunchPicker methods were added to
     // give the user more control of what time is displayed in the
     // timepicker dialog.
-    2: "noUpgrade"
+    2: "noUpgrade",
+    
+    // AI2: SetTimeToDisplayFromInstant method and Instant property are added.
+    3: "noUpgrade"
 
-  }, // End TimerPicker upgraders
+  }, // End TimePicker upgraders
 
   "TinyDB": {
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -336,8 +336,11 @@ public class YaVersion {
   // - CLOCK_COMPONENT_VERSION was incremented to 2
   // For YOUNG_ANDROID_VERSION 130:
   // - TEXTTOSPEECH_COMPONENT_VERSION was incremented to 4
+  // For YOUNG_ANDROID_VERSION 131:
+  // - DATEPICKER_COMPONENT_VERSION was incremented to 3
+  // - TIMEPICKER_COMPONENT_VERSION was incremented to 3
 
-  public static final int YOUNG_ANDROID_VERSION = 130;
+  public static final int YOUNG_ANDROID_VERSION = 131;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -561,7 +564,9 @@ public class YaVersion {
   // The SetDateToDisplay and LaunchPicker methods were added to
   // give the user more control of what time is displayed in the
   // datepicker dialog.
-  public static final int DATEPICKER_COMPONENT_VERSION = 2;
+  // For DATEPICKER_COMPONENT_VERSION 3:
+  // - SetDateToDisplayFromInstant, and Instant property are added.
+  public static final int DATEPICKER_COMPONENT_VERSION = 3;
 
   // For EMAILPICKER_COMPONENT_VERSION 2:
   // - The Alignment property was renamed to TextAlignment.
@@ -826,7 +831,9 @@ public class YaVersion {
   // The SetTimeToDisplay and LaunchPicker methods were added to
   // give the user more control of what time is displayed in the
   // timepicker dialog.
-  public static final int TIMEPICKER_COMPONENT_VERSION = 2;
+  // For TIMEPICKER_COMPONENT_VERSION 3:
+  // - SetTimeToDisplayFromInstant, and Instant property are added.
+  public static final int TIMEPICKER_COMPONENT_VERSION = 3;
 
   public static final int TINYDB_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
@@ -140,14 +140,6 @@ public class DatePicker extends ButtonBase {
 	  int year = Dates.Year(instant);
 	  int month = Dates.Month(instant);
 	  int day = Dates.Day(instant);
-	  int jMonth = month - 1;
-	  try {
-	    GregorianCalendar cal = new GregorianCalendar(year, jMonth, day);
-	    cal.setLenient(false);
-	    cal.getTime();
-	  } catch (java.lang.IllegalArgumentException e) {
-	    form.dispatchErrorOccurredEvent(this, "SetDateToDisplayFromInstant", ErrorMessages.ERROR_ILLEGAL_DATE);
-	  }
 	  date.updateDate(year, month, day);
 	  instant = Dates.DateInstant(year, month, day);
 	  customDate = true;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
@@ -17,6 +17,7 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.Dates;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 
 import java.text.DateFormatSymbols;
@@ -39,6 +40,7 @@ public class DatePicker extends ButtonBase {
   private DatePickerDialog date;
   //month is the property that AI devs see, and it's always javaMonth + 1; month is 0-based in Java
   private int year, month, javaMonth, day;
+  private Calendar instant;
   private String [] localizedMonths = new DateFormatSymbols().getMonths();
   private boolean customDate = false;
   private Form form;
@@ -57,6 +59,7 @@ public class DatePicker extends ButtonBase {
     javaMonth = c.get(Calendar.MONTH);
     month = javaMonth + 1;
     day = c.get(Calendar.DAY_OF_MONTH);
+    instant = Dates.DateInstant(year, month, day);
     date = new DatePickerDialog(this.container.$context(), datePickerListener, year, javaMonth,
         day);
 
@@ -106,6 +109,16 @@ public class DatePicker extends ButtonBase {
     return day;
   }
 
+  /**
+   * Returns instant of the date that was last picked using the DatePicker.
+   * @return instant of the date 
+   */
+  @SimpleProperty(description = "the instant of the date that was last picked using the DatePicker.",
+	      category = PropertyCategory.APPEARANCE)
+  public Calendar Instant() {
+    return instant;
+  }
+
   @SimpleFunction(description = "Allows the user to set the date to be displayed when the date picker opens.\n" +
     "Valid values for the month field are 1-12 and 1-31 for the day field.\n")
   public void SetDateToDisplay(int year, int month, int day) {
@@ -118,7 +131,26 @@ public class DatePicker extends ButtonBase {
       form.dispatchErrorOccurredEvent(this, "SetDateToDisplay", ErrorMessages.ERROR_ILLEGAL_DATE);
     }
     date.updateDate(year, jMonth, day);
+    instant = Dates.DateInstant(year, month, day);
     customDate = true;
+  }
+
+  @SimpleFunction(description = "Allows the user to set the date from the instant to be displayed when the date picker opens.")
+  public void SetDateToDisplayFromInstant(Calendar instant) {
+	  int year = Dates.Year(instant);
+	  int month = Dates.Month(instant);
+	  int day = Dates.Day(instant);
+	  int jMonth = month - 1;
+	  try {
+	    GregorianCalendar cal = new GregorianCalendar(year, jMonth, day);
+	    cal.setLenient(false);
+	    cal.getTime();
+	  } catch (java.lang.IllegalArgumentException e) {
+	    form.dispatchErrorOccurredEvent(this, "SetDateToDisplayFromInstant", ErrorMessages.ERROR_ILLEGAL_DATE);
+	  }
+	  date.updateDate(year, month, day);
+	  instant = Dates.DateInstant(year, month, day);
+	  customDate = true;
   }
 
   @SimpleFunction(description="Launches the DatePicker popup.")
@@ -137,6 +169,7 @@ public class DatePicker extends ButtonBase {
       int jMonth = c.get(Calendar.MONTH);
       int day = c.get(Calendar.DAY_OF_MONTH);
       date.updateDate(year, jMonth, day);
+      instant = Dates.DateInstant(year, jMonth+1, day);
     } else {
       customDate = false;
     }
@@ -157,6 +190,7 @@ public class DatePicker extends ButtonBase {
             month = javaMonth + 1;
             day = selectedDay;
             date.updateDate(year, javaMonth, day);
+            instant = Dates.DateInstant(year, month, day);
             // We post an event to the Android handler to do the App Inventor
             // event dispatch. This way it gets called outside of the context
             // of the datepicker's event. This permits the App Inventor dispatch

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
@@ -14,6 +14,7 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.Dates;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 
 import android.app.Dialog;
@@ -43,6 +44,7 @@ public class TimePicker extends ButtonBase {
   private TimePickerDialog time;
   private boolean customTime = false;
   private Form form;
+  private Calendar instant;
   private Handler androidUIHandler;
 
   /**
@@ -59,6 +61,7 @@ public class TimePicker extends ButtonBase {
     time = new TimePickerDialog(this.container.$context(),
         timePickerListener, hour, minute, false);
 
+    instant = Dates.TimeInstant(hour, minute);
     androidUIHandler = new Handler();
 
   }
@@ -92,6 +95,17 @@ public class TimePicker extends ButtonBase {
     return minute;
   }
 
+  /**
+   * Returns the instant in time that was last picked using the DatePicker.
+   * @return instant of the date 
+   */
+  @SimpleProperty(
+      description = "The instant of the last time set using the time picker",
+      category = PropertyCategory.APPEARANCE)
+  public Calendar Instant() {
+	  return instant;
+  }
+
   @SimpleFunction(description="Set the time to be shown in the Time Picker popup. Current time is shown by default.")
   public void SetTimeToDisplay(int hour, int minute) {
     if ((hour < 0) || (hour > 23)) {
@@ -100,8 +114,18 @@ public class TimePicker extends ButtonBase {
       form.dispatchErrorOccurredEvent(this, "SetTimeToDisplay", ErrorMessages.ERROR_ILLEGAL_MINUTE);
     } else {
       time.updateTime(hour, minute);
+      instant = Dates.TimeInstant(hour, minute);
       customTime = true;
     }
+  }
+
+  @SimpleFunction(description="Set the time from the instant to be shown in the Time Picker popup. Current time is shown by default.")
+  public void SetTimeToDisplayFromInstant(Calendar instant) {
+    int hour = Dates.Hour(instant);
+    int minute = Dates.Minute(instant);
+    time.updateTime(hour, minute);
+    instant = Dates.TimeInstant(hour, minute);
+    customTime = true; 
   }
 
   @SimpleFunction(description="Launches the TimePicker popup.")
@@ -116,6 +140,7 @@ public class TimePicker extends ButtonBase {
       int h = c.get(Calendar.HOUR_OF_DAY);
       int m = c.get(Calendar.MINUTE);
       time.updateTime(h, m);
+      instant = Dates.TimeInstant(hour, minute);
     } else {
       customTime = false;
     }
@@ -129,6 +154,7 @@ public class TimePicker extends ButtonBase {
           if (view.isShown()) {
             hour = selectedHour;
             minute = selectedMinute;
+            instant = Dates.TimeInstant(hour, minute);
             // We post an event to the Android handler to do the App Inventor
             // event dispatch. This way it gets called outside of the context
             // of the timepicker's event. This permits the App Inventor dispatch

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
@@ -194,6 +194,49 @@ public final class Dates {
   }
 
   /**
+   * Returns the instant of the given date (used in DatePicker component)
+   *
+   * @param year year of the date
+   * @param month month of the date
+   * @param day day of the date
+   * @return  Calendar (instant in time)
+   */
+  @SimpleFunction
+  public static Calendar DateInstant(int year, int month, int day) {
+	  String year_str = String.valueOf(year);
+	  String month_str = String.valueOf(month);
+	  String day_str = String.valueOf(day);
+	  String date;
+	  if (month < 10)
+	     month_str = "0" + month_str;
+	  if (day < 10)
+		 day_str = "0" + day_str;
+	  date = month_str + "/" + day_str + "/" + year_str;
+	  return Dates.DateValue(date);
+  }
+
+  /**
+   * Returns the instant of the given time (used in TimePicker component)
+   *
+   * @param year year of the date
+   * @param month month of the date
+   * @param day day of the date
+   * @return  Calendar (instant in time)
+   */
+  @SimpleFunction
+  public static Calendar TimeInstant(int hour, int minute) {
+	  String hour_str = String.valueOf(hour);
+	  String minute_str = String.valueOf(minute);
+	  String time;
+	  if (hour < 10)
+	     hour_str = "0" + hour_str;
+	  if (minute < 10)
+		 minute_str = "0" + minute_str;
+	  time = hour_str + ":" + minute_str;
+	  return Dates.DateValue(time);
+  }
+
+  /**
    * Returns the hours for the given date.
    *
    * @param date  date to use hours of

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -586,6 +586,8 @@
                     <dd></dd>
                     <dt><code>Image</code></dt>
                     <dd>Image to display on button.</dd>
+                    <dt><code>Instant</code></dt>
+                    <dd>Instant of date. This instant can be used with <a href="http://ai2.appinventor.mit.edu/reference/components/sensors.html#Clock">Clock</a> component for date documentation, conversion, and matriculation.</dd>
                     <dt><code><em>Month</em></code></dt>
                     <dd>the number of the Month that was last picked using the DatePicker. Note that months start in 1 = January, 12 = December.</dd>
                     <dt><code><em>MonthInText</em></code></dt>
@@ -629,6 +631,10 @@
                     <dt><code>SetDateToDisplay(number year, number month, number day)</code></dt>
                     <dd>Allows the user to set the date to be displayed when the date picker opens.
                       Valid values for the month field are 1-12 and 1-31 for the day field.</dd>
+                    <dt><code>SetDateToDisplayFromInstant(InstantInTime instant)</code></dt>
+                    <dd>Allows the instant to set the year, month, and day to
+                    be displayed when the date picker opens. Instants are used in Clock, DatePicker,
+                    and TimePicker components.</dd>
                   </dl>
 
                  <h2 id="Image">Image</h2>
@@ -1200,6 +1206,8 @@ none
                     <dd>The hour of the last time set using the time picker. The hour is in a 24 hour format. If the last time set was 11:53 pm, this property will return 23.</dd>
                     <dt><code>Image</code></dt>
                     <dd>Specifies the path of the button's image.  If there is both an Image and a BackgroundColor, only the Image will be visible.</dd>
+                    <dt><code>Instant</code></dt>
+                    <dd>Instant of time. This instant can be used with <a href="http://ai2.appinventor.mit.edu/reference/components/sensors.html#Clock">Clock</a> component for time documentation, conversion, and matriculation.</dd>
                     <dt><code><em>Minute</em></code></dt>
                     <dd>The minute of the last time set using the time picker</dd>
                     <dt><code>Shape</code> (designer only)</dt>
@@ -1231,7 +1239,17 @@ none
                   </dl>
 
                   <h3>Methods</h3>
-                  none
+                  <dl>
+                    <dt><code>LaunchPicker()</code></dt>
+                    <dd>Launches the TimePicker popup.</dd>
+                    <dt><code>SetTimeToDisplay(number hour, number minute)</code></dt>
+                    <dd>Allows the user to set the time to be displayed when the time picker opens.
+                      Valid values for the hour field are 0-23 and 0-59 for the second field.</dd>
+                    <dt><code>SetTimeToDisplayFromInstant(InstantInTime instant)</code></dt>
+                    <dd>Allows the instant to set the hour and minute to
+                    be displayed when the time picker opens. Instants are used in Clock, DatePicker,
+                    and TimePicker components.</dd>
+                  </dl>
 
 <h2 id="WebViewer"> WebViewer </h2>
 <img src="images/webviewer.png" alt="Picture of WebViewer component" />


### PR DESCRIPTION
TimePicker, DatePicker, and Clock components are all related to date and time. However, while most of Clock component methods take "instant" as arguments, there is no way to get an instant from DatePicker and TimePicker unless users manually create MM/dd/YYYY hh:mm:ss format by concatenating DatePicker.Month, DatePicker.Day, DatePicker.Year and so on. 

Thus, I added instant as a property in DatePicker and TimePicker. The initial date for DatePicker instant is set with current date, month, and year, and the initial time for TimePicker is set as current time. Since TimePicker does not have specified month, date, and year, the default date of the instant is set as Jan 01, 1970, following the Gregorian Calendar. (These are the same behavior as the way Clock component makes an instant.)

I also added two more methods, SetDateToDisplayFromInstant, SetTimeToDisplayFromInstant, which allow users to set Date and Time from the instant. 

Here are the instance and documentation. 

Instance:  http://grace-ai2.appspot.com/
Proposal: https://docs.google.com/document/d/1DmBi4iTSevmtREw5OD-x9kIWguPxyDt_NSZUfJN5Nmc/edit?usp=sharing

@ram8647 @halatmit @jisqyv

