### PR TITLE
Update ActivityStarter to use TextUtils.isEmpty(String)

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ActivityStarter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ActivityStarter.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Log;
 
 /**
@@ -455,7 +456,7 @@ public class ActivityStarter extends AndroidNonvisibleComponent
     Uri uri = (dataUri.length() != 0) ? Uri.parse(dataUri) : null;
     Intent intent = (uri != null) ? new Intent(action, uri) : new Intent(action);
 
-    if (Action().isEmpty()) {
+    if (TextUtils.isEmpty(Action())) {
       return null;
     }
 


### PR DESCRIPTION
ActivityStarter uses String.isEmpty(), which was introduced in Java
1.6. However, older versions of Android are only binary compatible
with Java 1.5, such as the version used in the emulator. This causes
the ActivityStarter to throw an exception when starting an activity.

This commit fixes the issue by replacing the call to String.isEmpty()
with android.text.TextUtils.isEmpty(String), which is available since
Android API version 1. This is consistent with other checks in
components, such as Canvas and Web.

Closes #827

Change-Id: I5c26bab97421a86b3d62888af447d999af38450a