### PR TITLE
Fixed broken generic component method blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -372,7 +372,7 @@ Blockly.Blocks.component_method = {
     if(!this.isGeneric) {
       container.setAttribute('instance_name', this.instanceName);//instance name not needed
     }
-    if (this.typeName == "Clock" && Blockly.ComponentBlock.isClockMethodName(this.methodName)) {
+    if (!this.isGeneric && this.typeName == "Clock" && Blockly.ComponentBlock.isClockMethodName(this.methodName)) {
       var timeUnit = this.getFieldValue('TIME_UNIT');
       container.setAttribute('method_name', 'Add' + timeUnit);
       container.setAttribute('timeUnit', timeUnit);

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -224,7 +224,7 @@ Blockly.Drawer.prototype.componentTypeToXMLArray = function(typeName) {
   goog.object.forEach(componentInfo.methodDictionary, function(method, name) {
     if (!method.deprecated) {
       Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_method', {
-        component_type: typeName, method_name: name
+        component_type: typeName, method_name: name, is_generic: "true"
       }));
     }
   }, this);


### PR DESCRIPTION
There was an issue where some generic component method blocks did not have the
mutator labeling them as such. This was fixed by explicitly setting the
is_generic mutator along with the other mutators when these blocks are generated
in the drawer.

There was another issue where generic clock add blocks expected a time unit
dropdown which only exists on the instance version of the clock add blocks. This
was fixed by only setting the time unit if the block is not generic, since this
attribute is only used in the instance version of these blocks.