### PR TITLE
Fixed Issue #707: Buttons with background images now have shape options

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
@@ -211,7 +211,6 @@ abstract class MockButtonBase extends MockVisibleComponent {
       hasImage = false;
       url = "";
       setBackgroundColorProperty(backgroundColor);
-      setShapeProperty(Integer.toString(shape));
     } else {
       hasImage = true;
       // Android Buttons do not show a background color if they have an image.
@@ -222,6 +221,7 @@ abstract class MockButtonBase extends MockVisibleComponent {
           "&H" + COLOR_NONE);
       DOM.setStyleAttribute(buttonWidget.getElement(), "borderRadius", "0px");
     }
+    setShapeProperty(Integer.toString(shape));
     MockComponentsUtil.setWidgetBackgroundImage(buttonWidget, url);
     image.setUrl(url);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
@@ -118,9 +118,6 @@ abstract class MockButtonBase extends MockVisibleComponent {
     shape = Integer.parseInt(text);
     // Android Buttons with images take the shape of the image and do not
     // use one of the defined Shapes.
-    if (hasImage) {
-      return;
-    }
     switch(shape) {
       case 0:
         // Default Button

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -316,6 +316,7 @@ public abstract class ButtonBase extends AndroidViewComponent
     // If it's the same as on the prior call and the prior load was successful,
     // do nothing.
     if (path.equals(imagePath) && backgroundImageDrawable != null) {
+      //updateAppearance();
       return;
     }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -18,7 +18,15 @@ import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import android.view.MotionEvent;
 import android.content.res.ColorStateList;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.OvalShape;
@@ -94,6 +102,10 @@ public abstract class ButtonBase extends AndroidViewComponent
   // If an Image has never been set or if the most recent Image
   // could not be loaded, this is null.
   private Drawable backgroundImageDrawable;
+
+  // This is the bitmap from backgroundImageDrawable 
+  // obtained using BitmapDrawable's getBitmap() method.
+  private Bitmap backgroundBitmap;
 
   /**
    * Creates a new ButtonBase component.
@@ -380,8 +392,38 @@ public abstract class ButtonBase extends AndroidViewComponent
         setShape();
       }
     } else {
-      // If there is a background image
-      ViewUtil.setBackgroundImage(view, backgroundImageDrawable);
+      if ((shape == Component.BUTTON_SHAPE_DEFAULT)) {
+        ViewUtil.setBackgroundImage(view, backgroundImageDrawable);
+      } else {
+        Paint paint = new Paint();
+        paint.setAntiAlias(true);
+
+        backgroundBitmap = ((BitmapDrawable) backgroundImageDrawable).getBitmap(); 
+
+        Bitmap result = Bitmap.createBitmap(backgroundBitmap.getWidth(), backgroundBitmap.getHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(result);
+
+        switch (shape) {
+          case Component.BUTTON_SHAPE_ROUNDED:
+            canvas.drawRoundRect(new RectF(0, 0, backgroundBitmap.getWidth(), backgroundBitmap.getHeight()), 100f, 100f, paint);
+            //100f was used because the rounded feature could not be seen with 10f in companion, emulator, and phone. 
+            break;
+          case Component.BUTTON_SHAPE_RECT:
+            canvas.drawRect(new RectF(0, 0, backgroundBitmap.getWidth(), backgroundBitmap.getHeight()), paint);
+            break;
+          case Component.BUTTON_SHAPE_OVAL:
+            canvas.drawOval(new RectF(0, 0, backgroundBitmap.getWidth(), backgroundBitmap.getHeight()), paint);
+            break;
+          default: //This should never happen like the case in MockButtonBase.java
+            throw new IllegalArgumentException();
+        }
+
+        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+
+        canvas.drawBitmap(backgroundBitmap, null, new Rect(0, 0, backgroundBitmap.getWidth(), backgroundBitmap.getHeight()), paint);
+
+        ViewUtil.setBackgroundImage(view, new BitmapDrawable(result));
+      }
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -316,7 +316,6 @@ public abstract class ButtonBase extends AndroidViewComponent
     // If it's the same as on the prior call and the prior load was successful,
     // do nothing.
     if (path.equals(imagePath) && backgroundImageDrawable != null) {
-      //updateAppearance();
       return;
     }
 
@@ -415,7 +414,7 @@ public abstract class ButtonBase extends AndroidViewComponent
           case Component.BUTTON_SHAPE_OVAL:
             canvas.drawOval(new RectF(0, 0, backgroundBitmap.getWidth(), backgroundBitmap.getHeight()), paint);
             break;
-          default: //This should never happen like the case in MockButtonBase.java
+          default: 
             throw new IllegalArgumentException();
         }
 


### PR DESCRIPTION
#707

@halatmit @jisqyv 

Buttons with background images no longer default to the rectangular shape and now instead have shape options that are available to buttons without background images (Default, Rounded, Rectangular, Oval).

Users can also adjust the height and the width of the button and the image will change accordingly.

![screenshot_20160802-103154](https://cloud.githubusercontent.com/assets/18460893/17332359/79addb8e-589c-11e6-85b7-179596fd146a.png)

**Note:** I increased the radius from the default 10f to 100f for the rounded shape button because the rounded feature could not be seen on the phone or companion with 10f. 

![screenshot](https://cloud.githubusercontent.com/assets/18460893/17331541/5ca10ab4-5899-11e6-8cce-5ad3408edb0a.png)
