### PR TITLE
Rename HoneycombUtil to HoneycomMR1Util

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
@@ -25,8 +25,8 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.HoneycombMR1Util;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
-import com.google.appinventor.components.runtime.util.HoneycombUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 
 /**
@@ -99,9 +99,9 @@ public class ContactPicker extends Picker implements ActivityResultListener {
     activityContext = container.$context();
 
     if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB && intentUri.equals(Contacts.People.CONTENT_URI)) {
-      this.intentUri = HoneycombUtil.getContentUri();
+      this.intentUri = HoneycombMR1Util.getContentUri();
     } else if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB && intentUri.equals(Contacts.Phones.CONTENT_URI)) {
-      this.intentUri = HoneycombUtil.getPhoneContentUri();
+      this.intentUri = HoneycombMR1Util.getPhoneContentUri();
     } else {
       this.intentUri = intentUri;
     }
@@ -224,14 +224,14 @@ public class ContactPicker extends Picker implements ActivityResultListener {
         Cursor dataCursor = null;
         try {
           if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
-            CONTACT_PROJECTION = HoneycombUtil.getContactProjection();
+            CONTACT_PROJECTION = HoneycombMR1Util.getContactProjection();
             contactCursor = activityContext.getContentResolver().query(receivedContactUri,
                 CONTACT_PROJECTION, null, null, null);
 
             String id = postHoneycombGetContactNameAndPicture(contactCursor);
 
-            DATA_PROJECTION = HoneycombUtil.getDataProjection();
-            dataCursor = HoneycombUtil.getDataCursor(id, activityContext, DATA_PROJECTION);
+            DATA_PROJECTION = HoneycombMR1Util.getDataProjection();
+            dataCursor = HoneycombMR1Util.getDataCursor(id, activityContext, DATA_PROJECTION);
             postHoneycombGetContactEmailAndPhone(dataCursor);
 
             //explicit set TextContactUri
@@ -284,10 +284,10 @@ public class ContactPicker extends Picker implements ActivityResultListener {
   public String postHoneycombGetContactNameAndPicture(Cursor contactCursor) {
     String id = "";
     if (contactCursor.moveToFirst()) {
-      final int ID_INDEX = HoneycombUtil.getIdIndex(contactCursor);
-      final int NAME_INDEX = HoneycombUtil.getNameIndex(contactCursor);
-      final int THUMBNAIL_INDEX = HoneycombUtil.getThumbnailIndex(contactCursor);
-      final int PHOTO_INDEX = HoneycombUtil.getPhotoIndex(contactCursor);
+      final int ID_INDEX = HoneycombMR1Util.getIdIndex(contactCursor);
+      final int NAME_INDEX = HoneycombMR1Util.getNameIndex(contactCursor);
+      final int THUMBNAIL_INDEX = HoneycombMR1Util.getThumbnailIndex(contactCursor);
+      final int PHOTO_INDEX = HoneycombMR1Util.getPhotoIndex(contactCursor);
       id = guardCursorGetString(contactCursor, ID_INDEX);
       contactName = guardCursorGetString(contactCursor, NAME_INDEX);
       contactPictureUri = guardCursorGetString(contactCursor, THUMBNAIL_INDEX);
@@ -308,12 +308,12 @@ public class ContactPicker extends Picker implements ActivityResultListener {
     List<String> emailListToStore = new ArrayList<String>();
 
     if (dataCursor.moveToFirst()) {
-      final int PHONE_INDEX = HoneycombUtil.getPhoneIndex(dataCursor);
-      final int EMAIL_INDEX = HoneycombUtil.getEmailIndex(dataCursor);
-      final int MIME_INDEX = HoneycombUtil.getMimeIndex(dataCursor);
+      final int PHONE_INDEX = HoneycombMR1Util.getPhoneIndex(dataCursor);
+      final int EMAIL_INDEX = HoneycombMR1Util.getEmailIndex(dataCursor);
+      final int MIME_INDEX = HoneycombMR1Util.getMimeIndex(dataCursor);
 
-      String phoneType = HoneycombUtil.getPhoneType();
-      String emailType = HoneycombUtil.getEmailType();
+      String phoneType = HoneycombMR1Util.getPhoneType();
+      String emailType = HoneycombMR1Util.getEmailType();
 
       while (!dataCursor.isAfterLast()) {
         String type = guardCursorGetString(dataCursor, MIME_INDEX);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/EmailAddressAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/EmailAddressAdapter.java
@@ -19,7 +19,7 @@ import android.widget.ResourceCursorAdapter;
 import android.widget.TextView;
 import android.util.Log;
 
-import com.google.appinventor.components.runtime.util.HoneycombUtil;
+import com.google.appinventor.components.runtime.util.HoneycombMR1Util;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 
 /**
@@ -53,14 +53,14 @@ public class EmailAddressAdapter extends ResourceCursorAdapter {
     ContactMethods.DATA,   // 2
   };
 
-  private static final String[] POST_HONEYCOMB_PROJECTION = HoneycombUtil.getEmailAdapterProjection();
+  private static final String[] POST_HONEYCOMB_PROJECTION = HoneycombMR1Util.getEmailAdapterProjection();
 
   public EmailAddressAdapter(Context context) {
     super(context, android.R.layout.simple_dropdown_item_1line, null);
     contentResolver = context.getContentResolver();
     this.context = context;
     if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
-      SORT_ORDER = HoneycombUtil.getTimesContacted() + " DESC, " + HoneycombUtil.getDisplayName();
+      SORT_ORDER = HoneycombMR1Util.getTimesContacted() + " DESC, " + HoneycombMR1Util.getDisplayName();
     } else {
       SORT_ORDER = People.TIMES_CONTACTED + " DESC, " + People.NAME;
     }
@@ -69,8 +69,8 @@ public class EmailAddressAdapter extends ResourceCursorAdapter {
   @Override
   public final String convertToString(Cursor cursor) {
 
-    int POST_HONEYCOMB_NAME_INDEX = cursor.getColumnIndex(HoneycombUtil.getDisplayName());
-    int POST_HONEYCOMB_EMAIL_INDEX = cursor.getColumnIndex(HoneycombUtil.getEmailAddress());
+    int POST_HONEYCOMB_NAME_INDEX = cursor.getColumnIndex(HoneycombMR1Util.getDisplayName());
+    int POST_HONEYCOMB_EMAIL_INDEX = cursor.getColumnIndex(HoneycombMR1Util.getEmailAddress());
     String name = "";
     String address = "";
 
@@ -87,8 +87,8 @@ public class EmailAddressAdapter extends ResourceCursorAdapter {
 
   private final String makeDisplayString(Cursor cursor) {
 
-    int POST_HONEYCOMB_NAME_INDEX = cursor.getColumnIndex(HoneycombUtil.getDisplayName());
-    int POST_HONEYCOMB_EMAIL_INDEX = cursor.getColumnIndex(HoneycombUtil.getEmailAddress());
+    int POST_HONEYCOMB_NAME_INDEX = cursor.getColumnIndex(HoneycombMR1Util.getDisplayName());
+    int POST_HONEYCOMB_EMAIL_INDEX = cursor.getColumnIndex(HoneycombMR1Util.getEmailAddress());
     StringBuilder s = new StringBuilder();
     boolean flag = false;
     String name = "";
@@ -136,8 +136,8 @@ public class EmailAddressAdapter extends ResourceCursorAdapter {
       String filter = DatabaseUtils.sqlEscapeString(constraint.toString() + '%');
 
       if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
-        db = HoneycombUtil.getDataContentUri();
-        s.append("(" + HoneycombUtil.getDataMimeType() + "='" + HoneycombUtil.getEmailType() + "')");
+        db = HoneycombMR1Util.getDataContentUri();
+        s.append("(" + HoneycombMR1Util.getDataMimeType() + "='" + HoneycombMR1Util.getEmailType() + "')");
         s.append(" AND ");
         s.append("(display_name LIKE ");
         s.append(filter);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneNumberPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneNumberPicker.java
@@ -13,7 +13,7 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
-import com.google.appinventor.components.runtime.util.HoneycombUtil;
+import com.google.appinventor.components.runtime.util.HoneycombMR1Util;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 
@@ -121,13 +121,13 @@ public class PhoneNumberPicker extends ContactPicker {
         Cursor dataCursor = null;
         try {
           if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
-            NAME_PROJECTION = HoneycombUtil.getNameProjection();
+            NAME_PROJECTION = HoneycombMR1Util.getNameProjection();
             contactCursor = activityContext.getContentResolver().query(phoneUri,
                 NAME_PROJECTION, null, null, null);
             String id = postHoneycombGetContactNameAndPicture(contactCursor);
 
-            DATA_PROJECTION = HoneycombUtil.getDataProjection();
-            dataCursor = HoneycombUtil.getDataCursor(id, activityContext, DATA_PROJECTION);
+            DATA_PROJECTION = HoneycombMR1Util.getDataProjection();
+            dataCursor = HoneycombMR1Util.getDataCursor(id, activityContext, DATA_PROJECTION);
             postHoneycombGetContactEmailsAndPhones(dataCursor);
           } else {
             contactCursor = activityContext.getContentResolver().query(phoneUri,
@@ -180,10 +180,10 @@ public class PhoneNumberPicker extends ContactPicker {
   public String postHoneycombGetContactNameAndPicture(Cursor contactCursor) {
     String id = "";
     if (contactCursor.moveToFirst()) {
-      final int CONTACT_ID_INDEX = HoneycombUtil.getContactIdIndex(contactCursor);
-      final int NAME_INDEX = HoneycombUtil.getNameIndex(contactCursor);
-      final int PHOTO_INDEX = HoneycombUtil.getThumbnailIndex(contactCursor);
-      final int PHONE_INDEX = HoneycombUtil.getPhoneIndex(contactCursor);
+      final int CONTACT_ID_INDEX = HoneycombMR1Util.getContactIdIndex(contactCursor);
+      final int NAME_INDEX = HoneycombMR1Util.getNameIndex(contactCursor);
+      final int PHOTO_INDEX = HoneycombMR1Util.getThumbnailIndex(contactCursor);
+      final int PHONE_INDEX = HoneycombMR1Util.getPhoneIndex(contactCursor);
       phoneNumber = guardCursorGetString(contactCursor, PHONE_INDEX);
       id = guardCursorGetString(contactCursor, CONTACT_ID_INDEX);
       contactName = guardCursorGetString(contactCursor, NAME_INDEX);
@@ -200,12 +200,12 @@ public class PhoneNumberPicker extends ContactPicker {
     List<String> phoneListToStore = new ArrayList<String>();
     List<String> emailListToStore = new ArrayList<String>();
     if (dataCursor.moveToFirst()) {
-      final int PHONE_INDEX = HoneycombUtil.getPhoneIndex(dataCursor);
-      final int EMAIL_INDEX = HoneycombUtil.getEmailIndex(dataCursor);
-      final int MIME_INDEX = HoneycombUtil.getMimeIndex(dataCursor);
+      final int PHONE_INDEX = HoneycombMR1Util.getPhoneIndex(dataCursor);
+      final int EMAIL_INDEX = HoneycombMR1Util.getEmailIndex(dataCursor);
+      final int MIME_INDEX = HoneycombMR1Util.getMimeIndex(dataCursor);
 
-      String phoneType = HoneycombUtil.getPhoneType();
-      String emailType = HoneycombUtil.getEmailType();
+      String phoneType = HoneycombMR1Util.getPhoneType();
+      String emailType = HoneycombMR1Util.getEmailType();
 
       // Get the first (default) email and phone number associated with the contact.
       while (!dataCursor.isAfterLast()) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombMR1Util.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombMR1Util.java
@@ -22,13 +22,13 @@ import android.provider.ContactsContract.Data;
 import java.io.InputStream;
 
 /**
- * Helper methods for calling methods added in Honeycomb (3.0, API level 12)
+ * Helper methods for calling methods added in HONEYCOMB_MR1 (3.1, API level 12)
  *
  *
  */
