### PR TITLE
Reduce the number of Datastore reads

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
@@ -143,6 +143,7 @@ public class StoredData {
   // Project files
   // Note: FileData has to be Serializable so we can put it into
   //       memcache.
+  @Cached
   @Unindexed
   static final class FileData implements Serializable {
     // The role that file play: source code, build target or temporary file
@@ -189,6 +190,10 @@ public class StoredData {
 
     // DateTime of last backup only used if GCS is enabled
     long lastBackup;
+
+    String userId;              // The userId which owns this file
+                                // if null or the empty string, we haven't initialized
+                                // it yet
   }
 
   // MOTD data.


### PR DESCRIPTION
Datastore reads are a significant cost of running MIT App
Inventor. To reduce the number of datastore reads we need to remove
calls that are of dubious value as well as use caching as much as
possible. The Objectify package which we use to interact with the
datastore implements both caching and transactions. However when we
use transactions, caching is disabled.

This change removes a very expensive access check and replaces it with
a much lighter weight version. It also reduces the use of transactions
where they add no value, which enables caching, which is of much
value.

Change-Id: Id215b15cd39579fea7854beaefd7c3594c161305