### PR TITLE
Make session timeout a fatal error

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/AdminUserList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/AdminUserList.java
@@ -507,7 +507,7 @@ public class AdminUserList extends Composite {
             Ode.getInstance().getAdminInfoService().switchUser(user, new OdeAsyncCallback<Void>("Oops") {
                 @Override
                 public void onSuccess(Void v) {
-                  Ode.getInstance().reloadWindow();
+                  Ode.getInstance().reloadWindow(false);
                 }
               });
           }

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeAsyncCallback.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeAsyncCallback.java
@@ -6,12 +6,17 @@
 
 package com.google.appinventor.client;
 
+import com.google.appinventor.client.output.OdeLog;
+
 import com.google.appinventor.shared.rpc.BlocksTruncatedException;
 import com.google.appinventor.shared.rpc.InvalidSessionException;
 import com.google.appinventor.shared.rpc.project.ChecksumedFileException;
-import com.google.appinventor.client.output.OdeLog;
+
+import com.google.gwt.http.client.Response;
+
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
+import com.google.gwt.user.client.rpc.StatusCodeException;
 
 /**
  * Provides common functionality for asynchronous callbacks from the ODE
@@ -65,6 +70,13 @@ public abstract class OdeAsyncCallback<T> implements AsyncCallback<T> {
     if (caught instanceof BlocksTruncatedException) {
       OdeLog.log("Caught BlocksTruncatedException");
       ErrorReporter.reportError("Caught BlocksTruncatedException");
+      return;
+    }
+    // SC_PRECONDITION_FAILED if our session has expired or login cookie
+    // has become invalid
+    if ((caught instanceof StatusCodeException) &&
+      ((StatusCodeException)caught).getStatusCode() == Response.SC_PRECONDITION_FAILED) {
+      Ode.getInstance().sessionDead();
       return;
     }
     String errorMessage =

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5800,4 +5800,14 @@ public interface OdeMessages extends Messages {
   @Description("")
   String readOnlyMode();
 
+  @DefaultMessage("Either your session has expired, or App Inventor has been upgraded. " +
+    "You will need to \"Reload\" your session to continue. Press the \"Reload\" Button " +
+    "below.")
+  @Description("")
+  String sessionDead();
+
+  @DefaultMessage("Reload")
+  @Description("")
+  String reloadWindow();
+
 }


### PR DESCRIPTION
Session timeouts can happen if a user is idle too long or when we
perform certain types of App Inventor updates. Without this change, the
standard red error bar is produced. However many users appear to ignore
this error and keep working, but this work will never be saved!

This patch instead provides a dialog box that requires them to reload
their browser. The reload should not only refresh their session, but
should load any new App Inventor client side code. There is a risk that
up to 30 seconds of work may be lost when this dialog appears (most
people might lose only 5 seconds, but the risk is up to 30 due to the
way the auto-save code operates).

Change-Id: I4301e6dbdef0c52681b90ede4b8d84d6f9445d97