### PR TITLE
Fix NPF in Player

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
@@ -471,7 +471,7 @@ public final class Player extends AndroidNonvisibleComponent
     if (audioFocusSupported && focusOn) {
       abandonFocus();
     }
-    if (playerState != State.INITIAL) {
+    if ((player != null) && (playerState != State.INITIAL)) {
       player.stop();
     }
     playerState = State.INITIAL;


### PR DESCRIPTION
If a Player is used only for vibration and no source sound is set,
then an NPF occurs on application exit.

Change-Id: I3de012ec71a1a085b0e13bb818708150f05efbea