### PR TITLE
Add WorkspaceMove event for undoing viewport moves

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -845,6 +845,7 @@ Blockly.Blocks['procedures_callnoreturn'] = {
       var def = Blockly.Procedures.getDefinition(name, workspace);
       if (def) {
         def.select();
+        var event = new AI.Events.WorkspaceMove(workspace.id);
 
         // Attempt to center the definition block, but preserve a minimum X, Y position so that
         // the definition of the block always appears on screen for visually large procedures
@@ -856,6 +857,9 @@ Blockly.Blocks['procedures_callnoreturn'] = {
         var midX = minLeft + (wh.width - metrics.viewWidth) / 2;
         var midY = minTop + (wh.height - metrics.viewHeight) / 2;
         def.workspace.scrollbar.set(Math.min(minLeft, midX), Math.min(minTop, midY));
+        event.recordNew();
+        Blockly.Events.fire(event);
+        workspace.getParentSvg().parentElement.focus();
       }
     };
     options.push(option);


### PR DESCRIPTION
We added a mechanism that moves the workspace when highlighting a
procedure definition block. However, we do not provide a mechanism to
go back to the original viewport position prior to the move. This
commit adds a WorkspaceMove event that is recorded when the workspace
is shifted and can be undo via the normal undo/redo stack to return
the user from where they came in the workspace.

Note this is not robust to changes in the viewport size between
operations.

Change-Id: I09f1af2f3d7db62af0f1487a90a56a66f99273bc