### PR TITLE
Doit and comment result balloons broken in Chrome #486

### DIFF
--- a/appinventor/lib/blockly/src/core/comment.js
+++ b/appinventor/lib/blockly/src/core/comment.js
@@ -102,14 +102,14 @@ Blockly.Comment.prototype.createEditor_ = function() {
   this.foreignObject_ = Blockly.createSvgElement('foreignObject',
       {'x': Blockly.Bubble.BORDER_WIDTH, 'y': Blockly.Bubble.BORDER_WIDTH},
       null);
-  var body = document.createElementNS(Blockly.HTML_NS, 'body');
-  body.setAttribute('xmlns', Blockly.HTML_NS);
-  body.className = 'blocklyMinimalBody';
+  this.foreignBody_ = document.createElementNS(Blockly.HTML_NS, 'body');
+  this.foreignBody_.setAttribute('xmlns', Blockly.HTML_NS);
+  this.foreignBody_.className = 'blocklyMinimalBody';
   this.textarea_ = document.createElementNS(Blockly.HTML_NS, 'textarea');
   this.textarea_.className = 'blocklyCommentTextarea';
   this.textarea_.setAttribute('dir', Blockly.RTL ? 'RTL' : 'LTR');
-  body.appendChild(this.textarea_);
-  this.foreignObject_.appendChild(body);
+  this.foreignBody_.appendChild(this.textarea_);
+  this.foreignObject_.appendChild(this.foreignBody_);
   Blockly.bindEvent_(this.textarea_, 'mouseup', this, this.textareaFocus_);
   return this.foreignObject_;
 };
@@ -138,8 +138,9 @@ Blockly.Comment.prototype.resizeBubble_ = function() {
   var doubleBorderWidth = 2 * Blockly.Bubble.BORDER_WIDTH;
   this.foreignObject_.setAttribute('width', size.width - doubleBorderWidth);
   this.foreignObject_.setAttribute('height', size.height - doubleBorderWidth);
-  this.textarea_.style.width = (size.width - doubleBorderWidth - 4) + 'px';
-  this.textarea_.style.height = (size.height - doubleBorderWidth - 4) + 'px';
+  this.foreignBody_.style.height = (size.height - doubleBorderWidth) + 'px';
+  this.textarea_.style.width = (size.width - doubleBorderWidth) + 'px';
+  this.textarea_.style.height = (size.height - doubleBorderWidth) + 'px';
 };
 
 /**


### PR DESCRIPTION
Issue #486 is probably related to a Chrome change.
When the "Clear Error" option [(link)](https://github.com/mit-cml/appinventor-sources/commit/b4ae70289183a6ef8a4e7d99a5e2c97d27f0c692) has been pushed there wasn't this problem and, since that, there aren't commits that can cause it.

This fix resizes the body element inside the bubble (the element that overflows) when the bubble is resized improving the bubbles in every browser

![fixsafari](https://cloud.githubusercontent.com/assets/11232797/9028429/e6367bf6-3978-11e5-9e22-2617a0490096.png)
![fixchrome](https://cloud.githubusercontent.com/assets/11232797/9028430/e656a746-3978-11e5-91f8-e5f917d02fc3.png)
![fixfirefox](https://cloud.githubusercontent.com/assets/11232797/9028431/e66470ba-3978-11e5-8996-42d088ef7e24.png)
