### PR TITLE
Properly adjust font sizes within a ListView

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -260,6 +260,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
     // TODO(hal): Generalize this so that different items could have different
     // colors and even fonts and sizes
     int size = items.size();
+    int displayTextSize = textSize;
     Spannable [] objects = new Spannable[size];
     for (int i = 1; i <= size; i++) {
       // Note that the ListPicker and otherPickers pickers convert Yail lists to string by calling
@@ -271,7 +272,10 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       // need to allocate new objects?
       Spannable chars = new SpannableString(itemString);
       chars.setSpan(new ForegroundColorSpan(textColor),0,chars.length(),0);
-      chars.setSpan(new AbsoluteSizeSpan(textSize),0,chars.length(),0);
+      if (!container.$form().getCompatibilityMode()) {
+        displayTextSize = (int) (textSize * container.$form().deviceDensity());
+      }
+      chars.setSpan(new AbsoluteSizeSpan(displayTextSize),0,chars.length(),0);
       objects[i - 1] = chars;
     }
     return objects;


### PR DESCRIPTION
Make sure fonts are scaled based on device density when in “Responsive”
mode. In Fixed mode, the layout level scaling takes care of it for us,
but we have to do it here when we are in responsive mode.

This fix addresses Issue #713

Change-Id: Id51898981ab5db451ed783bad2ea3c3fb2853846