### PR TITLE
Fix erroneous reference to getProcedureDef

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -490,7 +490,7 @@ Blockly.Blocks['procedures_defreturn'] = {
   decompose: Blockly.Blocks.procedures_defnoreturn.decompose,
   compose: Blockly.Blocks.procedures_defnoreturn.compose,
   dispose: Blockly.Blocks.procedures_defnoreturn.dispose,
-  getProcedureDef: Blockly.Blocks.getProcedureDef,
+  getProcedureDef: Blockly.Blocks.procedures_defnoreturn.getProcedureDef,
   getVars: Blockly.Blocks.procedures_defnoreturn.getVars,
   declaredNames: Blockly.Blocks.procedures_defnoreturn.declaredNames,
   renameVar: Blockly.Blocks.procedures_defnoreturn.renameVar,


### PR DESCRIPTION
When changing the called procedure name in a procedure block that
returns a value, the parameter sockets disappear and the block becomes
unusable. This is caused by the fact that the code looks to call
getProcedureDef but it is undefined, even on procedure blocks. The
issue was that it is supposed to be copied from the no return version
of the procedure call block, but the reference was wrong and so the
value was undefined. This commit fixes the erroneous reference in
order that the behavior is correct. This also has the side effect of
fixing the (unreported?) bug that the "Highlight Procedure" context
menu action was not working due to the same issue.

Fixes #844

Change-Id: I7041c3ab05a89c1a710128a7d91a543bb601940a