### PR TITLE
added project name validation to save project as, validation code mov…

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1965,6 +1965,18 @@ public interface OdeMessages extends Messages {
   @Description("Error shown when a new project name would be the same as an existing one")
   String duplicateProjectNameError(String projectName);
 
+  @DefaultMessage("Project names cannot contain spaces")
+  @Description("Error shown when user types space into project name.")
+  String whitespaceProjectNameError();
+
+  @DefaultMessage("Project names must begin with a letter")
+  @Description("Error shown when user does not type letter as first character in project name.")
+  String firstCharProjectNameError();
+  
+  @DefaultMessage("Invalid character. Project names can only contain letters, numbers, and underscores")
+  @Description("Error shown when user types invalid character into project name.")
+  String invalidCharProjectNameError();
+  
   // Used in youngandroid/YoungAndroidFormUpgrader.java
 
   @DefaultMessage("This project was created with an older version of the App Inventor " +

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
@@ -145,10 +145,7 @@ public final class CopyYoungAndroidProjectCommand extends ChainableCommand {
         @Override
         public boolean validate(String value) {
           errorMessage = TextValidators.getErrorMessage(value);
-          if (errorMessage.length()>0){
-            return false;
-          }
-            return true;
+          return !(errorMessage.length()>0);
         }
 
         @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
@@ -16,6 +16,7 @@ import com.google.appinventor.client.youngandroid.TextValidators;
 import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
 import com.google.appinventor.shared.rpc.project.UserProject;
+import com.google.appinventor.client.widgets.Validator;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
@@ -140,7 +141,21 @@ public final class CopyYoungAndroidProjectCommand extends ChainableCommand {
       }
 
       newNameTextBox = new LabeledTextBox(checkpoint ? MESSAGES.checkpointNameLabel()
-          : MESSAGES.newNameLabel());
+          : MESSAGES.newNameLabel(), new Validator(){
+        @Override
+        public boolean validate(String value) {
+          errorMessage = TextValidators.getErrorMessage(value);
+          if (errorMessage.length()>0){
+            return false;
+          }
+            return true;
+        }
+
+        @Override
+        public String getErrorMessage() {
+          return errorMessage;
+        }
+      });
       newNameTextBox.setText(defaultNewName);
       newNameTextBox.getTextBox().addKeyUpHandler(new KeyUpHandler() {
         @Override
@@ -150,6 +165,8 @@ public final class CopyYoungAndroidProjectCommand extends ChainableCommand {
             handleOkClick(oldProjectNode);
           } else if (keyCode == KeyCodes.KEY_ESCAPE) {
             hide();
+          } else {
+            newNameTextBox.validate();
           }
         }
       });

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/youngandroid/NewYoungAndroidProjectWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/youngandroid/NewYoungAndroidProjectWizard.java
@@ -21,6 +21,7 @@ import com.google.appinventor.client.youngandroid.TextValidators;
 import com.google.appinventor.common.utils.StringUtils;
 import com.google.appinventor.shared.rpc.project.youngandroid.NewYoungAndroidProjectParameters;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+import com.google.appinventor.client.youngandroid.TextValidators;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -54,25 +55,13 @@ public final class NewYoungAndroidProjectWizard extends NewProjectWizard {
     projectNameTextBox = new LabeledTextBox(MESSAGES.projectNameLabel(), new Validator() {
       @Override
       public boolean validate(String value) {
-        //Pattern validText = Pattern.compile("[\\p{L}][\\p{L}0-9_]*", Pattern.UNICODE_CHARACTER_CLASS);
-        //String newString = validText.toString();
-        if(!value.matches("[A-Za-z][A-Za-z0-9_]*") && value.length() > 0) {
+        errorMessage = TextValidators.getErrorMessage(value);
+        if (errorMessage.length()>0){
           disableOkButton();
-          String noWhitespace = "[\\S]+";
-          String firstCharacterLetter = "[A-Za-z].*";
-          if(!value.matches(noWhitespace)) { //Check to make sure that this project does not contain any whitespace
-            errorMessage = "Project names cannot contain spaces";
-          } else if (!value.matches(firstCharacterLetter)) { //Check to make sure that the first character is a letter
-            errorMessage = "Project names must begin with a letter";
-          } else { //The text contains a character that is not a letter, number, or underscore
-            errorMessage = "Invalid character. Project names can only contain letters, numbers, and underscores";
-          }
           return false;
-        } else { //this is valid text, return true
-          enableOkButton();
-          errorMessage = "";
-          return true;
         }
+          enableOkButton();
+          return true;
       }
 
       @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -101,4 +101,25 @@ public final class TextValidators {
   public static boolean isValidLengthFilename(String filename){
     return !(filename.length() > MAX_FILENAME_SIZE || filename.length() < MIN_FILENAME_SIZE);
   }
+
+  /**
+   * Determines human-readable message for specific error.
+   * @param filename The filename (not path) of uploaded file
+   * @return String representing error message, empty string if no error
+   */
+  public static String getErrorMessage(String filename){
+    String errorMessage = "";
+    String noWhitespace = "[\\S]+";
+    String firstCharacterLetter = "[A-Za-z].*";
+    if(!filename.matches("[A-Za-z][A-Za-z0-9_]*") && filename.length() > 0) {
+      if(!filename.matches(noWhitespace)) { //Check to make sure that this project does not contain any whitespace
+        errorMessage = "Project names cannot contain spaces";
+      } else if (!filename.matches(firstCharacterLetter)) { //Check to make sure that the first character is a letter
+        errorMessage = "Project names must begin with a letter";
+      } else { //The text contains a character that is not a letter, number, or underscore
+        errorMessage = "Invalid character. Project names can only contain letters, numbers, and underscores";
+      }
+    }
+    return errorMessage;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -113,11 +113,11 @@ public final class TextValidators {
     String firstCharacterLetter = "[A-Za-z].*";
     if(!filename.matches("[A-Za-z][A-Za-z0-9_]*") && filename.length() > 0) {
       if(!filename.matches(noWhitespace)) { //Check to make sure that this project does not contain any whitespace
-        errorMessage = "Project names cannot contain spaces";
+        errorMessage = MESSAGES.whitespaceProjectNameError();
       } else if (!filename.matches(firstCharacterLetter)) { //Check to make sure that the first character is a letter
-        errorMessage = "Project names must begin with a letter";
+        errorMessage = MESSAGES.firstCharProjectNameError();
       } else { //The text contains a character that is not a letter, number, or underscore
-        errorMessage = "Invalid character. Project names can only contain letters, numbers, and underscores";
+        errorMessage = MESSAGES.invalidCharProjectNameError();
       }
     }
     return errorMessage;


### PR DESCRIPTION
…ed to TextValidators.java

Current Implementation:
When creating a new project and input invalid project name, help text appears to warn you. When you "save project as", this help text does not appear until after you click "ok".

My fix:
Added validation to SaveAs. Had to move validation code to TextValidation for reuse.

To test:
In created project, rename project (Projects > Save Project As). Attempt to input invalid project name. Ensure appropriate error message appears (prior to clicking "ok")

NB:
-for SaveAs, could not disable OK button when invalid project name (I say this is ok because validation after clicking "ok" will catch this so invalid project name still rejected)
-validation needs to be added to RemixedYoungAndroidProjectWizard.java (should look exactly like NewYoungAndroidProjectWizard.java). I don't know how to test this (need gallery) so I did not do this.

@afmckinney 