### PR TITLE
Add “Shared Backpack”

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -737,6 +737,18 @@ public class Ode implements EntryPoint {
         user = result.getUser();
         isReadOnly = user.isReadOnly();
 
+        // load the user's backpack if we are not using a shared
+        // backpack
+
+        String backPackId = user.getBackpackId();
+        if (backPackId == null || backPackId.isEmpty()) {
+          loadBackpack();
+          OdeLog.log("backpack: No shared backpack");
+        } else {
+          BlocklyPanel.setBackpackShared(backPackId);
+          OdeLog.log("Have a shared backpack backPackId = " + backPackId);
+        }
+
         // Setup noop timer (if enabled)
         int noop = config.getNoop();
         if (noop > 0) {
@@ -876,20 +888,6 @@ public class Ode implements EntryPoint {
     // Newer sessions invalidate older sessions.
 
     userInfoService.getSystemConfig(sessionId, callback);
-
-    // We fetch the user's backpack here. This runs asynchronously with the rest
-    // of the system initialization.
-
-    userInfoService.getUserBackpack(new AsyncCallback<String>() {
-        @Override
-        public void onSuccess(String backpack) {
-          BlocklyPanel.setInitialBackpack(backpack);
-        }
-        @Override
-        public void onFailure(Throwable caught) {
-          OdeLog.log("Fetching backpack failed");
-        }
-      });
 
     History.addValueChangeHandler(new ValueChangeHandler<String>() {
       @Override
@@ -2418,6 +2416,21 @@ public class Ode implements EntryPoint {
       designToolbar.setTutorialToggleVisible(true);
       setTutorialVisible(true);
     }
+  }
+
+  // Load the user's backpack. This is not called if we are using
+  // a shared backpack
+  private void loadBackpack() {
+    userInfoService.getUserBackpack(new AsyncCallback<String>() {
+        @Override
+        public void onSuccess(String backpack) {
+          BlocklyPanel.setInitialBackpack(backpack);
+        }
+        @Override
+        public void onFailure(Throwable caught) {
+          OdeLog.log("Fetching backpack failed");
+        }
+      });
   }
 
   // Native code to set the top level rendezvousServer variable

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -745,7 +745,7 @@ public class Ode implements EntryPoint {
           loadBackpack();
           OdeLog.log("backpack: No shared backpack");
         } else {
-          BlocklyPanel.setBackpackShared(backPackId);
+          BlocklyPanel.setSharedBackpackId(backPackId);
           OdeLog.log("Have a shared backpack backPackId = " + backPackId);
         }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -895,7 +895,7 @@ public class BlocklyPanel extends HTMLPanel {
     Blockly.Backpack.contents = JSON.parse(backpack);
   }-*/;
 
-  public static native void setBackpackShared(String backPackId)/*-{
+  public static native void setSharedBackpackId(String backPackId)/*-{
     Blockly.Backpack.backPackId = backPackId;
   }-*/;
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -504,6 +504,49 @@ public class BlocklyPanel extends HTMLPanel {
     Ode.getUserSettings().saveSettings(null);
   }
 
+  /**
+   * Fetch a shared backpack from the server, call the callback with the
+   * backpack content.
+   *
+   * @param backPackId the backpack id
+   * @param callback callback to call with the backpack contents
+   */
+
+  public static void getSharedBackpack(String backPackId, final JavaScriptObject callback) {
+    Ode.getInstance().getUserInfoService().getSharedBackpack(backPackId,
+      new AsyncCallback<String>() {
+        @Override
+        public void onSuccess(String content) {
+          doCallBack(callback, content);
+        }
+        @Override
+        public void onFailure(Throwable caught) {
+          OdeLog.log("getSharedBackpack failed.");
+        }
+      });
+  }
+
+  /**
+   * Store shared backpack to the server.
+   *
+   * @param backPackId the backpack id
+   * @param content the contents to store (XML String)
+   */
+
+  public static void storeSharedBackpack(String backPackId, String content) {
+    Ode.getInstance().getUserInfoService().storeSharedBackpack(backPackId, content,
+      new AsyncCallback<Void>() {
+        @Override
+        public void onSuccess(Void v) {
+          // Nothing to do
+        }
+        @Override
+        public void onFailure(Throwable caught) {
+          OdeLog.log("storeSharedBackpack failed.");
+        }
+      });
+  }
+
   // ------------ Native methods ------------
 
   /**
@@ -511,9 +554,11 @@ public class BlocklyPanel extends HTMLPanel {
    * and call it.
    *
    * @param callback the Javascript callback.
+   * @param arg argument to the callback
    */
-  private static native void doCallBack(JavaScriptObject callback, String buttonName) /*-{
-    callback.call(null, buttonName);
+
+  private static native void doCallBack(JavaScriptObject callback, String arg) /*-{
+    callback.call(null, arg);
   }-*/;
 
   private static native void exportMethodsToJavascript() /*-{
@@ -554,6 +599,11 @@ public class BlocklyPanel extends HTMLPanel {
       $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getSnapEnabled());
     $wnd.BlocklyPanel_saveUserSettings =
       $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::saveUserSettings());
+    $wnd.BlocklyPanel_getSharedBackpack =
+      $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getSharedBackpack(Ljava/lang/String;Lcom/google/gwt/core/client/JavaScriptObject;));
+    $wnd.BlocklyPanel_storeSharedBackpack =
+      $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::storeSharedBackpack(Ljava/lang/String;Ljava/lang/String;));
+
   }-*/;
 
   private native void initWorkspace(String projectId, boolean readOnly, boolean rtl)/*-{
@@ -842,7 +892,11 @@ public class BlocklyPanel extends HTMLPanel {
    * @param backpack JSON-serialized backpack contents.
    */
   public static native void setInitialBackpack(String backpack)/*-{
-    Blockly.Backpack.shared_contents = JSON.parse(backpack);
+    Blockly.Backpack.contents = JSON.parse(backpack);
+  }-*/;
+
+  public static native void setBackpackShared(String backPackId)/*-{
+    Blockly.Backpack.backPackId = backPackId;
   }-*/;
 
   /**
@@ -853,7 +907,7 @@ public class BlocklyPanel extends HTMLPanel {
   }-*/;
 
   /**
-   * Store the backpack's contents to the App Inventor service.
+   * Store the backpack's contents to the App Inventor server.
    *
    * @param backpack JSON-serialized backpack contents.
    */

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -203,8 +203,8 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
    */
 
   @Override
-  public String getSharedBackpack(String BackPackId) {
-    return storageIo.downloadBackpack(BackPackId);
+  public String getSharedBackpack(String backPackId) {
+    return storageIo.downloadBackpack(backPackId);
   }
 
   /**
@@ -218,8 +218,8 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
    */
 
   @Override
-  public void storeSharedBackpack(String BackPackId, String content) {
-    storageIo.uploadBackpack(BackPackId, content);
+  public void storeSharedBackpack(String backPackId, String content) {
+    storageIo.uploadBackpack(backPackId, content);
   }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -194,4 +194,32 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
   @Override
   public void noop() {
   }
+
+  /**
+   * fetch the contents of a shared backpack.
+   *
+   * @param BackPackId the uuid of the backpack
+   * @return the backpack's content as an XML string
+   */
+
+  @Override
+  public String getSharedBackpack(String BackPackId) {
+    return storageIo.downloadBackpack(BackPackId);
+  }
+
+  /**
+   * store a shared backpack.
+   *
+   * Note: We overwrite any existing backpack. If merging of contents
+   * is desired, our caller has to take care of it.
+   *
+   * @param BackPackId the uuid of the shared backpack
+   * @param the new contents of the backpack
+   */
+
+  @Override
+  public void storeSharedBackpack(String BackPackId, String content) {
+    storageIo.uploadBackpack(BackPackId, content);
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/cookieauth/CookieAuth.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/cookieauth/CookieAuth.java
@@ -73,6 +73,32 @@ public final class CookieAuth {
      * </pre>
      */
     long getOneProjectId();
+
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    boolean hasBackpackid();
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    java.lang.String getBackpackid();
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getBackpackidBytes();
   }
   /**
    * Protobuf type {@code cookieauth.cookie}
@@ -150,6 +176,12 @@ public final class CookieAuth {
             case 48: {
               bitField0_ |= 0x00000010;
               oneProjectId_ = input.readUInt64();
+              break;
+            }
+            case 74: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000020;
+              backpackid_ = bs;
               break;
             }
           }
@@ -306,12 +338,67 @@ public final class CookieAuth {
       return oneProjectId_;
     }
 
+    public static final int BACKPACKID_FIELD_NUMBER = 9;
+    private java.lang.Object backpackid_;
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    public boolean hasBackpackid() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    public java.lang.String getBackpackid() {
+      java.lang.Object ref = backpackid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          backpackid_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string backpackid = 9;</code>
+     *
+     * <pre>
+     * backpackid for shared backpack
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getBackpackidBytes() {
+      java.lang.Object ref = backpackid_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        backpackid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private void initFields() {
       uuid_ = "";
       ts_ = 0L;
       isAdmin_ = false;
       isReadOnly_ = false;
       oneProjectId_ = 0L;
+      backpackid_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -349,6 +436,9 @@ public final class CookieAuth {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeUInt64(6, oneProjectId_);
       }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeBytes(9, getBackpackidBytes());
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -377,6 +467,10 @@ public final class CookieAuth {
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(6, oneProjectId_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(9, getBackpackidBytes());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -505,6 +599,8 @@ public final class CookieAuth {
         bitField0_ = (bitField0_ & ~0x00000008);
         oneProjectId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000010);
+        backpackid_ = "";
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -553,6 +649,10 @@ public final class CookieAuth {
           to_bitField0_ |= 0x00000010;
         }
         result.oneProjectId_ = oneProjectId_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.backpackid_ = backpackid_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -585,6 +685,11 @@ public final class CookieAuth {
         }
         if (other.hasOneProjectId()) {
           setOneProjectId(other.getOneProjectId());
+        }
+        if (other.hasBackpackid()) {
+          bitField0_ |= 0x00000020;
+          backpackid_ = other.backpackid_;
+          onChanged();
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -849,6 +954,106 @@ public final class CookieAuth {
         return this;
       }
 
+      private java.lang.Object backpackid_ = "";
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public boolean hasBackpackid() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public java.lang.String getBackpackid() {
+        java.lang.Object ref = backpackid_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            backpackid_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getBackpackidBytes() {
+        java.lang.Object ref = backpackid_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          backpackid_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public Builder setBackpackid(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        backpackid_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public Builder clearBackpackid() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        backpackid_ = getDefaultInstance().getBackpackid();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string backpackid = 9;</code>
+       *
+       * <pre>
+       * backpackid for shared backpack
+       * </pre>
+       */
+      public Builder setBackpackidBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        backpackid_ = value;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:cookieauth.cookie)
     }
 
@@ -874,11 +1079,11 @@ public final class CookieAuth {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\014cookie.proto\022\ncookieauth\"]\n\006cookie\022\014\n\004" +
+      "\n\014cookie.proto\022\ncookieauth\"q\n\006cookie\022\014\n\004" +
       "uuid\030\001 \002(\t\022\n\n\002ts\030\002 \002(\004\022\017\n\007isAdmin\030\003 \001(\010\022" +
       "\022\n\nisReadOnly\030\004 \001(\010\022\024\n\014oneProjectId\030\006 \001(" +
-      "\004B6\n(com.google.appinventor.server.cooki" +
-      "eauthB\nCookieAuth"
+      "\004\022\022\n\nbackpackid\030\t \001(\tB6\n(com.google.appi" +
+      "nventor.server.cookieauthB\nCookieAuth"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -897,7 +1102,7 @@ public final class CookieAuth {
     internal_static_cookieauth_cookie_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_cookieauth_cookie_descriptor,
-        new java.lang.String[] { "Uuid", "Ts", "IsAdmin", "IsReadOnly", "OneProjectId", });
+        new java.lang.String[] { "Uuid", "Ts", "IsAdmin", "IsReadOnly", "OneProjectId", "Backpackid", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/appinventor/appengine/src/com/google/appinventor/server/cookieauth/cookie.proto
+++ b/appinventor/appengine/src/com/google/appinventor/server/cookieauth/cookie.proto
@@ -12,5 +12,6 @@ message cookie {
 // do not recycle the id number too soon
 //  optional string locale = 5;
   optional uint64 oneProjectId = 6;
+  optional string backpackid = 9;         // backpackid for shared backpack
 }
 

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -25,6 +25,7 @@ import com.google.appinventor.server.CrashReport;
 import com.google.appinventor.server.FileExporter;
 import com.google.appinventor.server.Server;
 import com.google.appinventor.server.flags.Flag;
+import com.google.appinventor.server.storage.StoredData.Backpack;
 import com.google.appinventor.server.storage.StoredData.CorruptionRecord;
 import com.google.appinventor.server.storage.StoredData.FeedbackData;
 import com.google.appinventor.server.storage.StoredData.FileData;
@@ -193,6 +194,7 @@ public class ObjectifyStorageIo implements  StorageIo {
     ObjectifyService.register(CorruptionRecord.class);
     ObjectifyService.register(PWData.class);
     ObjectifyService.register(SplashData.class);
+    ObjectifyService.register(Backpack.class);
 
     // Learn GCS Bucket from App Configuration or App Engine Default
     String gcsBucket = Flag.createFlag("gcs.bucket", "").get();
@@ -2466,6 +2468,10 @@ public class ObjectifyStorageIo implements  StorageIo {
     return new Key<StoredData.PWData>(PWData.class, uid);
   }
 
+  private Key<StoredData.Backpack> backpackdataKey(String backPackId) {
+    return new Key<StoredData.Backpack>(Backpack.class, backPackId);
+  }
+
   // Create a name for a blob from a project id and file name. This is mostly
   // to help with debugging and viewing the blobstore via the admin console.
   // We don't currently use these blob names anywhere else.
@@ -2878,6 +2884,51 @@ public class ObjectifyStorageIo implements  StorageIo {
     }
   }
 
+  /* Store a shared backpack.
+   *
+   * We only store backpacks in the datastore (cached in
+   * memcache by Objectify). So backpacks are limited in
+   * size to what can be stored in a data store entity.
+   */
+
+  @Override
+  public String downloadBackpack(final String backPackId) {
+    final Result<Backpack> result = new Result<Backpack>();
+    try {
+      runJobWithRetries(new JobRetryHelper() {
+          @Override
+          public void run(Objectify datastore) {
+            Backpack backPack = datastore.find(backpackdataKey(backPackId));
+            if (backPack != null) {
+              result.t = backPack;
+            }
+          }
+        }, false);
+    } catch (ObjectifyException e) {
+      CrashReport.createAndLogError(LOG, null, null, e);
+    }
+    if (result.t != null) {
+      return result.t.content;
+    } else {
+      return "[]";              // No shared backpack, return an empty backpack
+    }
+  }
+
+  @Override
+  public void uploadBackpack(String backPackId, String content) {
+    final Backpack backPack = new Backpack();
+    backPack.id = backPackId;
+    backPack.content = content;
+    try {
+      runJobWithRetries(new JobRetryHelper() {
+          @Override
+          public void run(Objectify datastore) {
+            datastore.put(backPack);
+          }
+        }, true);
+    } catch (ObjectifyException e) {
+      throw CrashReport.createAndLogError(LOG, null, null, e);
+    }
+  }
+
 }
-
-

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -656,4 +656,32 @@ public interface StorageIo {
   List<AdminUser> searchUsers(String partialEmail);
   void storeUser(AdminUser user) throws AdminInterfaceException;
 
+  /**
+   * There are two kinds of backpacks. User backpacks, which are
+   * stored with the user's personal files (which today is just the
+   * backpack and the android keystore used for signing applications.
+   * The second kind of backpack is a shared backpack. It is
+   * identified by a uuid.  This code is associated with the shared
+   * backpack. Shared backpacks are used when a person is logged in
+   * via the SSO mechanism. It can optionally specify a backpack to
+   * use. If it doesn't specify a backpack, then the normal user
+   * specific version is used.
+   *
+   * @param backPackId uuid used to idenfity this backpack
+   * @return the contents of the backpack as an XML encoded string
+   */
+
+  public String downloadBackpack(String backPackId);
+
+  /**
+   * Used to upload a shared backpack Note: This code will over-write
+   * whatever contents is already stored in the the backpack. It is
+   * the responsibility of our caller to merge contents if desired.
+   *
+   * @param backPackId The uuid of the shared backpack to store
+   * @param String content the new contents of the backpack
+   */
+
+  public void uploadBackpack(String backPackId, String content);
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StoredData.java
@@ -290,4 +290,16 @@ public class StoredData {
     public String email;            // Email of account in question
   }
 
+  // A Shared backpack. Shared backpacks are not associated with
+  // any one user. Instead they are stored independent of projects
+  // and users. At login time a shared backpack may be specified.
+  // This requires an SSO Login from an external system to provide
+  // it.
+  @Cached(expirationSeconds=120)
+  @Unindexed
+  public static final class Backpack {
+    @Id public String id;
+    public String content;
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/User.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/User.java
@@ -48,6 +48,8 @@ public class User implements IsSerializable, UserInfoProvider, Serializable {
 
   private String password;      // Hashed password (if using local login system)
 
+  private String backPackId = null; // If non-null we have a shared backpack
+
   public final static String usercachekey = "f682688a-1065-4cda-8515-a8bd70200ac9"; // UUID
   // This UUID is prepended to any key lookup for User objects. Memcache is a common
   // key/value store for the entire application. By prepending a unique value, we ensure
@@ -317,6 +319,15 @@ public class User implements IsSerializable, UserInfoProvider, Serializable {
     return isReadOnly;
   }
 
+
+  public String getBackpackId() {
+    return backPackId;
+  }
+
+  public void setBackpackId(String backPackId) {
+    this.backPackId = backPackId;
+  }
+
   public User copy() {
     User retval = new User(id, email, name, link, emailFrequency, tosAccepted, isAdmin, type, sessionId);
     // We set the isReadOnly flag in the copy in this fashion so we do not have to
@@ -324,6 +335,8 @@ public class User implements IsSerializable, UserInfoProvider, Serializable {
     // only a few places where we assert or read the isReadOnly flag, so we want to
     // limit the places where we have to have knowledge of it to just those places that care
     retval.setReadOnly(isReadOnly);
+    retval.setBackpackId(this.backPackId);
+    retval.name = this.name;
     return retval;
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
@@ -103,12 +103,12 @@ public interface UserInfoService extends RemoteService {
   /**
    * Retrieve the contents of a shared backpack.
    */
-  public String getSharedBackpack(String BackPackId);
+  public String getSharedBackpack(String backPackId);
 
   /**
    * Store the contents of a shared backpack.
    */
 
-  public void storeSharedBackpack(String BackPackId, String content);
+  public void storeSharedBackpack(String backPackId, String content);
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
@@ -100,4 +100,15 @@ public interface UserInfoService extends RemoteService {
    */
   void noop();
 
+  /**
+   * Retrieve the contents of a shared backpack.
+   */
+  public String getSharedBackpack(String BackPackId);
+
+  /**
+   * Store the contents of a shared backpack.
+   */
+
+  public void storeSharedBackpack(String BackPackId, String content);
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
@@ -84,11 +84,11 @@ public interface UserInfoServiceAsync {
   /**
    * @see UserInfoService#getSharedBackpack(String)
    */
-  void getSharedBackpack(String BackPackId, AsyncCallback<String> callback);
+  void getSharedBackpack(String backPackId, AsyncCallback<String> callback);
 
   /**
    * @see UserInfoService#storeSharedBackpack(String, String)
    */
-  void storeSharedBackpack(String BackPackId, String content, AsyncCallback<Void> callback);
+  void storeSharedBackpack(String backPackId, String content, AsyncCallback<Void> callback);
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
@@ -81,4 +81,14 @@ public interface UserInfoServiceAsync {
    */
   void noop(AsyncCallback<Void> callback);
 
+  /**
+   * @see UserInfoService#getSharedBackpack(String)
+   */
+  void getSharedBackpack(String BackPackId, AsyncCallback<String> callback);
+
+  /**
+   * @see UserInfoService#storeSharedBackpack(String, String)
+   */
+  void storeSharedBackpack(String BackPackId, String content, AsyncCallback<Void> callback);
+
 }

--- a/appinventor/blocklyeditor/src/backpack.js
+++ b/appinventor/blocklyeditor/src/backpack.js
@@ -56,10 +56,10 @@ Blockly.Backpack = function(targetWorkspace, opt_options) {
   }
   this.workspace_ = targetWorkspace;
   this.flyout_ = new Blockly.BackpackFlyout(this.options);
-  // _NoAsync: A flag for getContents(). If true, getContents will use the
+  // NoAsync_: A flag for getContents(). If true, getContents will use the
   // already fetched backpack contents even when using a shared backpack
   // this is used by addAllToBackpack()
-  this._NoAsync = false;
+  this.NoAsync_ = false;
 };
 
 /**
@@ -317,12 +317,15 @@ Blockly.Backpack.prototype.addAllToBackpack = function() {
   var topBlocks = Blockly.mainWorkspace.getTopBlocks(false);
   var p = this;
   this.getContents(function(contents) {
-    var saveAsync = p._NoAsync;
-    p._NoAsync = true;
-    for (var x = 0; x < topBlocks.length; x++) {
-      p.addToBackpack(topBlocks[x], false);
+    var saveAsync = p.NoAsync_;
+    try {
+      p.NoAsync_ = true;
+      for (var x = 0; x < topBlocks.length; x++) {
+        p.addToBackpack(topBlocks[x], false);
+      }
+    } finally {
+      p.NoAsync_ = saveAsync;
     }
-    p._NoAsync = saveAsync;
     p.setContents(Blockly.Backpack.contents, true);
   });
 };
@@ -584,7 +587,7 @@ Blockly.Backpack.prototype.getContents = function(callback) {
   // fetched the contents, then we do not have to do it again. This
   // happens in addAllToBackpack()
   var p = this;
-  if (Blockly.Backpack.backPackId && !this._NoAsync) {
+  if (Blockly.Backpack.backPackId && !this.NoAsync_) {
     top.BlocklyPanel_getSharedBackpack(Blockly.Backpack.backPackId, function(content) {
       if (!content) {
         Blockly.Backpack.contents = [];

--- a/appinventor/blocklyeditor/src/backpack.js
+++ b/appinventor/blocklyeditor/src/backpack.js
@@ -25,7 +25,7 @@
  *
  * This is called from BlocklyPanel.
  *
- *  Backpack contents are stored in Blockly.Backpack.shared_contents.
+ *  Backpack contents are stored in Blockly.Backpack.contents.
  *
  * @author fraser@google.com (Neil Fraser)
  * @author ram8647@gmail.com (Ralph Morelli)
@@ -162,11 +162,21 @@ Blockly.Backpack.prototype.left_ = 0;
 Blockly.Backpack.prototype.top_ = 0;
 
 /**
- * Shared backpack contents across projects/screens.
+ * Backpack contents across projects/screens.
  * @type {string[]}
  * @public
+ *
  */
-Blockly.Backpack.shared_contents = [];
+Blockly.Backpack.contents = [];
+
+/**
+ * backPackId -- false if using non-shared backpack
+ * set to the backPackId (from Ode.java) if shared backpack
+ * in use. Note: we support quasi-simultaneous use of a
+ * shared backpack.
+ */
+
+Blockly.Backpack.backPackId = false;
 
 /**
  * Create the backpack SVG elements.
@@ -208,13 +218,17 @@ Blockly.Backpack.prototype.init = function() {
   // load files for sound effect
   Blockly.getMainWorkspace().loadAudio_(['assets/backpack.mp3', 'assets/backpack.ogg', 'assets/backpack.wav'], 'backpack');
 
-  var bp_contents = this.getContents();
-  if (!bp_contents)
-    return;
-  if (bp_contents.length == 0)
-    this.shrink();
-  else
-    this.grow();
+  var p = this;
+  this.getContents(function(contents) {
+    if (!contents) {
+      return;
+    }
+    if (contents.length === 0) {
+      p.shrink();
+    } else {
+      p.grow();
+    }
+  });
 };
 
 /**
@@ -234,42 +248,44 @@ Blockly.Backpack.prototype.dispose = function() {
  *  Pastes the backpack contents to the current workspace.
  */
 Blockly.Backpack.prototype.pasteBackpack = function() {
-  var bp_contents = this.getContents();
-  if (!bp_contents || bp_contents.length == 0)
-    return;
-  var lastPastedBlock = null;
-
-  try {
-    Blockly.Events.setGroup(true);
-    for (var i = 0; i < bp_contents.length; i++) {
-      var xml = Blockly.Xml.textToDom(bp_contents[i]);
-      var blk = xml.childNodes[0];
-      var arr = [];
-      this.checkValidBlockTypes(blk, arr);
-      var ok = true;
-      for (var j = 0; j < arr.length; j++) {
-        var type = arr[j];
-        if (!Blockly.Blocks[type] && !this.workspace_.getComponentDatabase().hasType(type)) {
-          ok = false;
-          break;
-        }
-      }
-      if (ok) {
-        var newBlock = this.workspace_.paste(blk);
-        if (newBlock) {
-          lastPastedBlock = newBlock;
-        }
-      }
-      else
-        window.alert('Sorry. You cannot paste a block of type "' + type +
-          '" because it doesn\'t exist in this workspace.');
+  var p = this;
+  this.getContents(function(bp_contents) {
+    if (bp_contents === undefined || bp_contents.length == 0) {
+      return;
     }
-  } finally {
-    Blockly.Events.setGroup(false);
-  }
-  if (lastPastedBlock) {
-    lastPastedBlock.select();
-  }
+    var lastPastedBlock = null;
+    try {
+      Blockly.Events.setGroup(true);
+      for (var i = 0; i < bp_contents.length; i++) {
+        var xml = Blockly.Xml.textToDom(bp_contents[i]);
+        var blk = xml.childNodes[0];
+        var arr = [];
+        p.checkValidBlockTypes(blk, arr);
+        var ok = true;
+        for (var j = 0; j < arr.length; j++) {
+          var type = arr[j];
+          if (!Blockly.Blocks[type] && !this.workspace_.getComponentDatabase().hasType(type)) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) {
+          var newBlock = p.workspace_.paste(blk);
+          if (newBlock) {
+            lastPastedBlock = newBlock;
+          }
+        }
+        else
+          window.alert('Sorry. You cannot paste a block of type "' + type +
+          '" because it doesn\'t exist in this workspace.');
+      }
+    } finally {
+      Blockly.Events.setGroup(false);
+    }
+    if (lastPastedBlock) {
+      lastPastedBlock.select();
+    }
+  });
 };
 
 /**
@@ -296,12 +312,13 @@ Blockly.Backpack.prototype.checkValidBlockTypes = function(block, arr) {
 Blockly.Backpack.prototype.addAllToBackpack = function() {
   var allBlocks = Blockly.mainWorkspace.getAllBlocks();
   var topBlocks = Blockly.mainWorkspace.getTopBlocks(false);
-  for (var x = 0; x < topBlocks.length; x++) {
-    this.addToBackpack(topBlocks[x], false);
-  }
-  // We have to read back the backpack (getContents) and store it again
-  // this time stating that it should be pushed up to the server
-  this.setContents(this.getContents(), true); // A little klunky but gets the job done
+  var p = this;
+  this.getContents(function(contents) {
+    for (var x = 0; x < topBlocks.length; x++) {
+      this.addToBackpack(topBlocks[x], false);
+    }
+    p.setContents(Blockly.Backpack.contents, true);
+  });
 };
 
 /**
@@ -309,10 +326,6 @@ Blockly.Backpack.prototype.addAllToBackpack = function() {
  *   blocks
  */
 Blockly.Backpack.prototype.addToBackpack = function(block, store) {
-  if (this.getContents() == undefined) {
-    this.setContents([], false);
-  }
-
   // Copy is made of the expanded block.
   var isCollapsed = block.collapsed_;
   block.setCollapsed(false);
@@ -325,21 +338,27 @@ Blockly.Backpack.prototype.addToBackpack = function(block, store) {
   block.setCollapsed(isCollapsed);
 
   // Add the block to the backpack
-  var bp_contents = this.getContents();
-  bp_contents.push("<xml>" + Blockly.Xml.domToText(xmlBlock) + "</xml>");
-  // We technically do not need to set the contents here since the contents are manipulated by
-  // reference, but separating the setting from modifying allows us to use different, non-in-memory
-  // storage in the future.
-  this.setContents(bp_contents, store);
-  this.grow();
-  Blockly.getMainWorkspace().playAudio('backpack');
+  var p = this;
+  this.getContents(function(bp_contents) {
+    if (!bp_contents) {
+      bp_contents = [];
+    }
+    bp_contents.push("<xml>" + Blockly.Xml.domToText(xmlBlock) + "</xml>");
+    // We technically do not need to set the contents here since the contents are manipulated by
+    // reference, but separating the setting from modifying allows us to use different, non-in-memory
+    // storage in the future.
+    p.setContents(bp_contents, store);
+    p.grow();
+    Blockly.getMainWorkspace().playAudio('backpack');
 
-  // update the flyout when it's visible
-  if (this.flyout_.isVisible()) {
-    this.isAdded = true;
-    this.openBackpack();
-    this.isAdded = false;
-  }
+    // update the flyout when it's visible
+    if (p.flyout_.isVisible()) {
+      p.isAdded = true;
+      p.openBackpack();
+      p.isAdded = false;
+    }
+  });
+
 };
 
 Blockly.Backpack.prototype.hide = function() {
@@ -397,15 +416,15 @@ Blockly.Backpack.prototype.openBackpack = function() {
   if (!this.isAdded && this.flyout_.isVisible()) {
     this.flyout_.hide();
   } else {
-    var backpack = this.getContents();
-    //get backpack contents from java
-
-    var len = backpack.length;
-    var newBackpack = [];
-    for (var i = 0; i < len; i++) {
-      newBackpack[i] = Blockly.Xml.textToDom(backpack[i]).firstChild;
-    }
-    this.flyout_.show(newBackpack);
+    var p = this;
+    this.getContents(function(backpack) {
+      var len = backpack.length;
+      var newBackpack = [];
+      for (var i = 0; i < len; i++) {
+        newBackpack[i] = Blockly.Xml.textToDom(backpack[i]).firstChild;
+      }
+      p.flyout_.show(newBackpack);
+    });
   }
 };
 
@@ -541,25 +560,54 @@ Blockly.Backpack.prototype.confirmClear = function() {
  * Returns count of the number of entries in the backpack.
  */
 Blockly.Backpack.prototype.count = function() {
-  var bp_contents = this.getContents();
+  var bp_contents = Blockly.Backpack.contents;
   return bp_contents ? bp_contents.length : 0;
 };
 
 /**
- * Get the contents of the shared Backpack.
+ * Get the contents of the Backpack.
  * @returns {string[]} Backpack contents encoded as an array of XML strings.
  */
-Blockly.Backpack.prototype.getContents = function() {
-  return Blockly.Backpack.shared_contents;
+Blockly.Backpack.prototype.getContents = function(callback) {
+  // Otherwise fetch the backpack from the server and call the
+  // the callback with it.
+  var p = this;
+  if (Blockly.Backpack.backPackId) {
+    top.BlocklyPanel_getSharedBackpack(Blockly.Backpack.backPackId, function(content) {
+      if (!content) {
+        Blockly.Backpack.contents = [];
+        p.shrink();
+        callback([]);
+      } else {
+        var parsed = JSON.parse(content);
+        Blockly.Backpack.contents = parsed;
+        if (parsed.length > 0) {
+          p.grow();
+        } else {
+          p.shrink();
+        }
+        callback(parsed);
+      }
+    });
+  } else {
+    callback(Blockly.Backpack.contents);
+  }
 };
 
 /**
- * Set the contents of the shared Backpack.
+ * Set the contents of the Backpack.
  * @param {string[]} backpack Array of XML strings to set as the new Backpack contents.
  * @param {boolean=false} store If true, store the backpack as a user file.
  */
 Blockly.Backpack.prototype.setContents = function(backpack, store) {
-  Blockly.Backpack.shared_contents = backpack;
-  if (store) window.parent.BlocklyPanel_storeBackpack(JSON.stringify(backpack));
+  Blockly.Backpack.contents = backpack;
+  if (store) {
+    if (Blockly.Backpack.backPackId) {
+      top.BlocklyPanel_storeSharedBackpack(Blockly.Backpack.backPackId,
+                                           JSON.stringify(backpack));
+    } else {
+      top.BlocklyPanel_storeBackpack(JSON.stringify(backpack));
+    }
+  }
 };
 


### PR DESCRIPTION
A shared backpack is enabled at SSO login time[1] by providing a
backPackId parameter in the SSO Token. Once enabled backpack contents
are not stored with the user account but instead in a specific location
defined by the backPackId. Multiple users can use the same shared
backpack at the same time. Each time the shared backpack is opened a
fresh copy is loaded from the server.

There is still a race condition if two users attempt to store blocks at
the same time. One will win and the other’s changes will not be added to
the backpack. This may be corrected or mitigated in a future release.

[1] Note: SSO Login is not currently implemented in the App Engine
version of MIT App Inventor. This commit updates the Backpack code to be
in alignment with the code we use in our Hong Kong deployment which is
not run in App Engine. We plan to implement SSO login in the App Engine
version in the near future.

Change-Id: I5957a42999ff14d7263a47993efaf8f3492c016g