### PR TITLE
controller.release() in beginning of start function in soundrecorder.java

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
@@ -43,6 +43,9 @@ import java.io.IOException;
   "android.permission.READ_EXTERNAL_STORAGE")
 public final class SoundRecorder extends AndroidNonvisibleComponent
     implements Component, OnErrorListener, OnInfoListener {
+    
+    
+ 
 
   private static final String TAG = "SoundRecorder";
 
@@ -148,7 +151,9 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
    */
   @SimpleFunction
   public void Start() {
+  
     if (controller != null) {
+      controller.release();
       Log.i(TAG, "Start() called, but already recording to " + controller.file);
       return;
     }


### PR DESCRIPTION
It is required to release controller in the beginning of start() function for app so that it doesn't crash due to previous controller inputs.There was issue of app crashing as soon as start function is called.
It can be of some other app using the microphone properties.