### PR TITLE
Fixed the Issue #624 (Download Blocks as Images, Comment Text Disappears)

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -70,6 +70,14 @@ out$.svgAsDataUri = function(el, optmetrics, options, cb) {
   options.scale = options.scale || 1;
   var xmlns = "http://www.w3.org/2000/xmlns/";  
   var outer = document.createElement("div");
+
+  var textAreas = document.getElementsByTagName("textarea");
+  
+  for (var i = 0; i < textAreas.length; i++)
+  {
+    textAreas[i].innerHTML = textAreas[i].value;
+  }
+
   var clone = el.cloneNode(true);
   var width, height;
   if(el.tagName == 'svg') {


### PR DESCRIPTION
#624 

When a comment block is created and the user edits the comment block by typing text, this action changes the value property of the textarea, which is not duplicated using the .CloneNode() method. This is the reason why comment text disappears when a user attempts to download blocks as images. 

@halatmit 