### PR TITLE
Bypass Closure's SafeHtml for HTML known to be safe

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -650,7 +650,15 @@ Blockly.ReplMgr.processRetvals = function(responses) {
         context.runtimeError.setTitle(Blockly.Msg.REPL_RUNTIME_ERROR);
         context.runtimeError.setButtonSet(new goog.ui.Dialog.ButtonSet().
                                        addButton({caption:Blockly.Msg.REPL_DISMISS}, false, true));
-        context.runtimeError.setTextContent(message);
+        if (context.runtimeError.getContentElement()) {
+            // This is not condoned by Google Closure Library rules, but we have already escaped
+            // the return value and the static content should be code reviewed to be safe.
+            context.runtimeError.getContentElement().innerHTML = message;
+        } else {
+            // Fallback option if for some reason the content element did not exist.
+            // This shouldn't happen in practice, but you never know...
+            context.runtimeError.setSafeHtmlContent(goog.html.SafeHtml.htmlEscape(message));
+        }
         context.runtimeError.setVisible(true);
     };
     // From http://forums.asp.net/t/1151879.aspx?HttpUtility+HtmlEncode+in+javaScript+


### PR DESCRIPTION
When we updated the Closure Compiler for the Blockly update, some
strings containing HTML were escaped unnecessarily. These strings are
part of internationalization, and so they will be code reviewed before
acceptance into the code base. We therefore break the SafeHtml
contract imposed by Google Closure Library and manipulate the content
element directly so that the static HTML content is preserved.

Fixes #985

Change-Id: I8a545d46aceedcb8039f194ce03a86d924ab0867