### PR TITLE
Update appengine/build.xml

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -96,6 +96,9 @@
         <filter token="GUID" value="${guid1}"/>
       </filterset>
     </copy>
+    <delete>
+      <fileset dir="${build.war.dir}" includes="blockly-*.js"/>
+    </delete>
     <copy file="${build.dir}/blocklyeditor/blockly-all.js" tofile="${build.war.dir}/blockly-${guid1}.js" />
     <copy todir="${build.war.dir}/">
       <fileset dir="${lib.dir}">


### PR DESCRIPTION
Delete old blockly-<guid>.js files before creating new one.

I noticed that everytime I do "ant" or "ant noplay", I end up with an additional blockly-<guid>.js file in the appengine/build/war directory. These files are 3.9M each.