### PR TITLE
Reimplement delete component confirm dialog in GWT

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -952,6 +952,10 @@ public interface OdeMessages extends Messages {
       "Yail code")
   String badComponentNameError();
 
+  @DefaultMessage("Delete Component")
+  @Description("Title for the delete component dialog")
+  String deleteTitle();
+
   @DefaultMessage("Deleting this component will delete all blocks associated with it in the " +
       "Blocks Editor. Are you sure you want to delete?")
   @Description("Confirmation query for deleting a component")

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -952,10 +952,6 @@ public interface OdeMessages extends Messages {
       "Yail code")
   String badComponentNameError();
 
-  @DefaultMessage("Delete Component")
-  @Description("Title for the delete component dialog")
-  String deleteTitle();
-
   @DefaultMessage("Deleting this component will delete all blocks associated with it in the " +
       "Blocks Editor. Are you sure you want to delete?")
   @Description("Confirmation query for deleting a component")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -214,6 +214,44 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     }
   }
 
+  /**
+   * This class defines the dialog box for deleting a component.
+   */
+  private class DeleteDialog extends DialogBox {
+    DeleteDialog() {
+      super(false, true);
+
+      setStylePrimaryName("ode-DialogBox");
+      setText(MESSAGES.deleteTitle());
+      VerticalPanel contentPanel = new VerticalPanel();
+
+      contentPanel.add(new HTML(MESSAGES.reallyDeleteComponent()));
+      Button cancelButton = new Button(MESSAGES.cancelButton());
+      cancelButton.addClickHandler(new ClickHandler() {
+        @Override
+        public void onClick(ClickEvent event) {
+          hide();
+        }
+      });
+      Button okButton = new Button(MESSAGES.okButton());
+      okButton.addClickHandler(new ClickHandler() {
+        @Override
+        public void onClick(ClickEvent event) {
+          hide();
+          MockComponent.this.delete();
+        }
+      });
+      HorizontalPanel buttonPanel = new HorizontalPanel();
+      buttonPanel.add(cancelButton);
+      buttonPanel.add(okButton);
+      buttonPanel.setSize("100%", "24px");
+      contentPanel.add(buttonPanel);
+      contentPanel.setSize("320px", "100%");
+
+      add(contentPanel);
+    }
+  }
+
   // Component database: information about components (including their properties and events)
   private final SimpleComponentDatabase COMPONENT_DATABASE;
 
@@ -304,9 +342,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       @Override
       public void delete() {
         if (!isForm()) {
-          if (Window.confirm(MESSAGES.reallyDeleteComponent())) {
-            MockComponent.this.delete();
-          }
+          new DeleteDialog().center();
         }
       }
     };

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -222,7 +222,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       super(false, true);
 
       setStylePrimaryName("ode-DialogBox");
-      setText(MESSAGES.deleteTitle());
+      setText(MESSAGES.deleteComponentButton());
       VerticalPanel contentPanel = new VerticalPanel();
 
       contentPanel.add(new HTML(MESSAGES.reallyDeleteComponent()));


### PR DESCRIPTION
I've reimplemented the delete component confirmation dialog in GWT matching the look and feel of the rename component dialog. Note that the title of the new GWT delete component confirmation dialog requires translation. There doesn't appear to be any existing tests for either component delete or rename.

**Delete Component Confirmation Dialog**
_Browser_
![browser-confirm-component-delete](https://cloud.githubusercontent.com/assets/1046027/20731306/b514500e-b63e-11e6-9db5-0bec9adb63e6.png)
_GWT_
![gwt-confirm-component-delete](https://cloud.githubusercontent.com/assets/1046027/20731307/b52460c0-b63e-11e6-9c06-2a86f09ac876.png)
**Rename Component Dialog**
_GWT_
![gwt-dialog-component-rename](https://cloud.githubusercontent.com/assets/1046027/20731309/b5313232-b63e-11e6-83cd-789c7681f861.png)

Please provide feedback and let me know what else I need to do to get this merged.

Thanks!

Close #852