### PR TITLE
Addressing-Correct-value-of-selection-index-with-filtered-list-pickers-#406

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -60,6 +60,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   // The adapter contains spannables rather than strings, since we will be changing the item
   // colors using ForegroundColorSpan
   private ArrayAdapter<Spannable> adapter;
+  private ArrayAdapter<Spannable> adapterCopy;
   private YailList items;
   private int selectionIndex;
   private String selection;
@@ -254,6 +255,11 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
     adapter = new ArrayAdapter<Spannable>(container.$context(), android.R.layout.simple_list_item_1,
         itemsToColoredText());
     view.setAdapter(adapter);
+
+    adapterCopy = new ArrayAdapter<Spannable>(container.$context(), android.R.layout.simple_list_item_1);
+    for (int i = 0; i < adapter.getCount(); ++i) {
+      adapterCopy.insert(adapter.getItem(i), i);
+    }
   }
 
   public Spannable[] itemsToColoredText() {
@@ -339,7 +345,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
     ArrayAdapter<Spannable> adapter = (ArrayAdapter<Spannable>) parent.getAdapter();
     Spannable item = (Spannable) adapter.getItem(position);
     this.selection = item.toString();
-    this.selectionIndex = adapter.getPosition(item) + 1; // AI lists are 1-based
+    this.selectionIndex = adapterCopy.getPosition(item) + 1; // AI lists are 1-based
 
     AfterPicking();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -336,8 +336,11 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
    */
   @Override
   public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-    this.selection = parent.getAdapter().getItem(position).toString();
-    this.selectionIndex = position + 1; // AI lists are 1-based
+    ArrayAdapter<Spannable> adapter = (ArrayAdapter<Spannable>) parent.getAdapter();
+    Spannable item = (Spannable) adapter.getItem(position);
+    this.selection = item.toString();
+    this.selectionIndex = adapter.getPosition(item) + 1; // AI lists are 1-based
+
     AfterPicking();
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -342,8 +342,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
    */
   @Override
   public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-    ArrayAdapter<Spannable> adapter = (ArrayAdapter<Spannable>) parent.getAdapter();
-    Spannable item = (Spannable) adapter.getItem(position);
+    Spannable item = (Spannable) parent.getAdapter().getItem(position);
     this.selection = item.toString();
     this.selectionIndex = adapterCopy.getPosition(item) + 1; // AI lists are 1-based
 


### PR DESCRIPTION
This pr fixes #406 . The change is minimal just to fix the issue.

>Below sample shows how filtering works. Select 1st a and then last a. On each selection, the selected text, index will display.

>Next, toggle filter and click on same selections. Notice the selectionIndex. Taifun's recommendation is to >keep / show the original unfiltered index. I can see the benefit in it, but not sure on how to accomplish it.

>Try test app here: http://3nportal.com/temp/TestListView.aia
