### PR TITLE
Mark Projects with our Host Name

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -198,7 +198,8 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     // this will be perfectly acceptable.  Until that happens, choosing 0 is just as safe as
     // allowing a random number to be chosen when the MockComponent is first created.
     return "#|\n$JSON\n" +
-        "{\"YaVersion\":\"" + YaVersion.YOUNG_ANDROID_VERSION + "\",\"Source\":\"Form\"," +
+        "{\"authURL\":[]," +
+        "\"YaVersion\":\"" + YaVersion.YOUNG_ANDROID_VERSION + "\",\"Source\":\"Form\"," +
         "\"Properties\":{\"$Name\":\"" + formName + "\",\"$Type\":\"Form\"," +
         "\"$Version\":\"" + YaVersion.FORM_COMPONENT_VERSION + "\",\"Uuid\":\"" + 0 + "\"," +
         "\"Title\":\"" + formName + "\",\"AppName\":\"" + packageName +"\"}}\n|#";

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -1826,6 +1826,7 @@ public class ObjectifyStorageIo implements  StorageIo {
 
     ByteArrayOutputStream zipFile = new ByteArrayOutputStream();
     final ZipOutputStream out = new ZipOutputStream(zipFile);
+    out.setComment("Built with MIT App Inventor");
 
     try {
       runJobWithRetries(new JobRetryHelper() {

--- a/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceTest.java
@@ -275,7 +275,8 @@ public class ProjectServiceTest {
         "build=../build\n");
     expectedYaFiles.put("src/com/domain/noname/Project1/Screen1.scm",
         "#|\n$JSON\n" +
-        "{\"YaVersion\":\"" + YaVersion.YOUNG_ANDROID_VERSION + "\",\"Source\":\"Form\"," +
+        "{\"authURL\":[]," +
+        "\"YaVersion\":\"" + YaVersion.YOUNG_ANDROID_VERSION + "\",\"Source\":\"Form\"," +
         "\"Properties\":{\"$Name\":\"Screen1\",\"$Type\":\"Form\"," +
         "\"$Version\":\"" + YaVersion.FORM_COMPONENT_VERSION + "\",\"Uuid\":\"0\"," +
         "\"Title\":\"Screen1\","+"\"AppName\":\"noname\"}}\n|#");


### PR DESCRIPTION
Because of the likely proliferation of various versions of App
Inventor, we want to mark a project with the history of which versions
have seen it. We do that with the "authURL" tag which we add to the
Form files. It is a JSON array of versions identified by the hostname
portion of the URL of the service editing the project. Older projects
will not have this field, so if we detect an older project (YAV <
OLD_PROJECT_YAV) we create the list and add ourselves. If we read in a
project where YAV >= OLD_PROJECT_YAV *and* there is no authURL, we
assume that it was created on a version of App Inventor that doesn't
support project tagging and we add an "*UNKNOWN*" tag to indicate
this. So for example if you examine a (newer) project and look in the
Screen1.scm file, you should just see an authURL that looks like
["ai2.appinventor.mit.edu"]. This would indicate a project that has
only been edited on MIT App Inventor. If instead you see something
like ["localhost", "ai2.appinventor.mit.edu"] it implies that at some
point in its history this project was edited using the local dev
server on someone's own computer.

Change-Id: I7a1012d163404eb6725944fbc56c0d50604a62c0