### PR TITLE
Configure ChoicePropertyEditor choices through annotations

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -331,9 +331,15 @@ class ComponentDatabase implements ComponentDatabaseInterface {
   private void findComponentProperties(ComponentDefinition component, JSONArray propertiesArray) {
     for (JSONValue propertyValue : propertiesArray.getElements()) {
       Map<String, JSONValue> properties = propertyValue.asObject().getProperties();
+
+      List<String> editorArgsList = new ArrayList<String>();
+      for (JSONValue val : properties.get("editorArgs").asArray().getElements())
+        editorArgsList.add(val.asString().getString());
+
       component.add(new PropertyDefinition(properties.get("name").asString().getString(),
-          properties.get("defaultValue").asString().getString(), properties.get("editorType")
-              .asString().getString()));
+                                           properties.get("defaultValue").asString().getString(),
+                                           properties.get("editorType").asString().getString(),
+                                           editorArgsList.toArray(new String[0])));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -337,9 +337,9 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         editorArgsList.add(val.asString().getString());
 
       component.add(new PropertyDefinition(properties.get("name").asString().getString(),
-                                           properties.get("defaultValue").asString().getString(),
-                                           properties.get("editorType").asString().getString(),
-                                           editorArgsList.toArray(new String[0])));
+          properties.get("defaultValue").asString().getString(),
+          properties.get("editorType").asString().getString(),
+          editorArgsList.toArray(new String[0])));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -332,9 +332,14 @@ class ComponentDatabase implements ComponentDatabaseInterface {
     for (JSONValue propertyValue : propertiesArray.getElements()) {
       Map<String, JSONValue> properties = propertyValue.asObject().getProperties();
 
+      // TODO Since older versions of extensions do not have the "editorArgs" key,
+      // we check if "editorArgs" exists before parsing as a workaround. We may
+      // need better approaches in future versions.
       List<String> editorArgsList = new ArrayList<String>();
-      for (JSONValue val : properties.get("editorArgs").asArray().getElements())
-        editorArgsList.add(val.asString().getString());
+      if (properties.containsKey("editorArgs")) {
+        for (JSONValue val : properties.get("editorArgs").asArray().getElements())
+          editorArgsList.add(val.asString().getString());
+      }
 
       component.add(new PropertyDefinition(properties.get("name").asString().getString(),
           properties.get("defaultValue").asString().getString(),

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1097,7 +1097,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     }
     for (PropertyDefinition property : newProperties) {
       if (toBeAdded.contains(property.getName())) {
-        PropertyEditor propertyEditor = PropertiesUtil.createPropertyEditor(property.getEditorType(), (YaFormEditor) editor);
+        PropertyEditor propertyEditor = PropertiesUtil.createPropertyEditor(property.getEditorType(), (YaFormEditor) editor, property.getEditorArgs());
         addProperty(property.getName(), property.getDefaultValue(), property.getCaption(), propertyEditor);
       }
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -38,6 +38,7 @@ import com.google.appinventor.client.editor.youngandroid.properties.
        YoungAndroidVerticalAlignmentChoicePropertyEditor;
 import com.google.appinventor.client.properties.BadPropertyEditorException;
 import com.google.appinventor.client.properties.Property;
+import com.google.appinventor.client.widgets.properties.ChoicePropertyEditor;
 import com.google.appinventor.client.widgets.properties.CountryChoicePropertyEditor;
 import com.google.appinventor.client.widgets.properties.EditableProperties;
 import com.google.appinventor.client.widgets.properties.EditableProperty;
@@ -91,7 +92,7 @@ public class PropertiesUtil {
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefintions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
           ComponentsTranslation.getPropertyName(property.getCaption()),
-          PropertiesUtil.createPropertyEditor(property.getEditorType(), editor));
+                                PropertiesUtil.createPropertyEditor(property.getEditorType(), editor, property.getEditorArgs()));
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "
           + TranslationComponentProperty.getName(property.getCaption()));*/
     }
@@ -166,7 +167,7 @@ public class PropertiesUtil {
   /*
    * Creates a new property editor.
    */
-  public static PropertyEditor createPropertyEditor(String editorType, YaFormEditor editor) {
+  public static PropertyEditor createPropertyEditor(String editorType, YaFormEditor editor, String[] editorArgs) {
     if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT)) {
       return new YoungAndroidHorizontalAlignmentChoicePropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT)) {
@@ -198,6 +199,8 @@ public class PropertiesUtil {
       return new YoungAndroidLegoEv3UltrasonicSensorModeChoicePropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_LEGO_EV3_GYRO_SENSOR_MODE)) {
       return new YoungAndroidLegoEv3GyroSensorModeChoicePropertyEditor();
+    } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_CHOICES)) {
+      return new ChoicePropertyEditor(editorArgs);
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_LEGO_NXT_SENSOR_PORT)) {
       return new YoungAndroidLegoNxtSensorPortChoicePropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_LEGO_NXT_GENERATED_COLOR)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -92,7 +92,7 @@ public class PropertiesUtil {
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefintions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
           ComponentsTranslation.getPropertyName(property.getCaption()),
-                                PropertiesUtil.createPropertyEditor(property.getEditorType(), editor, property.getEditorArgs()));
+          PropertiesUtil.createPropertyEditor(property.getEditorType(), editor, property.getEditorArgs()));
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "
           + TranslationComponentProperty.getName(property.getCaption()));*/
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
@@ -98,6 +98,32 @@ public class ChoicePropertyEditor extends PropertyEditor {
     initWidget(dropDownButton);
   }
 
