### PR TITLE
Oversize block comment display error

### DIFF
--- a/appinventor/blocklyeditor/media/blockly.css
+++ b/appinventor/blocklyeditor/media/blockly.css
@@ -126,6 +126,7 @@
   border: 0;
   resize: none;
   background-color: #ffc;
+  overflow: hidden;
 }
 .blocklyHtmlInput {
   font-family: sans-serif;


### PR DESCRIPTION
Dont know why default value of overflow(auto) doesnot work for textbox here, switch to hidden

was:
![image](https://user-images.githubusercontent.com/22613139/32977779-11b59d12-cc6f-11e7-93c0-cdc29b5d0c3f.png)

now:
![image](https://user-images.githubusercontent.com/22613139/32977770-fc325f3e-cc6e-11e7-835d-eaac31f29554.png)


Fixed: #1008 