### PR TITLE
Update ProjectBuilder.java

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -200,7 +200,7 @@ public final class ProjectBuilder {
 
         // Note (ralph):  deleteRecursively has been removed from the guava-11.0.1 lib
         // Replacing with deleteDirectory, which is supposed to delete the entire directory.
-        FileUtils.deleteDirectory(new File(projectRoot.getCanonicalPath()));
+        FileUtils.deleteQuietly(new File(projectRoot.getCanonicalPath()));
       }
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
deleteDirectory may cause an exception to fail the completed buiding.