-public class HoneycombUtil {
+public class HoneycombMR1Util {
 
-  private HoneycombUtil() {
+  private HoneycombMR1Util() {
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -205,7 +205,7 @@ public class MediaUtil {
         // Open the photo for the contact.
         InputStream is = null;
         if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
-          is = HoneycombUtil.openContactPhotoInputStreamHelper(form.getContentResolver(),
+          is = HoneycombMR1Util.openContactPhotoInputStreamHelper(form.getContentResolver(),
               Uri.parse(mediaPath));
         } else {
           is = Contacts.People.openContactPhotoInputStream(form.getContentResolver(),

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/SdkLevel.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/SdkLevel.java
@@ -25,11 +25,12 @@ public class SdkLevel {
   public static final int LEVEL_FROYO = 8;                // a.k.a. 2.2
   public static final int LEVEL_GINGERBREAD = 9;          // a.k.a. 2.3
   public static final int LEVEL_GINGERBREAD_MR1 = 10;     // a.k.a. 2.3.3
-  public static final int LEVEL_HONEYCOMB = 12;           // a.k.a. 3.0
+  public static final int LEVEL_HONEYCOMB_MR1 = 12;       // a.k.a. 3.1.X
+  public static final int LEVEL_HONEYCOMB = 11;           // a.k.a. 3.0.X
   public static final int LEVEL_ICE_CREAM_SANDWICH = 14;  // a.k.a. 4.0
   public static final int LEVEL_JELLYBEAN = 16;           // a.k.a. 4.1
   public static final int LEVEL_JELLYBEAN_MR1 = 17;       // a.k.a. 4.2
-  public static final int LEVEL_JELLYBEAN_MR2 = 18;       // a.k.a. 4.3 
+  public static final int LEVEL_JELLYBEAN_MR2 = 18;       // a.k.a. 4.3
 
   private SdkLevel() {
   }


### PR DESCRIPTION
HoneycombUtil, for API level 12 should really be named
HoneycombMR1Util which is the Android release that corresponds to API
12. Note: API4 Code will re-introduce HoneycombUtil for API 11.

Change-Id: Ic602cf7378877f9fdc2023748c3cdb0abd869e9c