### PR TITLE
Update build.xml

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -186,6 +186,8 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <arg value="--childProcessRamMb" />
+      <arg value="1024" />
       <arg value="--inputZipFile" />
       <arg value="${local.build.dir}/aiplayapp.zip" />
       <arg value="--userName" />


### PR DESCRIPTION
The default childProcessRamMb set to 2048MB is too large for 32bit OS.