### PR TITLE
Make sure the Web Component has the permissions it needs

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
@@ -68,7 +68,9 @@ import java.util.Map;
     nonVisible = true,
     iconName = "images/web.png")
 @SimpleObject
-@UsesPermissions(permissionNames = "android.permission.INTERNET")
+@UsesPermissions(permissionNames = "android.permission.INTERNET," +
+  "android.permission.WRITE_EXTERNAL_STORAGE," +
+  "android.permission.READ_EXTERNAL_STORAGE")
 @UsesLibraries(libraries = "json.jar")
 
 
@@ -358,6 +360,7 @@ public class Web extends AndroidNonvisibleComponent implements Component {
           form.dispatchErrorOccurredEvent(Web.this, "Get",
               e.getErrorMessageNumber());
         } catch (Exception e) {
+          Log.e(LOG_TAG, "ERROR_UNABLE_TO_GET", e);
           form.dispatchErrorOccurredEvent(Web.this, "Get",
               ErrorMessages.ERROR_WEB_UNABLE_TO_GET, webProps.urlString);
         }


### PR DESCRIPTION
The Web Component needs READ_EXTERNAL_STORAGE and
WRITE_EXTERNAL_STORAGE. When we created packages with minSdk of 3, we
didn’t need these permissions because they were not introduced until
API 4, so if you declared you minSdk to be 3 (or less) then their
granting was implied. When we updated our minSdk to 4, we lost this
grandfathered implied permission.

Change-Id: I01bedb15bc82e58231bf1ae3226af788b7d86bb5