### PR TITLE
Fix for #1195 NxtColorSensor default value property

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -215,7 +215,7 @@ public class PropertiesUtil {
       return new YoungAndroidLegoNxtSensorPortChoicePropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_LEGO_NXT_GENERATED_COLOR)) {
       return new YoungAndroidColorChoicePropertyEditor(
-          YoungAndroidColorChoicePropertyEditor.NXT_GENERATED_COLORS);
+          YoungAndroidColorChoicePropertyEditor.NXT_GENERATED_COLORS, defaultValue);
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_LONGITUDE)) {
       return new YoungAndroidFloatRangePropertyEditor(-180, 180);
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MAP_TYPE)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidColorChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidColorChoicePropertyEditor.java
@@ -39,7 +39,7 @@ public final class YoungAndroidColorChoicePropertyEditor extends ColorChoiceProp
     new Color(MESSAGES.noneColor(), Color.ALPHA_TRANSPARENT, "FFFFFF"),
     new Color(MESSAGES.redColor(), Color.ALPHA_OPAQUE, "FF0000"),
     new Color(MESSAGES.greenColor(), Color.ALPHA_OPAQUE, "00FF00"),
-    new Color(MESSAGES.blueColor(), Color.ALPHA_OPAQUE, "0000FF"),
+    new Color(MESSAGES.blueColor(), Color.ALPHA_OPAQUE, "0000FF")
   };
 
   /**
@@ -52,7 +52,7 @@ public final class YoungAndroidColorChoicePropertyEditor extends ColorChoiceProp
   /**
    * Creates a new property editor for a specific array of color RGB values.
    */
-  public YoungAndroidColorChoicePropertyEditor(Color[] colors) {
-    super(colors, "&H");
+  public YoungAndroidColorChoicePropertyEditor(Color[] colors, String defaultValue) {
+    super(colors, "&H", defaultValue);
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ColorChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ColorChoicePropertyEditor.java
@@ -142,8 +142,8 @@ public abstract class ColorChoicePropertyEditor extends PropertyEditor {
    * @param colors  colors to be shown in property editor - must not be
    *                {@code null} or empty
    */
-  public ColorChoicePropertyEditor(final Color[] colors, final String hexPrefix) {
-    this(colors, hexPrefix, "", false);
+  public ColorChoicePropertyEditor(final Color[] colors, final String hexPrefix, final String defaultValue) {
+    this(colors, hexPrefix, defaultValue, false);
   }
 
   /**


### PR DESCRIPTION
Not passing a default value, it tries to do `Long.valueOf` of an empty string at https://github.com/mit-cml/appinventor-sources/blob/master/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ColorChoicePropertyEditor.java#L167.

This is actually happening in production, as reported by @barreeeiroo in #1195
Please review @jisqyv @ewpatton 