### PR TITLE
Retry failed searches in Gallery

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/GallerySearchIndex.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/GallerySearchIndex.java
@@ -41,7 +41,8 @@ public class GallerySearchIndex {
       GalleryStorageIoInstanceHolder.INSTANCE;
   private static volatile GallerySearchIndex  instance= null;
   private static Cursor searchCursor;
-  private final int appResultMaxAccuracy = 100;
+  private static final int SEARCH_RETRY_MAX = 3;
+  private final int NUMBER_FOUND_ACCURACY = 100;
   /**
    * The default constructor of GallerySearchIndex
    */
@@ -113,32 +114,51 @@ public class GallerySearchIndex {
     final List<GalleryApp> apps = new ArrayList<GalleryApp>();
     final Result<Integer> size = new Result<Integer>();
 
-    try {
-      //New search
-      if (start == 0 || searchCursor == null){
-        searchCursor = Cursor.newBuilder().build();
-      }
-      Query query = Query.newBuilder()
-          .setOptions(QueryOptions.newBuilder()
-                  .setCursor(searchCursor)
-                  .setLimit(count)
-                  .setNumberFoundAccuracy(appResultMaxAccuracy)
-              // for deployed apps, uncomment the line below to demo snippeting.
-              // This will not work on the dev_appserver.
-              // setFieldsToSnippet("content").
-              .build())
-          .build(searchWords);
-      LOG.info("Sending query " + query);
-      Results<ScoredDocument> results = getIndex().search(query);
-      searchCursor = results.getCursor();
+    //New search
+    if (start == 0 || searchCursor == null){
+      searchCursor = Cursor.newBuilder().build();
+    }
+    Query query = Query.newBuilder()
+            .setOptions(QueryOptions.newBuilder()
+                    .setCursor(searchCursor)
+                    .setLimit(count)
+                    .setNumberFoundAccuracy(NUMBER_FOUND_ACCURACY)
+                    // for deployed apps, uncomment the line below to demo snippeting.
+                    // This will not work on the dev_appserver.
+                    // setFieldsToSnippet("content").
+                    .build())
+            .build(searchWords);
 
+    Results<ScoredDocument> results = null;
+    int attempts = 0;
+    boolean retry = true;
+    while (retry){
+      try {
+        LOG.info("Sending query " + query);
+        results = getIndex().search(query);
+        //search successful
+        retry = false;
+      } catch (SearchException e) {
+        if (StatusCode.TRANSIENT_ERROR.equals(e.getOperationResult().getCode())) {
+          //No more attempts
+          if (attempts++ == SEARCH_RETRY_MAX) {
+            retry = false;
+          }
+          LOG.info("Query failed on attempt:" + attempts);
+        }else {
+          retry = false;
+          LOG.log(Level.SEVERE, "SEARCH EXCEPTION: " + e.getMessage());
+        }
+      }
+    }
+
+    if (results != null){
       // Iterate over the documents in the results
       for (ScoredDocument document : results) {
         LOG.info("Find:" + document.getId());
       }
 
       // Iterate over the documents in the results
-      int index = 0;
       for (ScoredDocument document : results) {
         try{
           GalleryApp app = galleryStorageIo.getGalleryApp(Long.parseLong(document.getId()));
@@ -149,10 +169,11 @@ public class GallerySearchIndex {
         }
       }
       size.t = (int) results.getNumberFound();
-    } catch (SearchException e) {
-      if (StatusCode.TRANSIENT_ERROR.equals(e.getOperationResult().getCode())) {
-        // retry
-      }
+      searchCursor = results.getCursor();
+    }else {
+      //the search was not successful in the try and catch
+      size.t = 0;
+      LOG.info("Search failed after " + attempts + " attempts");
     }
     return new GalleryAppListResult(apps, size.t, searchWords);
   }


### PR DESCRIPTION
This pull request fixes the errors thrown in the current gallery search. Will retry up to 3 times in order to get the correct results if a Transient Error is thrown.

Working version (Although this cannot be tested here since I am not getting Transient Errors on my instance) : https://searchfix-dot-aigallerythomas.appspot.com/
Use the following search keywords on my instance: "search", "debug"

@jisqyv @wolberd 