### PR TITLE
Fixed the Ampersand problem in the app name

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -299,8 +299,8 @@ public final class Compiler {
 
   // This patches around a bug in AAPT (and other placed in Android)
   // where an ampersand in the name string breaks AAPT.
-  private String cleanVname(String vname) {
-    return vname.replace("&", "and");
+  private String cleanName(String name) {
+    return name.replace("&", "and");
   }
 
   /*
@@ -313,8 +313,8 @@ public final class Compiler {
     String className = Signatures.getClassName(mainClass);
     String projectName = project.getProjectName();
     String vCode = (project.getVCode() == null) ? DEFAULT_VERSION_CODE : project.getVCode();
-    String vName = (project.getVName() == null) ? DEFAULT_VERSION_NAME : cleanVname(project.getVName());
-    String aName = (project.getAName() == null) ? DEFAULT_APP_NAME : project.getAName();
+    String vName = (project.getVName() == null) ? DEFAULT_VERSION_NAME : cleanName(project.getVName());
+    String aName = (project.getAName() == null) ? DEFAULT_APP_NAME : cleanName(project.getAName());
     LOG.log(Level.INFO, "VCode: " + project.getVCode());
     LOG.log(Level.INFO, "VName: " + project.getVName());
 


### PR DESCRIPTION
This patches around a bug in AAPT (and other placed in Android) where an ampersand in the app name (android:label) string breaks AAPT.

This pull request addresses the problem in this issue - 
https://github.com/mit-cml/appinventor-sources/issues/456