### PR TITLE
Represent blocks as JSON objects and change code to support new format

### DIFF
--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -24,6 +24,10 @@
     <include path="/closure-library/closure/goog/deps.js" expiration="1d" />
     <include path="/robots.txt" expiration="30d" />
 
+    <!-- toolboxController.js for converting from tree to gameblox-like format 
+        added 1/20/2017-->
+    <include path="/toolboxController.js" expiration="1d" />
+
     <!-- These are not cached on purpose -->
     <include path="/ode/**.nocache.*" expiration="0s" />
     <include path="/blocklyframe.html" expiration="0s" />

--- a/appinventor/appengine/war/blocklyframe.html
+++ b/appinventor/appengine/war/blocklyframe.html
@@ -8,6 +8,7 @@
     <link type="text/css" rel="stylesheet" href="media/blockly.css">
     <link type="text/css" rel="stylesheet" href="closure-library/closure/goog/css/dialog.css">
     <script type="text/javascript" src="blockly-@GUID@.js"></script>
+    <script type="text/javascript" src="toolboxController.js"></script>
     <style>
       html, body {
       background-color: #fff;

--- a/appinventor/appengine/war/toolboxController.js
+++ b/appinventor/appengine/war/toolboxController.js
@@ -1,0 +1,71 @@
+goog.provide('bd.toolbox.ctr');
+
+bd.toolbox.ctr.blockInfoToBlockObject = function(blockInfo) {
+  var inputNameToInputTypeAndBlock = {};
+  if(blockInfo.input) {
+    for(var inputName in blockInfo.input) {
+      var innerBlockInfo = blockInfo.input[inputName].blockInfo;
+
+      var innerBlockObject = bd.toolbox.ctr.blockInfoToBlockObject(innerBlockInfo);
+      inputNameToInputTypeAndBlock[inputName] = {};
+      inputNameToInputTypeAndBlock[inputName].inputType = blockInfo.input[inputName].inputType;
+      inputNameToInputTypeAndBlock[inputName].blockObject = innerBlockObject;
+    }
+  }
+  if(blockInfo.next) {
+      var nextBlockObject = bd.toolbox.ctr.blockInfoToBlockObject(blockInfo.next);
+  }
+  var blockObject = new bd.toolbox.ctr.blockObject(blockInfo.type,blockInfo.fieldNameToValue,inputNameToInputTypeAndBlock,blockInfo.mutatorNameToValue,nextBlockObject);
+  return blockObject;
+}
+
+bd.toolbox.ctr.blockObject = function(type,fieldNameToValue,inputNameToInputTypeAndBlock,mutatorNameToValue,next) {
+  this.type = type;
+  this.inputNameToInputTypeAndBlock = (typeof inputNameToInputTypeAndBlock == "undefined" ? null : inputNameToInputTypeAndBlock);
+  this.fieldNameToValue = (typeof fieldNameToValue == "undefined" ? null : fieldNameToValue);
+  this.mutatorNameToValue = (typeof mutatorNameToValue == "undefined" ? null : mutatorNameToValue);
+  this.next = (typeof next == "undefined" ? null : next);
+}
+
+bd.toolbox.ctr.blockObjectToXML = function(block,withXMLTag) {
+  var element = goog.dom.createDom('block');
+  element.setAttribute('type', block.type);
+
+  if(block.mutatorNameToValue != null) {
+    var container = document.createElement('mutation');
+    for(mutatorName in block.mutatorNameToValue) {
+      container.setAttribute(mutatorName, block.mutatorNameToValue[mutatorName]);
+    }
+    element.appendChild(container);
+  }
+
+  if(block.fieldNameToValue != null) {
+    for(var fieldName in block.fieldNameToValue) {
+      var container = goog.dom.createDom('field', null, block.fieldNameToValue[fieldName]);
+      container.setAttribute('name', fieldName);
+      element.appendChild(container);
+    }
+  }
+  if(block.inputNameToInputTypeAndBlock != null) {
+    for(var inputName in block.inputNameToInputTypeAndBlock) {
+      var inputTypeNameAndBlock = block.inputNameToInputTypeAndBlock[inputName];
+      var container = document.createElement(inputTypeNameAndBlock.inputType);
+      container.appendChild(bd.toolbox.ctr.blockObjectToXML(inputTypeNameAndBlock.blockObject));
+      container.setAttribute('name', inputName);
+      element.appendChild(container);
+    }
+  }
+  if(block.next != null){
+    var container = document.createElement('next');
+    container.appendChild(bd.toolbox.ctr.blockObjectToXML(block.next));
+    element.appendChild(container);
+  }
+
+  if(typeof withXMLTag != "undefined" && withXMLTag) {
+    var xmlWrap = goog.dom.createDom('xml');
+    xmlWrap.setAttribute('id', 'toolbox');
+    xmlWrap.appendChild(element);
+    return xmlWrap;
+  }
+  return element;
+}

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -42,13 +42,18 @@ Blockly.Drawer.createDom = function() {
  * Initializes the drawer by initializing the flyout and creating the
  * language tree. Call after calling createDom.
  */
+
+ /* New edits 1/24/2017 - Janice
+ * Instead of creating the language tree, this will now create
+ * the category block dictionary - see createBlockInfoArray below.
+ */
 Blockly.Drawer.init = function() {
   Blockly.Drawer.flyout_.init(Blockly.mainWorkspace, true);
   for (var name in Blockly.DrawerInit) {
     Blockly.DrawerInit[name]();
   }
-
-  Blockly.Drawer.languageTree = Blockly.Drawer.buildTree_();
+  Blockly.Drawer.blockInfoArray = Blockly.Drawer.createBlockInfoArray();
+  // Blockly.Drawer.languageTree = Blockly.Drawer.buildTree_();
 };
 
 /**
@@ -59,27 +64,156 @@ Blockly.Drawer.init = function() {
 Blockly.Drawer.PREFIX_ = 'cat_';
 
 /**
- * Build the hierarchical tree of block types.
- * Note: taken from Blockly's toolbox.js
- * @return {!Object} Tree object.
- * @private
+ * [Janice, 1/23/2017] 
+ * Creates a dictionary mapping each category to an array of blocks 
+ * in that category. The blocks are in JSON format, and this array
+ * structure makes it easier to customize/manipulate block objects.
+ * Note: procedures_callreturn and procedures_callnoreturn are under
+ * 'list' property, not 'type'.
  */
-Blockly.Drawer.buildTree_ = function() {
-  var tree = {};
-  // Populate the tree structure.
-  for (var name in Blockly.Blocks) {
-    var block = Blockly.Blocks[name];
-    // Blocks without a category are fragments used by the mutator dialog.
-    if (block.category) {
-      var cat = Blockly.Drawer.PREFIX_ + window.encodeURI(block.category);
-      if (cat in tree) {
-        tree[cat].push(name);
-      } else {
-        tree[cat] = [name];
-      }
-    }
-  }
-  return tree;
+Blockly.Drawer.createBlockInfoArray = function() {
+  var blockArray = {
+    "cat_Logic": [
+      {type:"logic_boolean", fieldNameToValue:{"BOOL":"TRUE"}},
+      {type:"logic_boolean", fieldNameToValue:{"BOOL":"FALSE"}},
+      {type:"logic_negate"},
+      {type:"logic_compare",fieldNameToValue:{"OP":"EQ"}},
+      {type:"logic_operation", fieldNameToValue:{"OP":"AND"}},
+      {type:"logic_operation",fieldNameToValue:{"OP":"OR"}}
+    ],
+    "cat_Control": [
+      {type:"controls_if"},
+      {type:"controls_forRange", input:{
+        "START":{inputType:"value",blockInfo:{type:"math_number",fieldNameToValue:{"NUM":"1"}}},
+        "END":{inputType:"value",blockInfo:{type:"math_number",fieldNameToValue:{"NUM":"5"}}},
+        "STEP":{inputType:"value",blockInfo:{type:"math_number",fieldNameToValue:{"NUM":"1"}}}
+      }},
+      {type:"controls_forEach"},
+      {type:"controls_while"},
+      {type:"controls_choose"},
+      {type:"controls_do_then_return"},
+      {type:"controls_eval_but_ignore"},
+      {type:"controls_openAnotherScreen"},
+      {type:"controls_openAnotherScreenWithStartValue"},
+      {type:"controls_getStartValue"},
+      {type:"controls_closeScreen"},
+      {type:"controls_closeScreenWithValue"},
+      {type:"controls_closeApplication"},
+      {type:"controls_getPlainStartText"},
+      {type:"controls_closeScreenWithPlainText"}
+    ],
+    "cat_Math": [
+      {type:"math_number"},
+      {type:"math_compare"},
+      {type:"math_add"},
+      {type:"math_subtract"},
+      {type:"math_multiply"},
+      {type:"math_division"},
+      {type:"math_power"},
+      {type:"math_random_int", input:{
+        "FROM":{inputType:"value", blockInfo:{type:"math_number",fieldNameToValue:{"NUM":"1"}}},
+        "TO":{inputType:"value", blockInfo:{type:"math_number", fieldNameToValue:{"NUM":"10"}}}
+      }},
+      {type:"math_random_float"},
+      {type:"math_random_set_seed"},
+      {type:"math_on_list"},
+      {type:"math_single"},
+      {type:"math_abs"},
+      {type:"math_neg"},
+      {type:"math_round"},
+      {type:"math_ceiling"},
+      {type:"math_floor"},
+      {type:"math_divide"},
+      {type:"math_trig"},
+      {type:"math_cos"},
+      {type:"math_tan"},
+      {type:"math_atan2"},
+      {type:"math_convert_angles"},
+      {type:"math_format_as_decimal"},
+      {type:"math_is_a_number"},
+      {type:"math_convert_number"}
+    ],
+    "cat_Text": [
+      {type:"text"},
+      {type:"text_join"},
+      {type:"text_length"},
+      {type:"text_isEmpty"},
+      {type:"text_compare"},
+      {type:"text_trim"},
+      {type:"text_changeCase"},
+      {type:"text_starts_at"},
+      {type:"text_contains"},
+      {type:"text_split"},
+      {type:"text_split_at_spaces"},
+      {type:"text_segment"},
+      {type:"text_replace_all"},
+      {type:"obfuscated_text"}
+    ],
+    "cat_Lists": [
+      {type:"lists_create_with", mutatorNameToValue:{"items":"0"}},
+      {type:"lists_create_with"},
+      {type:"lists_add_items"},
+      {type:"lists_is_in"},
+      {type:"lists_length"},
+      {type:"lists_is_empty"},
+      {type:"lists_pick_random_item"},
+      {type:"lists_position_in"},
+      {type:"lists_select_item"},
+      {type:"lists_insert_item"},
+      {type:"lists_replace_item"},
+      {type:"lists_remove_item"},
+      {type:"lists_append_list"},
+      {type:"lists_copy"},
+      {type:"lists_is_list"},
+      {type:"lists_to_csv_row"},
+      {type:"lists_to_csv_table"},
+      {type:"lists_from_csv_row"},
+      {type:"lists_from_csv_table"},
+      {type:"lists_lookup_in_pairs", input:{
+        "NOTFOUND":{inputType:"value", blockInfo:{type:"text", fieldNameToValue:{"TEXT":"not found"}}}
+      }}
+    ],
+    "cat_Colors": [
+      {type:"color_black"},
+      {type:"color_white"},
+      {type:"color_red"},
+      {type:"color_pink"},
+      {type:"color_orange"},
+      {type:"color_yellow"},
+      {type:"color_green"},
+      {type:"color_cyan"},
+      {type:"color_blue"},
+      {type:"color_magenta"},
+      {type:"color_light_gray"},
+      {type:"color_gray"},
+      {type:"color_dark_gray"},
+      {type:"color_make_color", input:{
+        "COLORLIST":{inputType:"value", blockInfo:{
+          mutatorNameToValue:{"items":"3"},
+          type:"lists_create_with", input:{
+            "ADD0":{inputType:"value", blockInfo:{type:"math_number", fieldNameToValue:{"NUM":"255"}}},
+            "ADD1":{inputType:"value", blockInfo:{type:"math_number", fieldNameToValue:{"NUM":"0"}}},
+            "ADD2":{inputType:"value", blockInfo:{type:"math_number", fieldNameToValue:{"NUM":"0"}}}
+          }
+        }}
+      }},
+      {type:"color_split_color"}
+    ],
+    "cat_Variables": [
+      {type:"global_declaration"},
+      {type:"lexical_variable_get"},
+      {type:"lexical_variable_set"},
+      {type:"local_declaration_statement"},
+      {type:"local_declaration_expression"}
+    ],
+    "cat_Procedures": [
+      {type:"procedures_defnoreturn"},
+      {type:"procedures_defreturn"},
+      {list:"procedures_callnoreturn"},
+      {list:"procedures_callreturn"}
+    ]
+  };
+  return blockArray;
 };
 
 /**
@@ -88,29 +222,35 @@ Blockly.Drawer.buildTree_ = function() {
  * Blockly.MSG_PROCEDURE_CATEGORY, or one of the built-in block categories.
  * @param drawerName
  */
+
+ /**
+ * New edits 1/20/2017 - Janice
+ * Change to use of blockInfoArray - converts drawerName's 
+ * array of JSON objects into xmlList using bd.toolbox.ctr
+ * "If" statement handles blocks with property "list" (procedure callers)
+ */
 Blockly.Drawer.showBuiltin = function(drawerName) {
   drawerName = Blockly.Drawer.PREFIX_ + drawerName;
-  var blockSet = Blockly.Drawer.languageTree[drawerName];
-  if(drawerName == "cat_Procedures") {
-    var newBlockSet = [];
-    for(var i=0;i<blockSet.length;i++) {
-      if(!(blockSet[i] == "procedures_callnoreturn" // Include callnoreturn only if at least one defnoreturn declaration
-           && JSON.stringify(Blockly.AIProcedure.getProcedureNames(false))
-              == JSON.stringify([Blockly.FieldProcedure.defaultValue]))
-         &&
-         !(blockSet[i] == "procedures_callreturn" // Include callreturn only if at least one defreturn declaration
-           && JSON.stringify(Blockly.AIProcedure.getProcedureNames(true))
-              == JSON.stringify([Blockly.FieldProcedure.defaultValue]))){
-        newBlockSet.push(blockSet[i]);
-      }
-    }
-    blockSet = newBlockSet;
-  }
+  var blockInfoArray = Blockly.Drawer.blockInfoArray;
+  var drawerArray = blockInfoArray[drawerName];
 
-  if (!blockSet) {
+  if (!drawerArray) {
     throw "no such drawer: " + drawerName;
   }
-  var xmlList = Blockly.Drawer.blockListToXMLArray(blockSet);
+
+  var xmlList = [];
+  for(var i = 0; i < drawerArray.length; i++) {
+    if (drawerArray[i].list == "procedures_callnoreturn" || drawerArray[i].list == "procedures_callreturn") {
+      var returnBool = (drawerArray[i].list == "procedures_callreturn");
+      var callerArray = Blockly.Drawer.procedureCallersBlockArray(returnBool);
+      for (var k = 0; k < callerArray.length; k++) {
+        xmlList.push(Blockly.Drawer.blockInfoToXML(callerArray[k]));
+      }
+    } 
+    else {
+      xmlList.push(Blockly.Drawer.blockInfoToXML(drawerArray[i]));
+    }
+  }
   Blockly.Drawer.flyout_.show(xmlList);
 };
 
@@ -119,13 +259,18 @@ Blockly.Drawer.showBuiltin = function(drawerName) {
  * such component is found, currently we just log a message to the console
  * and do nothing.
  */
+
+ /**
+ * 1/23/2017 - Janice
+ * Edited instanceNameToXMLArray, but no edits made here.
+ */
 Blockly.Drawer.showComponent = function(instanceName) {
   if (Blockly.ComponentInstances[instanceName]) {
     Blockly.Drawer.flyout_.hide();
-
     var xmlList = Blockly.Drawer.instanceNameToXMLArray(instanceName);
     Blockly.Drawer.flyout_.show(xmlList);
-  } else {
+  }
+  else {
     console.log("Got call to Blockly.Drawer.showComponent(" +  instanceName +
                 ") - unknown component name");
   }
@@ -138,16 +283,336 @@ Blockly.Drawer.showComponent = function(instanceName) {
  * type is found, currently we just log a message to the console and do nothing.
  * @param drawerName
  */
+
+ /**
+ * 1/24/2017 - Janice
+ * Edited componentTypeToXMLArray, but no edits made here.
+ */
 Blockly.Drawer.showGeneric = function(typeName) {
   if (Blockly.ComponentTypes[typeName]) {
     Blockly.Drawer.flyout_.hide();
-
     var xmlList = Blockly.Drawer.componentTypeToXMLArray(typeName);
     Blockly.Drawer.flyout_.show(xmlList);
   } else {
     console.log("Got call to Blockly.Drawer.showGeneric(" +  typeName +
                 ") - unknown component type name");
   }
+};
+
+/** 
+ * [Janice, 1/24/2017]
+ * Adapted from procedureCallersXMLString
+ * Creates array of procedure call blocks - one call block for each procedure 
+ * declaration in main workspace.
+ *
+ * @param returnsValue (bool): true if procedure returns, false if no return
+ * @return blockArray (array): JSON object array of procedure call blocks
+ */
+Blockly.Drawer.procedureCallersBlockArray = function(returnsValue, proc_name) {
+  var decls = Blockly.AIProcedure.getProcedureDeclarationBlocks(returnsValue);
+  var blockArray = [];
+  // Used for typeblock
+  if (proc_name) {
+    for (var j = 0; j < decls.length; j++) {
+      if (decls[j].getFieldValue('NAME').toLocaleLowerCase() == proc_name) {
+        blockArray.push(Blockly.Drawer.proceduresBlockInfo(decls[j]))
+        break;
+      }
+    }
+  }
+  // Used for showBuiltin
+  else {
+    // sort decls lexicographically by procedure name
+    decls.sort(Blockly.Drawer.compareDeclarationsByName);
+    for (var j = 0; j < decls.length; j++) {
+      blockArray.push(Blockly.Drawer.procedureBlockInfo(decls[j]));
+    }
+  }
+  return blockArray;
+};
+
+/** 
+ * [Janice, 1/24/2017] 
+ * Creates JSON object for the procedure caller block associated with 
+ * the given procedure declaration block
+ *
+ * @param procBlock (object): procedure declaration block
+ * @return blockInfo (object): JSON representation of procedure's caller block
+ */
+Blockly.Drawer.procedureBlockInfo = function(procBlock) {
+  var declType = procBlock.type;
+  var callerType = (declType == 'procedures_defreturn') ? 'procedures_callreturn' : 'procedures_callnoreturn';
+  var blockInfo = {
+    type: callerType,
+    mutatorNameToValue: {"name":procBlock.getFieldValue('NAME')},
+    fieldNameToValue: {"PROCNAME":procBlock.getFieldValue('NAME')}
+  }
+  return blockInfo;
+}
+
+Blockly.Drawer.compareDeclarationsByName = function (decl1, decl2) {
+  var name1 = decl1.getFieldValue('NAME').toLocaleLowerCase();
+  var name2 = decl2.getFieldValue('NAME').toLocaleLowerCase();
+  return name1.localeCompare(name2);
+}
+
+/** 
+ * [Janice, 1/24/2017]
+ * Creates all events, methods, properties, and literal blocks
+ * for a specified instance Name 
+ * Used for Blockly.Drawer.showComponents
+ *
+ * @param instanceName (String)
+ * @return xmlArray: array of XML strings for all of the instance's blocks.
+ */
+Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
+  var xmlArray = [];
+  var typeName = Blockly.Component.instanceNameToTypeName(instanceName);
+
+  var blockObjects = Blockly.ComponentTypes[typeName].componentInfo;
+
+  // Create component event blocks
+  var blockEvents = blockObjects.events;
+  for (var i = 0; i < blockEvents.length; i++) {
+    if (blockEvents[i].deprecated === "true") continue;
+    var blockInfo = {
+      type:"component_event",
+      // typeName:typeName, 
+      fieldNameToValue: {"COMPONENT_SELECTOR":instanceName}, 
+      mutatorNameToValue: {
+        "instance_name":instanceName, 
+        "component_type":typeName, 
+        "event_name":blockEvents[i].name
+      }
+    };
+    xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo));
+  }
+
+  // Create component method blocks
+  var blockMethods = blockObjects.methods;
+  for (var i = 0; i < blockMethods.length; i++) {
+    if (blockMethods[i].deprecated === "true") continue;
+    var inputObject = Blockly.Drawer.blockMethodSpecial(typeName, blockMethods[i].name);
+    if (inputObject != null) {
+      var blockInfo = {
+        type:"component_method",
+        fieldNameToValue: {"COMPONENT_SELECTOR":instanceName}, 
+        mutatorNameToValue: {
+          "instance_name":instanceName, 
+          "component_type":typeName, 
+          "method_name":blockMethods[i].name,
+          "is_generic": "false"
+        },
+      input: inputObject
+      };
+    } 
+    else {
+      var blockInfo = {
+        type:"component_method",
+        fieldNameToValue: {"COMPONENT_SELECTOR":instanceName}, 
+        mutatorNameToValue: {
+          "instance_name":instanceName, 
+          "component_type":typeName, 
+          "method_name":blockMethods[i].name,
+          "is_generic": "false"
+        }
+      };
+    }
+    xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo));
+  }
+
+  // Create component property get and set blocks
+  var blockProps = blockObjects.blockProperties;
+  for (var i = 0; i < blockProps.length; i++) {
+    if (blockProps[i].deprecated === "true") continue;
+    for (var j = 0; j < 2; j++) {
+      var makeBlock = false;
+      if (j == 0 && (blockProps[i].rw == "read-write" || blockProps[i].rw == "read-only")) { 
+        var getSet = "get";
+        makeBlock = true;
+      }
+      if (j == 1 && (blockProps[i].rw == "read-write" || blockProps[i].rw == "write-only")) { 
+        var getSet = "set";
+        makeBlock = true;
+      }
+
+      if (makeBlock) {
+        var blockInfo = {
+          type:"component_set_get",
+          fieldNameToValue: {"COMPONENT_SELECTOR":instanceName}, 
+          fieldNameToValue: {"PROP":blockProps[i].name},
+          mutatorNameToValue: {
+            "instance_name":instanceName, 
+            "component_type":typeName, 
+            "property_name": blockProps[i].name,
+            "set_or_get": getSet,
+            "is_generic": "false",
+          }
+        };
+
+        xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo)); 
+      }  
+    }
+  }
+
+  // Create component literal block (component_component_block)
+  var blockInfo = {
+    type:"component_component_block",
+    fieldNameToValue:{"COMPONENT_SELECTOR":instanceName},
+    mutatorNameToValue: {"instance_name":instanceName}
+  };
+  xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo));
+
+  return xmlArray;
+};
+
+/** 
+ * [Janice, 1/24/2017]
+ * Creates all generic methods and property blocks for a component type
+ * Used for Blockly.Drawer.showGeneric
+ *
+ * @param typeName (string): name of component type
+ * @return xmlArray: array of XML strings for all of the component's blocks.
+ */
+Blockly.Drawer.componentTypeToXMLArray = function(typeName) {
+  var xmlArray = [];
+  var blockObjects = Blockly.ComponentTypes[typeName].componentInfo;
+
+  // Create generic method blocks
+  var blockMethods = blockObjects.methods;
+  for (var i = 0; i < blockMethods.length; i++) {
+    if (blockMethods[i].deprecated === "true") continue;
+    var inputObject = Blockly.Drawer.blockMethodSpecial(typeName, blockMethods[i].name);
+    // Create special blocks (those with default values)
+    if (inputObject != null) {
+      var blockInfo = {
+        type:"component_method",
+        mutatorNameToValue: {
+          "component_type":typeName, 
+          "method_name":blockMethods[i].name,
+          "is_generic": "true"
+        },
+      input: inputObject
+      };
+    } 
+    else {
+      // Create regular blocks
+      var blockInfo = {
+        type:"component_method",
+        mutatorNameToValue: {
+          "component_type":typeName, 
+          "method_name":blockMethods[i].name,
+          "is_generic": "true"
+        }
+      };
+    }
+    xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo));
+  }
+
+  // Create generic get and set blocks for each property
+  var blockProps = blockObjects.blockProperties;
+  for (var i = 0; i < blockProps.length; i++) {
+    if (blockProps[i].deprecated === "true") continue;
+    for (var j = 0; j < 2; j++) {
+      var makeBlock = false;
+      if (j == 0 && (blockProps[i].rw == "read-write" || blockProps[i].rw == "read-only")) { 
+        var getSet = "get";
+        makeBlock = true;
+      }
+      if (j == 1 && (blockProps[i].rw == "read-write" || blockProps[i].rw == "write-only")) { 
+        var getSet = "set";
+        makeBlock = true;
+      }
+
+      if (makeBlock) {
+        var blockInfo = {
+          type:"component_set_get",
+          fieldNameToValue: {"PROP":blockProps[i].name},
+          mutatorNameToValue: {
+            "component_type":typeName, 
+            "property_name": blockProps[i].name,
+            "set_or_get": getSet,
+            "is_generic": "true",
+          }
+        };
+
+        xmlArray.push(Blockly.Drawer.blockInfoToXML(blockInfo));      
+      }  
+    }
+  }
+
+  return xmlArray;
+};
+
+/**
+ * [Janice, 1/24/2017] 
+ * Deals with certain component method blocks that have default inputs
+ * Creates object that will go under the 'input' property for those blocks
+ * Used for showComponent and showGeneric
+ * @return: object that will be input property of blockInfo
+ *          null if component does not have method with special defaults
+ */
+Blockly.Drawer.blockMethodSpecial = function(componentType, methodName) {
+  // COMPONENTS TinyDB or FirebaseDB with METHOD GetValue
+  if (methodName == "GetValue" && (componentType == "TinyDB" || componentType == "FirebaseDB")) {
+    var inputObj = {"ARG1":{
+      inputType:"value", 
+      blockInfo:{type:"text", fieldNameToValue:{"TEXT":""}}
+    }};
+  }
+  // COMPONENT Notifier with METHODS ShowTextDialog or ShowChooseDialog
+  else if (componentType == "Notifier") {
+    if (methodName == "ShowTextDialog") {
+      var inputObj = {"ARG2":{
+        inputType:"value",
+        blockInfo:{type:"logic_boolean", fieldNameToValue:{"BOOL":"TRUE"}}
+      }};
+    }
+    else if (methodName == "ShowChooseDialog") {
+      var inputObj = {"ARG4":{
+        inputType:"value",
+        blockInfo:{type:"logic_boolean", fieldNameToValue:{"BOOL":"TRUE"}}
+      }};
+    }
+  }
+  // COMPONENT Canvas with METHOD DrawCircle
+  else if (componentType == "Canvas" && methodName == "DrawCircle") {
+    var inputObj = {"ARG3":{
+      inputType:"value",
+      blockInfo:{type:"logic_boolean", fieldNameToValue:{"BOOL":"TRUE"}}
+    }};
+  }
+  // COMPONENT Clock with METHODS FormatDate or FormatDateTime
+  else if (componentType == "Clock") {
+    if (methodName == "FormatDate") {
+      var inputObj = {"ARG1":{
+        inputType:"value",
+        blockInfo:{type:"text", fieldNameToValue:{"TEXT":"MMM d, yyyy"}}
+      }};
+    }
+    else if (methodName == "FormatDateTime") {
+      var inputObj = {"ARG1":{
+        inputType:"value",
+        blockInfo:{type:"text", fieldNameToValue:{"TEXT":"MM/dd/yyyy hh:mm:ss a"}}
+      }};
+
+    }
+  }
+  return inputObj;
+};
+
+/**
+ * [Janice, 1/23/2017]
+ * Turn JSON object with block information into XML string
+ * Combines bd.toolbox.ctr.blockInfoToBlockObject and
+ *  bd.toolbox.ctr.blockObjectToXMLArray into one function
+ * @param blockInfo - JSON object
+ * @returns XMLString
+ */
+Blockly.Drawer.blockInfoToXML = function(blockInfo) {
+  var blockObj = bd.toolbox.ctr.blockInfoToBlockObject(blockInfo);
+  var blockXMLString = bd.toolbox.ctr.blockObjectToXML(blockObj);
+  return blockXMLString;
 };
 
 /**
@@ -164,111 +629,12 @@ Blockly.Drawer.isShowing = function() {
   return Blockly.Drawer.flyout_.isVisible();
 };
 
-Blockly.Drawer.blockListToXMLArray = function(blockList) {
-  var xmlArray = [];
-  for(var i=0;i<blockList.length;i++) {
-    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray(blockList[i],null));
-  }
-  return xmlArray;
-};
-
-Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
-  var xmlArray = [];
-  var typeName = Blockly.Component.instanceNameToTypeName(instanceName);
-  var mutatorAttributes;
-
-  //create event blocks
-  var eventObjects = Blockly.ComponentTypes[typeName].componentInfo.events;
-  for(var i=0;i<eventObjects.length;i++) {
-    if (eventObjects[i].deprecated === "true") continue;
-    mutatorAttributes = {component_type: typeName, instance_name: instanceName, event_name : eventObjects[i].name};
-    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_event",mutatorAttributes));
-  }
-  //create non-generic method blocks
-  var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
-  for(var i=0;i<methodObjects.length;i++) {
-    if (methodObjects[i].deprecated === "true") continue;
-    mutatorAttributes = {component_type: typeName, instance_name: instanceName, method_name: methodObjects[i].name, is_generic:"false"};
-    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
-  }
-
-  //for each property
-  var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
-  for(var i=0;i<propertyObjects.length;i++) {
-    //create non-generic get block
-    if (propertyObjects[i].deprecated === "true") continue;
-    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
-      mutatorAttributes = {set_or_get:"get", component_type: typeName, instance_name: instanceName, property_name: propertyObjects[i].name, is_generic: "false"};
-      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
-    }
-    //create non-generic set block
-    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "write-only") {
-      mutatorAttributes = {set_or_get:"set", component_type: typeName, instance_name: instanceName, property_name: propertyObjects[i].name, is_generic: "false"};
-      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
-    }
-  }
-
-  //create component literal block
-  mutatorAttributes = {component_type: typeName, instance_name: instanceName};
-  xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_component_block",mutatorAttributes));
-
-  return xmlArray;
-};
-
-Blockly.Drawer.componentTypeToXMLArray = function(typeName) {
-  var xmlArray = [];
-  var mutatorAttributes;
-
-  //create generic method blocks
-  var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
-  for(var i=0;i<methodObjects.length;i++) {
-    if (methodObjects[i].deprecated === "true") continue;
-    mutatorAttributes = {component_type: typeName, method_name: methodObjects[i].name, is_generic:"true"};
-    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
-  }
-
-  //for each property
-  var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
-  for(var i=0;i<propertyObjects.length;i++) {
-    //create generic get block
-    if (propertyObjects[i].deprecated === "true") continue;
-    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
-      mutatorAttributes = {set_or_get: "get", component_type: typeName, property_name: propertyObjects[i].name, is_generic: "true"};
-      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
-    }
-    //create generic set block
-    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "write-only") {
-      mutatorAttributes = {set_or_get: "set", component_type: typeName, property_name: propertyObjects[i].name, is_generic: "true"};
-      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
-    }
-  }
-  return xmlArray;
-};
-
-Blockly.Drawer.blockTypeToXMLArray = function(blockType,mutatorAttributes) {
-  var xmlString = Blockly.Drawer.getDefaultXMLString(blockType,mutatorAttributes);
-  if(xmlString == null) {
-    // [lyn, 10/23/13] Handle procedure calls in drawers specially
-    if (blockType == 'procedures_callnoreturn' || blockType == 'procedures_callreturn') {
-      xmlString = Blockly.Drawer.procedureCallersXMLString(blockType == 'procedures_callreturn');
-    } else {
-      xmlString = '<xml><block type="' + blockType + '">';
-      if(mutatorAttributes) {
-        xmlString += Blockly.Drawer.mutatorAttributesToXMLString(mutatorAttributes);
-      }
-      xmlString += '</block></xml>';
-    }
-  }
-  var xmlBlockArray = [];
-  var xmlFromString = Blockly.Xml.textToDom(xmlString);
-  // [lyn, 11/10/13] Use goog.dom.getChildren rather than .children or .childNodes
-  //   to make this code work across browsers.
-  var children = goog.dom.getChildren(xmlFromString);
-  for(var i=0;i<children.length;i++) {
-    xmlBlockArray.push(children[i]);
-  }
-  return xmlBlockArray;
-}
+/** #################################################################
+ * The five functions below are not needed to show block drawers. 
+ * However, they are used in typeblock.js (for typeblock-ing), 
+ * so they could not be deleted.
+ * 1/24/2017 - Janice
+ */
 
 Blockly.Drawer.mutatorAttributesToXMLString = function(mutatorAttributes){
   var xmlString = '<mutation ';
@@ -279,9 +645,11 @@ Blockly.Drawer.mutatorAttributesToXMLString = function(mutatorAttributes){
   return xmlString;
 }
 
-// [lyn, 10/22/13] return an XML string including one procedure caller for each procedure declaration
-// in main workspace.
-// [jos, 10/18/15] if we pass a proc_name, we only want one procedure returned as xmlString
+/**
+ * [lyn, 10/22/13] return an XML string including one procedure caller for each procedure declaration
+ * in main workspace.
+ * [jos, 10/18/15] if we pass a proc_name, we only want one procedure returned as xmlString
+ */
 Blockly.Drawer.procedureCallersXMLString = function(returnsValue, proc_name) {
   var xmlString = '<xml>'  // Used to accumulate xml for each caller
   var decls = Blockly.AIProcedure.getProcedureDeclarationBlocks(returnsValue);
@@ -304,21 +672,17 @@ Blockly.Drawer.procedureCallersXMLString = function(returnsValue, proc_name) {
   return xmlString;
 };
 
-Blockly.Drawer.compareDeclarationsByName = function (decl1, decl2) {
-  var name1 = decl1.getFieldValue('NAME').toLocaleLowerCase();
-  var name2 = decl2.getFieldValue('NAME').toLocaleLowerCase();
-  return name1.localeCompare(name2);
-}
-
-// [lyn, 10/22/13] return an XML string for a caller block for the give procedure declaration block
-// Here's an example:
-//   <block type="procedures_callnoreturn" inline="false">
-//     <title name="PROCNAME">p2</title>
-//     <mutation name="p2">
-//       <arg name="b"></arg>
-//       <arg name="c"></arg>
-//    </mutation>
-//  </block>
+/**
+ * [lyn, 10/22/13] return an XML string for a caller block for the give procedure declaration block
+ * Here's an example:
+ *   <block type="procedures_callnoreturn" inline="false">
+ *     <title name="PROCNAME">p2</title>
+ *     <mutation name="p2">
+ *       <arg name="b"></arg>
+ *       <arg name="c"></arg>
+ *    </mutation>
+ *  </block>
+ */
 Blockly.Drawer.procedureCallerBlockString = function(procDeclBlock) {
   var declType = procDeclBlock.type;
   var callerType = (declType == 'procedures_defreturn') ? 'procedures_callreturn' : 'procedures_callnoreturn';
@@ -508,3 +872,199 @@ Blockly.Drawer.defaultBlockXMLStrings = {
          '</xml>';}}
   ]
 };
