### PR TITLE
Fix for Issue #800

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ActivityStarter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ActivityStarter.java
@@ -436,19 +436,28 @@ public class ActivityStarter extends AndroidNonvisibleComponent
       requestCode = form.registerForActivityResult(this);
     }
 
-    try {
-      container.$context().startActivityForResult(intent, requestCode);
-      String openAnim = container.$form().getOpenAnimType();
-      AnimationUtil.ApplyOpenScreenAnimation(container.$context(), openAnim);
-    } catch (ActivityNotFoundException e) {
-      form.dispatchErrorOccurredEvent(this, "StartActivity",
-          ErrorMessages.ERROR_ACTIVITY_STARTER_NO_CORRESPONDING_ACTIVITY);
-    }
+    if (intent == null) {
+    	form.dispatchErrorOccurredEvent(this, "StartActivity", 
+    		ErrorMessages.ERROR_ACTIVITY_STARTER_NO_ACTION_INFO);
+    } else {
+	    try {
+	      container.$context().startActivityForResult(intent, requestCode);
+	      String openAnim = container.$form().getOpenAnimType();
+	      AnimationUtil.ApplyOpenScreenAnimation(container.$context(), openAnim);
+	    } catch (ActivityNotFoundException e) {
+	      form.dispatchErrorOccurredEvent(this, "StartActivity",
+	          ErrorMessages.ERROR_ACTIVITY_STARTER_NO_CORRESPONDING_ACTIVITY);
+	    }
+	}
   }
 
   private Intent buildActivityIntent() {
     Uri uri = (dataUri.length() != 0) ? Uri.parse(dataUri) : null;
     Intent intent = (uri != null) ? new Intent(action, uri) : new Intent(action);
+
+    if (Action().isEmpty()) {
+    	return null;
+    }
 
     if (dataType.length() != 0) {
       if (uri != null) {
@@ -461,6 +470,8 @@ public class ActivityStarter extends AndroidNonvisibleComponent
     if (activityPackage.length() != 0 || activityClass.length() != 0) {
       ComponentName component = new ComponentName(activityPackage, activityClass);
       intent.setComponent(component);
+    } else if (Action() == "android.intent.action.MAIN") {
+    	return null;
     }
 
     if (extraKey.length() != 0 && extraValue.length() != 0) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
@@ -84,6 +84,7 @@ public final class ErrorMessages {
   public static final int ERROR_BLUETOOTH_UNSUPPORTED_ENCODING = 519;
   // ActivityStarter errors
   public static final int ERROR_ACTIVITY_STARTER_NO_CORRESPONDING_ACTIVITY = 601;
+  public static final int ERROR_ACTIVITY_STARTER_NO_ACTION_INFO = 602;
   // Media errors
   public static final int ERROR_UNABLE_TO_LOAD_MEDIA = 701;
   public static final int ERROR_UNABLE_TO_PREPARE_MEDIA = 702;
@@ -356,6 +357,8 @@ public final class ErrorMessages {
     // ActivityStarter errors
     errorMessages.put(ERROR_ACTIVITY_STARTER_NO_CORRESPONDING_ACTIVITY,
         "No corresponding activity was found.");
+    errorMessages.put(ERROR_ACTIVITY_STARTER_NO_ACTION_INFO,
+        "No Action information in ActivityStarter was found.");
     // Media errors
     errorMessages.put(ERROR_UNABLE_TO_LOAD_MEDIA,
         "Unable to load %s.");


### PR DESCRIPTION
@halatmit 

#800 

When ActivityStarter is called without any action information, the intent is pointed to an action that requires permission and is denied that permission. It results in a runtime error which gives little information for users. 

![106c0560-b197-4b24-8d52-270984f6a5f9](https://cloud.githubusercontent.com/assets/18460893/16850946/53b85976-49cf-11e6-8524-820f9d86e407.png)


I added another error message that replaces this runtime error to inform the user that no information was found in ActivityStarter. It seems that the default action is android.intent.action.MAIN if no information was enter in the Action properties for the ActivityStarter.

[AIA](https://drive.google.com/file/d/0B9cmuy8O4JxKT1gyNmxnOXJhbVU/view?usp=sharing) and[ APK](https://drive.google.com/file/d/0B9cmuy8O4JxKUTY4aTNOMjloMlk/view?usp=sharing) to reproduce error.