### PR TITLE
Load all jars in launch-buildserver script with wildcard

### DIFF
--- a/appinventor/misc/buildserver/launch-buildserver
+++ b/appinventor/misc/buildserver/launch-buildserver
@@ -42,6 +42,7 @@ cd `dirname $0`/lib;
 # Revised 10/24 to add updated jackson and guava libs
 # Revised 10/25 to add commons-io-2.0.1.jar
 # Revised 07/03 to add bcprov-jdk15on-149.jar and bcpkix-jdk15on-149.jar:sdklib.jar to support Android SDK 4.2.2
+# Revised 2018/04/20 to switch to wildcard inclusion of jars in classpath
 
-exec nohup java -Xmx1828m -cp activation-1.1.jar:jersey-bundle-1.3.jar:args4j-2.0.18.jar:jersey-multipart-1.3.jar:asm-3.1.jar:jettison-1.1.jar:BuildServer.jar:json.jar:CommonUtils.jar:jsr311-api-1.1.1.jar:CommonVersion.jar:localizer.jar:FastInfoset-1.2.2.jar:mail-1.4.jar:grizzly-servlet-webserver-1.9.18-i.jar:commons-io-2.0.1.jar:guava-14.0.1.jar:rome-0.9.jar:http-20070405.jar:bcprov-jdk15on-149.jar:bcpkix-jdk15on-149.jar:sdklib.jar:jackson-core-asl-1.9.4.jar:stax-api-1.0-2.jar:jaxb-api-2.1.jar:wadl2java.jar:jaxb-impl-2.1.10.jar:wadl-cmdline.jar:jaxb-xjc.jar:wadl-core.jar:jdom-1.0.jar -Dfile.encoding=UTF-8 com.google.appinventor.buildserver.BuildServer --dexCacheDir /tmp/dxcache $LAUNCH_BUILDSERVER_OPT &> $LAUNCH_BUILDSERVER_LOG_PATH &
+exec nohup java -Xmx1828m -cp "*" -Dfile.encoding=UTF-8 com.google.appinventor.buildserver.BuildServer --dexCacheDir /tmp/dxcache $LAUNCH_BUILDSERVER_OPT &> $LAUNCH_BUILDSERVER_LOG_PATH &
 fi


### PR DESCRIPTION
fixes #1217 

Requested by @halatmit 
fix suggested by @ewpatton 