### PR TITLE
Close blocks drawer when deleting component

### DIFF
--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -46,6 +46,7 @@ Blockly.Drawer = function(parentWorkspace, opt_options) {
     svg.insertBefore(flyoutGroup, this.workspace_.svgGroup_.nextSibling);
   }
   this.flyout_.init(parentWorkspace);
+  this.lastComponent = null;
 };
 
 /**
@@ -120,6 +121,7 @@ Blockly.Drawer.prototype.showComponent = function(instanceName) {
   if (component) {
     this.flyout_.hide();
     this.flyout_.show(this.instanceRecordToXMLArray(component));
+    this.lastComponent = instanceName;
   } else {
     console.log("Got call to Blockly.Drawer.showComponent(" +  instanceName +
                 ") - unknown component name");
@@ -149,6 +151,7 @@ Blockly.Drawer.prototype.showGeneric = function(typeName) {
  * Hide the Drawer flyout
  */
 Blockly.Drawer.prototype.hide = function() {
+  this.lastComponent = null;
   this.flyout_.hide();
 };
 

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -332,6 +332,12 @@ Blockly.WorkspaceSvg.prototype.addComponent = function(uid, instanceName, typeNa
  */
 Blockly.WorkspaceSvg.prototype.removeComponent = function(uid) {
   var component = this.componentDb_.getInstance(uid);
+
+  // Fixes #1175
+  if (component.name === this.drawer_.lastComponent) {
+    this.drawer_.hide();
+  }
+
   if (!this.componentDb_.removeInstance(uid)) {
     return this;
   }


### PR DESCRIPTION
If one deleted a component while on the blocks screen, the drawer
remained open. This commit tracks the last component opened and, if
the deleted component name matches the last component opened, it will
close the drawer. We track the last component referenced so that we
don't hide the drawer in the event a component is deleted when another
drawer, for example the built-in math blocks, is open.

Resolves #1175 

Change-Id: I4808a069b38986e44892e721b2d35132bfdae943