### PR TITLE
added functionality to make custom blocks that run javascript functions in webviewer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2895,6 +2895,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String IsLoopingProperties();
 
+  @DefaultMessage("JSONBlocks")
+  @Description("")
+  String JSONBlocksProperties();
+
   @DefaultMessage("KeyFile")
   @Description("")
   String KeyFileProperties();
@@ -4188,6 +4192,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String urlParams();
 
+  @DefaultMessage("inputs")
+  @Description("")
+  String inputsParams();
+
   @DefaultMessage("responseCode")
   @Description("")
   String responseCodeParams();
@@ -4821,6 +4829,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("ReceiveUnsignedBytes")
   @Description("")
   String ReceiveUnsignedBytesMethods();
+
+  @DefaultMessage("RunJavaScript")
+  @Description("")
+  String RunJavaScriptMethods();
 
   @DefaultMessage("Send1ByteNumber")
   @Description("")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -407,6 +407,10 @@ public class BlocklyPanel extends HTMLPanel {
     return YaBlocksEditor.getComponentInstanceTypeName(formName, instanceName);
   }
 
+  public static String getComponentInstancePropertyValue(String formName, String instanceName, String propertyName) {
+    return YaBlocksEditor.getComponentInstancePropertyValue(formName, instanceName, propertyName);
+  }
+
   public static int getYaVersion() {
     return YaVersion.YOUNG_ANDROID_VERSION;
   }
@@ -536,6 +540,8 @@ public class BlocklyPanel extends HTMLPanel {
         $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::SetDialogContent(Lcom/google/gwt/user/client/ui/DialogBox;Ljava/lang/String;));
     $wnd.BlocklyPanel_getComponentInstanceTypeName =
         $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getComponentInstanceTypeName(Ljava/lang/String;Ljava/lang/String;));
+    $wnd.BlocklyPanel_getComponentInstancePropertyValue =
+        $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getComponentInstancePropertyValue(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;));
     $wnd.BlocklyPanel_getComponentInfo =
         $entry(@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::getComponentInfo(Ljava/lang/String;));
     $wnd.BlocklyPanel_getComponentsJSONString =

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -378,6 +378,14 @@ public final class YaBlocksEditor extends FileEditor
       return blocksEditor.myFormEditor.getComponentInstanceTypeName(instanceName);
   }
 
