### PR TITLE
Prerequisite commits for Maps

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/text.js
+++ b/appinventor/blocklyeditor/src/blocks/text.js
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2013-2014 MIT, All rights reserved
+// Copyright 2013-2017 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 /**
@@ -473,4 +473,18 @@ Blockly.Blocks['obfuscated_text'] = {
     return container;
   },
   typeblock: [{translatedName: Blockly.Msg.LANG_TEXT_TEXT_OBFUSCATE}]
+};
+
+Blockly.Blocks['text_is_string'] = {
+  category: 'Text',
+  helpUrl: Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_HELPURL,
+  init: function() {
+    this.setColour(Blockly.TEXT_CATEGORY_HUE);
+    this.appendValueInput('ITEM')
+      .appendField(Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_TITLE)
+      .appendField(Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_INPUT_THING);
+    this.setOutput(true, Blockly.Blocks.Utilities.YailTypeToBlocklyType("boolean", Blockly.Blocks.Utilities.OUTPUT));
+    this.setTooltip(Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_TOOLTIP);
+  },
+  typeblock: [{translatedName: Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_TITLE}]
 };

--- a/appinventor/blocklyeditor/src/generators/yail/text.js
+++ b/appinventor/blocklyeditor/src/generators/yail/text.js
@@ -1,9 +1,9 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2012 Massachusetts Institute of Technology. All rights reserved.
+// Copyright 2012-2017 Massachusetts Institute of Technology. All rights reserved.
 
 /**
  * @license
- * @fileoverview Color blocks yail generators for Blockly, modified for MIT App Inventor.
+ * @fileoverview Text blocks yail generators for Blockly, modified for MIT App Inventor.
  * @author mckinney@mit.edu (Andrew F. McKinney)
  */
 
@@ -302,5 +302,18 @@ Blockly.Yail['obfuscated_text'] = function() {
       + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
   code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "deobfuscate text"
       + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  return [ code, Blockly.Yail.ORDER_ATOMIC ];
+};
+
+Blockly.Yail['text_is_string'] = function() {
+  // Check if the argument is a string
+  var argument0 = Blockly.Yail.valueToCode(this, 'ITEM', Blockly.Yail.ORDER_NONE) || Blockly.Yail.YAIL_FALSE;
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "string?" + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;
+  code = code + argument0;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + Blockly.Yail.YAIL_OPEN_COMBINATION;
+  code = code + "any" + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "is a string?" + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
   return [ code, Blockly.Yail.ORDER_ATOMIC ];
 };

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -5,7 +5,7 @@
  * Visual Blocks Language
  *
  * Copyright © 2012 Google Inc.
- * Copyright © 2012-2016 Massachusetts Institute of Technology
+ * Copyright © 2012-2017 Massachusetts Institute of Technology
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -709,6 +709,11 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_TEXT_REPLACE_ALL_INPUT = 'replace all text %1 segment %2 replacement %3';
     Blockly.Msg.LANG_TEXT_REPLACE_ALL_TOOLTIP = 'Returns a new text obtained by replacing all occurrences\n'
         + 'of the segment with the replacement.';
+
+    Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_HELPURL = 'http://appinventor.mit.edu/explore/ai2/support/blocks/text#isstring';
+    Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_TITLE = 'is a string?';
+    Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_INPUT_THING = 'thing';
+    Blockly.Msg.LANG_TEXT_TEXT_IS_STRING_TOOLTIP = 'Returns true if <code>thing</code> is a string.';
 
 // Lists Blocks.
     Blockly.Msg.LANG_CATEGORY_LISTS = 'Lists';

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright © 2013-2016 Massachusetts Institute of Technology, All rights reserved
+// Copyright © 2013-2017 Massachusetts Institute of Technology, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 /**
@@ -1667,7 +1667,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
 
     // AI2: In BLOCKS_LANGUAGE_VERSION 20// Rename 'obsufcated_text' text block to 'obfuscated_text'
-    20: Blockly.Versioning.renameBlockType('obsufcated_text', 'obfuscated_text')
+    20: Blockly.Versioning.renameBlockType('obsufcated_text', 'obfuscated_text'),
+
+    // AI2: Added is a string? block to test whether values are strings.
+    21: "noUpgrade"
 
 
   }, // End Language upgraders

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2017 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -399,8 +399,10 @@ public class YaVersion {
   // - FORM_COMPONENT_VERSION was incremented to 20
   // For YOUNG_ANDROID_VERSION_160:
   // - FORM_COMPONENT_VERSION was incremented to 21
+  // For YOUNG_ANDROID_VERSION_161:
+  // - BLOCKS_LANGUAGE_VERSION was incremented to 21
 
-  public static final int YOUNG_ANDROID_VERSION = 160;
+  public static final int YOUNG_ANDROID_VERSION = 161;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -460,8 +462,10 @@ public class YaVersion {
   // The number-convert blocks was added
   // For BLOCKS_LANGUAGE_VERSION 20:
   // - Spelling of "Obsfucate" was corrected to Obfuscate in Text Block
+  // For BLOCKS_LANGUAGE_VERSION 21:
+  // - The is-text block was added.
 
-  public static final int BLOCKS_LANGUAGE_VERSION = 20;
+  public static final int BLOCKS_LANGUAGE_VERSION = 21;
 
   // ................................. Component Version Numbers ..................................
 


### PR DESCRIPTION
Includes the following changes:

* Make module tests run in the module directory regardless of whether they are run from appinventor/ or the module directory.
* Add support for Android Archives.
* Add 32-bit color picker.
* Add appcompat library support for themes (Classic, Holo, Material)
* Add an is-text? block
* Enable type inference in ComponentProcessor to allow any Java type inheriting from Component to be used in a property, method, or event definition.

These are pending review on Gerrit.