### PR TITLE
Exportselectedprojects cleaned up

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -467,6 +467,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("Export selected project (.aia) to my computer")
   @Description("Name of Export Project menuitem")
   String exportProjectMenuItem();
+  
+  @DefaultMessage("Export selected projects")
+  @Description("Name of Export selected Project menuitem")
+  String exportSelectedProjectsMenuItem();
 
   @DefaultMessage("Export all projects")
   @Description("Name of Export all Project menuitem")

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -108,6 +108,7 @@ public class TopToolbar extends Composite {
   private static final String WIDGET_NAME_IMPORTPROJECT = "ImportProject";
   private static final String WIDGET_NAME_IMPORTTEMPLATE = "ImportTemplate";
   private static final String WIDGET_NAME_EXPORTALLPROJECTS = "ExportAllProjects";
+  private static final String WIDGET_NAME_EXPORTSELECTEDPROJECTS = "ExportSelectedProjects";
   private static final String WIDGET_NAME_EXPORTPROJECT = "ExportProject";
 
   private static final String WIDGET_NAME_ADMIN = "Admin";
@@ -157,6 +158,8 @@ public class TopToolbar extends Composite {
     fileItems.add(null);
     fileItems.add(new DropDownItem(WIDGET_NAME_EXPORTPROJECT, MESSAGES.exportProjectMenuItem(),
         new ExportProjectAction()));
+    fileItems.add(new DropDownItem(WIDGET_NAME_EXPORTSELECTEDPROJECTS, MESSAGES.exportSelectedProjectsMenuItem(),
+        new ExportSelectedProjectsAction()));
     fileItems.add(new DropDownItem(WIDGET_NAME_EXPORTALLPROJECTS, MESSAGES.exportAllProjectsMenuItem(),
         new ExportAllProjectsAction()));
     fileItems.add(null);
@@ -406,11 +409,12 @@ public class TopToolbar extends Composite {
       }
     }
   }
