### PR TITLE
Add IgnoreSslErrors to Web and improve error messages

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
@@ -131,6 +131,7 @@ public final class ErrorMessages {
   public static final int ERROR_WEB_BUILD_REQUEST_DATA_NOT_TWO_ELEMENTS = 1113;
   public static final int ERROR_WEB_UNABLE_TO_DELETE = 1114;
   public static final int ERROR_WEB_XML_TEXT_DECODE_FAILED = 1115;
+  public static final int ERROR_WEB_SSL_ERROR = 1116;
   // Contact picker (and PhoneNumberPicker) errors
   public static final int ERROR_PHONE_UNSUPPORTED_CONTACT_PICKER = 1107;
   public static final int ERROR_PHONE_UNSUPPORTED_SEARCH_IN_CONTACT_PICKING = 1108;
@@ -442,6 +443,8 @@ public final class ErrorMessages {
         "Unable to build request data: element %s does not contain two elements");
     errorMessages.put(ERROR_WEB_UNABLE_TO_DELETE,
             "Unable to delete a resource with the specified URL: %s");
+    errorMessages.put(ERROR_WEB_SSL_ERROR,
+        "SSL error when accessing URL %1$s: %2$s");
     // Contact picker (and PhoneNumberPicker) errors
     errorMessages.put(ERROR_PHONE_UNSUPPORTED_CONTACT_PICKER,
         "The software used in this app cannot extract contacts from this type of phone.");

--- a/appinventor/docs/reference/components/connectivity.html
+++ b/appinventor/docs/reference/components/connectivity.html
@@ -699,6 +699,8 @@ delimiter byte value is received. </dd>
 <dl>
   <dt><code>AllowCookies</code></dt>
   <dd>Whether the cookies from a response should be saved and used in subsequent requests. Cookies are only supported on Android version 2.3 or greater.</dd>
+  <dt><code>IgnoreSslErrors</code></dt>
+  <dd>Sets whether or not to ignore SSL errors when connecting to an untrusted server. Note that this is extremely insecure and may open your app to man-in-the-middle attacks, making app users' data susceptible to monitoring by a third party.</dd>
   <dt><code>RequestHeaders</code></dt>
   <dd>The request headers, as a list of two-element sublists. The first element of each sublist represents the request header field name. The second element of each sublist represents the request header field values, either a single value or a list containing multiple values.</dd>
   <dt><code>ResponseFileName</code></dt>


### PR DESCRIPTION
This change adds an IgnoreSslErrors to the Web component that works
similarly to the property of the same name on WebViewer. Enabling this
property will suppress hostname and certificate chain validation for
any operations with the given component. There is also a new error
message for reporting SSL errors separately from Web errors that gives
more detailed feedback about the SSL handshaking procedure (useful for
debugging certificate issues on the Companion).

Fixes #791
Fixes #886

Change-Id: I595892920e92543bfaea590bdaa86e0caf781563