### PR TITLE
Fix MediaUtil for devices with density of 1.0

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -339,7 +339,7 @@ public class MediaUtil {
       //   5. set the density in the scaled bitmap.
 
       originalBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
-      if (options.inSampleSize != 1) {
+      if ((options.inSampleSize != 1) || (form.deviceDensity() == 1.0f)) {
         return originalBitmapDrawable;
       }
       int scaledWidth = (int) (form.deviceDensity() * originalBitmapDrawable.getIntrinsicWidth());
@@ -351,8 +351,6 @@ public class MediaUtil {
           scaledWidth, scaledHeight, false);
       BitmapDrawable scaledBitmapDrawable = new BitmapDrawable(scaledBitmap);
       scaledBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
-      originalBitmapDrawable.getBitmap().recycle(); // Free's native resources used by the bitmap
-                                                    // may not really be needed, but it doesn't hurt
       System.gc();              // We likely used a lot of memory, so gc now.
       return scaledBitmapDrawable;
 


### PR DESCRIPTION
Turns out that calling scaling with a density of 1.0 causes Android to
just return the original bitmap. But we called recycle() on the
original bitmap, which results in an error when the scaled
bitmap (which is “eq” to the original bitmap) is used.

Remove the call to recycle() as it likely isn’t needed. Don’t bother
attempting to scale a bitmap when the density is 1.0

Change-Id: Ib9b52baa29c99b2ccd77fbef299522446552ab60