+  public static String getComponentInstancePropertyValue(String formName, String instanceName, String propertyName){
+    //use form name to get blocks editor
+    YaBlocksEditor blocksEditor = formToBlocksEditor.get(formName);
+    Map<String, MockComponent> componentMap = blocksEditor.myFormEditor.getComponents();
+    MockComponent mockComponent = componentMap.get(instanceName);
+    return mockComponent.getPropertyValue(propertyName);
+  }
+
   public void addComponent(String typeName, String instanceName, String uuid) {
     if (componentUuids.add(uuid)) {
       blocksArea.addComponent(uuid, instanceName, typeName);

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -1066,6 +1066,63 @@ Blockly.ComponentBlock.createClockAddDropDown = function(/*block*/){
   return componentDropDown;
 };
 
+/*
+  1.two versions!!!
+  2. start with "move cube"
+  3. build cube --> create with XML --> mutation(domtomMutation, mutationtoDom)
+
+  xml = Blockly.Xml.blockToDom_(Blockly.selected)
+  text = Blockly.Xml.domToText(xml);
+  text = '<xml><block xmlns="http://www.w3.org/1999/xhtml" type="text_join"
+    id="16" inline="false"><mutation items="4"></mutation></block></xml>'
+  new_xml = Blockly.Xml.textToDom(text)
+  Blockly.Xml.domToBlock( Blockly.mainWorkspace,new_xml.children[0])
+
+
+ */
+//JSON.parse --> from string to object
+//JSON.stringify --> from object to string
+
+//for escape characters
+//encoded = encodeURIComponent(text)
+//decodeURIComponent(encoded)
+
+// with socket for  number
+Blockly.Blocks['customizable_block'] = {
+
+    init:function(){
+        this.setColour(160);
+        this.setTooltip('customizable block with JSON format data');
+    },
+
+
+    mutationToDom: function(){
+        var container = document.createElement('mutation');
+        container.setAttribute('block_info', this.block_info);
+        container.setAttribute('webviewer_name', this.webviewer_name);
+        return container;
+    },
+
+    //this function gets called first!
+    domToMutation: function(xmlElement) {
+
+        this.block_info = xmlElement.getAttribute('block_info');
+        this.webviewer_name = xmlElement.getAttribute('webviewer_name');
+        var decoded_block_info = decodeURIComponent(this.block_info);
+        var info_object = JSON.parse(decoded_block_info);
+        this.jsonInit(info_object);
+
+
+    },
+
+    rename: function(oldname, newname){
+        if (this.webviewer_name == oldname){
+            this.webviewer_name = newname;
+        }
+    }
+}
+
+
 Blockly.ComponentBlock.HELPURLS = {
   "Button": Blockly.Msg.LANG_COMPONENT_BLOCK_BUTTON_HELPURL,
   "Canvas": Blockly.Msg.LANG_COMPONENT_BLOCK_CANVAS_HELPURL,

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -174,6 +174,37 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
   var xmlArray = [];
   var typeName = instanceRecord.typeName;
   var componentInfo = this.workspace_.getComponentDatabase().getType(typeName);
+  var instanceName = instanceRecord.name;
+
+  if(typeName == "WebViewer"){
+      var formName = Blockly.mainWorkspace.formName;
+
+      var jsonDataString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName , instanceName , "JSONBlocks");
+      var jsonDataArray = [];
+
+      // If jsonDataString is not the right format, JSON.parse(jsonDataString) will make an error.
+      // In this case ensure only WebViewer blocks come out safely without any error by using try...catch.
+      try {
+          jsonDataArray = JSON.parse(jsonDataString);
+      }
+      catch(err){
+      }
+
+
+      // Below code in the for loop will only execute when JSON.parse(jsonDataString) have returned an array safely.
+      for(var i=0; i<jsonDataArray.length; i++){
+          var jsonData = JSON.stringify(jsonDataArray[i]);
+          var encodedURI = encodeURIComponent(jsonData); //what about ''?
+
+          var xmlString = '<xml><block xmlns="http://www.w3.org/1999/xhtml" type="customizable_block" '
+              + '><mutation block_info=' + '\"'+encodedURI +'\"'
+              + ' webviewer_name=' + '\"'+instanceName+'\"'
+              + '></mutation></block></xml>';
+
+          var xmlFromString = Blockly.Xml.textToDom(xmlString).children[0];
+          xmlArray.push(xmlFromString);
+      }
+  }
 
   //create event blocks
   goog.object.forEach(componentInfo.eventDictionary, function(event, name) {

--- a/appinventor/blocklyeditor/src/generators/yail/componentblock.js
+++ b/appinventor/blocklyeditor/src/generators/yail/componentblock.js
@@ -321,3 +321,74 @@ Blockly.Yail.component_component_block = function() {
   return [Blockly.Yail.YAIL_GET_COMPONENT + this.getFieldValue("COMPONENT_SELECTOR") + Blockly.Yail.YAIL_CLOSE_COMBINATION,
           Blockly.Yail.ORDER_ATOMIC];
 };
+
+getStringOfParameter = function(parameter, thisBlock){ //should put in parameter_array[i], this
+    // "parameters":[{"name":"ID", "type": "input_value"},{"name":"DIRECTION", "type": "field_dropdown"}
+    if(parameter["type"] == "INPUT"){
+        return Blockly.Yail.valueToCode(thisBlock, parameter["name"], Blockly.Yail.ORDER_NONE )
+
+    }else if(parameter["type"] == "FIELD"){
+
+        return thisBlock.getFieldValue(parameter["name"]);
+
+    }else{
+
+    }
+};
+
+Blockly.Yail['customizable_block'] = function(){
+
+    //get information of block in JSON format
+    var decoded_block_info = decodeURIComponent(this.block_info);
+    var webviewer_name = this.webviewer_name;
+    console.log("webviewer" + webviewer_name);
+    var info_JSON_format = JSON.parse(decoded_block_info);
+
+    //get the function name
+    var function_name = info_JSON_format["methodName"];
+
+    //get the parameters, assuming that the user has put an array which contains labels of parameters in order, inside the JSON format
+    var parameter_array = info_JSON_format["parameters"];
+
+    //have to join the parameters into one text blob. Use App Inventor's yail code for text join block
+    var string_of_parameters = '(call-yail-primitive string-append (*list-for-runtime*  ';
+
+    //string_of_parameters += ' \"\\\"\" ' // to make "\""
+
+
+    for(var i=0; i<parameter_array.length; i++){
+        if(i!=0){
+            string_of_parameters += " \",\" " //for ","
+        }
+
+        //call-yail-primitive string-append (*list-for-runtime* "\""     "'"       "hi"          "'"       ","  "\"" ) '(text text text text text ) "join")
+        string_of_parameters +=  ' \"\'\" '
+        //string_of_parameters += ' \" '+ getStringOfParameter(parameter_array[i], this) + ' \" '
+        string_of_parameters +=  getStringOfParameter(parameter_array[i], this)
+        string_of_parameters += ' \"\'\" ';
+
+    }
+
+    //end
+    //string_of_parameters += ' \"\\\"\" '; // to make "\""
+    string_of_parameters += ' ) \'('
+
+    for(var i=0; i<(3 * parameter_array.length + (parameter_array.length - 1)); i++){
+
+        string_of_parameters += 'text ';
+    }
+
+    string_of_parameters += ') "join") ';
+
+    var code = Blockly.Yail.YAIL_CALL_COMPONENT_METHOD + Blockly.Yail.YAIL_SPACER + '\''+ webviewer_name +' \'RunJavaScript' + Blockly.Yail.YAIL_SPACER ;
+    code += Blockly.Yail.YAIL_OPEN_BLOCK + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER ;
+    code += '\"' + function_name + '\"' + Blockly.Yail.YAIL_SPACER;
+
+    code += string_of_parameters + Blockly.Yail.YAIL_SPACER;
+    code += Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+    code += '\'' +Blockly.Yail.YAIL_OPEN_COMBINATION+'text'+ Blockly.Yail.YAIL_SPACER +'text';
+    code += Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+    return code;
+
+
+};

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -628,6 +628,8 @@ public final class Compiler {
         }
       }
 
+      minSdk = 22;
+
       // make permissions unique by putting them in one set
       Set<String> permissions = Sets.newHashSet();
       for (Set<String> compPermissions : permissionsNeeded.values()) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -89,6 +89,12 @@ public final class WebViewer extends AndroidViewComponent {
   // allows passing strings to javascript
   WebViewInterface wvInterface;
 
+  //path to javascript library uploaded by user
+  private String jsLibraryPath = "";
+
+  //JSON string for creating new blocks
+  private String userBlockInformation = "";
+
   /**
    * Creates a new WebViewer component.
    *
@@ -133,6 +139,7 @@ public final class WebViewer extends AndroidViewComponent {
     HomeUrl("");
     Width(LENGTH_FILL_PARENT);
     Height(LENGTH_FILL_PARENT);
+    JSONBlocks("");
   }
 
   /**
@@ -205,6 +212,19 @@ public final class WebViewer extends AndroidViewComponent {
   public String HomeUrl() {
     return homeUrl;
   }
+
+  /**
+   * User specifies the type of block they want to make
+   *
+   * @param userBlockInformation information of JSON format of the block user wants to make
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
+          defaultValue = "")
+  @SimpleProperty()
+  public void JSONBlocks(String userBlockInformation){
+    this.userBlockInformation = userBlockInformation;
+  }
+
 
   /**
    * Specifies the URL of the page the WebVewier should load
@@ -420,6 +440,15 @@ public final class WebViewer extends AndroidViewComponent {
       EclairUtil.clearWebViewGeoLoc();
   }
 
+  /*
+*  Takes a JS function name and calls that function in the webViewer.
+*/
+  @SimpleFunction(description = "Run JavaScript method.")
+  public void RunJavaScript(String functionName, String inputs) {
+
+    webview.loadUrl("javascript:window.AppInventor.runMethod(" + functionName + "(" + inputs + "))");
+  }
+
   private void resetWebViewClient() {
     if (SdkLevel.getLevel() >= SdkLevel.LEVEL_FROYO) {
       webview.setWebViewClient(FroyoUtil.getWebViewClient(ignoreSslErrors, followLinks, container.$form(), this));
@@ -447,11 +476,13 @@ public final class WebViewer extends AndroidViewComponent {
   public class WebViewInterface {
     Context mContext;
     String webViewString;
+    String returnString;
 
     /** Instantiate the interface and set the context */
     WebViewInterface(Context c) {
       mContext = c;
       webViewString = " ";
+      returnString = " ";
     }
 
     /**
@@ -470,6 +501,15 @@ public final class WebViewer extends AndroidViewComponent {
     public void setWebViewString(String newString) {
       webViewString = newString;
     }
+
+    /**
+     * Set returnString to value returned by JavaScript method.
+     */
+    @JavascriptInterface
+    public void runMethod(String value) {
+      returnString = value;
+    }
+
 
   }
 }


### PR DESCRIPTION
Changes: Changed component.js in blocks in blocklyeditor to include customizeable blocks, which is like a “ditto” block that will parse JSON information to make a customizeable block

Changed componentblock in yail in generators which will generate yail for the customizable block
In WebViewer, we added a property to take in JSONBlock string (as generated from the blockly developer tools) and a RunJavaScript method

Added the corresponding method, property, and param names in OdeMessages

Added the block to be in the WebView drawer in drawer.js

In BlocklyPanel, enabled the blocks to get the right property in webviewer
