### PR TITLE
Improve MockFeatureCollection behavior

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
@@ -11,6 +11,7 @@ import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.SimplePanel;
 
 import java.util.ArrayList;
@@ -31,8 +32,11 @@ public class MockFeatureCollection extends MockContainer implements MockMapFeatu
     super(editor, TYPE, images.featurecollection(), new MockFeatureCollectionLayout());
 
     SimplePanel panel = new SimplePanel();
-    panel.setWidth("0px");
-    panel.setHeight("0px");
+    panel.setWidth("16px");
+    panel.setHeight("16px");
+    panel.setStylePrimaryName("ode-SimpleMockComponent");
+    Image icon = new Image(images.featurecollection());
+    panel.add(icon);
 
     initComponent(panel);
     initCollection();
@@ -45,6 +49,9 @@ public class MockFeatureCollection extends MockContainer implements MockMapFeatu
 
   @Override
   public void addToMap(MockMap map) {
+    setVisible(false);  // MockFeatureCollection is managed by Leaflet
+    layout.layoutWidth = 0;
+    layout.layoutHeight = 0;
     this.map = map;
     setContainer(map);
     addToMap(map.getMapInstance());

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollectionLayout.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollectionLayout.java
@@ -12,8 +12,8 @@ import java.util.Map;
 public class MockFeatureCollectionLayout extends MockLayout {
 
   MockFeatureCollectionLayout() {
-    layoutWidth = 0;
-    layoutHeight = 0;
+    layoutWidth = 16;
+    layoutHeight = 16;
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidGeoJSONPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidGeoJSONPropertyEditor.java
@@ -107,6 +107,7 @@ public class YoungAndroidGeoJSONPropertyEditor extends AdditionalChoicePropertyE
           }
         };
         UrlImportWizard wizard = new UrlImportWizard(assetsFolder, callback);
+        wizard.center();
         wizard.show();
       }
     });
@@ -140,6 +141,15 @@ public class YoungAndroidGeoJSONPropertyEditor extends AdditionalChoicePropertyE
     Project project = Ode.getInstance().getProjectManager().getProject(assetsFolder.getProjectId());
     project.removeProjectChangeListener(this);
     super.orphan();
+  }
+
+  @Override
+  protected String getPropertyValueSummary() {
+    String value = property.getValue();
+    if (choices.containsValue(value)) {
+      return choices.getDisplayItemForValue(value);
+    }
+    return value;
   }
 
   @Override


### PR DESCRIPTION
1. Makes the GeoJSON asset picker show "None..." instead of "..." when
   nothing is selected
2. Makes MockFeatureCollection icon show when dragging from the palette
3. Centers the "From URL" dialog that appears when retrieving GeoJSON
   from a URL

Fixes #1074

Change-Id: Ib88eb768df5421b8be4defb472e4b516a3ca94fa