### PR TITLE
Make sure /about and /static are served

### DIFF
--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -10,6 +10,8 @@
     </include>
     <include path="/assets/*" />
     <include path="/companions/*" />
+    <include path="/about/*" expiration="1d" />
+    <include path="/static/**" expiration="1d" />
     <include path="/images/*" expiration="365d" />
     <include path="/Ya_tos_form.html" expiration="1d" />
     <include path="/favicon.ico" expiration="365d" />


### PR DESCRIPTION
App Engine may soon require that static content be declared static in
appengine-web.xml. This change makes sure these directories, which hold
the “Terms of Service” among other things, are properly declared.

Change-Id: Id7409362e96a731cec75bd6cbbe3de376bf2beec