### PR TITLE
Add open screen blocks with screen selection dropdown

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
+++ b/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
@@ -11,8 +11,7 @@
   -->
 
   <inherits name='com.google.gwt.user.UserAgent'/>
-  <!-- <set-property name="user.agent" value="safari,gecko1_8" /> -->
-  <set-property name="user.agent" value="safari" />
+  <set-property name="user.agent" value="safari,gecko1_8" />
 
   <!-- inherits -->
 
@@ -109,23 +108,23 @@
   <!-- English language, independent of country -->
   <extend-property name="locale" values="en"/>
   <!-- Simplified Chinese -->
-  <!-- <extend-property name="locale" values="zh_CN"/> -->
+  <extend-property name="locale" values="zh_CN"/>
   <!-- Traditional Chinese -->
-  <!-- <extend-property name="locale" values="zh_TW"/> -->
+  <extend-property name="locale" values="zh_TW"/>
   <!-- Spanish from Spain -->
-  <!-- <extend-property name="locale" values="es_ES"/> -->
+  <extend-property name="locale" values="es_ES"/>
   <!-- French -->
-  <!-- <extend-property name="locale" values="fr_FR"/> -->
+  <extend-property name="locale" values="fr_FR"/>
   <!-- Italian -->
-  <!-- <extend-property name="locale" values="it_IT"/> -->
+  <extend-property name="locale" values="it_IT"/>
   <!-- Russian -->
-  <!-- <extend-property name="locale" values="ru"/> -->
+  <extend-property name="locale" values="ru"/>
   <!-- Korean -->
-  <!-- <extend-property name="locale" values="ko_KR"/> -->
+  <extend-property name="locale" values="ko_KR"/>
   <!-- Swedish -->
-  <!-- <extend-property name="locale" values="sv"/> -->
+  <extend-property name="locale" values="sv"/>
   <!-- Portuguese (Brazilian) -->
-  <!-- <extend-property name="locale" values="pt_BR"/> -->
+  <extend-property name="locale" values="pt_BR"/>
 
   <set-property-fallback name="locale" value="en"/>
 

--- a/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
+++ b/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
@@ -11,7 +11,8 @@
   -->
 
   <inherits name='com.google.gwt.user.UserAgent'/>
-  <set-property name="user.agent" value="safari,gecko1_8" />
+  <!-- <set-property name="user.agent" value="safari,gecko1_8" /> -->
+  <set-property name="user.agent" value="safari" />
 
   <!-- inherits -->
 
@@ -108,23 +109,23 @@
   <!-- English language, independent of country -->
   <extend-property name="locale" values="en"/>
   <!-- Simplified Chinese -->
-  <extend-property name="locale" values="zh_CN"/>
+  <!-- <extend-property name="locale" values="zh_CN"/> -->
   <!-- Traditional Chinese -->
-  <extend-property name="locale" values="zh_TW"/>
+  <!-- <extend-property name="locale" values="zh_TW"/> -->
   <!-- Spanish from Spain -->
-  <extend-property name="locale" values="es_ES"/>
+  <!-- <extend-property name="locale" values="es_ES"/> -->
   <!-- French -->
-  <extend-property name="locale" values="fr_FR"/>
+  <!-- <extend-property name="locale" values="fr_FR"/> -->
   <!-- Italian -->
-  <extend-property name="locale" values="it_IT"/>
+  <!-- <extend-property name="locale" values="it_IT"/> -->
   <!-- Russian -->
-  <extend-property name="locale" values="ru"/>
+  <!-- <extend-property name="locale" values="ru"/> -->
   <!-- Korean -->
-  <extend-property name="locale" values="ko_KR"/>
+  <!-- <extend-property name="locale" values="ko_KR"/> -->
   <!-- Swedish -->
-  <extend-property name="locale" values="sv"/>
+  <!-- <extend-property name="locale" values="sv"/> -->
   <!-- Portuguese (Brazilian) -->
-  <extend-property name="locale" values="pt_BR"/>
+  <!-- <extend-property name="locale" values="pt_BR"/> -->
 
   <set-property-fallback name="locale" value="en"/>
 

