### PR TITLE
Make blocks marked as bad persistent

### DIFF
--- a/appinventor/lib/blockly/src/core/xml.js
+++ b/appinventor/lib/blockly/src/core/xml.js
@@ -124,6 +124,9 @@ Blockly.Xml.blockToDom_ = function(block) {
   if (block.isCollapsed()) {
     element.setAttribute('collapsed', true);
   }
+  if (block.isBadBlock()) {
+    element.setAttribute('badblock', true);
+  }
   if (block.disabled) {
     element.setAttribute('disabled', true);
   }
@@ -347,27 +350,6 @@ Blockly.Xml.domToBlockInner = function(workspace, xmlBlock, opt_reuseBlock) {
     block.initSvg();
   }
 
-  var inline = xmlBlock.getAttribute('inline');
-  if (inline) {
-    block.setInputsInline(inline == 'true');
-  }
-  var disabled = xmlBlock.getAttribute('disabled');
-  if (disabled) {
-    block.setDisabled(disabled == 'true');
-  }
-  var deletable = xmlBlock.getAttribute('deletable');
-  if (deletable) {
-    block.setDeletable(deletable == 'true');
-  }
-  var movable = xmlBlock.getAttribute('movable');
-  if (movable) {
-    block.setMovable(movable == 'true');
-  }
-  var editable = xmlBlock.getAttribute('editable');
-  if (editable) {
-    block.setEditable(editable == 'true');
-  }
-
   var blockChild = null;
   for (var x = 0, xmlChild; xmlChild = xmlBlock.childNodes[x]; x++) {
     if (xmlChild.nodeType == 3 && xmlChild.data.match(/^\s*$/)) {
@@ -461,6 +443,10 @@ Blockly.Xml.domToBlockInner = function(workspace, xmlBlock, opt_reuseBlock) {
   var inline = xmlBlock.getAttribute('inline');
   if (inline) {
     block.setInputsInline(inline == 'true');
+  }
+  var badblock = xmlBlock.getAttribute('badblock');
+  if (badblock) {
+    block.badBlock();
   }
   var disabled = xmlBlock.getAttribute('disabled');
   if (disabled) {


### PR DESCRIPTION
Fix a bug where a reload of a project with bad blocks would “unbad”
those blocks. Make sure we store whether or not a block is bad in the
blocks file.

Also, some minor code cleanup (deleting redundant code).

Change-Id: I0300554ec9a1c8805e48aa579c8c24f3960f08ce