### PR TITLE
Use GeometryUtil for interpreting Map BoundingBox

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -10,6 +10,7 @@ import com.google.appinventor.components.runtime.LocationSensor.LocationSensorLi
 import com.google.appinventor.components.runtime.util.AsynchUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.GeoJSONUtil;
+import com.google.appinventor.components.runtime.util.GeometryUtil;
 import com.google.appinventor.components.runtime.util.MapFactory;
 import com.google.appinventor.components.runtime.util.YailList;
 import org.osmdroid.util.BoundingBox;
@@ -402,10 +403,10 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
 
   @SimpleProperty
   public void BoundingBox(YailList boundingbox) {
-    double latNorth = (Double)((YailList)boundingbox.get(1)).get(1);
-    double longWest = (Double)((YailList)boundingbox.get(1)).get(2);
-    double latSouth = (Double)((YailList)boundingbox.get(2)).get(1);
-    double longEast = (Double)((YailList)boundingbox.get(2)).get(2);
+    double latNorth = GeometryUtil.coerceToDouble(((YailList) boundingbox.get(1)).get(1));
+    double longWest = GeometryUtil.coerceToDouble(((YailList)boundingbox.get(1)).get(2));
+    double latSouth = GeometryUtil.coerceToDouble(((YailList)boundingbox.get(2)).get(1));
+    double longEast = GeometryUtil.coerceToDouble(((YailList)boundingbox.get(2)).get(2));
     mapController.setBoundingBox(new BoundingBox(latNorth, longEast, latSouth, longWest));
   }
 


### PR DESCRIPTION
When setting a BoundingBox to a specific set of coordinates we attempt
to cast a value to double that isn't necessarily double. If coming
directly from blocks, the values are Kawa DFloNum values. This commit
uses GeometryUtil's coerseToDouble helper function to convert the
value into a double.

Fixes #1145

Change-Id: I6404c783caa81fb31e03557e58cabc5474f2eb38