### PR TITLE
Remove a vestigial property from CloudDB

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCloudDB.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCloudDB.java
@@ -28,7 +28,6 @@ public class MockCloudDB extends MockNonVisibleComponent {
 
   public static final String TYPE = "CloudDB";
   private static final String PROPERTY_NAME_PROJECT_ID = "ProjectID";
-  private static final String PROPERTY_NAME_ACCOUNT_NAME = "AccountName";
   private static final String PROPERTY_NAME_TOKEN = "Token";
   private static final String PROPERTY_NAME_REDIS_SERVER = "RedisServer";
   private static final String PROPERTY_NAME_DEFAULT_REDISSERVER = "DefaultRedisServer";
@@ -48,14 +47,13 @@ public class MockCloudDB extends MockNonVisibleComponent {
   }
 
   /**
-   * Initializes the "ProjectID", "AccountName" properties dynamically.
+   * Initializes the "ProjectID" property dynamically.
    *
    * @param widget the iconImage for the MockCloudDB
    */
   @Override
   public final void initComponent(Widget widget) {
     super.initComponent(widget);
-    String accName = Ode.getInstance().getUser().getUserEmail() + "";
     DesignToolbar.DesignProject currentProject = Ode.getInstance().getDesignToolbar().getCurrentProject();
     String projectID = "";
     if (currentProject != null) {
@@ -63,7 +61,6 @@ public class MockCloudDB extends MockNonVisibleComponent {
     }
 
     changeProperty(PROPERTY_NAME_PROJECT_ID, projectID);
-    changeProperty(PROPERTY_NAME_ACCOUNT_NAME, accName);
     String defaultRedisServer = Ode.getInstance().getSystemConfig().getDefaultCloudDBserver();
     changeProperty(PROPERTY_NAME_DEFAULT_REDISSERVER, defaultRedisServer);
     getTokenFromServer();       // Get Token from the server
@@ -71,8 +68,7 @@ public class MockCloudDB extends MockNonVisibleComponent {
 
   @Override
   public boolean isPropertyforYail(String propertyName) {
-    if (propertyName.equals(PROPERTY_NAME_ACCOUNT_NAME) ||
-      (propertyName.equals(PROPERTY_NAME_PROJECT_ID)) ||
+    if ((propertyName.equals(PROPERTY_NAME_PROJECT_ID)) ||
       (propertyName.equals(PROPERTY_NAME_DEFAULT_REDISSERVER)) ||
       (propertyName.equals(PROPERTY_NAME_TOKEN))) {
       return true;


### PR DESCRIPTION
We no longer use the “AccountName” property and it has been removed from
CloudDB.java. However a reference remained in MockCloudDB which causes a
problem when a project with a CloudDB component is upgraded due to an
increment in YOUNG_ANDROID_VERSION.

Change-Id: I8a6234993df32ff087fbcbd79edf447c3e39c9c5