### PR TITLE
Update How Build Server progress is reported.

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/ReceiveBuildServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ReceiveBuildServlet.java
@@ -74,11 +74,16 @@ public class ReceiveBuildServlet extends OdeServlet {
           LOG.info("Saving android.keystore for user: " + userId);
           storageIo.addFilesToUser(userId, StorageUtil.ANDROID_KEYSTORE_FILENAME);
           storageIo.uploadRawUserFile(userId, fileName, fileBytes);
+        } else if (fileName.equals("build.status")) {
+          int progress = Integer.parseInt((new String(fileBytes)).trim());
+          LOG.info("Received a build.status file contents = " + progress);
+          storageIo.storeBuildStatus(userId, projectId, progress);
         } else {
           String filePath = buildFileDirPath + "/" + fileName;
           LOG.info("Saving build output files: " + filePath);
           storageIo.addOutputFilesToProject(userId, projectId, filePath);
           storageIo.uploadRawFileForce(projectId, filePath, userId, fileBytes);
+          storageIo.storeBuildStatus(userId, projectId, 0); // Reset for the next build
         }
       }
     } finally {

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -857,42 +857,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
    * @param target  build target (optional, implementation dependent)
    */
   public void updateCurrentProgress(User user, long projectId, String target) {
-    try {
-      String userId = user.getUserId();
-      String projectName = storageIo.getProjectName(userId, projectId);
-      String outputFileDir = BUILD_FOLDER + '/' + target;
-      URL buildServerUrl = null;
-      ProjectSourceZip zipFile = null;
-
-      buildServerUrl = new URL(getBuildServerUrlStr(user.getUserEmail(),
-        userId, projectId, outputFileDir));
-      HttpURLConnection connection = (HttpURLConnection) buildServerUrl.openConnection();
-      connection.setDoOutput(true);
-      connection.setRequestMethod("POST");
-
-      int responseCode = connection.getResponseCode();
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-          try {
-            String content = readContent(connection.getInputStream());
-            if (content != null && !content.isEmpty()) {
-              if (DEBUG) {
-                LOG.info("The current progress is " + content + "%.");
-              }
-              currentProgress = Integer.parseInt(content);
-            }
-          } catch (IOException e) {
-            // No content. That's ok.
-          }
-         }
-      } catch (MalformedURLException e) {
-        // that's ok, nothing to do
-      } catch (IOException e) {
-        // that's ok, nothing to do
-      } catch (EncryptionException e) {
-        // that's ok, nothing to do
-      } catch (RuntimeException e) {
-        // that's ok, nothing to do
-      }
+    currentProgress = storageIo.getBuildStatus(user.getUserId(), projectId);
   }
 
   // Nicely format floating number using only two decimal places

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -2922,4 +2922,23 @@ public class ObjectifyStorageIo implements  StorageIo {
     }
   }
 
