### PR TITLE
Set scaleFrameLayout scale to 1.0 when keyboard open

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -342,18 +342,19 @@ public class Form extends Activity
       Log.d(LOG_TAG, "keyboard hidden!");
       if (keyboardShown) {
         keyboardShown = false;
-        if (sCompatibilityMode) { // Only need this in "Fixed" mode
-          androidUIHandler.postDelayed(new Runnable() {
-              public void run() {
-                recomputeLayout();
-              }
-            }, 100);
+        if (sCompatibilityMode) { // Put us back in "Fixed" Mode
+          scaleLayout.setScale(compatScalingFactor);
+          scaleLayout.invalidate();
         }
       }
     } else {
       int keyboardHeight = heightDiff - contentViewTop;
       Log.d(LOG_TAG, "keyboard shown!");
       keyboardShown = true;
+      if (scaleLayout != null) { // Effectively put us in responsive mode
+        scaleLayout.setScale(1.0f);
+        scaleLayout.invalidate();
+      }
     }
   }
 


### PR DESCRIPTION
Set scaling to 1.0 when the keyboard is open. This effectively puts us
in Responsive mode when the keyboard is open. Set it back to the
appropriate value (when in Fixed mode) when the keyboard is
closed. This works around the issue where the screen gets improperly
scaled when the keyboard is open. We suspect there is a bad
interaction between our scaling in Fixed mode and the scaling that
Android provides (at least in Android 5.1.1) when the keybaord is
opened. So we remove ours.

Change-Id: I1cec18ea57ead5527885d96c8b395ab90c240f5d