### PR TITLE
Allow Background Color and Background Image simultaneously on Canvas

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
@@ -93,8 +93,7 @@ import java.util.Set;
     category = ComponentCategory.ANIMATION)
 @SimpleObject
 @UsesPermissions(permissionNames = "android.permission.INTERNET," +
-                 "android.permission.WRITE_EXTERNAL_STORAGE," +
-                 "android.permission.CAMERA" )
+                 "android.permission.WRITE_EXTERNAL_STORAGE")
 public final class Canvas extends AndroidViewComponent implements ComponentContainer {
   private static final String LOG_TAG = "Canvas";
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
@@ -6,6 +6,8 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -91,7 +93,8 @@ import java.util.Set;
     category = ComponentCategory.ANIMATION)
 @SimpleObject
 @UsesPermissions(permissionNames = "android.permission.INTERNET," +
-                 "android.permission.WRITE_EXTERNAL_STORAGE")
+                 "android.permission.WRITE_EXTERNAL_STORAGE," +
+                 "android.permission.CAMERA" )
 public final class Canvas extends AndroidViewComponent implements ComponentContainer {
   private static final String LOG_TAG = "Canvas";
 
@@ -553,17 +556,23 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
         }
       }
 
-      setBackgroundDrawable(backgroundDrawable);
-
-      // If the path was null or the empty string, or if IOException was
-      // raised, backgroundDrawable will be null.  The only difference
-      // from the case of a successful image load is that we must draw
-      // in the background color, if present.
-      if (backgroundDrawable == null) {
-        super.setBackgroundColor(backgroundColor);
-      }
+      setBackground();
 
       clearDrawingLayer();  // will call invalidate()
+    }
+
+    private void setBackground() {
+      Drawable setDraw = backgroundDrawable;
+      if (backgroundImagePath != "" && backgroundDrawable != null) {
+        setDraw = backgroundDrawable.getConstantState().newDrawable();
+        setDraw.setColorFilter((backgroundColor != Component.COLOR_DEFAULT) ? backgroundColor : Component.COLOR_WHITE,
+            PorterDuff.Mode.DST_OVER);
+      }
+      else {
+        setDraw = new ColorDrawable(
+            (backgroundColor != Component.COLOR_DEFAULT) ? backgroundColor : Component.COLOR_WHITE);
+      }
+      setBackgroundDrawable(setDraw);
     }
 
     private void clearDrawingLayer() {
@@ -578,10 +587,7 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
     public void setBackgroundColor(int color) {
       backgroundColor = color;
 
-      // Only draw the background color if no image.
-      if (backgroundDrawable == null) {
-        super.setBackgroundColor(color);
-      }
+      setBackground();
 
       clearDrawingLayer();
     }


### PR DESCRIPTION
Currently Canvas does not support both Background Color and Image at the same time. This PR fixes that issue and allows both Background Color and Image simultaneously. 

Background Image is drawn on top of Background Color. 
The Companion side has been corrected. 
