### PR TITLE
Supports user defined android activities in extensions.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/annotations/CustomActivities.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/CustomActivities.java
@@ -1,0 +1,27 @@
+package com.google.appinventor.components.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate Android permissions required by components.
+ *
+ * @author bigeyex@gmail.com (Yu Wang)
+ *
+ * Modified after:
+ * @author markf@google.com (Mark Friedman)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CustomActivities {
+
+  /**
+   * The names of the permissions separated by commas.
+   *
+   * @return  the permission name
+   * @see android.Manifest.permission
+   */
+  String activityNames() default "";
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListPicker.java
@@ -6,7 +6,6 @@
 
 package com.google.appinventor.components.runtime;
 
-import com.google.appinventor.components.annotations.CustomActivities;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -41,7 +40,6 @@ import android.view.WindowManager;
     "Other properties affect the appearance of the button " +
     "(<code>TextAlignment</code>, <code>BackgroundColor</code>, etc.) and " +
     "whether it can be clicked on (<code>Enabled</code>).</p>")
-@CustomActivities(activityNames = "com.google.appinventor.components.runtime.ListPickerActivity")
 @SimpleObject
 public class ListPicker extends Picker implements ActivityResultListener, Deleteable, OnResumeListener {
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListPicker.java
@@ -6,6 +6,7 @@
 
 package com.google.appinventor.components.runtime;
 
+import com.google.appinventor.components.annotations.CustomActivities;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -40,6 +41,7 @@ import android.view.WindowManager;
     "Other properties affect the appearance of the button " +
     "(<code>TextAlignment</code>, <code>BackgroundColor</code>, etc.) and " +
     "whether it can be clicked on (<code>Enabled</code>).</p>")
+@CustomActivities(activityNames = "com.google.appinventor.components.runtime.ListPickerActivity")
 @SimpleObject
 public class ListPicker extends Picker implements ActivityResultListener, Deleteable, OnResumeListener {
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
@@ -22,6 +22,7 @@ import javax.tools.FileObject;
 public final class ComponentListGenerator extends ComponentProcessor {
   // Names of component information types to be output. Must match buildserver.compiler constants.
   private static final String PERMISSIONS_TARGET = "permissions";
+  private static final String CUSTOMACTIVITIES_TARGET = "customActivities";
   private static final String LIBRARIES_TARGET = "libraries";
   private static final String ASSETS_TARGET = "assets";
   private static final String NATIVE_TARGET = "native";
@@ -79,6 +80,7 @@ public final class ComponentListGenerator extends ComponentProcessor {
     sb.append("{\"type\": \"");
     sb.append(component.type + "\"");
     appendComponentInfo(sb, PERMISSIONS_TARGET, component.permissions);
+    appendComponentInfo(sb, CUSTOMACTIVITIES_TARGET, component.customActivities);
     appendComponentInfo(sb, LIBRARIES_TARGET, component.libraries);
     appendComponentInfo(sb, NATIVE_TARGET, component.nativeLibraries);
     appendComponentInfo(sb, ASSETS_TARGET, component.assets);

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -6,6 +6,7 @@
 
 package com.google.appinventor.components.scripts;
 
+import com.google.appinventor.components.annotations.CustomActivities;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -447,6 +448,11 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     protected final Set<String> permissions;
 
     /**
+     * custom Activities required by this component.
+     */
+    protected final Set<String> customActivities;
+
+    /**
      * Libraries required by this component.
      */
     protected final Set<String> libraries;
@@ -523,6 +529,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       type = element.asType().toString();
       displayName = getDisplayNameForComponentType(name);
       permissions = Sets.newHashSet();
+      customActivities = Sets.newHashSet();
       libraries = Sets.newHashSet();
       nativeLibraries = Sets.newHashSet();
       assets = Sets.newHashSet();
@@ -781,6 +788,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       if (parentComponent != null) {
         // Copy its build info, designer properties, properties, methods, and events.
         componentInfo.permissions.addAll(parentComponent.permissions);
+        componentInfo.customActivities.addAll(parentComponent.customActivities);
         componentInfo.libraries.addAll(parentComponent.libraries);
         componentInfo.nativeLibraries.addAll(parentComponent.nativeLibraries);
         componentInfo.assets.addAll(parentComponent.assets);
@@ -810,6 +818,14 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     if (usesPermissions != null) {
       for (String permission : usesPermissions.permissionNames().split(",")) {
         componentInfo.permissions.add(permission.trim());
+      }
+    }
+
+    // Gather Custom Activities.
+    CustomActivities customActivitiesInfo = element.getAnnotation(CustomActivities.class);
+    if(customActivitiesInfo != null){
+      for (String activity : customActivitiesInfo.activityNames().split(",")) {
+        componentInfo.customActivities.add(activity.trim());
       }
     }
 


### PR DESCRIPTION
add @CustomActivities annotation before @SimpleObject.
eg. @CustomActivities(activityNames = "com.google.appinventor.components.runtime.ListPickerActivity")
multiple activities can be separated by commas.

This will add an <activity/> tag in Android Manifest file, giving the app the permission to start the newly defined Activity.
existing classes that involves activities (eg. ListPicker) are unchanged, since they have additional attributes besides just a name in the Manifest file though they works fine with the new CustomActivities annotation.
