### PR TITLE
Bugfixes for master

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -21,7 +21,6 @@ import com.google.appinventor.client.output.OdeLog;
 import com.google.appinventor.client.properties.BadPropertyEditorException;
 import com.google.appinventor.client.widgets.properties.EditableProperties;
 import com.google.appinventor.shared.settings.SettingsConstants;
-import com.google.gwt.core.client.Duration;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -600,30 +599,18 @@ public final class MockForm extends MockContainer {
    *
    */
 
-  private Duration lastRefresh = new Duration();
-  private boolean refreshPending = false;
+  private Timer refreshTimer = null;
   public final void refresh() {
     Ode.CLog("MockForm: refresh() called.");
-    /* We refresh less then two seconds ago! */
-    if (lastRefresh.elapsedMillis() < 2000) {
-      if (!refreshPending) {
-        Ode.CLog("MockForm: refresh() called < 2 seconds ago, setting up timer.");
-        refreshPending = true;
-        Timer t = new Timer() {
-            @Override
-            public void run() {
-              refreshPending = false;
-              doRefresh();
-            }
-          };
-        t.schedule(2000);        // Two Seconds
-      } else {
-        Ode.CLog("MockForm: refresh() while timer running, IGNORING!");
+    if (refreshTimer != null) return;
+    refreshTimer = new Timer() {
+      @Override
+      public void run() {
+        doRefresh();
+        refreshTimer = null;
       }
-    } else {
-      lastRefresh = new Duration();
-      doRefresh();
-    }
+    };
+    refreshTimer.schedule(0);
   }
 
   /*

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -596,6 +596,9 @@ public class BlocklyPanel extends HTMLPanel {
     Blockly.mainWorkspace = this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
     // Trigger a screen switch to send new YAIL.
     var parts = Blockly.mainWorkspace.formName.split(/_/);
+    if (Blockly.ReplMgr.isConnected()) {
+      Blockly.ReplMgr.pollYail(Blockly.mainWorkspace);
+    }
     Blockly.mainWorkspace.fireChangeListener(new AI.Events.ScreenSwitch(parts[0], parts[1]));
   }-*/;
 

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -79,6 +79,10 @@ top.ReplState.phoneState = {};
 
 // Blockly.mainWorkSpace --- hold the main workspace
 
+Blockly.ReplMgr.isConnected = function() {
+    return top.ReplState.state === Blockly.ReplMgr.rsState.CONNECTED;
+};
+
 /**
  * Build YAIL for sending to the companion.
  * @param {Blockly.WorkspaceSvg} workspace

--- a/appinventor/blocklyeditor/src/xml.js
+++ b/appinventor/blocklyeditor/src/xml.js
@@ -79,6 +79,29 @@ Blockly.Xml.domToWorkspaceHeadless = function(xml, workspace) {
   workspace.updateVariableList(false);
 };
 
+/**
+ * Encode a block subtree as XML with XY coordinates.
+ * @param {!Blockly.Block} block The root block to encode.
+ * @param {boolean} opt_noId True if the encoder should skip the block id.
+ * @return {!Element} Tree of XML elements.
+ */
+Blockly.Xml.blockToDomWithXY = (function(f) {
+  return function(block, opt_noId) {
+    var element = f(block, opt_noId);
+    if (!Blockly.Block.isRenderingOn) {
+      // isRenderingOn is off during loading, so we are serializing in the middle of loading a file.
+      // Save the XY coordinate of the block so that we don't end up with all blocks at (0, 0).
+      // App Inventor only positions the blocks at the very end to reduce repositioning churn going
+      // to/from the Blockly workspace representation. Ideally we wouldn't go between the two
+      // representation because DOM manipulations are costly.
+      var width = block.workspace.RTL ? block.workspace.getWidth() : 0;
+      element.setAttribute('x', block.workspace.RTL ? width - block.x : block.x);
+      element.setAttribute('y', block.y);
+    }
+    return element;
+  };
+})(Blockly.Xml.blockToDomWithXY);
+
 if (Blockly.Instrument.isOn) {
 
 Blockly.Xml.domToWorkspace = (function(func) {

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/moleMashTest.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/moleMashTest.js
@@ -52,6 +52,18 @@ page.open('blocklyeditor/src/demos/yail/yail_testing_index.html', function(statu
 
   }, expected, formJson, blocks, args[1], args[2]); // args[1] and args[2] are blocks Version and YaV
 
+  // Assert that the block position of the global variable matches the pre-upgraded position.
+  passed = passed && page.evaluate(function() {
+    var topBlocks = Blockly.mainWorkspace.getTopBlocks();
+    for (var i = 0, block; i < topBlocks.length; i++) {
+      block = topBlocks[i];
+      if (block.type === 'global_declaration') {
+        return block.x === 16 && block.y === 182;
+      }
+    }
+    return false;
+  });
+
   //This is the actual result of the test
   console.log(passed);
   //Exit the phantom process


### PR DESCRIPTION
This PR includes the following changes:

* Fixes a bug where the block position in older projects was sometimes forgotten during an upgrade
* Fixes a bug introduced in the Blockly update where switching projects didn't trigger the ReplMgr to update the companion
* Fixes a rendering glitch on project load caused by 2 second delay in MockForm.refresh()

The changes have also been submitted to gerrit for CI.