### PR TITLE
Provide a Menu Item to Update the Companion

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -563,6 +563,14 @@ public interface OdeMessages extends Messages {
   @Description("Information about the Companion")
   String companionInformation();
 
+  @DefaultMessage("Update the Companion")
+  @Description("Menu item to update the Companion to the latest version")
+  String companionUpdate();
+
+  @DefaultMessage("You must have a project open to update the Companion")
+  @Description("")
+  String companionUpdateMustHaveProject();
+
   @DefaultMessage("Show Splash Screen")
   @Description("Redisplay the Splash Screen")
   String showSplashMenuItem();

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -95,6 +95,7 @@ public class TopToolbar extends Composite {
   private static final String WIDGET_NAME_FORUMS = "Forums";
   private static final String WIDGET_NAME_FEEDBACK = "ReportIssue";
   private static final String WIDGET_NAME_COMPANIONINFO = "CompanionInformation";
+  private static final String WIDGET_NAME_COMPANIONUPDATE = "CompanionUpdate";
   private static final String WIDGET_NAME_IMPORTPROJECT = "ImportProject";
   private static final String WIDGET_NAME_IMPORTTEMPLATE = "ImportTemplate";
   private static final String WIDGET_NAME_EXPORTALLPROJECTS = "ExportAllProjects";
@@ -223,6 +224,8 @@ public class TopToolbar extends Composite {
     }
     helpItems.add(new DropDownItem(WIDGET_NAME_COMPANIONINFO, MESSAGES.companionInformation(),
         new AboutCompanionAction()));
+    helpItems.add(new DropDownItem(WIDGET_NAME_COMPANIONUPDATE, MESSAGES.companionUpdate(),
+        new CompanionUpdateAction()));
     helpItems.add(new DropDownItem(WIDGET_NAME_SHOWSPLASH, MESSAGES.showSplashMenuItem(),
         new ShowSplashAction()));
 
@@ -756,6 +759,19 @@ public class TopToolbar extends Composite {
       DialogBoxContents.add(holder);
       db.setWidget(DialogBoxContents);
       db.show();
+    }
+  }
+
+  private static class CompanionUpdateAction implements Command {
+    @Override
+    public void execute() {
+      DesignToolbar.DesignProject currentProject = Ode.getInstance().getDesignToolbar().getCurrentProject();
+      if (currentProject == null) {
+        Window.alert(MESSAGES.companionUpdateMustHaveProject());
+        return;
+      }
+      DesignToolbar.Screen screen = currentProject.screens.get(currentProject.currentScreen);
+      screen.blocksEditor.updateCompanion();
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/FileEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/FileEditor.java
@@ -160,9 +160,17 @@ public abstract class FileEditor extends Composite {
    *
    * @param newLanguage
    *          The desired new language setting
-//   * @param formName
+   * @param formName
    */
   public void switchLanguage(String newLanguage) {
+  }
+
+  /**
+   * Trigger and Update of the Companion.
+   *
+   */
+
+  public void updateCompanion() {
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -772,6 +772,22 @@ public class BlocklyPanel extends HTMLPanel {
     doSwitchLanguage(formName, languageSetting);
   }
 
+  /**
+   * Trigger and Update of the Companion if the Companion is connected
+   * and an update is available. Note: We do not compare the currently
+   * running Companion's version against the version we are going to load
+   * we just do it. If YaVersion.COMPANION_UPDATE_URL is "", then no
+   * Update is available.
+   */
+
+  public void updateCompanion() {
+    updateCompanion(formName);
+  }
+
+  public static void updateCompanion(String formName) {
+    doUpdateCompanion(formName);
+  }
+
   public static String getLocalizedPropertyName(String key) {
     return ComponentsTranslation.getPropertyName(key);
   }
@@ -986,6 +1002,10 @@ public class BlocklyPanel extends HTMLPanel {
    */
   public static native void doSwitchLanguage(String formName, String language) /*-{
     $wnd.Blocklies[formName].language_switch.switchLanguage(language);
+  }-*/;
+
+  public static native void doUpdateCompanion(String formName) /*-{
+    $wnd.Blocklies[formName].ReplMgr.triggerUpdate();
   }-*/;
 
   public static native String getURL() /*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -604,6 +604,14 @@ public final class YaBlocksEditor extends FileEditor
   }
 
   /*
+   * Trigger a Companion Update
+   */
+  @Override
+  public void updateCompanion() {
+    blocksArea.updateCompanion();
+  }
+
+  /*
    * [lyn, 2014/10/28] Added for accessing current form json from BlocklyPanel
    * Encodes the associated form's properties as a JSON encoded string. Used by YaBlocksEditor as well,
    * to send the form info to the blockly world during code generation.

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1310,6 +1310,8 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.REPL_GOT_IT = "Got It";
     Blockly.Msg.REPL_UPDATE_INFO = 'The update is now being installed on your device. Watch your device (or emulator) screen and approve the software installation when prompted.<br /><br />IMPORTANT: When the update finishes, choose "DONE" (don\'t click "open"). Then go to App Inventor in your web browser, click the "Connect" menu and choose "Reset Connection".  Then reconnect the device.';
 
+    Blockly.Msg.REPL_UPDATE_NO_UPDATE = "No Update is Available";
+    Blockly.Msg.REPL_UPDATE_NO_CONNECTION = "You must be connected to a Companion to update it";
     Blockly.Msg.REPL_UNABLE_TO_UPDATE = "Unable to send update to device/emulator";
     Blockly.Msg.REPL_UNABLE_TO_LOAD = "Unable to load update from App Inventor server";
     Blockly.Msg.REPL_UNABLE_TO_LOAD_NO_RESPOND = "Unable to load update from App Inventor server (server not responding)";

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -516,6 +516,16 @@ Blockly.ReplMgr.triggerUpdate = function() {
         reset();
     };
 
+    if (top.COMPANION_UPDATE_URL === "") {
+        showdialog(Blockly.Msg.REPL_OK, Blockly.Msg.REPL_UPDATE_NO_UPDATE);
+        return;
+    }
+
+    if (top.ReplState.state != Blockly.ReplMgr.rsState.CONNECTED) {
+        showdialog(Blockly.Msg.REPL_OK, Blockly.Msg.REPL_UPDATE_NO_CONNECTION);
+        return;
+    }
+
     encoder.add('package', 'update.apk');
     var qs = encoder.toString();
     fetchconn.open("GET", top.COMPANION_UPDATE_URL, true);
@@ -532,6 +542,10 @@ Blockly.ReplMgr.triggerUpdate = function() {
                                              conn.onreadystatechange = function() {
                                                  if (this.readyState == 4 && this.status == 200) {
                                                      console.log("Update: _package success");
+                                                     reset(); //  New companion, no connection left!
+                                                 } else if (this.readyState == 4) {
+                                                     console.log("Update: _package state = 4 probably ok");
+                                                     reset();
                                                  }
                                              };
                                              conn.send(qs);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AppInvHTTPD.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AppInvHTTPD.java
@@ -312,6 +312,10 @@ public class AppInvHTTPD extends NanoHTTPD {
       intent.setDataAndType(packageuri, "application/vnd.android.package-archive");
       form.startActivity(intent);
       res = new Response(HTTP_OK, MIME_PLAINTEXT, "OK");
+      res.addHeader("Access-Control-Allow-Origin", "*");
+      res.addHeader("Access-Control-Allow-Headers", "origin, content-type");
+      res.addHeader("Access-Control-Allow-Methods", "POST,OPTIONS,GET,HEAD,PUT");
+      res.addHeader("Allow", "POST,OPTIONS,GET,HEAD,PUT");
       return (res);
     }
 


### PR DESCRIPTION
Provide a Menu Item under the “Help” Menu to trigger a manual update
of the Companion. Also fix a bug in the Companion itself so that the
correct CORS headers are returned during the update (also put a work
around in replmgr.js to deal with the non-fixed
Companion). Automatically disconnect the Companion after the update so
the user doesn’t have to use the “Reset Connection” item before
connecting to the newly installed companion.

Change-Id: I31215863163974cf8f23bb68b03200cad8229ae5