### PR TITLE
Add Help Menu Item to show the Splash Screen

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1363,13 +1363,24 @@ public class Ode implements EntryPoint {
   }
 
   /**
-   * Creates, visually centers, and optionally displays the dialog box
-   * that informs the user how to start learning about using App Inventor
-   * or create a new project.
-   * @param showDialog Convenience variable to show the created DialogBox.
+   * public entry for (re)displaying the welcome dialog box.
+   * Bypass the "Do Not Show Again" feature. This is used by the
+   * menu choice to explicitly show the dialog box. This lets
+   * people who have dismissed the dialog to manually decide to
+   * see it again.
+   *
    */
-  private void createWelcomeDialog(boolean showDialog) {
-    if (!shouldShowWelcomeDialog()) {
+  public void showWelcomeDialog() {
+    createWelcomeDialog(true);
+  }
+
+  /**
+   * Possibly display the MIT App Inventor "Splash Screen"
+   *
+   * @param force Bypass the check to see if they have dimissed this version
+   */
+  private void createWelcomeDialog(boolean force) {
+    if (!shouldShowWelcomeDialog() && !force) {
       openProjectsTab();
       return;
     }
@@ -1405,9 +1416,7 @@ public class Ode implements EntryPoint {
     DialogBoxContents.add(message);
     DialogBoxContents.add(holder);
     dialogBox.setWidget(DialogBoxContents);
-    if (showDialog) {
-      dialogBox.show();
-    }
+    dialogBox.show();
   }
 
   /**
@@ -1520,7 +1529,7 @@ public class Ode implements EntryPoint {
 
   private void maybeShowSplash() {
     if (AppInventorFeatures.showSplashScreen()) {
-      createWelcomeDialog(true);
+      createWelcomeDialog(false);
     } else {
       openProjectsTab();
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -559,6 +559,10 @@ public interface OdeMessages extends Messages {
   @Description("Information about the Companion")
   String companionInformation();
 
+  @DefaultMessage("Show Splash Screen")
+  @Description("Redisplay the Splash Screen")
+  String showSplashMenuItem();
+
   @DefaultMessage("Library")
   @Description("Name of Library link")
   String libraryMenuItem();

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -100,6 +100,7 @@ public class TopToolbar extends Composite {
   private static final String WIDGET_NAME_LIBRARY = "Library";
   private static final String WIDGET_NAME_GETSTARTED = "GetStarted";
   private static final String WIDGET_NAME_TUTORIALS = "Tutorials";
+  private static final String WIDGET_NAME_SHOWSPLASH = "ShowSplash";
   private static final String WIDGET_NAME_TROUBLESHOOTING = "Troubleshooting";
   private static final String WIDGET_NAME_FORUMS = "Forums";
   private static final String WIDGET_NAME_FEEDBACK = "ReportIssue";
@@ -190,7 +191,8 @@ public class TopToolbar extends Composite {
           new GenerateYailAction()));
     }
 
-    // Help -> {About, Library, Get Started, Tutorials, Troubleshooting, Forums, Report an Issue}
+    // Help -> {About, Library, Get Started, Tutorials, Troubleshooting, Forums, Report an Issue,
+    //  Companion Information, Show Splash Screen}
     helpItems.add(new DropDownItem(WIDGET_NAME_ABOUT, MESSAGES.aboutMenuItem(),
         new AboutAction()));
     helpItems.add(null);
@@ -210,6 +212,8 @@ public class TopToolbar extends Composite {
     helpItems.add(null);
     helpItems.add(new DropDownItem(WIDGET_NAME_COMPANIONINFO, MESSAGES.companionInformation(),
         new AboutCompanionAction()));
+    helpItems.add(new DropDownItem(WIDGET_NAME_SHOWSPLASH, MESSAGES.showSplashMenuItem(),
+        new ShowSplashAction()));
 
     // Create the TopToolbar drop down menus.
     fileDropDown = new DropDownButton(WIDGET_NAME_PROJECT, MESSAGES.projectsTabName(),
@@ -733,6 +737,13 @@ public class TopToolbar extends Composite {
       DialogBoxContents.add(holder);
       db.setWidget(DialogBoxContents);
       db.show();
+    }
+  }
+
+  private static class ShowSplashAction implements Command {
+    @Override
+    public void execute() {
+      Ode.getInstance().showWelcomeDialog();
     }
   }
 


### PR DESCRIPTION
Now that users can permanently dismiss the splash screen (until we
increment the version) there needs to be a way to explicitly decide to
see it again. This code adds a menu choice in the Help menu to do just
that. Also included is some minor code and comments cleanup.

Change-Id: Ica68d05678bd1748c1144a1e4c2e1820343e2c63