### PR TITLE
clean up broadcast receiver permission

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -486,8 +486,7 @@ public final class Compiler {
             "<intent-filter> \n" +
             "<action android:name=\"android.provider.Telephony.SMS_RECEIVED\" /> \n" +
             "<action \n" +
-            "android:name=\"com.google.android.apps.googlevoice.SMS_RECEIVED\" \n" +
-            "android:permission=\"com.google.android.apps.googlevoice.permission.RECEIVE_SMS\" /> \n" +
+            "android:name=\"com.google.android.apps.googlevoice.SMS_RECEIVED\" /> \n" +
             "</intent-filter>  \n" +
         "</receiver> \n");
       }


### PR DESCRIPTION
Here's the change I mentioned in #699 (have rebased, so should be clean to merge when reviewed).

I am working on an annotation for broadcast receivers, using Texting as a test, and I noticed that weird permission in a place that is not even [allowed in the xml schema](http://developer.android.com/guide/topics/manifest/action-element.html). Kinda surprised it does not crash.

@halatmit @jisqyv 