### PR TITLE
Adds an annotation for Broadcast Receivers

### DIFF
--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -37,5 +37,18 @@ public class CompilerTest extends TestCase {
         "android.permission.ACCESS_MOCK_LOCATION"));
     assertTrue(permissions.contains(
         "android.permission.ACCESS_LOCATION_EXTRA_COMMANDS"));
+  }
+
+  public void testGenerateBroadcastReceiver() throws Exception {
+    Set<String> componentTypes = Sets.newHashSet("Texting");
+    Compiler compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    Set<String> classNames = compiler.generateBroadcastReceiver();
+    assertEquals(1, classNames.size());
+    assertTrue(classNames.contains("com.google.appinventor.components.runtime.util.SmsBroadcastReceiver,android.provider.Telephony.SMS_RECEIVED,com.google.android.apps.googlevoice.SMS_RECEIVED"));
+
+    componentTypes = Sets.newHashSet("Texting", "Label");
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    classNames = compiler.generateBroadcastReceiver();
+    assertEquals(1, classNames.size());
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/annotations/SimpleBroadcastReceiver.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/SimpleBroadcastReceiver.java
@@ -1,0 +1,34 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2009-2011 Google, All Rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate that a file is a BroadcastReceiver and will need to be written to the Android Manifest in
+ * Compiler.java
+ * For each receiver <i>android:exported</i> will default to true if any actions are declared, false if no actions are passed.
+ * <i>android:enabled</i> will default to true because the same attribute in the <i>application</i> tag is not specified.
+ * If any other attributes are ever needed for the receiver, the annotation can be extended.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SimpleBroadcastReceiver {
+
+  /**
+   * The class name of the Broadcast Receiver
+   */
+  String className() default "";
+
+  /**
+   * The names of the actions for the receiver's intent filter, separated by commas.
+   */
+  String actions() default "";
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -36,6 +36,7 @@ import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.SimpleBroadcastReceiver;
 import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
@@ -121,7 +122,9 @@ import android.widget.Toast;
   "google-http-client-android3-beta.jar," +
   "google-oauth-client-beta.jar," +
   "guava-14.0.1.jar")
-
+@SimpleBroadcastReceiver(
+    className = "com.google.appinventor.components.runtime.util.SmsBroadcastReceiver",
+    actions = "android.provider.Telephony.SMS_RECEIVED, com.google.android.apps.googlevoice.SMS_RECEIVED")
 public class Texting extends AndroidNonvisibleComponent
   implements Component, OnResumeListener, OnPauseListener, OnInitializeListener, OnStopListener {
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -14,7 +14,7 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 
 /**
- * Tool to generate a list of the simple component types, and the permissions and libraries
+ * Tool to generate a list of the simple component types, permissions, libraries, and Broadcast Receivers
  * (build info) required for each component.
  *
  * @author lizlooney@google.com (Liz Looney)
@@ -25,6 +25,7 @@ public final class ComponentListGenerator extends ComponentProcessor {
   private static final String LIBRARIES_TARGET = "libraries";
   private static final String ASSETS_TARGET = "assets";
   private static final String NATIVE_TARGET = "native";
+  private static final String BROADCAST_RECEIVER_TARGET = "broadcastReceiver";
   // Where to write results.  Build Info is the collection of permissions, asset and library info.
   private static final String COMPONENT_LIST_OUTPUT_FILE_NAME = "simple_components.txt";
   private static final String COMPONENT_BUILD_INFO_OUTPUT_FILE_NAME =
@@ -81,6 +82,7 @@ public final class ComponentListGenerator extends ComponentProcessor {
     appendComponentInfo(sb, LIBRARIES_TARGET, component.libraries);
     appendComponentInfo(sb, NATIVE_TARGET, component.nativeLibraries);
     appendComponentInfo(sb, ASSETS_TARGET, component.assets);
+    appendComponentInfo(sb, BROADCAST_RECEIVER_TARGET, component.classNameAndActionsBR);
     sb.append("}");
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -13,6 +13,7 @@ import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.SimpleBroadcastReceiver;
 import com.google.appinventor.components.annotations.UsesAssets;
 import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.annotations.UsesNativeLibraries;
@@ -89,6 +90,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       "com.google.appinventor.components.annotations.SimpleFunction",
       "com.google.appinventor.components.annotations.SimpleObject",
       "com.google.appinventor.components.annotations.SimpleProperty",
+      "com.google.appinventor.components.annotations.SimpleBroadcastReceiver",
       "com.google.appinventor.components.annotations.UsesAssets",
       "com.google.appinventor.components.annotations.UsesLibraries",
       "com.google.appinventor.components.annotations.UsesNativeLibraries",
@@ -460,6 +462,11 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     protected final Set<String> assets;
 
     /**
+     * Class Name and Filter Actions for a Broadcast Receiver
+     */
+    protected final Set<String> classNameAndActionsBR;
+
+    /**
      * Properties of this component that are visible in the Designer.
      * @see DesignerProperty
      */
@@ -515,6 +522,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       libraries = Sets.newHashSet();
       nativeLibraries = Sets.newHashSet();
       assets = Sets.newHashSet();
+      classNameAndActionsBR = Sets.newHashSet();
       designerProperties = Maps.newTreeMap();
       properties = Maps.newTreeMap();
       methods = Maps.newTreeMap();
@@ -760,6 +768,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
         componentInfo.libraries.addAll(parentComponent.libraries);
         componentInfo.nativeLibraries.addAll(parentComponent.nativeLibraries);
         componentInfo.assets.addAll(parentComponent.assets);
+        componentInfo.classNameAndActionsBR.addAll(parentComponent.classNameAndActionsBR);
         // Since we don't modify DesignerProperties, we can just call Map.putAll to copy the
         // designer properties from parentComponent to componentInfo.
         componentInfo.designerProperties.putAll(parentComponent.designerProperties);
@@ -812,6 +821,21 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     if (usesAssets != null) {
       for (String file : usesAssets.fileNames().split(",")) {
         componentInfo.assets.add(file.trim());
+      }
+    }
+
+    //Gather required actions for Broadcast Receivers. The annotation has a Class Name and zero or more Filter Actions.
+    //In the resulting String, Class name will go first, and each Action will be added, separated by a comma.
+    SimpleBroadcastReceiver simpleBroadcastReceiver = element.getAnnotation(SimpleBroadcastReceiver.class);
+    if (simpleBroadcastReceiver != null) {
+      for (String className : simpleBroadcastReceiver.className().split(",")){
+        StringBuffer nameAndActions = new StringBuffer();
+        nameAndActions.append(className.trim());
+        for (String action : simpleBroadcastReceiver.actions().split(",")) {
+          nameAndActions.append("," + action.trim());
+        }
+        componentInfo.classNameAndActionsBR.add(nameAndActions.toString());
+        break; // We only need one class name; If more than one is passed, ignore all but first.
       }
     }
 


### PR DESCRIPTION
Adds an annotation to mark a class as a _@SimpleBroadcastReceiver_ with attributes _class name_ and _actions_ (to be added as intent filters).

The **_Texting_** component is changed to use the new annotation (it's the only example in the system right now).

The main purpose of this change is that _Extension_ developers can create extensions that use receivers without having to modify Compiler.java directly.

Please review @halatmit @jisqyv 