+  /**
+   * Creates a new instance of the property editor with choice names.
+   * Each choice name is treated as both the captain and the value of a choice.
+   *
+   * @param choiceNames  array of choice names to choose from
+   */
+  public ChoicePropertyEditor(String[] choiceNames) {
+    this.choices = new Choice[choiceNames.length];
+    for (int idx = 0; idx < choiceNames.length; idx += 1)
+      this.choices[idx] = new Choice(choiceNames[idx], choiceNames[idx]);
+
+    List<DropDownItem> items = Lists.newArrayList();
+    for(final Choice choice : choices) {
+      items.add(new DropDownItem("Choice Property Editor", choice.caption, new Command() {
+        @Override
+        public void execute() {
+          property.setValue(choice.value);
+        }
+      }));
+    }
+    dropDownButton = new DropDownButton("Choice Property Editor", choices[0].caption, items, false);
+    dropDownButton.setStylePrimaryName("ode-ChoicePropertyEditor");
+
+    initWidget(dropDownButton);
+  }
+
   @Override
   protected void updateValue() {
     String propertyValue = property.getValue();
@@ -108,7 +134,7 @@ public class ChoicePropertyEditor extends PropertyEditor {
       }
     }
   }
-  
+
   /**
    * Enables the dropdown selector for this property
    */

--- a/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
@@ -159,16 +159,18 @@ public interface ComponentDatabaseInterface {
     private final String defaultValue;
     private final String caption;
     private final String editorType;
+    private final String[] editorArgs;
 
-    public PropertyDefinition(String name, String defaultValue, String editorType) {
-      this(name, defaultValue, name, editorType);
+    public PropertyDefinition(String name, String defaultValue, String editorType, String[] editorArgs) {
+      this(name, defaultValue, name, editorType, editorArgs);
     }
 
-    public PropertyDefinition(String name, String defaultValue, String caption, String editorType) {
+    public PropertyDefinition(String name, String defaultValue, String caption, String editorType, String[] editorArgs) {
       this.name = name;
       this.defaultValue = defaultValue;
       this.caption = caption;
       this.editorType = editorType;
+      this.editorArgs = editorArgs;
     }
 
     public String getName() {
@@ -185,6 +187,10 @@ public interface ComponentDatabaseInterface {
 
     public String getEditorType() {
       return editorType;
+    }
+
+    public String[] getEditorArgs() {
+      return editorArgs;
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/annotations/DesignerProperty.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/DesignerProperty.java
@@ -36,4 +36,11 @@ public @interface DesignerProperty {
    * @return  default property value
    */
   String defaultValue() default "";
+
+  /**
+   * Arguments passed to editor class.
+   *
+   * @return  editor arguments
+   */
+  String[] editorArgs() default {};
 }

--- a/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
@@ -138,6 +138,13 @@ public class PropertyTypeConstants {
   public static final String PROPERTY_TYPE_LEGO_EV3_GENERATED_COLOR = "lego_ev3_generated_color";
 
   /**
+   * Choices.
+   * @see
+   * com.google.appinventor.client.widgets.properties.ChoicePropertyEditor
+   */
+  public static final String PROPERTY_TYPE_CHOICES = "choices";
+
+  /**
    * Non-negative (positive or zero) floating-point values.
    * @see com.google.appinventor.client.widgets.properties.NonNegativeFloatPropertyEditor
    */

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -137,7 +137,14 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append(dp.editorType());
     sb.append("\", \"defaultValue\": \"");
     sb.append(dp.defaultValue().replace("\"", "\\\""));
-    sb.append("\"}");
+
+    sb.append("\", \"editorArgs\": ");
+    String[] editorArgs = dp.editorArgs();
+    for (int idx = 0; idx < editorArgs.length; idx += 1)
+      editorArgs[idx] = "\"" + editorArgs[idx].replace("\"", "\\\"") + "\"";
+
+    sb.append("[" + String.join(", ", editorArgs) + "]");
+    sb.append("}");
   }
 
   private void outputBlockProperty(String propertyName, Property prop, StringBuilder sb) {

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -143,7 +143,21 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     for (int idx = 0; idx < editorArgs.length; idx += 1)
       editorArgs[idx] = "\"" + editorArgs[idx].replace("\"", "\\\"") + "\"";
 
-    sb.append("[" + String.join(", ", editorArgs) + "]");
+    StringBuilder listLiteralBuilder = new StringBuilder();
+    listLiteralBuilder.append("[");
+
+    if (editorArgs.length > 0) {
+      listLiteralBuilder.append(editorArgs[0]);
+
+      for (int ind = 1; ind < editorArgs.length; ind += 1) {
+        listLiteralBuilder.append(", ");
+        listLiteralBuilder.append(editorArgs[ind]);
+      }
+    }
+
+    listLiteralBuilder.append("]");
+
+    sb.append(listLiteralBuilder.toString());
     sb.append("}");
   }
 


### PR DESCRIPTION
Currently AI2 is lack of a configurable choice-like property. It could be troublesome when I was developing components or extensions. It's a hassle to create editor classes for choice property classes (eg. `YoungAndroidLegoEv3{Color,Gyro,Ultrasonic}SensorModeChoicePropertyEditor`), and it seems there's no way to create choice-like properties for extensions without patching AI2 sources.

I made some modifications on ChoicePropertyEditor, and thus you can configure your choices with `editorArgs` argument in annotation like this.
```java
@DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_CHOICES,
                  defaultValue = "A",
                  editorArgs = {"A", "B", "C", "D"})
@SimpleProperty
public void SomeMethod(String choice) { /* blablabla */ }
```

This patch is mainly done by an additional String array `editorArgs` in class `ChoicePropertyEditor`. The `findComponentProperties` function passes `editorArgs` to editor objects if need.