### PR TITLE
An approach to deprecation of component events/methods/properties tha…

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -425,6 +425,7 @@ Blockly.Blocks.component_set_get = {
     this.typeName = xmlElement.getAttribute('component_type');
     this.setOrGet = xmlElement.getAttribute('set_or_get');
     this.propertyName = xmlElement.getAttribute('property_name');
+    this.propertyObject = this.getPropertyObject(this.propertyName);
     var isGenericString = xmlElement.getAttribute('is_generic');
     this.isGeneric = (isGenericString == "true" ? true : false);
     if(!this.isGeneric) {
@@ -438,7 +439,9 @@ Blockly.Blocks.component_set_get = {
 
     var thisBlock = this;
     var dropdown = new Blockly.FieldDropdown(
-      function() {return thisBlock.getPropertyDropDownList(); },
+      function() {
+        return thisBlock.getPropertyDropDownList();
+      },
       // change the output type and tooltip to match the new selection
       function(selection) {
         this.setValue(selection);
@@ -512,7 +515,13 @@ Blockly.Blocks.component_set_get = {
     this.setTooltip(this.getPropertyObject(this.propertyName).description);
 
     this.errors = [{name:"checkIsInDefinition"},{name:"checkComponentNotExistsError"}];
-    //this.typeblock = this.createTypeBlock();
+
+    if (this.propertyObject.deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
+      // [lyn, 2015/12/27] mark deprecated properties as bad
+      this.badBlock();
+      this.setDisabled(true);
+    }
+
   },
 
   setTypeCheck : function() {
@@ -540,7 +549,9 @@ Blockly.Blocks.component_set_get = {
   getPropertyDropDownList : function() {
     var dropDownList = [];
     var propertyNames = [];
-    if(this.setOrGet == "set") {
+    if (this.propertyObject.deprecated == "true") { // [lyn, 2015/12/27] Handle deprecated properties specially
+      propertyNames = [this.propertyObject.name]; // Only list the deprecated property name and no others
+    } else if(this.setOrGet == "set") {
       propertyNames = Blockly.ComponentTypes[this.typeName].setPropertyList;
     } else {
       propertyNames = Blockly.ComponentTypes[this.typeName].getPropertyList;

--- a/appinventor/blocklyeditor/src/component.js
+++ b/appinventor/blocklyeditor/src/component.js
@@ -243,6 +243,7 @@ Blockly.ComponentTypes.populateTypes = function() {
     }
     for(var k=0;k<componentInfo.blockProperties.length;k++) {
       Blockly.ComponentTypes[typeName].properties[componentInfo.blockProperties[k].name] = componentInfo.blockProperties[k];
+      if (componentInfo.blockProperties[k].deprecated == "true") continue;
       if(componentInfo.blockProperties[k].rw == "read-write" || componentInfo.blockProperties[k].rw == "read-only") {
         Blockly.ComponentTypes[typeName].getPropertyList.push(componentInfo.blockProperties[k].name);
       }

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -196,6 +196,7 @@ Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
   var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
   for(var i=0;i<propertyObjects.length;i++) {
     //create non-generic get block
+    if (propertyObjects[i].deprecated === "true") continue;
     if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
       mutatorAttributes = {set_or_get:"get", component_type: typeName, instance_name: instanceName, property_name: propertyObjects[i].name, is_generic: "false"};
       xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
@@ -221,6 +222,7 @@ Blockly.Drawer.componentTypeToXMLArray = function(typeName) {
   //create generic method blocks
   var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
   for(var i=0;i<methodObjects.length;i++) {
+    if (methodObjects[i].deprecated === "true") continue;
     mutatorAttributes = {component_type: typeName, method_name: methodObjects[i].name, is_generic:"true"};
     xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
   }
@@ -229,6 +231,7 @@ Blockly.Drawer.componentTypeToXMLArray = function(typeName) {
   var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
   for(var i=0;i<propertyObjects.length;i++) {
     //create generic get block
+    if (propertyObjects[i].deprecated === "true") continue;
     if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
       mutatorAttributes = {set_or_get: "get", component_type: typeName, property_name: propertyObjects[i].name, is_generic: "true"};
       xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
@@ -81,8 +81,8 @@ public class Camera extends AndroidNonvisibleComponent
    *
    * @return {@code true} indicates front-facing is to be used, {@code false} will open default
    */
-  @SimpleProperty(
-    category = PropertyCategory.BEHAVIOR)
+  @Deprecated
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public boolean UseFront() {
     return useFront;
   }
@@ -93,7 +93,9 @@ public class Camera extends AndroidNonvisibleComponent
    * @param front
    *          {@code true} for front-facing camera, {@code false} for default
    */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN, defaultValue = "False")
+  @Deprecated
+  // Hide the deprecated property from the Designer
+  //  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN, defaultValue = "False")
   @SimpleProperty(description = "Specifies whether the front-facing camera should be used (when available). "
     + "If the device does not have a front-facing camera, this option will be ignored "
     + "and the camera will open normally.")

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FusiontablesControl.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FusiontablesControl.java
@@ -374,8 +374,10 @@ public class FusiontablesControl extends AndroidNonvisibleComponent implements C
     new QueryProcessorV1(activity).execute(query);
   }
 
-//Deprecated  -- Won't work after 12/2012
-  @SimpleFunction(userVisible = false,
+  //Deprecated  -- Won't work after 12/2012
+  @Deprecated // [lyn, 2015/12/30] In AI2, now use explicit @Deprecated annotation rather than
+              // userVisible = false to deprecate an event, method, or property.
+  @SimpleFunction(
       description = "DEPRECATED. This block is deprecated as of the end of 2012.  Use SendQuery.")
   public void DoQuery() {
     if (requestHelper != null) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Twitter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Twitter.java
@@ -158,7 +158,13 @@ public final class Twitter extends AndroidNonvisibleComponent implements
   /**
    * Logs in to Twitter with a username and password.
    */
-  @Deprecated
+  // @Deprecated
+  // [lyn, 2015/12/30] Removed @Deprecated annotation for this method, which was deprecated in AI1
+  // by setting userVisible = false. The @Deprecated annotation should only be used for
+  // events/methods/properties deprecated in AI2. The problem with using it for methods deprecated
+  // in AI1 is that the names of such methods no longer exist in OdeMessages.java, but the
+  // AI2 bad blocks mechanism (which uses the @Deprecated annotation) requires the method names
+  // to exist and be translatable so that they can appear in a block marked bad.
   @SimpleFunction(userVisible = false, description = "Twitter's API no longer supports login via username and "
       + "password. Use the Authorize call instead.")
   public void Login(String username, String password) {
@@ -218,7 +224,8 @@ public final class Twitter extends AndroidNonvisibleComponent implements
    * TwitPicAPIkey property getter method.
    */
   @Deprecated
-  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
+  @SimpleProperty( // [lyn 2015/12/30] removed userVisible = false, which is superseded by @Deprecated
+      category = PropertyCategory.BEHAVIOR)
   public String TwitPic_API_Key() {
      return TwitPic_API_Key;
   }
@@ -233,7 +240,8 @@ public final class Twitter extends AndroidNonvisibleComponent implements
   @Deprecated
   // Hide the deprecated property from the Designer
   //@DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING, defaultValue = "")
-  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR,
+  @SimpleProperty( // [lyn 2015/12/30] removed userVisible = false, which is superseded by @Deprecated
+      category = PropertyCategory.BEHAVIOR,
       description="The API Key for image uploading, provided by TwitPic.")
   public void TwitPic_API_Key(String TwitPic_API_Key) {
     this.TwitPic_API_Key = TwitPic_API_Key;

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -109,14 +109,14 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     separator = "";
     for (Event event : component.events.values()) {
       sb.append(separator);
-      outputBlockEvent(event.name, event, sb, !event.userVisible);
+      outputBlockEvent(event.name, event, sb, event.userVisible, event.deprecated);
       separator = ",\n    ";
     }
     sb.append("],\n  \"methods\": [");
     separator = "";
     for (Method method : component.methods.values()) {
       sb.append(separator);
-      outputBlockMethod(method.name, method, sb, !method.userVisible);
+      outputBlockMethod(method.name, method, sb, method.userVisible, method.deprecated);
       separator = ",\n    ";
     }
     sb.append("]}\n");
@@ -141,15 +141,24 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append(javaTypeToYailType(prop.getType()));
     sb.append("\", \"rw\": \"");
     sb.append(prop.isUserVisible() ? prop.getRwString() : "invisible");
-    sb.append("\"}");
+    // [lyn, 2015/12/20] Added deprecated field to JSON.
+    // If we want to save space in simple-components.json,
+    // we could include this field only when it is "true"
+    sb.append("\", \"deprecated\": \"" + prop.isDeprecated() + "\"");
+    sb.append("}");
   }
   
   private void outputBlockEvent(String eventName, Event event, StringBuilder sb,
-                                boolean deprecated) {
+                                boolean userVisible, boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(eventName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(event.description));
+    // [lyn, 2015/12/20] Remove userVisible field from JSON, which is no longer used for events.
+    // sb.append(", \"userVisible\": \"" + userVisible + "\"");
+    // [lyn, 2015/12/20] Added deprecated field to JSON.
+    // If we want to save space in simple-components.json,
+    // we could include this field only when it is "true"
     sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(event.parameters, sb);
@@ -157,11 +166,16 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
   }
   
   private void outputBlockMethod(String methodName, Method method, StringBuilder sb,
-                                 boolean deprecated) {
+                                 boolean userVisible, boolean deprecated) {
     sb.append("{ \"name\": \"");
     sb.append(methodName);
     sb.append("\", \"description\": ");
     sb.append(formatDescription(method.description));
+    // [lyn, 2015/12/20] Remove userVisible field from JSON, which is no longer used for methods.
+    // sb.append(", \"userVisible\": \"" + userVisible + "\"");
+    // [lyn, 2015/12/20] Added deprecated field to JSON.
+    // If we want to save space in simple-components.json,
+    // we could include this field only when it is "true"
     sb.append(", \"deprecated\": \"" + deprecated + "\"");
     sb.append(", \"params\": ");
     outputParameters(method.parameters, sb);

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
@@ -25,21 +25,31 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
     sb.append("\n\n/* Properties */\n\n");
     for (Property prop : component.properties.values()) {
       String propertyName = prop.name;
-      if (prop.isUserVisible() || component.designerProperties.containsKey(propertyName)) {
+      if (prop.isUserVisible()
+          || component.designerProperties.containsKey(propertyName)
+          || prop.isDeprecated() // [lyn, 2015/12/30] For deprecated AI2 blocks (but not AI1 blocks)
+                                 // must translate property names so they can be displayed in bad blocks.
+          ) {
         sb.append("    map.put(\"PROPERTY-" + propertyName + "\", MESSAGES." + propertyName + "Properties());\n");
       }
     }
     sb.append("\n\n/* Events */\n\n");
     for (Event event : component.events.values()) {
       String propertyName = event.name;
-      if (event.userVisible) {
+      if (event.userVisible
+          || event.deprecated // [lyn, 2015/12/30] For deprecated AI2 blocks (but not AI1 blocks)
+                              // must translate property names so they can be displayed in bad blocks.
+          ) {
         sb.append("    map.put(\"EVENT-" + propertyName + "\", MESSAGES." + propertyName + "Events());\n");
       }
     }
     sb.append("\n\n/* Methods */\n\n");
     for (Method method : component.methods.values()) {
       String propertyName = method.name;
-      if (method.userVisible) {
+      if (method.userVisible
+          || method.deprecated // [lyn, 2015/12/30] For deprecated AI2 blocks (but not AI1 blocks)
+                               // must translate property names so they can be displayed in bad blocks.
+          ) {
         sb.append("    map.put(\"METHOD-" + propertyName + "\", MESSAGES." + propertyName + "Methods());\n");
       }
     }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/DocumentationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/DocumentationGenerator.java
@@ -181,6 +181,7 @@ public class DocumentationGenerator extends ComponentProcessor {
     boolean definitionWritten = false;
     for (Map.Entry<String, Property> entry : component.properties.entrySet()) {
       Property property = entry.getValue();
+      if (property.isDeprecated()) continue;
       if (property.isUserVisible() || component.designerProperties.containsKey(property.name)) {
         if (!definitionWritten) {
           writer.write("<dl>\n");
@@ -206,6 +207,7 @@ public class DocumentationGenerator extends ComponentProcessor {
     boolean definitionWritten = false;
     for (Map.Entry<String, Event> entry : component.events.entrySet()) {
       Event event = entry.getValue();
+      if (event.deprecated) continue;
       if (event.userVisible) {
         if (!definitionWritten) {
           writer.write("<dl>\n");
@@ -227,6 +229,7 @@ public class DocumentationGenerator extends ComponentProcessor {
     boolean definitionWritten = false;
     for (Map.Entry<String, Method> entry : component.methods.entrySet()) {
       Method method = entry.getValue();
+      if (method.deprecated) continue;
       if (method.userVisible) {
         if (!definitionWritten) {
           writer.write("<dl>\n");


### PR DESCRIPTION
…t improves

upon the fix to issue #112. The key features are:

* The @Deprecated annotation is used to deprecate any component event/method/property.
  Previously, declaring userVisible = false in a SimpleEvent or SimpleFunction was
  used to deprecate component events and methods, but this approach does not work
  for component properties, where userVisible = false can indicate that a property
  appears only in the designer (not in the blocks editor) or is hidden from the user.

* Blocks for all deprecated events/methods/properties are automatically marked bad
  (highlighed with a red outline) and disabled. There is no need to have a special
  version upgrader in versioning.js to mark deprecated blocks bad, but the fact that
  a block has been deprecated should still be documented in YaVersion.java and
  versioning.js.

* Deprecated event/method/property blocks do not appear in the block drawers for a
  component, nor do deprecated method/propety blocks appear in the generic component
  block drawer. Property drop down lists do not include a deprecated property name.

* Deprecated event/method/property names should still appear in OdeMessages.java
  and in language translations. Otherwise, they would not appear on blocks marked bad.

* Note: there are certain component event/method names deprecated in AI1 that
  are still marked userVisible = false rather than @Deprecated. The reason is
  that their names have been removed from OdeMessages.java and the AI1 to AI2
  converter does not handle them, but ComponentTranslationGenerator.java would
  fail if they were marked @Deprecated because their names are not in OdeMessages.java.
  Here are these special AI1-deprecated component events/methods:
    events: ActivityError, BluetoothError, PlayerError, SoundError, VideoPlayerError
    method: Login (for Twitter component)

Change-Id: Ie98e01298a5840acc2eb6d4b619526de4e09eeeb