### PR TITLE
Add new Toast

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
@@ -492,4 +492,13 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
   public void LogInfo(String message) {
     Log.i(LOG_TAG, message);
   }
+
+  @SimpleFunction(description="Show a toast message with duration")
+  public void Toast(String text, int duration) {
+    if(duration != 0 || duration != 1) {
+      Toast.makeText(getApplicationContext(), text, 0).show();
+    } else {
+      Toast.makeText(getApplicationContext(), text, duration).show();
+    }
+  }
 }


### PR DESCRIPTION
I have added a new method called "Toast". This is different than the "Show Alert" method. It will show a 'toast' the bottom of the screen, above the device's navigation bar.

The duration can either be set to "0" or "1". 0 is Toast.LENGTH_SHORT and 1 is Toast.LENGTH_LONG. If the user sets the duration to a number that isn't 0 or 1, then it will automatically change to 0.

https://developer.android.com/guide/topics/ui/notifiers/toasts.html