### PR TITLE
Add a No-Op function

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -675,6 +675,26 @@ public class Ode implements EntryPoint {
         user = result.getUser();
         isReadOnly = user.isReadOnly();
 
+        // Setup noop timer (if enabled)
+        int noop = config.getNoop();
+        if (noop > 0) {
+          // If we have a noop time, setup a timer to do the noop
+          Timer t = new Timer() {
+              @Override
+              public void run() {
+                userInfoService.noop(new AsyncCallback<Void>() {
+                    @Override
+                    public void onSuccess(Void e) {
+                    }
+                    @Override
+                    public void onFailure(Throwable e) {
+                    }
+                  });
+              }
+            };
+            t.scheduleRepeating(1000*60*noop);
+        }
+
         // If user hasn't accepted terms of service, ask them to.
         if (!user.getUserTosAccepted() && !isReadOnly) {
           // We expect that the redirect to the TOS page should be handled

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -60,6 +60,7 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
     config.setGuideUrl(Flag.createFlag("guide.url", "").get());
     config.setReferenceComponentsUrl(Flag.createFlag("reference.components.url", "").get());
     config.setFirebaseURL(Flag.createFlag("firebase.url", "").get());
+    config.setNoop(Flag.createFlag("session.noop", 0).get());
 
     // Check to see if we need to upgrade this user's project to GCS
     storageIo.checkUpgrade(userInfoProvider.getUserId());
@@ -158,4 +159,14 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
   public void deleteUserFile(String fileName) {
     storageIo.deleteUserFile(userInfoProvider.getUserId(), fileName);
   }
+
+  /**
+   * No-Op (No Operation). However because we are going through
+   * OdeAuthFilter to get this far, a session cookie due for renewal
+   * will be renewed.
+   */
+  @Override
+  public void noop() {
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
@@ -33,6 +33,7 @@ public class Config implements IsSerializable, Serializable {
   private String guideUrl;
   private String referenceComponentsUrl;
   private String firebaseURL;   // Default Firebase URL
+  private int noop;            // No-op interval
 
   public Config() {
   }
@@ -163,6 +164,14 @@ public class Config implements IsSerializable, Serializable {
 
   public void setFirebaseURL(String url) {
     firebaseURL = url;
+  }
+
+  public int getNoop() {
+    return noop;
+  }
+
+  public void setNoop(int noop) {
+    this.noop = noop;
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
@@ -82,5 +82,9 @@ public interface UserInfoService extends RemoteService {
    */
   void deleteUserFile(String fileName);
 
+  /**
+   * No-Op Do nothing, but will refresh the session cookie as a side-effect
+   */
+  void noop();
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
@@ -65,4 +65,10 @@ public interface UserInfoServiceAsync {
    * @see UserInfoService#deleteUserFile(String)
    */
   void deleteUserFile(String fileName, AsyncCallback<Void> callback);
+
+  /**
+   * @see UserInfoService#noop(String)
+   */
+  void noop(AsyncCallback<Void> callback);
+
 }

--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -107,10 +107,28 @@
          buildserver to match -->
     <property name="build.send.git.version" value="true" />
 
+    <!-- Session Management Variables. -->
+    <!-- We define three variables here.
+         All variables are defined in minutes
+         session.idletimeout - defines how long until an idle session
+                               is considered invalid.
+         session.renew       - defines the time after which a new session
+                               cookie is generated.
+         session.noop        - defines the time interval between no-op calls
+                               from Ode. 0 means never perform a no-op (the default)
+
+         Note: If renew is > idletimeout, then people will get logged
+         out involuntarily after idletimeout because their session
+         will never renew and therefore is considered idle.
+    -->
+
+    <property name="session.idletimeout" value="120" />
+    <property name="session.renew" value="30" />
+    <property name="session.noop" value="0" />
+
     <!-- Set this to true to enable the use of Wifi connections from the blocks editor to
          the phone. The phone must have an up-to-date copy of the MIT AICompanion App to
          use this feature. -->
-
     <property name="wifi.enabled" value="true" />
 
     <!-- Firebase Secret for the shared datastore -->


### PR DESCRIPTION
Add a No-Op function. Along with a session idle timeout and session
renew time, we can ensure that closed browsers (which will stop
performing no-op operations) will be logged out.

Change-Id: Ibdd1a55b172fc2aad2c8bed012ae86508d1d025b