### PR TITLE
Fixed collapsed block text on renaming

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -13,7 +13,7 @@
 
 goog.provide('Blockly.Blocks.components');
 goog.provide('Blockly.ComponentBlock');
-
+goog.require('Blockly.Blocks.Utilities');
 goog.require('Blockly.TypeBlock');
 
 /*
@@ -170,7 +170,7 @@ Blockly.Blocks.component_event = {
     if (this.instanceName == oldname) {
       this.instanceName = newname;
       this.componentDropDown.setValue(this.instanceName);
-      Blockly.ComponentBlock.renameCollapsed(this);
+      Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
   renameVar: function(oldName, newName) {
@@ -341,7 +341,7 @@ Blockly.Blocks.component_method = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText('call ' + this.instanceName + '.' + this.methodType.name);
       this.componentDropDown.setValue(this.instanceName);
-      Blockly.ComponentBlock.renameCollapsed(this);
+      Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
   getMethodTypeObject : function() {
@@ -561,7 +561,7 @@ Blockly.Blocks.component_set_get = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText(this.instanceName + '.');
       this.componentDropDown.setValue(this.instanceName);
-      Blockly.ComponentBlock.renameCollapsed(this);
+      Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
   typeblock : function(){
@@ -673,7 +673,7 @@ Blockly.Blocks.component_component_block = {
       //var title = this.inputList[0].titleRow[0];
       //title.setText(this.instanceName);
       this.componentDropDown.setValue(this.instanceName);
-      Blockly.ComponentBlock.renameCollapsed(this);
+      Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
 
@@ -708,15 +708,6 @@ Blockly.ComponentBlock.createComponentDropDown = function(block){
     }
   };
   return componentDropDown;
-}
-
-Blockly.ComponentBlock.renameCollapsed = function(block){
-  if (block.isCollapsed()) {
-    var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
-    block.removeInput(COLLAPSED_INPUT_NAME);
-    var text = block.toString(Blockly.COLLAPSE_CHARS);
-    block.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
-  }
 }
 
 Blockly.ComponentBlock.HELPURLS = {

--- a/appinventor/blocklyeditor/src/blocks/lexical-variables.js
+++ b/appinventor/blocklyeditor/src/blocks/lexical-variables.js
@@ -137,6 +137,12 @@ Blockly.Blocks['lexical_variable_get'] = {
     // console.log("Renaming lexical variable from " + oldName + " to " + newName);
     if (oldName === this.getFieldValue('VAR')) {
         this.setFieldValue(newName, 'VAR');
+        if (this.isCollapsed()) {
+        var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
+        this.removeInput(COLLAPSED_INPUT_NAME);
+        var text = this.toString(Blockly.COLLAPSE_CHARS);
+        this.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
+      }
     }
   },
   renameFree: function (freeSubstitution) {

--- a/appinventor/blocklyeditor/src/blocks/lexical-variables.js
+++ b/appinventor/blocklyeditor/src/blocks/lexical-variables.js
@@ -137,12 +137,7 @@ Blockly.Blocks['lexical_variable_get'] = {
     // console.log("Renaming lexical variable from " + oldName + " to " + newName);
     if (oldName === this.getFieldValue('VAR')) {
         this.setFieldValue(newName, 'VAR');
-        if (this.isCollapsed()) {
-        var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
-        this.removeInput(COLLAPSED_INPUT_NAME);
-        var text = this.toString(Blockly.COLLAPSE_CHARS);
-        this.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
-      }
+        Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
   renameFree: function (freeSubstitution) {

--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -252,14 +252,11 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 
       var callers = Blockly.Procedures.getCallers(procName, procWorkspace);
       for (var x = 0; x < callers.length; x++) {
-          var block = callers[x];
-          if (block.isCollapsed()) {
-          var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
-          block.removeInput(COLLAPSED_INPUT_NAME);
-          var text = block.toString(Blockly.COLLAPSE_CHARS);
-          block.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
-          block.moveInputBefore(COLLAPSED_INPUT_NAME, 'ARG0');
-        }
+           var block = callers[x];
+           Blockly.Blocks.Utilities.renameCollapsed(block, 0);
+      //     if (block.isCollapsed()) {
+      //     block.moveInputBefore(COLLAPSED_INPUT_NAME, 'ARG0');
+      //   }
       }
 
       // 2. If there's an open mutator, change the name in the corresponding slot.
@@ -763,12 +760,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   renameProcedure: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getFieldValue('PROCNAME'))) {
       this.setFieldValue(newName, 'PROCNAME');
-      if (this.isCollapsed()) {
-        var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
-        this.removeInput(COLLAPSED_INPUT_NAME);
-        var text = this.toString(Blockly.COLLAPSE_CHARS);
-        this.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
-      }
+      Blockly.Blocks.Utilities.renameCollapsed(this, 0);
     }
   },
   // [lyn, 10/27/13] Renamed "fromChange" parameter to "startTracking", because it should be true in any situation

--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -252,11 +252,8 @@ Blockly.Blocks['procedures_defnoreturn'] = {
 
       var callers = Blockly.Procedures.getCallers(procName, procWorkspace);
       for (var x = 0; x < callers.length; x++) {
-           var block = callers[x];
-           Blockly.Blocks.Utilities.renameCollapsed(block, 0);
-      //     if (block.isCollapsed()) {
-      //     block.moveInputBefore(COLLAPSED_INPUT_NAME, 'ARG0');
-      //   }
+        var block = callers[x];
+        Blockly.Blocks.Utilities.renameCollapsed(block, 0);      
       }
 
       // 2. If there's an open mutator, change the name in the corresponding slot.

--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -250,6 +250,18 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       // 1. Change all callers so label reflects new name
       Blockly.Procedures.mutateCallers(procName, procWorkspace, newArguments, procDecl.paramIds_);
 
+      var callers = Blockly.Procedures.getCallers(procName, procWorkspace);
+      for (var x = 0; x < callers.length; x++) {
+          var block = callers[x];
+          if (block.isCollapsed()) {
+          var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
+          block.removeInput(COLLAPSED_INPUT_NAME);
+          var text = block.toString(Blockly.COLLAPSE_CHARS);
+          block.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
+          block.moveInputBefore(COLLAPSED_INPUT_NAME, 'ARG0');
+        }
+      }
+
       // 2. If there's an open mutator, change the name in the corresponding slot.
       if (procDecl.mutator && procDecl.mutator.rootBlock_) {
         // Iterate through mutatorarg param blocks and change name of one at paramIndex
@@ -751,6 +763,12 @@ Blockly.Blocks['procedures_callnoreturn'] = {
   renameProcedure: function(oldName, newName) {
     if (Blockly.Names.equals(oldName, this.getFieldValue('PROCNAME'))) {
       this.setFieldValue(newName, 'PROCNAME');
+      if (this.isCollapsed()) {
+        var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
+        this.removeInput(COLLAPSED_INPUT_NAME);
+        var text = this.toString(Blockly.COLLAPSE_CHARS);
+        this.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
+      }
     }
   },
   // [lyn, 10/27/13] Renamed "fromChange" parameter to "startTracking", because it should be true in any situation

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -75,6 +75,9 @@ Blockly.Blocks.Utilities.wrapSentence = function(str, len) {
   }
 };
 
+// Change the text of collapsed blocks on rename
+// Recurse to fix collapsed parents
+
 Blockly.Blocks.Utilities.MAX_COLLAPSE = 4;
 
 Blockly.Blocks.Utilities.renameCollapsed = function(block, n) {

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -75,6 +75,26 @@ Blockly.Blocks.Utilities.wrapSentence = function(str, len) {
   }
 };
 
+Blockly.Blocks.Utilities.MAX_COLLAPSE = 4;
+
+Blockly.Blocks.Utilities.renameCollapsed = function(block, n){
+  if(n > Blockly.Blocks.Utilities.MAX_COLLAPSE) return;
+  if (block.isCollapsed()) {
+    var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';
+    block.removeInput(COLLAPSED_INPUT_NAME);
+    var text = block.toString(Blockly.COLLAPSE_CHARS);
+    block.appendDummyInput(COLLAPSED_INPUT_NAME).appendField(text);
+
+    if(block.type.indexOf("procedures_call") != -1) {
+      block.moveInputBefore(COLLAPSED_INPUT_NAME, 'ARG0');
+    }
+  }
+
+  if(block.parentBlock_) {
+    Blockly.Blocks.Utilities.renameCollapsed(block.parentBlock_, n+1);
+  }
+}
+
 // unicode multiplication symbol
 Blockly.Blocks.Utilities.times_symbol = '\u00D7';
 

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -77,7 +77,7 @@ Blockly.Blocks.Utilities.wrapSentence = function(str, len) {
 
 Blockly.Blocks.Utilities.MAX_COLLAPSE = 4;
 
-Blockly.Blocks.Utilities.renameCollapsed = function(block, n){
+Blockly.Blocks.Utilities.renameCollapsed = function(block, n) {
   if(n > Blockly.Blocks.Utilities.MAX_COLLAPSE) return;
   if (block.isCollapsed()) {
     var COLLAPSED_INPUT_NAME = '_TEMP_COLLAPSED_INPUT';


### PR DESCRIPTION
This fix creates a utility function for block types that can be renamed by the user (components, procedures and variables).

It recursively checks for collapsed parent blocks as these might also contain the old name of the renamed block. There is a constant maximum number of recursive calls. 

Examples and further details [here](https://docs.google.com/document/d/1FPpiiGsVax3muclKTaGGTWiKgGLRrMMptiI1fHMopqs/edit?usp=sharing).

Try it - http://ai2-collapsed-fix.appspot.com/

CC: @josmas 