--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -467,6 +467,17 @@ public class DesignToolbar extends Toolbar {
     }
   }
 
+  /**
+   * Gets the names of screens
+   * Originally created for the "OpenAnotherScreen block" in control.js
+   *
+   * @return the names of screens
+   */
+  public static String[] getScreenNames() {
+    DesignToolbar designToolbar = Ode.getInstance().getDesignToolbar();
+    return designToolbar.getDropDownListItems(WIDGET_NAME_SCREENS_DROPDOWN);
+  }
+
   public DesignProject getCurrentProject() {
     return currentProject;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -809,6 +809,26 @@ public class BlocklyPanel extends HTMLPanel {
     return TranslationDesignerPallete.getCorrespondingString(key);
   }
 
+  /**
+   *  To get the names of screens for "OpenAnotherScreen block" in control.js
+   *
+   *  @return an array of tuples of screen names
+   */
+  public static String[][] getScreenNames() {
+    String[] names = DesignToolbar.getScreenNames();
+    String[][] screenTuple = new String[names.length][2];
+    //This is required for a dropdown menu, which takes tuples.
+    //The first item is the string displayed
+    //The second item is the actual string passed back when the menu is clicked
+    //It needs quotes because of how the OpenAnotherScreen block functions.
+    for (int i=0;i<names.length;i++) {
+      String nameWithQuotes = "\"" + names[i] + "\"";
+      screenTuple[i][0] = nameWithQuotes;
+      screenTuple[i][1] = nameWithQuotes;
+    }
+    return screenTuple;
+  }
+
   // ------------ Native methods ------------
 
   /**
@@ -871,6 +891,8 @@ public class BlocklyPanel extends HTMLPanel {
       $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getBackpack());
     $wnd.BlocklyPanel_setBackpack =
       $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::setBackpack(Ljava/lang/String;));
+    $wnd.BlocklyPanel_getScreenNames =
+          $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getScreenNames());
   }-*/;
 
   private native void initJS() /*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/DropDownButton.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/DropDownButton.java
@@ -208,4 +208,11 @@ public class DropDownButton extends TextButton {
   public ContextMenu getContextMenu() {
     return menu;
   }
+
+  public List<MenuItem> getItems() {
+    //getter method
+    List<MenuItem> itemsCopy = new ArrayList<MenuItem>();
+    itemsCopy.addAll(items);
+    return itemsCopy;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/Toolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/Toolbar.java
@@ -145,6 +145,27 @@ public class Toolbar extends Composite {
   }
 
   /**
+   * Gets the names of menu items
+   * Originally created for the "OpenAnotherScreen block" in control.js
+   *
+   * @param dropWidgetName name of the drop-down widget
+   * @return the names of the specified menu items - if no matching menu item to widget, will return an empty array
+   */
+  public String[] getDropDownListItems(String dropWidgetName) {
+    List<MenuItem> itemList = dropDownButtonMap.get(dropWidgetName).getItems();
+    if (itemList != null) {
+      int listSize = itemList.size();
+      String[] itemArray = new String[listSize];
+      for (int i = 0; i < listSize; i++) {
+        itemArray[i] = itemList.get(i).getText();
+      }
+      return itemArray;
+    }
+    else
+      return new String[0];
+  }
+
+  /**
    * Adds a button to the toolbar
    *
    * @param item button to add

--- a/appinventor/blocklyeditor/src/blocks/control.js
+++ b/appinventor/blocklyeditor/src/blocks/control.js
@@ -603,6 +603,23 @@ Blockly.Blocks['controls_openAnotherScreen'] = {
   typeblock: [{translatedName: Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TITLE}]
 };
 
+//Same as openAnotherScreen above but with a dropdown list for screens to make selection more intuitive.
+Blockly.Blocks['controls_openAnotherScreenDropDown'] = {
+  // Open another screen
+  category: 'Control',
+  helpUrl: Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_HELPURL,
+  init: function () {
+    this.setColour(Blockly.CONTROL_CATEGORY_HUE);
+    this.appendDummyInput()
+        .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TITLE)
+        .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_INPUT_SCREENNAME)
+        .appendField(new Blockly.FieldDropdown(window.parent.BlocklyPanel_getScreenNames), "SCREEN_PICK");
+    this.setPreviousStatement(true);
+    this.setTooltip(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TOOLTIP);
+  },
+  typeblock: [{translatedName: Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TITLE}]
+};
+
 Blockly.Blocks['controls_openAnotherScreenWithStartValue'] = {
   // Open another screen with start value
   category: 'Control',
@@ -614,6 +631,26 @@ Blockly.Blocks['controls_openAnotherScreenWithStartValue'] = {
         .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_TITLE)
         .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_INPUT_SCREENNAME)
         .setAlign(Blockly.ALIGN_RIGHT);
+    this.appendValueInput('STARTVALUE')
+        .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_INPUT_STARTVALUE)
+        .setAlign(Blockly.ALIGN_RIGHT);
+    this.setPreviousStatement(true);
+    this.setTooltip(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_TOOLTIP);
+  },
+  typeblock: [{translatedName: Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_TITLE}]
+};
+
+//Same as openAnotherScreenWithStartValue above but with a dropdown list for screens to make selection more intuitive.
+Blockly.Blocks['controls_openAnotherScreenWithStartValueDropDown'] = {
+  // Open another screen with start value
+  category: 'Control',
+  helpUrl: Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_HELPURL,
+  init: function () {
+    this.setColour(Blockly.CONTROL_CATEGORY_HUE);
+    this.appendDummyInput()
+        .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_TITLE)
+        .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_INPUT_SCREENNAME)
+        .appendField(new Blockly.FieldDropdown(window.parent.BlocklyPanel_getScreenNames), "SCREEN_PICK");
     this.appendValueInput('STARTVALUE')
         .appendField(Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_INPUT_STARTVALUE)
         .setAlign(Blockly.ALIGN_RIGHT);

--- a/appinventor/blocklyeditor/src/generators/yail/control.js
+++ b/appinventor/blocklyeditor/src/generators/yail/control.js
@@ -154,9 +154,34 @@ Blockly.Yail['controls_openAnotherScreen'] = function() {
   return code;
 };
 
+Blockly.Yail['controls_openAnotherScreenDropDown'] = function() {
+  // Open another screen
+  var argument0 = this.getFieldValue('SCREEN_PICK');
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "open-another-screen" + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;
+  code = code + argument0 + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + Blockly.Yail.YAIL_OPEN_COMBINATION;
+  code = code + "text" + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "open another screen" + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  return code;
+};
+
 Blockly.Yail['controls_openAnotherScreenWithStartValue'] = function() {
   // Open another screen with start value
   var argument0 = Blockly.Yail.valueToCode(this, 'SCREENNAME', Blockly.Yail.ORDER_NONE) || null;
+  var argument1 = Blockly.Yail.valueToCode(this, 'STARTVALUE', Blockly.Yail.ORDER_NONE) || null;
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "open-another-screen-with-start-value" + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;
+  code = code + argument0 + Blockly.Yail.YAIL_SPACER + argument1 + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + Blockly.Yail.YAIL_OPEN_COMBINATION;
+  code = code + "text any" + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "open another screen with start value" + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  return code;
+};
+
+Blockly.Yail['controls_openAnotherScreenWithStartValueDropDown'] = function() {
+  // Open another screen with start value
+  var argument0 = this.getFieldValue('SCREEN_PICK');
   var argument1 = Blockly.Yail.valueToCode(this, 'STARTVALUE', Blockly.Yail.ORDER_NONE) || null;
   var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "open-another-screen-with-start-value" + Blockly.Yail.YAIL_SPACER;
   code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;


### PR DESCRIPTION
All edits Laura and I made to create a 'open a new screen' dropdown block, intended to serve as a template for issues #195 and #155.
Design doc for our change: https://docs.google.com/document/d/1rW2I4sa9jSIQVFFkqQDgW9giPtAxOLeV7nQNbz91Pns/edit