### PR TITLE
Update whitelist.py and /remote_api

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/Whitelist.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/Whitelist.java
@@ -94,8 +94,6 @@ public class Whitelist {
       LOG.severe("No whitelist found.");
     } catch (SecurityException e) {
       LOG.severe("Whitelist found, but wrong permission.");
-    } catch (IOException e) {
-      LOG.log(Level.SEVERE, "Unexpected whitelist error", e);
     }
   }
 

--- a/appinventor/appengine/war/WEB-INF/web.xml
+++ b/appinventor/appengine/war/WEB-INF/web.xml
@@ -56,6 +56,7 @@
       <url-pattern>/forum/*</url-pattern>
       <url-pattern>/b/*</url-pattern>
       <url-pattern>/rendezvous/*</url-pattern>
+      <url-pattern>/remote_api/*</url-pattern>
     </web-resource-collection>
   </security-constraint>
 
@@ -64,7 +65,6 @@
     <web-resource-collection>
       <url-pattern>/appstats/*</url-pattern>
       <url-pattern>/convert/</url-pattern>
-      <url-pattern>/remote_api/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
       <role-name>admin</role-name>

--- a/appinventor/misc/whitelist/whitelist.py
+++ b/appinventor/misc/whitelist/whitelist.py
@@ -18,6 +18,8 @@ def auth_func():
   return (raw_input('Email: '), getpass.getpass('Password: '))
 
 def main():
+    if sys.modules.has_key('google'):
+      del sys.modules['google'] # This interferes with imports later
     getlibdir()
     from google.appengine.ext import db
     from google.appengine.ext.remote_api import remote_api_stub
@@ -57,10 +59,13 @@ def main():
     else:
         secure = True
 
-    remote_api_stub.ConfigureRemoteApi(None, '/remote_api', auth_func,
-                                       servername=host,
-                                       save_cookies=True, secure=secure,
-                                       rpc_server_factory=appengine_rpc.HttpRpcServer)
+    if secure:
+      remote_api_stub.ConfigureRemoteApiForOAuth(host, '/remote_api',
+                                                 secure=secure)
+    else:
+      remote_api_stub.ConfigureRemoteApi(None, '/remote_api', auth_func,
+                                         servername=host,
+                                         save_cookies=True, secure=secure)
     remote_api_stub.MaybeInvokeAuthentication()
 
     input_people = open(whitelistname).readlines()


### PR DESCRIPTION
Update whitelist.py so it works with the latest App Engine SDK. Also
update permissions on /remote_api to be compatible with the latest App
Engine SDK. Note: The change appears to remove the requirement for admin
rights to use the /remote_api facility. However this admin requirement
is now enforced by the Google supplied code which runs behind
/remote_api. Performing the additional check in web.xml just causes an
error about too many authentication attempts.

Also remove excess catch statement in Whitelist.java that has been
giving us compilation warnings for a very long time. Note:
Whitelist.java is no longer in use, but can be enabled via a simple edit
to OdeAuthFilter.java, so we are not removing it yet.

Change-Id: I30cbb0eba3fba3f20d8443a94dae837c827f0b20