### PR TITLE
Add Rotation property

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -7003,4 +7003,8 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("SetCenter")
   @Description("")
   String SetCenterMethods();
+
+  @DefaultMessage("Rotation")
+  @Description("")
+  String RotationProperties();
 }

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -848,7 +848,9 @@ public class YaVersion {
   // For MAP_COMPONENT_VERSION 3:
   // - GotGeoJSON was renamed to GotFeatures
   // - GeoJSONError was renamed to LoadError
-  public static final int MAP_COMPONENT_VERSION = 3;
+  // For MAP_COMPONENT_VERSION 4:
+  // - Added Rotation property
+  public static final int MAP_COMPONENT_VERSION = 4;
 
   // For MARKER_COMPONENT_VERSION 1:
   // - Initial Marker implementation using OpenStreetMap

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -259,6 +259,17 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
     return mapController.isZoomEnabled();
   }
 
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT, defaultValue = "0.0")
+  @SimpleProperty
+  public void Rotation(float rotation) {
+	mapController.setRotation(rotation);
+  }
+
+  @SimpleProperty (category = PropertyCategory.APPEARANCE, description = "Sets or gets the rotation of the map in decimal degrees if any")
+  public float Rotation() {
+	return mapController.getRotation();
+  }
+
   /**
    * <p>Set the type of map tile used for the base tile layer. Valid values are:</p>
    * <ol>

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
@@ -44,6 +44,14 @@ class DummyMapController implements MapController {
     throw new UnsupportedOperationException();
   }
 
+  public void setRotation(float Rotation) {
+    throw new UnsupportedOperationException();
+  }
+
+  public float getRotation() {
+    throw new UnsupportedOperationException();
+  }
+
   public int getZoom() {
     throw new UnsupportedOperationException();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
@@ -512,6 +512,18 @@ public final class MapFactory {
      * @return  the number of overlays on the map
      */
     int getOverlayCount();
+
+    /**
+     * Sets the rotation of the map in degrees
+     * @param Rotation in degrees
+     */
+    void setRotation(float Rotation);
+
+    /**
+     * Gets the rotation of the map in degrees
+     * @return the rotation
+     */
+    float getRotation();
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -1170,12 +1170,12 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   @Override
   public void setRotation(float Rotation) {
-	  view.setMapOrientation(Rotation);
+    view.setMapOrientation(Rotation);
   }
 
   @Override
   public float getRotation() {
-	  return view.getMapOrientation();
+    return view.getMapOrientation();
   }
 
   static class MultiPolygon extends Polygon {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -1168,6 +1168,16 @@ class NativeOpenStreetMapController implements MapController, MapListener {
     return view.getOverlays().size();
   }
 
+  @Override
+  public void setRotation(float Rotation) {
+	  view.setMapOrientation(Rotation);
+  }
+
+  @Override
+  public float getRotation() {
+	  return view.getMapOrientation();
+  }
+
   static class MultiPolygon extends Polygon {
 
     private List<Polygon> children = new ArrayList<Polygon>();


### PR DESCRIPTION
Users could rotate the map but not programmatically. This change adds
blocks to allow developers to programmatically change the map rotation.

Fixes #1082