### PR TITLE
Do not erase UserSettings when App Inventor Closed

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/settings/user/UserSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/user/UserSettings.java
@@ -23,6 +23,7 @@ import com.google.gwt.user.client.DeferredCommand;
  */
 public final class UserSettings extends CommonSettings implements SettingsAccessProvider {
   private boolean loading;
+  private boolean loaded;
 
   /**
    * Creates new user settings object.
@@ -45,6 +46,7 @@ public final class UserSettings extends CommonSettings implements SettingsAccess
             OdeLog.log("Loaded global settings: " + result);
             decodeSettings(result);
 
+            loaded = true;
             loading = false;
           }
 
@@ -69,6 +71,15 @@ public final class UserSettings extends CommonSettings implements SettingsAccess
           saveSettings(command);
         }
       });
+    } else if (!loaded) {
+      // Do not save settings that have not been loaded. We should
+      // only wind up in this state if we are in the early phases of
+      // loading the App Inventor client code. If saveSettings is
+      // called in this state, it is from the onWindowClosing
+      // handler. We do *not* want to over-write a persons valid
+      // settings with this empty version, so we just return.
+      return;
+
     } else {
       String s = encodeSettings();
       OdeLog.log("Saving global settings: " + s);


### PR DESCRIPTION
There is a race condition where if App Inventor is closed (browser
window closed) while the system is still initializing, the user’s global
settings will be over-written by an empty settings object because the
global settings have not finished loading. We detect that with this code
and avoid over-writing the settings.

Change-Id: Icfcf8204b860984bf36e2a7d525ebf5814a2ffd8