### PR TITLE
Update block tooltips when property selection changed

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -723,8 +723,13 @@ Blockly.Blocks.component_set_get = {
       function(selection) {
         this.setValue(selection);
         thisBlock.propertyName = selection;
+        thisBlock.propertyObject = thisBlock.getPropertyObject(selection);
         thisBlock.setTypeCheck();
-        thisBlock.setTooltip(tooltipDescription);
+        if (thisBlock.propertyObject) {
+          thisBlock.setTooltip(thisBlock.propertyObject.description);
+        } else {
+          thisBlock.setTooltip(Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP);
+        }
       }
     );
 


### PR DESCRIPTION
Prior to this commit, changing the target property in a getter/setter
block would not update the tooltip of the block to match the new
property. This commit updates the tooltip in response to the dropdown
selection changing.

Fixes #964

Change-Id: I7ab095699f533fd262f2dc69cbae515e96163b8f