### PR TITLE
Fix emulator hard reset not working in locales other than en

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1213,7 +1213,7 @@ Blockly.ReplMgr.ehardreset = function(formName) {
     var context = this;
     var dialog = new Blockly.Util.Dialog(Blockly.Msg.REPL_DO_YOU_REALLY_Q, Blockly.Msg.REPL_FACTORY_RESET, Blockly.Msg.REPL_OK, Blockly.Msg.REPL_CANCEL, 0, function(response) {
         dialog.hide();
-        if (response == "OK") {
+        if (response == Blockly.Msg.REPL_OK) {
             context.hardreset(formName, function() {
                 var xhr = goog.net.XmlHttp();
                 xhr.open("GET", "http://localhost:8004/emulatorreset/", true);


### PR DESCRIPTION
## Issue
`Connect->Hard Reset` requires a user confirmation:
![ss1](https://user-images.githubusercontent.com/16166040/29905038-ba1c7cd8-8e3e-11e7-8f61-ec128cf400d0.png)
It works fine in the `en` locale:
![ss2](https://user-images.githubusercontent.com/16166040/29905183-aa029b88-8e3f-11e7-9280-efb3bed9504e.png)
However in other locales (e.g. `zh_CN`), clicking "OK" dismisses the dialog and **does nothing** afterwards. No requests are sent.
![ss3](https://user-images.githubusercontent.com/16166040/29905218-e2dbd79e-8e3f-11e7-92d1-8d83fb7f95ad.png)

## Reason and Fix
The parameter `response` of the dialog callback function is either `Blockly.Msg.REPL_OK` or `Blockly.Msg.REPL_CANCEL`.  
In the `en` locale, `Blockly.Msg.REPL_OK == "OK"`.   
In other languages, `Blockly.Msg.REPL_OK` is replaced by localized texts (e.g. `"确定"`).   

By replacing `"OK"` with `Blockly.Msg.REPL_OK` fixes the issue.
![ss3](https://user-images.githubusercontent.com/16166040/29905805-673f3f0a-8e43-11e7-9284-e2fc044593bb.png)
