### PR TITLE
Prevent error checking on block during drag

### DIFF
--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -247,6 +247,9 @@ Blockly.WarningHandler.prototype['checkIfUndefinedBlock'] = function(block) {
 
 //Check if the block has an invalid drop down value, if so, create an error
 Blockly.WarningHandler.prototype['checkDropDownContainsValidValue'] = function(block, params){
+  if (Blockly.dragMode_ === Blockly.DRAG_FREE && Blockly.selected === block) {
+    return false;  // wait until the user is done dragging to check validity.
+  }
   for(var i=0;i<params.dropDowns.length;i++){
     var dropDown = block.getField(params.dropDowns[i]);
     var dropDownList = dropDown.menuGenerator_();


### PR DESCRIPTION
There was a visual glitch when dragging variable getters into sockets
due to the error icon appearing and shifting the block visually from
the coordinate Blockly maintained as the drag position. This resulted
in the connection highlight and checking algorithms to not fire when
the blocks were visually aligned but rather when the internal states
were visually aligned. This commit prevents checking a block for
errors if the block is being dragged. After the drag is complete, a
Move event will be triggered and the workspaceChanged listener will
perform an error check at the time the block is dropped. This prevents
an error icon from causing the aforementioned glitch.

Fixes #971

Change-Id: I225dac2a278b58dae9e520747a9f2c69c96bf109