### PR TITLE
Fix Gallery "Likes" Feature

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/GalleryPage.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/GalleryPage.java
@@ -601,8 +601,6 @@ panel
     initTutorialSection(container);
     // Adds dynamic salvage
     initSalvageSection(container);
-    // Adds dynamic salvage
-    initSalvageAllSection(container);
 
     // We are not using views and comments at initial launch
     /*
@@ -1051,34 +1049,6 @@ panel
       };
     Ode.getInstance().getGalleryService().isLikedByUser(app.getGalleryAppId(),
         isLikedCallback);
-  }
-
-  /**
-   * Helper method called by constructor to initialize the salvage all section
-   * @param container   The container that salvage label reside
-   */
-  private void initSalvageAllSection(Panel container) { //TODO: Update the location of this button
-    if(!canSalvage()){                                   // Permitted to Salvage Apps?
-      return;
-    }
-
-    final Label salvagePrompt = new Label("salvageAll");
-    salvagePrompt.addStyleName("primary-link");
-    container.add(salvagePrompt);
-
-    salvagePrompt.addClickHandler(new ClickHandler() {
-      public void onClick(ClickEvent event) {
-        final OdeAsyncCallback<Void> callback = new OdeAsyncCallback<Void>(
-            // failure message
-            MESSAGES.galleryError()) {
-              @Override
-              public void onSuccess(Void bool) {
-                salvagePrompt.setText("done");
-              }
-          };
-        Ode.getInstance().getGalleryService().salvageAllGalleryApps(callback);
-      }
-    });
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/server/GalleryServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/GalleryServiceImpl.java
@@ -375,14 +375,6 @@ public class GalleryServiceImpl extends OdeRemoteServiceServlet implements Galle
   }
 
   /**
-   * salvage all gallery app
-   */
-  @Override
-  public void salvageAllGalleryApps() {
-    galleryStorageIo.salvageAllGalleryApps();
-  }
-
-  /**
    * adds a report (flag) to a gallery app
    * @param galleryId id of gallery app that was commented on
    * @param report report

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/GalleryStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/GalleryStorageIo.java
@@ -201,11 +201,6 @@ public interface GalleryStorageIo {
   void salvageGalleryApp(long galleryId);
 
   /**
-   * salvage all gallery app
-   */
-  void salvageAllGalleryApps();
-
-  /**
    * save AttributionId
    * @param galleryId id of gallery app that was like
    * @param attributionId id of project's attribution

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyGalleryStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyGalleryStorageIo.java
@@ -9,6 +9,7 @@ package com.google.appinventor.server.storage;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -610,10 +611,19 @@ public class ObjectifyGalleryStorageIo implements  GalleryStorageIo {
         public void run(Objectify datastore) {
           GalleryAppData galleryAppData = datastore.find(galleryKey(galleryId));
           if (galleryAppData != null) {
-            // Forge the like data entry
             Key<GalleryAppData> galleryKey = galleryKey(galleryId);
+
+            // Make sure it isn't already liked (people have subverted the client
+            // based checks!)
+            for (GalleryAppLikeData likeData : datastore.query(GalleryAppLikeData.class).ancestor(galleryKey)) {
+              if(likeData.userId.equals(userId)){
+                return;         // We're done, already liked.
+              }
+            }
+
+            // Forge the like data entry
             GalleryAppLikeData likeData = new GalleryAppLikeData();
-            likeData.galleryKey = galleryKey(galleryId);
+            likeData.galleryKey = galleryKey;
             likeData.userId = userId;
             datastore.put(likeData);
 
@@ -653,7 +663,9 @@ public class ObjectifyGalleryStorageIo implements  GalleryStorageIo {
             for (GalleryAppLikeData likeData : datastore.query(GalleryAppLikeData.class).ancestor(galleryKey)) {
               if(likeData.userId.equals(userId)){
                 datastore.delete(likeData);
-                break;
+                // break;
+                // We don't break because there might be more then one likeData object for this
+                // person
               }
             }
             numLikes.t = datastore.query(GalleryAppLikeData.class).ancestor(galleryKey).count();
@@ -749,6 +761,23 @@ public class ObjectifyGalleryStorageIo implements  GalleryStorageIo {
         public void run(Objectify datastore) {
           int num = 0;
           Key<GalleryAppData> galleryKey = galleryKey(galleryId);
+          // We need to extract a unique set of userId's for the Likes of this app
+          // Because of past bugs and abuse, a user can Like an app more then once
+          // So we fix that here...
+          TreeMap<String,Boolean> likeTree = new TreeMap();
+          for (GalleryAppLikeData likeData : datastore.query(GalleryAppLikeData.class).ancestor(galleryKey)) {
+            likeTree.put(likeData.userId, true);
+          }
+          for (GalleryAppLikeData likeData : datastore.query(GalleryAppLikeData.class).ancestor(galleryKey)) {
+            datastore.delete(likeData);
+          }
+          for (String treeUserId : likeTree.keySet()) {
+            GalleryAppLikeData likeData = new GalleryAppLikeData();
+            likeData.userId = treeUserId;
+            likeData.galleryKey = galleryKey;
+            datastore.put(likeData);
+          }
+
           num = datastore.query(GalleryAppLikeData.class).ancestor(galleryKey).count();
           GalleryAppData galleryAppData = datastore.find(galleryKey);
           galleryAppData.numLikes = num;

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyGalleryStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyGalleryStorageIo.java
@@ -792,31 +792,6 @@ public class ObjectifyGalleryStorageIo implements  GalleryStorageIo {
   }
 
   /**
-   * salvage all gallery app
-   */
-  @Override
-  public void salvageAllGalleryApps() {
-    try {
-      runJobWithRetries(new JobRetryHelper() {
-        @Override
-        public void run(Objectify datastore) {
-          datastore = ObjectifyService.begin();
-          int num = 0;
-          for (GalleryAppData appData : datastore.query(GalleryAppData.class).list()) {
-            Key<GalleryAppData> galleryKey = galleryKey(appData.id);
-            num = datastore.query(GalleryAppLikeData.class).ancestor(galleryKey).count();
-            appData.numLikes = num;
-            datastore.put(appData);
-            LOG.info("salvage on gallerId:" + appData.id + ", total likes:" + appData.numLikes);
-          }
-        }
-      });
-    } catch (ObjectifyException e) {
-      throw CrashReport.createAndLogError(LOG, null,
-          "error in galleryStorageIo.salvageAllGalleryApps", e);
-    }
-  }
-  /**
    * save the attribution of a gallery app
    *
    * @param galleryId

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/GalleryService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/GalleryService.java
@@ -227,11 +227,6 @@ public interface GalleryService extends RemoteService {
   void salvageGalleryApp(long galleryId);
 
   /**
-   * salvage all gallery app
-   */
-  void salvageAllGalleryApps();
-
-  /**
   * adds a report (flag) to a gallery app
   * @param app app that is being reported
   * @param reportText the report

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/GalleryServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/GalleryServiceAsync.java
@@ -154,11 +154,6 @@ public interface GalleryServiceAsync {
   void salvageGalleryApp(long galleryId, AsyncCallback<java.lang.Void> callback);
 
   /**
-   * salvage all gallery apps
-   */
-  void salvageAllGalleryApps(AsyncCallback<java.lang.Void> callback);
-
-  /**
    * @see @link{@link GalleryService#isLikedByUser(long)
    */
   void isLikedByUser(long galleryId, AsyncCallback<java.lang.Boolean> bool);


### PR DESCRIPTION
This change involves two commits (which will *not* be merged together
as they represent two distinct, although related, changes).

1. Fix Gallery Like Data Management

Make sure a person can only like an App once. Enforce this on the
server side. Also add code to the Like Salvager to fix things when a
person has managed to like something more then once.

2. Remove the “salvageAll” feature from the Gallery

The “salvageAll” feature, available only to Gallery moderators was
useful back when the Gallery only had a few apps. However there are
too many apps today for it to be of much use. It would just use a lot
of resources and then fail. Because the salvageAll link is very near
the “salvage” and other related links, there is a risk of accidentally
invoking it. So we remove it here.
