### PR TITLE
Ensure Image Manipulation doesn't use too much memory

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1793,4 +1793,8 @@ public class Form extends Activity
     bgview.invalidate();
   }
 
+  public static boolean getCompatibilityMode() {
+    return sCompatibilityMode;
+  }
+
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -316,29 +316,47 @@ public class MediaUtil {
 
     BitmapFactory.Options options;
     try {
-      options = getBitmapOptions(form, is1);
+      options = getBitmapOptions(form, is1, mediaPath);
     } finally {
       is1.close();
     }
 
     InputStream is2 = openMedia(form, mediaPath, mediaSource);
     try {
+      Log.d(LOG_TAG, "mediaPath = " + mediaPath);
       BitmapDrawable originalBitmapDrawable = new BitmapDrawable(decodeStream(is2, null, options));
-      // To be able to support different density devices, we might need to scale the bitmap
-      // The steps are:
+      // If options.inSampleSize == 1, then the image was not unreasonably large and may represent
+      // the actual size the user intended for the image. However we still have to scale it by
+      // the device density.
+      // However if we *did* sample the image to make it smaller, then that means that the image
+      // was not sized specifically for the application. In that case it makes no sense to
+      // scale it, so we don't.
+      // When we scale the image we do the following steps:
       //   1. set the density in the returned bitmap drawable.
       //   2. calculate scaled width and height
       //   3. create a scaled bitmap with the scaled measures
       //   4. create a new bitmap drawable with the scaled bitmap
       //   5. set the density in the scaled bitmap.
+
+      // Note: The log line below requires HoneycombMR1, but we may not keep it, so punting for now
+      Log.d(LOG_TAG, "originalBitmap.getByteCount() = " + originalBitmapDrawable.getBitmap().getByteCount());
+
       originalBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
+      if (options.inSampleSize != 1) {
+        return originalBitmapDrawable;
+      }
       int scaledWidth = (int) (form.deviceDensity() * originalBitmapDrawable.getIntrinsicWidth());
       int scaledHeight = (int) (form.deviceDensity() * originalBitmapDrawable.getIntrinsicHeight());
+      Log.d(LOG_TAG, "form.deviceDensity() = " + form.deviceDensity());
+      Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicWidth() = " + originalBitmapDrawable.getIntrinsicWidth());
+      Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicHeight() = " + originalBitmapDrawable.getIntrinsicHeight());
       Bitmap scaledBitmap = Bitmap.createScaledBitmap(originalBitmapDrawable.getBitmap(),
           scaledWidth, scaledHeight, false);
       BitmapDrawable scaledBitmapDrawable = new BitmapDrawable(scaledBitmap);
       scaledBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
-
+      originalBitmapDrawable.getBitmap().recycle(); // Free's native resources used by the bitmap
+                                                    // may not really be needed, but it doesn't hurt
+      System.gc();              // We likely used a lot of memory, so gc now.
       return scaledBitmapDrawable;
 
     } finally {
@@ -381,7 +399,7 @@ public class MediaUtil {
     }
   }
 
-  private static BitmapFactory.Options getBitmapOptions(Form form, InputStream is) {
+  private static BitmapFactory.Options getBitmapOptions(Form form, InputStream is, String mediaPath) {
     // Get the size of the image.
     BitmapFactory.Options options = new BitmapFactory.Options();
     options.inJustDecodeBounds = true;
@@ -397,13 +415,26 @@ public class MediaUtil {
     // width/height of the screen.
     // The goal is to never make an image that is actually larger than the screen end up appearing
     // smaller than the screen.
-    int maxWidth = 2 * display.getWidth();
-    int maxHeight = 2 * display.getHeight();
+    // int maxWidth = 2 * display.getWidth();
+    // int maxHeight = 2 * display.getHeight();
+    int maxWidth;
+    int maxHeight;
+    if (form.getCompatibilityMode()) { // Compatibility Mode
+      maxWidth = 360 * 2;     // Originally used 2 times device size, continue to do so here
+      maxHeight = 420 * 2;
+    } else {                    // Responsive Mode
+      maxWidth = (int) (display.getWidth() / form.deviceDensity());
+      maxHeight = (int) (display.getHeight() / form.deviceDensity());
+    }
+
     int sampleSize = 1;
     while ((imageWidth / sampleSize > maxWidth) && (imageHeight / sampleSize > maxHeight)) {
       sampleSize *= 2;
     }
     options = new BitmapFactory.Options();
+    Log.d(LOG_TAG, "getBitmapOptions: sampleSize = " + sampleSize + " mediaPath = " + mediaPath
+      + " maxWidth = " + maxWidth + " maxHeight = " + maxHeight +
+      " display width = " + display.getWidth() + " display height = " + display.getHeight());
     options.inSampleSize = sampleSize;
     return options;
   }


### PR DESCRIPTION
When an image is smaller then the screen size, then scale it up by the
device pixel density. However when an image is larger then the screen,
sample it down to fit and then do not scale it again by pixel size.

The rationale for this change is that if someone uploads a “small”
image, they are likely to have sized it for their application, in
which case we will want to scale it based on device screen
density. However if the image is larger then the screen, we can
presume some other mechanism will be used to adjust its displayed size
(for example a set length and width in an Image component). In this
case we sample it down to fit on the screen but we do not scale it
based on pixel density.