+
+  @Override
+  public void storeBuildStatus(String userId, long projectId, int progress) {
+    String prelim = "40bae275-070f-478b-9a5f-d50361809b99";
+    String cacheKey = prelim + userId + projectId;
+    memcache.put(cacheKey, progress);
+  }
+
+  @Override
+  public int getBuildStatus(String userId, long projectId) {
+    String prelim = "40bae275-070f-478b-9a5f-d50361809b99";
+    String cacheKey = prelim + userId + projectId;
+    Integer ival = (Integer) memcache.get(cacheKey);
+    if (ival == null) {         // not in memcache (or memcache service down)
+      return 50;
+    } else {
+      return ival.intValue();
+    }
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -684,4 +684,26 @@ public interface StorageIo {
 
   public void uploadBackpack(String backPackId, String content);
 
+  /**
+   * Store the status of a pending build. We used to poll the buildserver
+   * for the progress of a build. However that was never correct as while
+   * polling you would likely wind up talking to a different buildserver
+   * then you originally started with! So now the buildserver does a callback
+   * to the server indicating progress. Here is where we store that
+   * progress. The reason we do this in this module is because we have
+   * different versions of storageio for our three (so far) backends, the
+   * App Engine based version, the stand alone version and the "scale-able"
+   * version. Each version will likely want to store this information in
+   * a different fashion.
+   *
+   * Note: The App Engine version uses memcache and if memcache isn't
+   * available (yes, it can be down!) then we cheat and just return
+   * 50 (for 50%).
+   *
+   */
+
+  public void storeBuildStatus(String userId, long projectId, int progress);
+
+  public int getBuildStatus(String userId, long projectId);
+
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -22,11 +22,14 @@ import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.OperatingSystemMXBean;
@@ -65,6 +68,59 @@ import javax.ws.rs.core.Response;
 @Path("/buildserver")
 public class BuildServer {
   private ProjectBuilder projectBuilder = new ProjectBuilder();
+
+  static class ProgressReporter {
+    // We create a ProgressReporter instance which is handed off to the
+    // project builder and compiler. It is called to report the progress
+    // of the build. The reporting is done by calling the callback URL
+    // and putting the status inside a "build.status" file. This isn't
+    // particularly efficient, but this is the version 0.9 implementation
+    String callbackUrlStr;
+    ProgressReporter(String callbackUrlStr) {
+      this.callbackUrlStr = callbackUrlStr;
+    }
+
+    public void report(int progress) {
+      try {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ZipOutputStream zipoutput = new ZipOutputStream(output);
+        zipoutput.putNextEntry(new ZipEntry("build.status"));
+        PrintWriter pout = new PrintWriter(zipoutput);
+        pout.println(progress);
+        pout.flush();
+        zipoutput.flush();
+        zipoutput.close();
+        ByteArrayInputStream zipinput = new ByteArrayInputStream(output.toByteArray());
+        URL callbackUrl = new URL(callbackUrlStr);
+        HttpURLConnection connection = (HttpURLConnection) callbackUrl.openConnection();
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        // Make sure we aren't misinterpreted as
+        // form-url-encoded
+        connection.addRequestProperty("Content-Type","application/zip; charset=utf-8");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(connection.getOutputStream());
+        try {
+          BufferedInputStream bufferedInputStream = new BufferedInputStream(zipinput);
+          try {
+            ByteStreams.copy(bufferedInputStream,bufferedOutputStream);
+            bufferedOutputStream.flush();
+          } finally {
+            bufferedInputStream.close();
+          }
+        } finally {
+          bufferedOutputStream.close();
+        }
+        if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+          LOG.severe("Bad Response Code! (sending status): "+ connection.getResponseCode());
+        }
+      } catch (IOException e) {
+        LOG.severe("IOException during progress report!");
+      }
+    }
+  }
+
 
   static class CommandLineOptions {
     @Option(name = "--shutdownToken",
@@ -311,7 +367,7 @@ public class BuildServer {
         .entity("Entry point unavailable unless debugging.").build();
 
     try {
-      build(userName, zipFile);
+      build(userName, zipFile, null);
       String attachedFilename = outputApk.getName();
       FileInputStream outputApkDeleteOnClose = new DeleteFileOnCloseFileInputStream(outputApk);
       // Set the outputApk field to null so that it won't be deleted in cleanUp().
@@ -354,7 +410,7 @@ public class BuildServer {
         .entity("Entry point unavailable unless debugging.").build();
 
     try {
-      buildAndCreateZip(userName, inputZipFile);
+      buildAndCreateZip(userName, inputZipFile, null);
       String attachedFilename = outputZip.getName();
       FileInputStream outputZipDeleteOnClose = new DeleteFileOnCloseFileInputStream(outputZip);
       // Set the outputZip field to null so that it won't be deleted in cleanUp().
@@ -462,7 +518,7 @@ public class BuildServer {
             try {
               LOG.info("START NEW BUILD " + count);
               checkMemory();
-              buildAndCreateZip(userName, inputZipFile);
+              buildAndCreateZip(userName, inputZipFile, new ProgressReporter(callbackUrlStr));
               // Send zip back to the callbackUrl
               LOG.info("CallbackURL: " + callbackUrlStr);
               URL callbackUrl = new URL(callbackUrlStr);
@@ -517,13 +573,16 @@ public class BuildServer {
         return Response.status(Response.Status.SERVICE_UNAVAILABLE).type(MediaType.TEXT_PLAIN_TYPE).entity("The build server is currently at maximum capacity.").build();
       }
     }
+    // Note: The code below should no longer be invoked. Progress reports
+    // are now handled via a callback mechanism. The "50" here is just a plug
+    // number.
     return Response.ok().type(MediaType.TEXT_PLAIN_TYPE)
-      .entity("" + projectBuilder.getProgress()).build();
+      .entity("" + 50).build();
   }
 
-  private void buildAndCreateZip(String userName, File inputZipFile)
+  private void buildAndCreateZip(String userName, File inputZipFile, ProgressReporter reporter)
     throws IOException, JSONException {
-    Result buildResult = build(userName, inputZipFile);
+    Result buildResult = build(userName, inputZipFile, reporter);
     boolean buildSucceeded = buildResult.succeeded();
     outputZip = File.createTempFile(inputZipFile.getName(), ".zip");
     outputZip.deleteOnExit();  // In case build server is killed before cleanUp executes.
@@ -561,7 +620,7 @@ public class BuildServer {
     return buildOutputJsonObj.toString();
   }
 
-  private Result build(String userName, File zipFile) throws IOException {
+  private Result build(String userName, File zipFile, ProgressReporter reporter) throws IOException {
     outputDir = Files.createTempDir();
     // We call outputDir.deleteOnExit() here, in case build server is killed before cleanUp
     // executes. However, it is likely that the directory won't be empty and therefore, won't
@@ -569,7 +628,7 @@ public class BuildServer {
     // is happening, so we should be careful about that.
     outputDir.deleteOnExit();
     Result buildResult = projectBuilder.build(userName, new ZipFile(zipFile), outputDir, false,
-      commandLineOptions.childProcessRamMb, commandLineOptions.dexCacheDir);
+                              commandLineOptions.childProcessRamMb, commandLineOptions.dexCacheDir, reporter);
     String buildOutput = buildResult.getOutput();
     LOG.info("Build output: " + buildOutput);
     String buildError = buildResult.getError();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
@@ -84,7 +84,7 @@ public final class Main {
                                          commandLineOptions.outputDir,
                                          commandLineOptions.isForCompanion,
                                          commandLineOptions.childProcessRamMb,
-                                         commandLineOptions.dexCacheDir);
+                                         commandLineOptions.dexCacheDir, null);
     System.exit(result.getResult());
   }
 

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/CompilerTest.java
@@ -22,14 +22,14 @@ public class CompilerTest extends TestCase {
   public void testGeneratePermissions() throws Exception {
     Set<String> noComponents = Sets.newHashSet();
     Compiler compiler = new Compiler(null, noComponents, System.out, System.err, System.err, false,
-                                     2048, null);
+                                     2048, null, null);
 
     compiler.generatePermissions();
     Map<String,Set<String>> permissions = compiler.getPermissions();
     assertEquals(0, permissions.size());
 
     Set<String> componentTypes = Sets.newHashSet("com.google.appinventor.components.runtime.LocationSensor");
-    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generatePermissions();
     permissions = compiler.getPermissions();
     Set<String> flatPermissions = Sets.newHashSet();
@@ -53,7 +53,7 @@ public class CompilerTest extends TestCase {
     String label = "com.google.appinventor.components.runtime.Label";
     
     Set<String> componentTypes = Sets.newHashSet(texting);
-    Compiler compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    Compiler compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generateBroadcastReceivers();
     Map<String, Set<String>> componentReceivers = compiler.getBroadcastReceivers();
     Set<String> receivers = componentReceivers.get(texting);
@@ -64,7 +64,7 @@ public class CompilerTest extends TestCase {
     assertTrue(receiverElementString.contains("com.google.android.apps.googlevoice.SMS_RECEIVED"));
 
     componentTypes = Sets.newHashSet(texting, label);
-    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generateBroadcastReceivers();
     componentReceivers = compiler.getBroadcastReceivers();
     receivers = componentReceivers.get(texting);
@@ -78,7 +78,7 @@ public class CompilerTest extends TestCase {
     String twitter = "com.google.appinventor.components.runtime.Twitter";
     
     Set<String> componentTypes = Sets.newHashSet(barcodeScanner);
-    Compiler compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    Compiler compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generateActivities();
     Map<String, Set<String>> componentActivities = compiler.getActivities();
     Set<String> activities = componentActivities.get(barcodeScanner);
@@ -92,7 +92,7 @@ public class CompilerTest extends TestCase {
     assertTrue(activityElementString.contains("windowSoftInputMode=\"stateAlwaysHidden\""));
   
     componentTypes = Sets.newHashSet(listPicker);
-    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generateActivities();
     componentActivities = compiler.getActivities();
     activities = componentActivities.get(listPicker);
@@ -103,7 +103,7 @@ public class CompilerTest extends TestCase {
     assertTrue(activityElementString.contains("screenOrientation=\"behind\""));
   
     componentTypes = Sets.newHashSet(twitter);
-    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null);
+    compiler = new Compiler(null, componentTypes, System.out, System.err, System.err, false, 2048, null, null);
     compiler.generateActivities();
     componentActivities = compiler.getActivities();
     activities = componentActivities.get(twitter);


### PR DESCRIPTION
Buildserver progress, as reported in the progress bar during a build,
used to work by having the client poll the App Inventor server, which
would in turn poll the buildserver to learn the progress of the build.

However this code would only work properly if there was only one
buildserver and only one build in progress. In reality we handle dozens
of builds simultaneously via a number of independent buildservers. So
the progress being returned to the user was the progress of *some* build
in the system, most likely not theirs!

The constant polling by the App Inventor server also causes problems
with the load balancer in front of the buildservers. This is because
most “jobs” are not real build jobs, but just polls for progress. This
may result in a non-optimal distribution of jobs between the various
buildservers.

This code changes things so that the buildserver does a callback to the
App Inventor server when appropriate milestones are reached in the
build job. The client still polls to App Inventor server for progress,
but the App Inventor server no longer polls the buildserver. This should
result in a better distribution of build jobs on the buildservers and
also returns to the end user the correct status of their build.

We also removed some obsolete code that attempts to generate the Yail
within the Buildserver. We *always* generate the yail in the client now
and it is sent to the buildserver.

Change-Id: Ibaa9a7e3ff6576335d5ab6261a4121f27a1daf1d