### PR TITLE
Icon display error when using base64 at any component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -754,9 +754,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   public void collectTypesAndIcons(Map<String, String> typesAndIcons) {
     String name = getVisibleTypeName();
     if (!isForm() && !typesAndIcons.containsKey(name)) {
-      String imageHTML = new ClippedImagePrototype(iconImage.getUrl(), iconImage.getOriginLeft(),
-          iconImage.getOriginTop(), ICON_IMAGE_WIDTH, ICON_IMAGE_HEIGHT).getHTML();
-      typesAndIcons.put(name, imageHTML);
+      typesAndIcons.put(name, iconImage.getElement().getString());
     }
   }
 


### PR DESCRIPTION
Fixed #1107 
Same as what [this commit](https://github.com/mit-cml/appinventor-sources/commit/6c36d5aa5a9ab17e71dd8d20c00a8156a21e63da) did: 
![image](https://user-images.githubusercontent.com/22613139/34611588-08fd1c14-f261-11e7-88a9-ca5db05e239e.png)
