### PR TITLE
remove align restriction, and set linearlayout baselineAlign to false…

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVArrangement.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVArrangement.java
@@ -43,8 +43,6 @@ public class MockHVArrangement extends MockContainer {
   private YoungAndroidHorizontalAlignmentChoicePropertyEditor myHAlignmentPropertyEditor;
   private YoungAndroidVerticalAlignmentChoicePropertyEditor myVAlignmentPropertyEditor;
   
-  private boolean initialized = false;
-  
  /**
    * Creates a new MockHVArrangement component.
    */
@@ -79,8 +77,7 @@ public class MockHVArrangement extends MockContainer {
       OdeLog.log(MESSAGES.badAlignmentPropertyEditorForArrangement());
       return;
     }
-    enableAndDisableDropdowns();
-    initialized = true;
+
   }
 
   
@@ -95,30 +92,10 @@ public class MockHVArrangement extends MockContainer {
       refreshForm();
     } else {
       if (propertyName.equals(PROPERTY_NAME_WIDTH) || propertyName.equals(PROPERTY_NAME_HEIGHT)) {
-        adjustAlignmentDropdowns();
         refreshForm();
       }
     }
   }
 
-  // enableAndDisable It should not be called until the component is initialized.
-  // Otherwise, we'll get NPEs in trying to use myAlignmentPropertyEditor.
-  private void adjustAlignmentDropdowns() {
-    if (initialized) enableAndDisableDropdowns();
-  }
-
-  // If the width is automatic, the selector for horizontal alignment should be disabled.
-  // If the length is automatic, the selector for vertical alignment should be disabled.
-  private void enableAndDisableDropdowns() {
-    String width = properties.getProperty(MockVisibleComponent.PROPERTY_NAME_WIDTH).getValue();
-    if (width.equals(YoungAndroidLengthPropertyEditor.CONST_AUTOMATIC)) {
-      myHAlignmentPropertyEditor.disable();
-    } else myHAlignmentPropertyEditor.enable();
-
-    String height = properties.getProperty(MockVisibleComponent.PROPERTY_NAME_HEIGHT).getValue();
-    if (height.equals(YoungAndroidLengthPropertyEditor.CONST_AUTOMATIC)) {
-      myVAlignmentPropertyEditor.disable();
-    } else myVAlignmentPropertyEditor.enable();
-  }
 }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
@@ -574,8 +574,11 @@ abstract class MockHVLayoutBase extends MockLayout {
       int childWidthWithBorder = childLayoutInfo.width + BORDER_SIZE;
       int childHeightWithBorder = childLayoutInfo.height + BORDER_SIZE;
 
-      // The middle of the child needs to be at centerY, so the
-      // top of the child is above that by childHeightWithBorder/2
+      // topY is where the top of each component goes.  It starts out either at zero, or offset
+      // so the entire stack is vertically centered in the arrangement (i.e., offset by
+      // (containerLayoutInfo.height / 2) - (childHeightWithBorder / 2)) or offset so that
+      // the bottom of the stack of components is at the bottom of the layout
+      // (i.e., offset by containerLayoutInfo.height - childHeightWithBorder).
       int topY = 0;
 
       switch (alignV) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
@@ -535,27 +535,6 @@ abstract class MockHVLayoutBase extends MockLayout {
       }
     }
 
-    // centerY is where the middle of each child should be: either vertically
-    // centered at the top of the arrangement, or each child at the middle of the
-    // arrangement.
-
-   //we have to initialize this, or else Eclipse will whine at us
-    int centerY = 0;
-
-    switch (alignV) {
-    case Top:
-      centerY = maxHeight / 2;
-      break;
-    case Center:
-      centerY = containerLayoutInfo.height / 2;
-      break;
-    case Bottom:
-      centerY = containerLayoutInfo.height - (maxHeight / 2);
-    default:
-      OdeLog.elog("System error: Bad value for vertical alignment -- MockHVLayoutBase");
-    }
-
-
     // NOTE(hal) What is this for?
     layoutHeight = 0;
 
@@ -597,7 +576,20 @@ abstract class MockHVLayoutBase extends MockLayout {
 
       // The middle of the child needs to be at centerY, so the
       // top of the child is above that by childHeightWithBorder/2
-      int topY = centerY - (childHeightWithBorder / 2);
+      int topY = 0;
+
+      switch (alignV) {
+        case Top:
+          topY = 0;
+          break;
+        case Center:
+          topY = (containerLayoutInfo.height / 2) - (childHeightWithBorder / 2);
+          break;
+        case Bottom:
+          topY = containerLayoutInfo.height - childHeightWithBorder;
+        default:
+          OdeLog.elog("System error: Bad value for vertical alignment -- MockHVLayoutBase");
+      }
 
       container.setChildSizeAndPosition(child, childLayoutInfo, leftX, topY);
       layoutHeight = Math.max(layoutHeight, topY + childHeightWithBorder);

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
@@ -131,4 +131,8 @@ public class ChoicePropertyEditor extends PropertyEditor {
       }
     }
   }
+
+  public void setVisible(boolean visible) {
+    dropDownButton.setVisible(visible);
+  }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -57,6 +57,7 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     viewLayout = new LinearLayout(context, orientation,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT);
+    viewLayout.setBaselineAligned(false);
     alignmentSetter = new AlignmentUtil(viewLayout);
 
     horizontalAlignment = ComponentConstants.HORIZONTAL_ALIGNMENT_DEFAULT;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/LinearLayout.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LinearLayout.java
@@ -120,4 +120,6 @@ public final class LinearLayout implements Layout {
     layoutManager.setVerticalGravity(gravity);
   }
 
+  public void setBaselineAligned(boolean baselineAligned) { layoutManager.setBaselineAligned(baselineAligned); }
+
 }


### PR DESCRIPTION
This commit is for solving issue #410 and #468 .

The part for #410 is to remove restriction code for alignVertical/alignHorizontal property.

The part for #468  is to add method for setting baselineAlign property, and set it to false by default when initialize arrangement.

Other than this, there are some code to be done on designer screen side. But I create this pull request for testing for this change first, designer won't cause any problem if this one can be integrated to App Inventor.