### PR TITLE
Add "Extension Version" field to help widget

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1028,6 +1028,10 @@ public interface OdeMessages extends Messages {
 
   // Used in editor/simple/palette/ComponentHelpWidget.java
 
+  @DefaultMessage("Extension Version:")
+  @Description("Header for extension version information")
+  String externalComponentVersion();
+
   @DefaultMessage("More information")
   @Description("Label of the link to a component's reference docs")
   String moreInformation();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
@@ -68,6 +68,7 @@ public final class ComponentHelpWidget extends Image {
       // GWT supported String.format.
       String referenceComponentsUrl = Ode.getSystemConfig().getReferenceComponentsUrl();
       String url = null;
+      int version = -1;
       if (scd.getExternal()) {  // extensions will not have documentation hosted in ai2
         url = scd.getHelpUrl().isEmpty() ? null : scd.getHelpUrl();
         if (url != null) {
@@ -80,6 +81,7 @@ public final class ComponentHelpWidget extends Image {
                 .replaceAll("\"", "%22");
           }
         }
+        version = scd.getVersion();
       } else if (!Strings.isNullOrEmpty(referenceComponentsUrl)) {
         if (!referenceComponentsUrl.endsWith("/")) {
           referenceComponentsUrl += "/";
@@ -88,6 +90,11 @@ public final class ComponentHelpWidget extends Image {
         url = (categoryDocUrlString == null)
             ? referenceComponentsUrl + "index.html"
             : referenceComponentsUrl + categoryDocUrlString + ".html#" + scd.getName();
+      }
+      if (version > 0) {
+        HTML html = new HTML("<b>" + MESSAGES.externalComponentVersion() + "</b> " + version);
+        html.setStyleName("ode-ComponentHelpPopup-Body");
+        inner.add(html);
       }
       if (url != null) {  // only show if there is a relevant URL
         HTML link = new HTML("<a href=\"" + url + "\" target=\"_blank\">" +

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimpleComponentDescriptor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimpleComponentDescriptor.java
@@ -85,6 +85,9 @@ public final class SimpleComponentDescriptor {
   // to get the image, category, and description
   private MockComponent cachedMockComponent = null;
 
+  // The version of the extension (meaning is defined by the extension author).
+  private int version = -1;
+
   // Component database: information about components (including their properties and events)
   private final SimpleComponentDatabase COMPONENT_DATABASE;
 
@@ -150,6 +153,7 @@ public final class SimpleComponentDescriptor {
    */
   public SimpleComponentDescriptor(String name,
                                    SimpleEditor editor,
+                                   int version,
                                    String helpString,
                                    String helpUrl,
                                    String categoryDocUrlString,
@@ -158,6 +162,7 @@ public final class SimpleComponentDescriptor {
                                    boolean external) {
     this.name = name;
     this.editor = editor;
+    this.version = version;
     this.helpString = helpString;
     this.helpUrl = helpUrl;
     this.categoryDocUrlString = categoryDocUrlString;
@@ -251,6 +256,15 @@ public final class SimpleComponentDescriptor {
     } else {
       return getCachedMockComponent(name, editor).getIconImage();
     }
+  }
+
+  /**
+   * Returns the version of the component, if any.
+   *
+   * @return  component version string
+   */
+  public int getVersion() {
+    return version;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
@@ -148,6 +148,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
     if (simplePaletteItems.containsKey(componentTypeName)) { // We are upgrading
       removeComponent(componentTypeName);
     }
+    int version = COMPONENT_DATABASE.getComponentVersion(componentTypeName);
     String helpString = COMPONENT_DATABASE.getHelpString(componentTypeName);
     String helpUrl = COMPONENT_DATABASE.getHelpUrl(componentTypeName);
     String categoryDocUrlString = COMPONENT_DATABASE.getCategoryDocUrlString(componentTypeName);
@@ -158,7 +159,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
     ComponentCategory category = ComponentCategory.valueOf(categoryString);
     if (showOnPalette && showCategory(category)) {
       SimplePaletteItem item = new SimplePaletteItem(
-          new SimpleComponentDescriptor(componentTypeName, editor, helpString, helpUrl,
+          new SimpleComponentDescriptor(componentTypeName, editor, version, helpString, helpUrl,
               categoryDocUrlString, showOnPalette, nonVisible, external),
             dropTargetProvider);
       simplePaletteItems.put(componentTypeName, item);


### PR DESCRIPTION
Assisting users with extensions is difficult because it is unclear
whether problems occur because of bugs in the extension or due to a
mismatch in versions when extensions work together. This commit adds
an "Extension Version" header on the helper widget that displays the
version number specified in the @DesignerComponent annotation if the
version number is greater than 0.

Closes #894

Change-Id: If7fdd49795e81f8ff784036ce5745de499aafbd9