+
+// #################################################################
+// Below functions were part of original drawer.js code, but
+// are no longer needed.
+// 1/24/2017 - Janice
+
+/**
+ * Build the hierarchical tree of block types.
+ * Note: taken from Blockly's toolbox.js
+ * @return {!Object} Tree object.
+ * @private
+ */
+/*
+Blockly.Drawer.buildTree_ = function() {
+  var tree = {};
+  // Populate the tree structure.
+  for (var name in Blockly.Blocks) {
+    var block = Blockly.Blocks[name];
+    // Blocks without a category are fragments used by the mutator dialog.
+    if (block.category) {
+      var cat = Blockly.Drawer.PREFIX_ + window.encodeURI(block.category);
+      if (cat in tree) {
+        tree[cat].push(name);
+      } else {
+        tree[cat] = [name];
+      }
+    }
+  }
+  return tree;
+};
+*/
+
+/**
+ * [Janice, 1/23/2017] 
+ * If drawer blocks are shown using bd.toolbox.ctr, 
+ * then return True.  Else return False.
+ */
+/*
+Blockly.Drawer.isDrawer = function(name) {
+  var drawers = ["cat_Logic", "cat_Control", "cat_Math", "cat_Text", "cat_Lists", "cat_Colors", "cat_Variables", "cat_Procedures"];
+  for (var n = 0; n < drawers.length; n++) {
+    if (name == drawers[n]) {
+      return true;
+    }
+  }
+  return false;
+};
+*/
+
+/**
+ * [Janice, 1/24/2017] 
+ * Return JSON object Array of all Procedure blocks that need to be displayed
+ */
+/*
+Blockly.Drawer.procedureBlockArray = function(procArray) {
+  // Creates array of TYPES of blocks that should be in drawer
+  var newArray = [];
+  for(var i=0;i<procArray.length;i++) {
+    if(!(procArray[i].type == "procedures_callnoreturn" 
+      // Include callnoreturn only if at least one defnoreturn declaration
+         && JSON.stringify(Blockly.AIProcedure.getProcedureNames(false))
+            == JSON.stringify([Blockly.FieldProcedure.defaultValue]))
+      &&
+       !(procArray[i].type == "procedures_callreturn"
+       // Include callreturn only if at least one defreturn declaration
+         && JSON.stringify(Blockly.AIProcedure.getProcedureNames(true))
+            == JSON.stringify([Blockly.FieldProcedure.defaultValue]))){
+      newArray.push(procArray[i]);
+    }
+  }
+  procArray = newArray;
+
+  // Gets specific blocks for procedures
+  var blockArray = [];
+  for (var i = 0; i < procArray.length; i++) {
+    // for the call blocks
+    if (procArray[i].type == 'procedures_callnoreturn' || procArray[i].type == 'procedures_callreturn') {
+      // Blockly.Drawer.procedureCallersBlockArray(blockType == 'procedures_callreturn')
+      blockArray = blockArray.concat(Blockly.Drawer.procedureCallersBlockArray(procArray[i].type == 'procedures_callreturn'));
+    }
+    // for the default procedures def blocks
+    else {
+      blockArray.push(procArray[i]);
+    }
+  }
+  return blockArray;
+}
+*/
+
+/*
+Blockly.Drawer.blockListToXMLArray = function(blockList) {
+  var xmlArray = [];
+  for(var i=0;i<blockList.length;i++) {
+    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray(blockList[i],null));
+  }
+  return xmlArray;
+};
+
+Blockly.Drawer.instanceNameToXMLArray = function(instanceName) {
+  var xmlArray = [];
+  var typeName = Blockly.Component.instanceNameToTypeName(instanceName);
+  var mutatorAttributes;
+
+  //create event blocks
+  var eventObjects = Blockly.ComponentTypes[typeName].componentInfo.events;
+  for(var i=0;i<eventObjects.length;i++) {
+    if (eventObjects[i].deprecated === "true") continue;
+    mutatorAttributes = {component_type: typeName, instance_name: instanceName, event_name : eventObjects[i].name};
+    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_event",mutatorAttributes));
+  }
+  //create non-generic method blocks
+  var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
+  for(var i=0;i<methodObjects.length;i++) {
+    if (methodObjects[i].deprecated === "true") continue;
+    mutatorAttributes = {component_type: typeName, instance_name: instanceName, method_name: methodObjects[i].name, is_generic:"false"};
+    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
+  }
+
+  //for each property
+  var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
+  for(var i=0;i<propertyObjects.length;i++) {
+    //create non-generic get block
+    if (propertyObjects[i].deprecated === "true") continue;
+    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
+      mutatorAttributes = {set_or_get:"get", component_type: typeName, instance_name: instanceName, property_name: propertyObjects[i].name, is_generic: "false"};
+      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
+    }
+    //create non-generic set block
+    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "write-only") {
+      mutatorAttributes = {set_or_get:"set", component_type: typeName, instance_name: instanceName, property_name: propertyObjects[i].name, is_generic: "false"};
+      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
+    }
+  }
+
+  //create component literal block
+  mutatorAttributes = {component_type: typeName, instance_name: instanceName};
+  xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_component_block",mutatorAttributes));
+
+  return xmlArray;
+};
+
+Blockly.Drawer.componentTypeToXMLArray = function(typeName) {
+  var xmlArray = [];
+  var mutatorAttributes;
+
+  //create generic method blocks
+  var methodObjects = Blockly.ComponentTypes[typeName].componentInfo.methods;
+  for(var i=0;i<methodObjects.length;i++) {
+    if (methodObjects[i].deprecated === "true") continue;
+    mutatorAttributes = {component_type: typeName, method_name: methodObjects[i].name, is_generic:"true"};
+    xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_method",mutatorAttributes));
+  }
+
+  //for each property
+  var propertyObjects = Blockly.ComponentTypes[typeName].componentInfo.blockProperties;
+  for(var i=0;i<propertyObjects.length;i++) {
+    //create generic get block
+    if (propertyObjects[i].deprecated === "true") continue;
+    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "read-only") {
+      mutatorAttributes = {set_or_get: "get", component_type: typeName, property_name: propertyObjects[i].name, is_generic: "true"};
+      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
+    }
+    //create generic set block
+    if(propertyObjects[i].rw == "read-write" || propertyObjects[i].rw == "write-only") {
+      mutatorAttributes = {set_or_get: "set", component_type: typeName, property_name: propertyObjects[i].name, is_generic: "true"};
+      xmlArray = xmlArray.concat(Blockly.Drawer.blockTypeToXMLArray("component_set_get",mutatorAttributes));
+    }
+  }
+  return xmlArray;
+};
+
+Blockly.Drawer.blockTypeToXMLArray = function(blockType,mutatorAttributes) {
+  var xmlString = Blockly.Drawer.getDefaultXMLString(blockType,mutatorAttributes);
+  if(xmlString == null) {
+    // [lyn, 10/23/13] Handle procedure calls in drawers specially
+    if (blockType == 'procedures_callnoreturn' || blockType == 'procedures_callreturn') {
+      xmlString = Blockly.Drawer.procedureCallersXMLString(blockType == 'procedures_callreturn');
+    } else {
+      xmlString = '<xml><block type="' + blockType + '">';
+      if(mutatorAttributes) {
+        xmlString += Blockly.Drawer.mutatorAttributesToXMLString(mutatorAttributes);
+      }
+      xmlString += '</block></xml>';
+    }
+  }
+  var xmlBlockArray = [];
+  var xmlFromString = Blockly.Xml.textToDom(xmlString);
+  // [lyn, 11/10/13] Use goog.dom.getChildren rather than .children or .childNodes
+  //   to make this code work across browsers.
+  var children = goog.dom.getChildren(xmlFromString);
+  for(var i=0;i<children.length;i++) {
+    xmlBlockArray.push(children[i]);
+  }
+  return xmlBlockArray;
+}
+*/


### PR DESCRIPTION
JSON representation of blocks allows easier conversion to XML and better manipulation of blocks layout, useful for future customization of editor.

drawer.js - use dictionary (which maps categories to JSON block objects), convert blocks to XML using toolboxController.js
toolboxController.js  - provides bd.toolbox.ctr functions for changing JSON block objects into XML strings
blocklyframe.html - added script tag linked to toolboxController.js
appengine-web.xml - includes path for toolboxController.js because it is a static file