### PR TITLE
fix for #562 procedures missing sockets in typeblocks

### DIFF
--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -278,16 +278,28 @@ Blockly.Drawer.mutatorAttributesToXMLString = function(mutatorAttributes){
 
 // [lyn, 10/22/13] return an XML string including one procedure caller for each procedure declaration
 // in main workspace.
-Blockly.Drawer.procedureCallersXMLString = function(returnsValue) {
+// [jos, 10/18/15] if we pass a proc_name, we only want one procedure returned as xmlString
+Blockly.Drawer.procedureCallersXMLString = function(returnsValue, proc_name) {
   var xmlString = '<xml>'  // Used to accumulate xml for each caller
   var decls = Blockly.AIProcedure.getProcedureDeclarationBlocks(returnsValue);
-  decls.sort(Blockly.Drawer.compareDeclarationsByName); // sort decls lexicographically by procedure name
-  for (var i = 0; i < decls.length; i++) {
-    xmlString += Blockly.Drawer.procedureCallerBlockString(decls[i]);
+
+  if (proc_name) {
+    for (var i = 0; i < decls.length; i++) {
+      if (decls[i].getFieldValue('NAME').toLocaleLowerCase() == proc_name){
+        xmlString += Blockly.Drawer.procedureCallerBlockString(decls[i]);
+        break;
+      }
+    }
+  }
+  else {
+    decls.sort(Blockly.Drawer.compareDeclarationsByName); // sort decls lexicographically by procedure name
+    for (var i = 0; i < decls.length; i++) {
+      xmlString += Blockly.Drawer.procedureCallerBlockString(decls[i]);
+    }
   }
   xmlString += '</xml>';
   return xmlString;
-}
+};
 
 Blockly.Drawer.compareDeclarationsByName = function (decl1, decl2) {
   var name1 = decl1.getFieldValue('NAME').toLocaleLowerCase();

--- a/appinventor/lib/blockly/src/core/typeblock.js
+++ b/appinventor/lib/blockly/src/core/typeblock.js
@@ -464,7 +464,8 @@ Blockly.TypeBlock.createAutoComplete_ = function(inputText){
         if (xmlString === null) {
           var blockType = blockToCreate.canonicName;
           if (blockType == 'procedures_callnoreturn' || blockType == 'procedures_callreturn') {
-            xmlString = Blockly.Drawer.procedureCallersXMLString(blockType == 'procedures_callreturn');
+            xmlString = Blockly.Drawer.procedureCallersXMLString(blockType == 'procedures_callreturn',
+                blockToCreate.dropDown.value);
           } else {
             xmlString = '<xml><block type="' + blockType + '">';
             if(!goog.object.isEmpty(blockToCreate.mutatorAttributes)) {


### PR DESCRIPTION
The previous code would return a list of all procedures and always pick the first one (lexicographically sorted). Now it returns the right procedure by using its original name.

You can play with it at: http://ai-procs-typeblock.appspot.com/
#562 has a good step by step guide on how to reproduce the error.

Please review @jisqyv @halatmit @fturbak 