### PR TITLE
Don't export yail -- other changes

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -369,6 +369,13 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     return true;
   }
 
+  protected boolean isPropertyforYail(String propertyName) {
+    // By default we use the same criterion as persistance
+    // This method can then be overriden by the invididual
+    // component Mocks
+    return isPropertyPersisted(propertyName);
+  }
+
   /**
    * Invoked after a component is created from the palette.
    *
@@ -442,6 +449,9 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     }
     if (!isPropertyVisible(name)) {
       type |= EditableProperty.TYPE_INVISIBLE;
+    }
+    if (isPropertyforYail(name)) {
+      type |= EditableProperty.TYPE_DOYAIL;
     }
     properties.addProperty(name, defaultValue, caption, editor, type);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -552,7 +552,7 @@ public class BlocklyPanel extends HTMLPanel {
   // [lyn, 2014/10/28] Handle these cases
   public String getFormJson() {
     if (blocksInited(formName)) {
-      return myBlocksEditor.encodeFormAsJsonString();
+      return myBlocksEditor.encodeFormAsJsonString(true);
     } else {
       // in case someone clicks Save before the blocks area is inited
       String formJson = pendingFormJsonMap.get(formName);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -316,7 +316,7 @@ public final class YaBlocksEditor extends FileEditor
 
   public synchronized void sendComponentData() {
     try {
-      blocksArea.sendComponentData(myFormEditor.encodeFormAsJsonString(),
+      blocksArea.sendComponentData(myFormEditor.encodeFormAsJsonString(true),
         packageNameFromPath(getFileId()));
     } catch (YailGenerationException e) {
       e.printStackTrace();
@@ -346,7 +346,7 @@ public final class YaBlocksEditor extends FileEditor
 
   public FileDescriptorWithContent getYail() throws YailGenerationException {
     return new FileDescriptorWithContent(getProjectId(), yailFileName(),
-        blocksArea.getYail(myFormEditor.encodeFormAsJsonString(),
+        blocksArea.getYail(myFormEditor.encodeFormAsJsonString(true),
             packageNameFromPath(getFileId())));
   }
 
@@ -608,8 +608,8 @@ public final class YaBlocksEditor extends FileEditor
    * Encodes the associated form's properties as a JSON encoded string. Used by YaBlocksEditor as well,
    * to send the form info to the blockly world during code generation.
    */
