### PR TITLE
Patch to make sure event parameter blocks can be renamed

### DIFF
--- a/appinventor/blocklyeditor/src/field_lexical_variable.js
+++ b/appinventor/blocklyeditor/src/field_lexical_variable.js
@@ -90,6 +90,19 @@ Blockly.FieldLexicalVariable.prototype.getValue = function() {
 Blockly.FieldLexicalVariable.prototype.setValue = function(text) {
   this.value_ = text;
   this.setText(text);
+  // The code below is almost certainly in the wrong place
+  // but it seems to fix the problem by making sure that any
+  // eventparam value in a variable block is removed. The next
+  // time it is needed, it will be re-computed. There *has*
+  // to be a better place for this code, but I couldn't find it in the
+  // short time I had to work on this. So consider this a patch
+  // until we figure out where this code really belongs!
+  if (this.block_) {
+    if (this.block_.eventparam) {
+      this.block_.eventparam = undefined; // unset it
+    }
+  }
+
 };
 
 /**


### PR DESCRIPTION
The English (aka internal) parameter names are stored in the
“eventparam” field of a block. However when a parameter block is
renamed (which can only happen when an event has multiple arguments
and you are renaming one to the others, say startX to startY) the
eventparam field was not being updated. This patch makes sure it is
updated, but is likely not being done “in the right place.” but until
we find the correct fix, this patch should alleviate the symptoms of
the problem.

Change-Id: I8c189b271a693793afbb8d9cf255b8f0672a70a8