### PR TITLE
Fix extension upgrade issues

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -13,6 +13,7 @@ import com.google.appinventor.client.ErrorReporter;
 import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.OdeAsyncCallback;
 import com.google.appinventor.client.boxes.AssetListBox;
+import com.google.appinventor.client.editor.EditorManager;
 import com.google.appinventor.client.editor.FileEditor;
 import com.google.appinventor.client.editor.ProjectEditor;
 import com.google.appinventor.client.editor.ProjectEditorFactory;
@@ -522,6 +523,9 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
             name = packageName;
             if (!externalComponents.contains(name)) {
               externalComponents.add(name);
+            } else {
+              // Upgraded an extension. Force a save to ensure version numbers are updated serverside.
+              saveProject();
             }
           }
         } else {
@@ -530,6 +534,9 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
           // In case of upgrade, we do not need to add entry
           if (!externalComponents.contains(componentJSONObject.get("type").toString())) {
             externalComponents.add(componentJSONObject.get("type").toString());
+          } else {
+            // Upgraded an extension. Force a save to ensure version numbers are updated serverside.
+            saveProject();
           }
         }
         numExternalComponentsLoaded++;
@@ -735,6 +742,19 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
       EditorSet editors = editorMap.get(formName);
       editors.formEditor.onResetDatabase();
       editors.blocksEditor.onResetDatabase();
+    }
+  }
+
+  /**
+   * Save all editors in the project.
+   */
+  public void saveProject() {
+    EditorManager manager = Ode.getInstance().getEditorManager();
+    for (EditorSet editors : editorMap.values()) {
+      // It would be more efficient to check if the editors use the component in question,
+      // but we are conservative and save everything, for now.
+      manager.scheduleAutoSave(editors.formEditor);
+      manager.scheduleAutoSave(editors.blocksEditor);
     }
   }
 }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -153,6 +153,10 @@ Blockly.Versioning.upgrade = function (preUpgradeFormJsonString, blocksContent, 
   var preUpgradeComponentVersionDict = Blockly.Versioning.makeComponentVersionDict(preUpgradeFormJsonObject);
   for (var componentType in preUpgradeComponentVersionDict) {
     if (!preUpgradeComponentVersionDict.hasOwnProperty(componentType)) continue;
+
+    // Cannot upgrade extensions as they are not part of the system
+    if (Blockly.Versioning.isExternal(componentType, opt_workspace)) continue;
+
     var preUpgradeVersion = preUpgradeComponentVersionDict[componentType];
     var systemVersion = Blockly.Versioning.getSystemComponentVersion(componentType, opt_workspace);
     blocksRep = upgradeComponentType(componentType, preUpgradeVersion, systemVersion, blocksRep);
@@ -411,6 +415,15 @@ Blockly.Versioning.getSystemComponentVersion = function (componentType, workspac
     return parseInt(versionString);
   } else {
     throw "Blockly.Versioning.getSystemComponentVersion: No version for component type " + componentType;
+  }
+};
+
+Blockly.Versioning.isExternal = function(componentType, workspace) {
+  var description = workspace.getComponentDatabase().getType(componentType);
+  if (description && description.componentInfo) {
+    return 'true' === description.componentInfo.external;
+  } else {
+    return false;
   }
 };
 


### PR DESCRIPTION
An interaction between an upgrading an extension with a new version
number and a change to YaVersion results in being unable to open a
project with extensions. This fix does two things to address this:

1. Force a save of the project so that the version numbers of the
extension are persisted back to the server.
2. Check whether a component to be upgraded is an external component,
and if so, skip the upgrade step since we don't have an upgrader for
it anyway.

Fixes #996

Change-Id: I6d39f70b3cac80961ed538f5a2bd99ab81729a5e