### PR TITLE
Fixed the search to allow for pagination through all the search results

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/GalleryList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/GalleryList.java
@@ -69,7 +69,6 @@ public class GalleryList extends Composite implements GalleryRequestListener {
   private GalleryAppTab appSearchTab;
   private GalleryAppTab appTutorialTab;
 
-
   public static final int REQUEST_FEATURED = 1;
   public static final int REQUEST_RECENT = 2;
   public static final int REQUEST_SEARCH = 3;
@@ -87,6 +86,7 @@ public class GalleryList extends Composite implements GalleryRequestListener {
   private int appPopularCounter = 0;
   private int appSearchCounter = 0;
   private int appTutorialCounter = 0;
+
   private boolean appRecentExhausted = false;
   private boolean appFeaturedExhausted = false;
   private boolean appPopularExhausted = false;
@@ -369,7 +369,7 @@ public class GalleryList extends Composite implements GalleryRequestListener {
 
   /**
    * Loads the proper tab GUI with gallery's app data.
-   * @param apps: list of returned gallery apps from callback.
+   * @param appsResult: list of returned gallery apps from callback.
    * @param requestId: determines the specific type of app data.
    */
   private void refreshApps(GalleryAppListResult appsResult, int requestId, boolean refreshable) {
@@ -427,6 +427,10 @@ public class GalleryList extends Composite implements GalleryRequestListener {
         }else{
           appSearchTab.getNoResultsFound().setVisible(false);
         }
+        if (refreshable){
+          appSearchCounter = 0;
+        }
+
         if(appSearchCounter + NUMAPPSTOSHOW >= appsResult.getTotalCount()){
           appSearchTab.getButtonNext().setVisible(false);
         }else{


### PR DESCRIPTION
A working version of this code can be found at:
http://searchfix.aigallerythomas.appspot.com/
note: In order to test the search on this site, search for the keyword "search". It is a keyword that is in most of the app's descriptions.

Changes made to the code
------------------------------------
*Reset the search counter when a new search is performed. This is done in GalleryList.refreshApps() if the refreshable variable is true, meaning that a new search is performed.

*Cursor is added to the query in order to page through the database. A new Cursor is created if the search is starting at index 0 or it is null.

*The total result number accuracy on a search is <=100. Meaning that unless the total number of results from the search is <= 100, it is just an estimation. This is because no one would be counting the accuracy of the results passed 100. 

*Set the limit on the search to 10. The reason for this is because the cursor points to the app after the last one returned from the search and the search originally queried 20 apps (by default since there was no limitation) but only 10 were shown (because this was the constant number of apps to show), then the next search (if using a cursor) would point to the 21st app skipping the previous 10.

*No longer skipping apps with a counter variable because the cursor will return the right results that allows the SearchIndex to just iterate over them
