### PR TITLE
Check for warnings before build

### DIFF
--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -103,6 +103,7 @@ Blockly.Yail.FLONUM_REGEXP = "^[\\s]*[-+]?([0-9]*)((\\.[0-9]+)|[0-9]\\.)[\\s]*$"
  * @returns {String} the generated code if there were no errors.
  */
 Blockly.Yail.getFormYail = function(formJson, packageName, forRepl) {
+  //check for warnings
   if (Blockly.WarningHandler.getWarningCount() > 0) {
     throw "Cannot build with warnings";
   }

--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -103,6 +103,9 @@ Blockly.Yail.FLONUM_REGEXP = "^[\\s]*[-+]?([0-9]*)((\\.[0-9]+)|[0-9]\\.)[\\s]*$"
  * @returns {String} the generated code if there were no errors.
  */
 Blockly.Yail.getFormYail = function(formJson, packageName, forRepl) {
+  if (Blockly.WarningHandler.getWarningCount() > 0) {
+    throw "Cannot build with warnings";
+  }
   var jsonObject = JSON.parse(formJson); 
   // TODO: check for JSON parse error
   var componentNames = [];

--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -103,7 +103,10 @@ Blockly.Yail.FLONUM_REGEXP = "^[\\s]*[-+]?([0-9]*)((\\.[0-9]+)|[0-9]\\.)[\\s]*$"
  * @returns {String} the generated code if there were no errors.
  */
 Blockly.Yail.getFormYail = function(formJson, packageName, forRepl) {
-  //check for warnings
+  //check for errors and warnings
+  if (Blockly.WarningHandler.getErrorCount() > 0) {
+    throw "Cannot build with errors";
+  }
   if (Blockly.WarningHandler.getWarningCount() > 0) {
     throw "Cannot build with warnings";
   }

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -32,6 +32,11 @@ Blockly.WarningHandler.updateWarningErrorCount = function() {
   Blockly.mainWorkspace.warningIndicator.updateWarningAndErrorCount();
 }
 
+Blockly.WarningHandler.getWarningCount = function() {
+  //update the error and warning count in the UI
+  return Blockly.WarningHandler.warningCount;
+}
+
 //Call to toggle the visibility of the warnings on the blocks
 Blockly.WarningHandler.warningToggle = function() {
   if(Blockly.WarningHandler.showWarningsToggle) {

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -37,6 +37,11 @@ Blockly.WarningHandler.getWarningCount = function() {
   return Blockly.WarningHandler.warningCount;
 }
 
+Blockly.WarningHandler.getErrorCount = function() {
+  //return current warning count
+  return Blockly.WarningHandler.errorCount;
+}
+
 //Call to toggle the visibility of the warnings on the blocks
 Blockly.WarningHandler.warningToggle = function() {
   if(Blockly.WarningHandler.showWarningsToggle) {

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -33,7 +33,7 @@ Blockly.WarningHandler.updateWarningErrorCount = function() {
 }
 
 Blockly.WarningHandler.getWarningCount = function() {
-  //update the error and warning count in the UI
+  //return current warning count
   return Blockly.WarningHandler.warningCount;
 }
 


### PR DESCRIPTION
Fix for #394.

Checks whether warning count > 0 before generating Yail.

Will throw an error -
![selection_003](https://cloud.githubusercontent.com/assets/8927635/10911534/480777be-826b-11e5-972e-62318ad7b360.png)

@halatmit @josmas @afmckinney 