-  protected String encodeFormAsJsonString() {
-    return myFormEditor.encodeFormAsJsonString();
+  protected String encodeFormAsJsonString(boolean forYail) {
+    return myFormEditor.encodeFormAsJsonString(forYail);
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -236,7 +236,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
 
   @Override
   public String getRawFileContent() {
-    String encodedProperties = encodeFormAsJsonString();
+    String encodedProperties = encodeFormAsJsonString(false);
     JSONObject propertiesObject = JSON_PARSER.parse(encodedProperties).asObject();
     return YoungAndroidSourceAnalyzer.generateSourceFile(propertiesObject);
   }
@@ -564,13 +564,13 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
    * Encodes the form's properties as a JSON encoded string. Used by YaBlocksEditor as well,
    * to send the form info to the blockly world during code generation.
    */
-  protected String encodeFormAsJsonString() {
+  protected String encodeFormAsJsonString(boolean forYail) {
     StringBuilder sb = new StringBuilder();
     sb.append("{");
     sb.append("\"YaVersion\":\"").append(YaVersion.YOUNG_ANDROID_VERSION).append("\",");
     sb.append("\"Source\":\"Form\",");
     sb.append("\"Properties\":");
-    encodeComponentProperties(form, sb);
+    encodeComponentProperties(form, sb, forYail);
     sb.append("}");
     return sb.toString();
   }
@@ -584,7 +584,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
   /*
    * Encodes a component and its properties into a JSON encoded string.
    */
-  private void encodeComponentProperties(MockComponent component, StringBuilder sb) {
+  private void encodeComponentProperties(MockComponent component, StringBuilder sb, boolean forYail) {
     // The component encoding starts with component name and type
     String componentType = component.getType();
     EditableProperties properties = component.getProperties();
@@ -599,7 +599,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     // Next the actual component properties
     //
     // NOTE: It is important that these be encoded before any children components.
-    String propertiesString = properties.encodeAsPairs();
+    String propertiesString = properties.encodeAsPairs(forYail);
     if (propertiesString.length() > 0) {
       sb.append(',');
       sb.append(propertiesString);
@@ -612,7 +612,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
       String separator = "";
       for (MockComponent child : children) {
         sb.append(separator);
-        encodeComponentProperties(child, sb);
+        encodeComponentProperties(child, sb, forYail);
         separator = ",";
       }
       sb.append(']');

--- a/appinventor/appengine/src/com/google/appinventor/client/properties/Properties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/properties/Properties.java
@@ -78,7 +78,7 @@ public class Properties<T extends Property> implements Iterable<T> {
    * @return  encoded properties
    */
   public final String encodeAsJsonString() {
-    return '{' + encodeAsPairs() + '}';
+    return '{' + encodeAsPairs(false) + '}';
   }
 
   /**
@@ -96,8 +96,8 @@ public class Properties<T extends Property> implements Iterable<T> {
    *
    * @return  encoded properties
    */
-  public String encodeAsPairs() {
-    return encode(false);
+  public String encodeAsPairs(boolean forYail) {
+    return encode(forYail, false);
   }
 
   /**
@@ -106,7 +106,7 @@ public class Properties<T extends Property> implements Iterable<T> {
    * @return  encoded properties
    */
   public String encodeAllAsPairs() {
-    return encode(true);
+    return encode(true, true);
   }
 
   /**
@@ -117,7 +117,7 @@ public class Properties<T extends Property> implements Iterable<T> {
    *             value
    * @return  encoded property pairs
    */
-  protected String encode(boolean all) {
+  protected String encode(boolean forYail, boolean all) {
     StringBuilder sb = new StringBuilder();
 
     sb.append(getPrefix());
@@ -126,7 +126,7 @@ public class Properties<T extends Property> implements Iterable<T> {
     for (Property property : this) {
       // Don't encode non-persistable properties or properties being assigned their default value
       // unless encoding for all properties was explicitly requested
-      if (property.isPersisted() &&
+      if ((property.isPersisted() || (property.isYail() && forYail)) &&
           (all || !property.getDefaultValue().equals(property.getValue()))) {
         sb.append(separator);
         separator = ",";

--- a/appinventor/appengine/src/com/google/appinventor/client/properties/Property.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/properties/Property.java
@@ -83,6 +83,10 @@ public class Property {
     return true;
   }
 
+  protected boolean isYail() {
+    return true;
+  }
+
   /**
    * Resets the value the property to its default value.
    */

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/Settings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/Settings.java
@@ -45,9 +45,9 @@ public abstract class Settings extends EditableProperties implements PropertyCha
   }
 
   @Override
-  protected String encode(boolean all) {
+  protected String encode(boolean forYail, boolean all) {
     updateBeforeEncoding();
-    return super.encode(all);
+    return super.encode(forYail, all);
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
@@ -49,7 +49,7 @@ public final class EditableProperty extends Property {
   private final EditableProperties properties;
 
   // Type of property
-  private final int type;
+  private int type;
 
   // Property editor for use in properties panel
   private final PropertyEditor editor;
@@ -157,4 +157,13 @@ public final class EditableProperty extends Property {
   final void orphan() {
     editor.orphan();
   }
+
+  public int getType() {
+    return type;
+  }
+
+  public void setType(int aType) {
+    this.type = aType;
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
@@ -33,6 +33,18 @@ public final class EditableProperty extends Property {
    */
   public static final int TYPE_INVISIBLE = 0x02;
 
+  /**
+   * Properties of this type will be included in a yail generation
+   * even if they are not persisted. This is used for computed properties
+   * which aren't stored, but which must be passed to a component both
+   * in the Companion and went built. Example: The FirebaseToken and
+   * deveoperId which are computed on the fly by MockFirebaseDB but
+   * which are not persisted for security reasons. Yet we still need
+   * to output them in the Yail.
+   */
+
+  public static final int TYPE_DOYAIL = 0x04;
+
   // EditableProperties that contains this EditableProperty
   private final EditableProperties properties;
 
@@ -97,6 +109,11 @@ public final class EditableProperty extends Property {
    */
   final boolean isVisible() {
     return (type & TYPE_INVISIBLE) == 0;
+  }
+
+  @Override
+  protected final boolean isYail() {
+    return (type & TYPE_DOYAIL) != 0;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
@@ -37,7 +37,7 @@ public final class EditableProperty extends Property {
    * Properties of this type will be included in a yail generation
    * even if they are not persisted. This is used for computed properties
    * which aren't stored, but which must be passed to a component both
-   * in the Companion and went built. Example: The FirebaseToken and
+   * in the Companion and when built. Example: The FirebaseToken and
    * deveoperId which are computed on the fly by MockFirebaseDB but
    * which are not persisted for security reasons. Yet we still need
    * to output them in the Yail.

--- a/appinventor/appengine/src/com/google/appinventor/server/DownloadServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/DownloadServlet.java
@@ -103,7 +103,7 @@ public class DownloadServlet extends OdeServlet {
       // First, call split with no limit parameter.
       String[] uriComponents = uri.split("/");
       String downloadKind = uriComponents[DOWNLOAD_KIND_INDEX];
-      
+
       userId = userInfoProvider.getUserId();
 
       if (downloadKind.equals(ServerLayout.DOWNLOAD_PROJECT_OUTPUT)) {
@@ -122,14 +122,21 @@ public class DownloadServlet extends OdeServlet {
         final boolean includeProjectHistory = true;
         String zipName = (projectTitle == null) ? null :
             StringUtils.normalizeForFilename(projectTitle) + ".aia";
+        // If the requester is an Admin, we include any Yail files in the
+        // project in the export
+        boolean includeYail = userInfoProvider.getIsAdmin();
         ProjectSourceZip zipFile = fileExporter.exportProjectSourceZip(userId,
-            projectId, includeProjectHistory, false, zipName, false);
+            projectId, includeProjectHistory, false, zipName, includeYail, false);
         downloadableFile = zipFile.getRawFile();
 
       } else if (downloadKind.equals(ServerLayout.DOWNLOAD_USER_PROJECT_SOURCE)) {
+        if (!userInfoProvider.getIsAdmin()) {
+          throw new IllegalArgumentException("Unauthorized.");
+        }
+
         // Download project source files for the specified user project as a zip.
         uriComponents = uri.split("/", SPLIT_LIMIT_USER_PROJECT_SOURCE);
-        
+
         String userIdOrEmail = uriComponents[USER_PROJECT_USERID_INDEX];
         String projectUserId;
         StorageIo storageIo = StorageIoInstanceHolder.INSTANCE;
@@ -174,9 +181,9 @@ public class DownloadServlet extends OdeServlet {
           zipName = "u" + projectUserId + "_p" + projectId + ".aia";
         }
         ProjectSourceZip zipFile = fileExporter.exportProjectSourceZip(projectUserId,
-            projectId, /* include history*/ true, /* include keystore */ true, zipName, false);
+            projectId, /* include history*/ true, /* include keystore */ true, zipName, true, false);
         downloadableFile = zipFile.getRawFile();
-        
+
       } else if (downloadKind.equals(ServerLayout.DOWNLOAD_ALL_PROJECTS_SOURCE)) {
         // Download all project source files as a zip of zips.
         ProjectSourceZip zipFile = fileExporter.exportAllProjectsSourceZip(

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
@@ -53,6 +53,7 @@ public interface FileExporter {
   ProjectSourceZip exportProjectSourceZip(String userId, long projectId,
                                           boolean includeProjectHistory,
                                           boolean includeAndroidKeystore, @Nullable String zipName,
+                                          boolean includeYail,
                                           boolean fatalError)
       throws IOException;
 

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -62,11 +62,12 @@ public final class FileExporterImpl implements FileExporter {
                                                  boolean includeProjectHistory,
                                                  boolean includeAndroidKeystore,
                                                  @Nullable String zipName,
+                                                 boolean includeYail,
                                                  boolean fatalError) throws IOException {
     // Download project source files as a zip.
     if (storageIo instanceof ObjectifyStorageIo) {
       return ((ObjectifyStorageIo)storageIo).exportProjectSourceZip(userId, projectId,
-          includeProjectHistory, includeAndroidKeystore, zipName, fatalError);
+          includeProjectHistory, includeAndroidKeystore, zipName, includeYail, fatalError);
     } else {
       throw new IllegalArgumentException("Objectify only");
     }
@@ -87,8 +88,11 @@ public final class FileExporterImpl implements FileExporter {
     String metadata = "";
     for (Long projectId : projectIds) {
       try {
+        // Note: We never include Yail files when exporting all source projects
+        // even for Admins. If you are an admin and want to debug a project, download
+        // it explicitly.
         ProjectSourceZip projectSourceZip =
-            exportProjectSourceZip(userId, projectId, false, false, null, false);
+            exportProjectSourceZip(userId, projectId, false, false, null, false, false);
         byte[] data = projectSourceZip.getContent();
         String name = projectSourceZip.getFileName();
 

--- a/appinventor/appengine/src/com/google/appinventor/server/GalleryServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/GalleryServiceImpl.java
@@ -491,7 +491,7 @@ public class GalleryServiceImpl extends OdeRemoteServiceServlet implements Galle
     byte[] aiaBytes= null;
     try {
       ProjectSourceZip zipFile = fileExporter.exportProjectSourceZip(userId,
-            projectId, true, false, aiaName, false);
+        projectId, true, false, aiaName, false, false);
       aiaFile = zipFile.getRawFile();
       aiaBytes = aiaFile.getContent();
       LOG.log(Level.INFO, "aiaFile numBytes:"+aiaBytes.length);

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -565,7 +565,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
       FileExporter fileExporter = new FileExporterImpl();
       zipFile = fileExporter.exportProjectSourceZip(userId, projectId, false,
           /* includeAndroidKeystore */ true,
-          projectName + ".aia", true);
+          projectName + ".aia", true, true);
       bufferedOutputStream.write(zipFile.getContent());
       bufferedOutputStream.flush();
       bufferedOutputStream.close();

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -1808,6 +1808,7 @@ public class ObjectifyStorageIo implements  StorageIo {
                                                  final boolean includeProjectHistory,
                                                  final boolean includeAndroidKeystore,
                                                  @Nullable String zipName,
+                                                 final boolean includeYail,
                                                  final boolean fatalError) throws IOException {
     validateGCS();
     final Result<Integer> fileCount = new Result<Integer>();
@@ -1837,6 +1838,16 @@ public class ObjectifyStorageIo implements  StorageIo {
             if (fd.role.equals(FileData.RoleEnum.SOURCE)) {
               if (fileName.equals(FileExporter.REMIX_INFORMATION_FILE_PATH)) {
                 // Skip legacy remix history files that were previous stored with the project
+                continue;
+              }
+              if (fileName.endsWith(".yail") && !includeYail) {
+                // Don't include YAIL files when exporting projects
+                // includeYail will be set to true when we are exporting the source
+                // to send to the buildserver or when the person exporting
+                // a project is an Admin (for debugging).
+                // Otherwise Yail files are confusing cruft. In the case of
+                // the Firebase Component they may contain secrets which we would
+                // rather not have leak into an export .aia file or into the Gallery
                 continue;
               }
               fileData.add(fd);

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -524,6 +524,7 @@ public interface StorageIo {
                                           boolean includeProjectHistory,
                                           boolean includeAndroidKeystore,
                                           @Nullable String zipName,
+                                          boolean includeYail,
                                           boolean fatalError) throws IOException;
 
   /**

--- a/appinventor/appengine/tests/com/google/appinventor/server/DownloadServletTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/DownloadServletTest.java
@@ -76,7 +76,7 @@ public class DownloadServletTest {
   public void testDownloadProjectSourceZipWithoutTitle() throws Exception {
     MockHttpServletRequest request = new MockHttpServletRequest(DOWNLOAD_URL +
         "project-source/1234");
-    expect(exporterMock.exportProjectSourceZip(USER_ID, PROJECT_ID, true, false, null, false))
+    expect(exporterMock.exportProjectSourceZip(USER_ID, PROJECT_ID, true, false, null, false, false))
         .andReturn(dummyZip);
     PowerMock.replayAll();
     DownloadServlet download = new DownloadServlet();
@@ -92,7 +92,7 @@ public class DownloadServletTest {
     MockHttpServletRequest request = new MockHttpServletRequest(DOWNLOAD_URL +
         "project-source/1234/My Project Title 123");
     expect(exporterMock.exportProjectSourceZip(USER_ID, PROJECT_ID, true, false,
-        "MyProjectTitle123.aia", false))
+        "MyProjectTitle123.aia", false, false))
         .andReturn(dummyZipWithTitle);
     PowerMock.replayAll();
     DownloadServlet download = new DownloadServlet();
@@ -108,7 +108,7 @@ public class DownloadServletTest {
     IllegalArgumentException expectedException = new IllegalArgumentException();
     MockHttpServletRequest request = new MockHttpServletRequest(DOWNLOAD_URL +
         "project-source/12345");
-    expect(exporterMock.exportProjectSourceZip(USER_ID, 12345L, true, false, null, false))
+    expect(exporterMock.exportProjectSourceZip(USER_ID, 12345L, true, false, null, false, false))
         .andThrow(expectedException);
     PowerMock.replayAll();
     DownloadServlet download = new DownloadServlet();

--- a/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
@@ -105,7 +105,7 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
 
   public void testExportProjectSourceZipWithoutHistory() throws IOException {
     ProjectSourceZip project = exporter.exportProjectSourceZip(USER_ID, projectId,
-        false, false, null, false);
+        false, false, null, false, false);
     Map<String, byte[]> content = testExportProjectSourceZipHelper(project);
     assertEquals(2, content.size());
     /* Do not expect remix history when includeProjectHistory parameter is false
@@ -116,7 +116,7 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
   // TODO(user): Add test with properly formatted history
   public void testExportProjectSourceZipWithHistory() throws IOException {
     ProjectSourceZip project = exporter.exportProjectSourceZip(USER_ID, projectId,
-        true, false, null, false);
+        true, false, null, false, false);
     Map<String, byte[]> content = testExportProjectSourceZipHelper(project);
     assertEquals(3, content.size());
     // Expect the remix file to be in
@@ -127,7 +127,7 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
 
   public void testExportProjectSourceZipWithNonExistingProject() throws IOException {
     try {
-      exporter.exportProjectSourceZip(USER_ID, projectId + 1, false, false, null, false);
+      exporter.exportProjectSourceZip(USER_ID, projectId + 1, false, false, null, false, false);
       fail();
     } catch (Exception e) {
       assertTrue(e instanceof IllegalArgumentException ||


### PR DESCRIPTION
This PR contains two commits (which will be kept separate). The first is to inhibit the exporting of project Yail except when doing a build or when the user is an admin. If necessary we can add a new menu item under the "Project" Menu to export a project along with its yail. That isn't included here and I'm not quite sure what to call it!

These commits are a pre-requisite for the FirebaseDB component addition, which I'll submit after one more minor change (and after these changes are merged). We are getting very close on FirebaseDB.