### PR TITLE
Preventing AIA files from being uploaded as media assets Bug fix #173

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1569,6 +1569,10 @@ public interface OdeMessages extends Messages {
   @Description("Confirmation message shown when conflicting files are about to be deleted.")
   String confirmOverwrite(String newFile, String existingFile);
 
+  @DefaultMessage("Error: AIA files can not be uploaded as media assets.")
+  @Description("Error message reported when an aia file is selected.")
+  String wrongFileTypeSelected();
+  
   // Used in wizards/KeystoreUploadWizard.java
 
   @DefaultMessage("Upload Keystore...")

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadWizard.java
@@ -90,7 +90,10 @@ public class FileUploadWizard extends Wizard {
           } else if (!TextValidators.isValidLengthFilename(filename)){
             Window.alert(MESSAGES.filenameBadSize());
             return;
-          }
+          }else if (filename.substring(filename.lastIndexOf('.')+1, filename.length()) == "aia"){
+              Window.alert(MESSAGES.wrongFileTypeSelected());
+              return;
+            }
           String fn = conflictingExistingFile(folderNode, filename);
           if (fn != null && !confirmOverwrite(folderNode, fn, filename)) {
             return;

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1030,11 +1030,6 @@ select.ode-PropertyEditor[disabled] {
   color: #8fc202;
 }
 
-.ode-ComponentHelpPopup > .popupContent > table{
-	width: 100%;
-	word-break: break-word;
-}
-
 .compiler-ErrorMarker {
   color: red;
 }

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1030,6 +1030,11 @@ select.ode-PropertyEditor[disabled] {
   color: #8fc202;
 }
 
+.ode-ComponentHelpPopup > .popupContent > table{
+	width: 100%;
+	word-break: break-word;
+}
+
 .compiler-ErrorMarker {
   color: red;
 }


### PR DESCRIPTION
Here are the changes to prevent AIA files from being uploaded as media assets reported here https://github.com/mit-cml/appinventor-sources/issues/173