### PR TITLE
Fixes an issue with blocks copy/pasting using keyboard

### DIFF
--- a/appinventor/blocklyeditor/src/typeblock.js
+++ b/appinventor/blocklyeditor/src/typeblock.js
@@ -161,12 +161,11 @@ Blockly.TypeBlock.prototype.handleKey = function(e){
     switch (e.keyCode) {
       case 9:   // Tab
       case 16:  // Enter
-      case 17:  // Ctrl
       case 18:  // Alt
       case 19:  // Home
       case 20:  // Caps Lock
-      case 33:  // PageUp
-      case 34:  // PageDown
+      case 33:  // Page Up
+      case 34:  // Page Down
       case 35:  // Shift
       case 36:  // End
       case 45:  // Ins

--- a/appinventor/blocklyeditor/src/typeblock.js
+++ b/appinventor/blocklyeditor/src/typeblock.js
@@ -141,6 +141,7 @@ Blockly.TypeBlock.prototype.handleKey = function(e){
     // Don't steal input from Blockly fields.
     if (e.target != this.ac_.getTarget() &&
       (e.target.tagName == 'INPUT' || e.target.tagName == 'TEXTAREA')) return;
+    if (e.altKey || e.ctrlKey || e.metaKey || e.keyCode === 9) return; // 9 is tab
     //We need to duplicate delete handling here from blockly.js
     if (e.keyCode === 8 || e.keyCode === 46) {
       // Delete or backspace.
@@ -161,6 +162,7 @@ Blockly.TypeBlock.prototype.handleKey = function(e){
     switch (e.keyCode) {
       case 9:   // Tab
       case 16:  // Enter
+      case 17:  // Ctrl
       case 18:  // Alt
       case 19:  // Home
       case 20:  // Caps Lock


### PR DESCRIPTION
As a part of @ColinTree commit ba120fc773b654ea8c4fe7d9f4877d9e03c816df, blocks copy/pasting using keyboard was removed. This commit strikes to fix issue #1068. Also, I added a few spaces for better naming...