### PR TITLE
Sidebar tutorial images now scale to fit the window.

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/TutorialPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/TutorialPanel.java
@@ -8,6 +8,7 @@ package com.google.appinventor.client.editor.youngandroid;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.event.dom.client.LoadHandler;
 
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.DialogBox;
@@ -74,9 +75,27 @@ public class TutorialPanel extends Frame {
     ok.setStyleName("DialogBox-button");
 
     // Adds Image
-    Image image = new Image(img);
+    final Image image = new Image(img);
     image.addLoadHandler(new LoadHandler() {
         public void onLoad(LoadEvent evt) {
+          final int imageWidth = image.getWidth();
+          final int imageHeight = image.getHeight();
+          final int windowWidth = (int) ((float) Window.getClientWidth() * 0.8);
+          final int windowHeight = (int) ((float) Window.getClientHeight() * 0.9);
+          int effectiveWidth = imageWidth;
+          int effectiveHeight = imageHeight;
+
+          if (imageWidth > windowWidth) {
+            effectiveWidth = windowWidth;
+            effectiveHeight = (int)(imageHeight * ((float)effectiveWidth / imageWidth));
+          }
+
+          if (effectiveHeight > windowHeight) {
+            effectiveHeight = windowHeight;
+            effectiveWidth = (int)(imageWidth * ((float)effectiveHeight / imageHeight));
+          }
+
+          image.setPixelSize(effectiveWidth, effectiveHeight);
           dialogBox.center();
         }
       });


### PR DESCRIPTION
This was a huge issue at Malden High School, and was reproducible on any low-pixel-density monitor. 

The images came up at the images' size, not the screen size, so they often were too huge and couldn't be seen. 

The fix queries the client's size (the visible window) and scales the image to fit nicely inside it. 

It's not necessarily pixel-perfect scaling, as it relies on integer division, but is close enough for the tutorials. It also does the math when creating the onLoadHandler, so 