### PR TITLE
Enforce that block definitions exist for designer properties

### DIFF
--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -405,8 +405,12 @@ Blockly.Yail.getPropertySetterString = function(componentName, componentType, pr
   var code = Blockly.Yail.YAIL_SET_AND_COERCE_PROPERTY + Blockly.Yail.YAIL_QUOTE + 
     componentName + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + propertyName + 
     Blockly.Yail.YAIL_SPACER;
-  var propType = Blockly.Yail.YAIL_QUOTE +
-    componentDb.getPropertyForType(componentType, propertyName).type;
+  var propDef = componentDb.getPropertyForType(componentType, propertyName);
+  // If a designer property does not have a corresponding block property, then propDef will be
+  // undefined. In this case, we assume "any" as the type. A corresponding fix is included in
+  // ComponentProcessor to enforce that newer components/extensions always have both a designer
+  // and block definition.
+  var propType = Blockly.Yail.YAIL_QUOTE + (propDef ? propDef.type : "any");
   var value = Blockly.Yail.getPropertyValueString(propertyValue, propType);
   code = code.concat(value + Blockly.Yail.YAIL_SPACER + propType + Blockly.Yail.YAIL_CLOSE_BLOCK);
   return code;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/GameClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/GameClient.java
@@ -316,6 +316,7 @@ public class GameClient extends AndroidNonvisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
       defaultValue = "http://appinvgameserver.appspot.com")
+  @SimpleProperty(userVisible = false)
   public void ServiceURL(String url){
     if (url.endsWith("/")) {
       this.serviceUrl = url.substring(0, url.length() - 1);


### PR DESCRIPTION
If a designer property is included in a component without a
corresponding block entry, then the YAIL code generator will throw an
exception attempting to look up the type of the property when
generating set-and-coerce-property! code for the designer. This change
enforces that every `@DesignerProperty` have a corresponding
`@SimpleProperty` to ensure that components and extensions include the
necessary information.

Resolves #1229 

Change-Id: I85cf53b1b657254658fd0cb0f05af3dde6b32740