### PR TITLE
Make if block mutator robust to undo/redo operations

### DIFF
--- a/appinventor/blocklyeditor/src/events.js
+++ b/appinventor/blocklyeditor/src/events.js
@@ -432,10 +432,17 @@ Blockly.Events.filter = function(queueIn, forward) {
         event.element == 'warningOpen')) {
         // Merge change events.
         hash[key].newValue = event.newValue;
+      } else {
+        // Collision, but newer events should merge into this event to maintain order
+        hash[key] = event;
+        queue2.push(event);
       }
     }
   }
-  queue = queue2;
+  // After merging, it is possible that the product of merging two events where isNull() returned
+  // false now returns true. This is one last pass to remove these null events on the filtered
+  // queue.
+  queue = queue2.filter(function(e) { return !e.isNull(); });
   if (!forward) {
     // Restore undo order.
     queue.reverse();


### PR DESCRIPTION
This commit reconciles our implementation of the `if` block with the
implementation in Blockly. In particular, our implementation only
works under the assumption that the user is making changes via the
mutator and causes graphical problems when the undo/redo feature in
Blockly is used. The Blockly version correctly handles undo/redo, but
the mutator is slightly different in its implementation. This change
maintains our visual presentation of the mutator but uses the Blockly
logic for updating.

Fixes #973

Change-Id: Ib335d4cd7f132f8bf21f9c691ee7a7e53f28e674