### PR TITLE
Fix null dereference when deleting component before opening blocks

### DIFF
--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -334,7 +334,7 @@ Blockly.WorkspaceSvg.prototype.removeComponent = function(uid) {
   var component = this.componentDb_.getInstance(uid);
 
   // Fixes #1175
-  if (component.name === this.drawer_.lastComponent) {
+  if (this.drawer_ && component.name === this.drawer_.lastComponent) {
     this.drawer_.hide();
   }
 


### PR DESCRIPTION
Checks whether the workspace drawer is initialized before attempting to deference the last component shown. Otherwise, deleting a component prior to opening the blocks error would result in an uncaught exception [as reported here](https://github.com/mit-cml/appinventor-sources/pull/1249#issuecomment-397404373).

Change-Id: Id93060e5d4a9c9b8ae153a7c2ac57dac92ad99f6