+
   private static class ExportProjectAction implements Command {
     @Override
     public void execute() {
       List<Project> selectedProjects =
-          ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
+        ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
       if (Ode.getInstance().getCurrentView() == Ode.PROJECTS) {
         //If we are in the projects view
         if (selectedProjects.size() == 1) {
@@ -427,10 +431,35 @@ public class TopToolbar extends Composite {
 
     private void exportProject(Project project) {
       Tracking.trackEvent(Tracking.PROJECT_EVENT,
-          Tracking.PROJECT_ACTION_DOWNLOAD_PROJECT_SOURCE_YA, project.getProjectName());
+        Tracking.PROJECT_ACTION_DOWNLOAD_PROJECT_SOURCE_YA, project.getProjectName());
 
       Downloader.getInstance().download(ServerLayout.DOWNLOAD_SERVLET_BASE +
-          ServerLayout.DOWNLOAD_PROJECT_SOURCE + "/" + project.getProjectId());
+        ServerLayout.DOWNLOAD_PROJECT_SOURCE + "/" + project.getProjectId());
+    }
+  }
+
+  private static class ExportSelectedProjectsAction implements Command {
+    @Override
+    public void execute() {
+      List<Project> selectedProjects =
+        ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
+      if (Ode.getInstance().getCurrentView() == Ode.PROJECTS) {
+        exportProject(selectedProjects);
+      }
+    }
+
+    private void exportProject(List<Project> projects) {
+      Tracking.trackEvent(Tracking.PROJECT_EVENT,
+        Tracking.PROJECT_ACTION_DOWNLOAD_SELECTED_PROJECTS_SOURCE_YA);
+
+      String selectedProjPath = ServerLayout.DOWNLOAD_SERVLET_BASE +
+        ServerLayout.DOWNLOAD_SELECTED_PROJECTS_SOURCE + "/";
+
+      for(Project project : projects) {
+        selectedProjPath += project.getProjectId() + "-";
+      }
+
+      Downloader.getInstance().download(selectedProjPath);
     }
   }
 
@@ -868,6 +897,8 @@ public class TopToolbar extends Composite {
           Ode.getInstance().getProjectManager().getProjects() == null);
       fileDropDown.setItemEnabled(MESSAGES.exportAllProjectsMenuItem(),
           Ode.getInstance().getProjectManager().getProjects().size() > 0);
+      fileDropDown.setItemEnabled(MESSAGES.exportSelectedProjectsMenuItem(),
+          Ode.getInstance().getProjectManager().getProjects().size() > 0);
       fileDropDown.setItemEnabled(MESSAGES.exportProjectMenuItem(), false);
       fileDropDown.setItemEnabled(MESSAGES.saveMenuItem(), false);
       fileDropDown.setItemEnabled(MESSAGES.saveAsMenuItem(), false);
@@ -877,6 +908,7 @@ public class TopToolbar extends Composite {
     } else { // We have to be in the Designer/Blocks view
       fileDropDown.setItemEnabled(MESSAGES.deleteProjectButton(), true);
       fileDropDown.setItemEnabled(MESSAGES.exportAllProjectsMenuItem(), false);
+      fileDropDown.setItemEnabled(MESSAGES.exportSelectedProjectsMenuItem(), false);
       fileDropDown.setItemEnabled(MESSAGES.exportProjectMenuItem(), true);
       fileDropDown.setItemEnabled(MESSAGES.saveMenuItem(), true);
       fileDropDown.setItemEnabled(MESSAGES.saveAsMenuItem(), true);

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
@@ -233,6 +233,8 @@ public class ProjectToolbar extends Toolbar {
         numSelectedProjects > 0);
     Ode.getInstance().getTopToolbar().fileDropDown.setItemEnabled(MESSAGES.exportProjectMenuItem(),
         numSelectedProjects > 0);
+    Ode.getInstance().getTopToolbar().fileDropDown.setItemEnabled(MESSAGES.exportSelectedProjectsMenuItem(),
+        numSelectedProjects > 1);
     Ode.getInstance().getTopToolbar().fileDropDown.setItemEnabled(MESSAGES.exportAllProjectsMenuItem(),
         numSelectedProjects > 0);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/tracking/Tracking.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/tracking/Tracking.java
@@ -35,6 +35,8 @@ public class Tracking {
       "BuildYail-YA";
   public static final String PROJECT_ACTION_DOWNLOAD_PROJECT_SOURCE_YA = PROJECT_ACTION_PREFIX +
       "DownloadProjectSource-YA";
+  public static final String PROJECT_ACTION_DOWNLOAD_SELECTED_PROJECTS_SOURCE_YA = 
+	  PROJECT_ACTION_PREFIX + "DownloadSelectedProjectsSource-YA";
   public static final String PROJECT_ACTION_DOWNLOAD_FILE_YA = PROJECT_ACTION_PREFIX +
       "DownloadFile-YA";
   public static final String PROJECT_ACTION_DOWNLOAD_ALL_PROJECTS_SOURCE_YA =

--- a/appinventor/appengine/src/com/google/appinventor/server/DownloadServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/DownloadServlet.java
@@ -22,6 +22,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Servlet for downloading project source and output files.
@@ -42,7 +44,7 @@ public class DownloadServlet extends OdeServlet {
   // Constants for accessing split URI
   /*
    * Download kind can be: "project-output", "project-source",
-   * "all-projects-source", "file", or "userfile".
+   * "selected-projects-source", "all-projects-source", "file", or "userfile".
    * Constants for these are defined in ServerLayout.
    */
   private static final int DOWNLOAD_KIND_INDEX = 3;
@@ -177,6 +179,16 @@ public class DownloadServlet extends OdeServlet {
             projectId, /* include history*/ true, /* include keystore */ true, zipName, false);
         downloadableFile = zipFile.getRawFile();
         
+      } else if (downloadKind.equals(ServerLayout.DOWNLOAD_SELECTED_PROJECTS_SOURCE)) {
+    	  String[] projectIdStrings = uriComponents[PROJECT_ID_INDEX].split("-");
+    	  List<Long> projectIds = new ArrayList<Long>();
+    	  for (String projectId : projectIdStrings) {
+    		projectIds.add(Long.valueOf(projectId));  
+    	  }
+    	  ProjectSourceZip zipFile = fileExporter.exportSelectedProjectsSourceZip(
+    		userId, "selected-projects.zip", projectIds);
+    	  downloadableFile = zipFile.getRawFile();
+      
       } else if (downloadKind.equals(ServerLayout.DOWNLOAD_ALL_PROJECTS_SOURCE)) {
         // Download all project source files as a zip of zips.
         ProjectSourceZip zipFile = fileExporter.exportAllProjectsSourceZip(

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
@@ -10,6 +10,7 @@ import com.google.appinventor.shared.rpc.project.ProjectSourceZip;
 import com.google.appinventor.shared.rpc.project.RawFile;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -54,6 +55,18 @@ public interface FileExporter {
                                           boolean includeProjectHistory,
                                           boolean includeAndroidKeystore, @Nullable String zipName,
                                           boolean fatalError)
+      throws IOException;
+  
+  /**
+   * Exports projects selected by the user as a zip.
+   * 
+   * @param userId the userId
+   * @param zipName the desired name for the zip
+   * @param projectIds the list of project ids corresponding to selected projects
+   */
+
+  ProjectSourceZip exportSelectedProjectsSourceZip(String userId, String zipName,
+		  										   List<Long> projectIds)
       throws IOException;
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -72,6 +72,75 @@ public final class FileExporterImpl implements FileExporter {
     }
   }
 
+  public ProjectSourceZip exportSelectedProjectsSourceZip(String userId,
+                                                          String zipName,
+                                                          List<Long> projectIds)
+                                                          throws IOException {
+    // Create a zip file for each project's sources.
+    if (projectIds.size() == 0) {
+      throw new IllegalArgumentException("No projects to download");
+    }
+
+    ByteArrayOutputStream zipFile = new ByteArrayOutputStream();
+    ZipOutputStream out = new ZipOutputStream(zipFile);
+    int count = 0;
+    String metadata = "";
+    for (Long projectId : projectIds) {
+      try {
+        ProjectSourceZip projectSourceZip =
+            exportProjectSourceZip(userId, projectId, false, false, null, false);
+        byte[] data = projectSourceZip.getContent();
+        String name = projectSourceZip.getFileName();
+
+        // If necessary, rename duplicate projects
+        while (true) {
+          try {
+            out.putNextEntry(new ZipEntry(name));
+            break;
+          } catch (IOException e) {
+            name = "duplicate-" + name;
+          }
+        }
+        metadata += projectSourceZip.getMetadata() + "\n";
+
+        out.write(data, 0, data.length);
+        out.closeEntry();
+        count++;
+      } catch (IllegalArgumentException e) {
+        System.err.println("No files found for userid: " + userId +
+            " for projectid: " + projectId);
+        continue;
+      } catch (IOException e) {
+        System.err.println("IOException while reading files found for userid: " +
+            userId + " for projectid: " + projectId);
+        continue;
+      }
+    }
+    if (count == 0) {
+      throw new IllegalArgumentException("No files to download");
+    }
+
+    List<String> userFiles = storageIo.getUserFiles(userId);
+    if (userFiles.contains(StorageUtil.ANDROID_KEYSTORE_FILENAME)) {
+      byte[] androidKeystoreBytes =
+          storageIo.downloadRawUserFile(userId, StorageUtil.ANDROID_KEYSTORE_FILENAME);
+      if (androidKeystoreBytes.length > 0) {
+        out.putNextEntry(new ZipEntry(StorageUtil.ANDROID_KEYSTORE_FILENAME));
+        out.write(androidKeystoreBytes, 0, androidKeystoreBytes.length);
+        out.closeEntry();
+        count++;
+      }
+    }
+
+    out.close();
+
+    // Package the big zip file up as a ProjectSourceZip and return it.
+    byte[] content = zipFile.toByteArray();
+    ProjectSourceZip projectSourceZip = new ProjectSourceZip(zipName, content, count);
+    projectSourceZip.setMetadata(metadata);
+    return projectSourceZip;
+  }
+
   @Override
   public ProjectSourceZip exportAllProjectsSourceZip(String userId,
       String zipName) throws IOException {

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/ServerLayout.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/ServerLayout.java
@@ -111,6 +111,12 @@ public class ServerLayout {
 
   /**
    * Relative path within {@link com.google.appinventor.server.DownloadServlet}
+   * for downloading selectedof a user's projects' sources.
+   */
+  public static final String DOWNLOAD_SELECTED_PROJECTS_SOURCE = 
+		  "selected-projects-source";
+  /**
+   * Relative path within {@link com.google.appinventor.server.DownloadServlet}
    * for downloading all of a user's projects' sources.
    */
   public static final String DOWNLOAD_ALL_PROJECTS_SOURCE = "all-projects-source";


### PR DESCRIPTION
This branch adds a "Export selected projects" menu item to the Projects dropdown in the menu at the top. It downloads all projects the user selects (using the check boxes next to the projects) as a zip file.

I closed my last pull request and opened a new one because my last pull request a) had a bunch of extra additions, and b) was not squashed into one commit.

@afmckinney 
