### PR TITLE
Force draw compass on enable

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -62,6 +62,7 @@ import org.osmdroid.views.overlay.OverlayWithIWVisitor;
 import org.osmdroid.views.overlay.Polygon;
 import org.osmdroid.views.overlay.Polyline;
 import org.osmdroid.views.overlay.compass.CompassOverlay;
+import org.osmdroid.views.overlay.compass.InternalCompassOrientationProvider;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 import org.osmdroid.views.overlay.infowindow.OverlayInfoWindow;
 import org.osmdroid.views.overlay.mylocation.IMyLocationConsumer;
@@ -107,6 +108,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
   private OverlayInfoWindow defaultInfoWindow = null;
   private boolean ready = false;
   private ZoomControlView zoomControls = null;
+  private float lastAzimuth = Float.NaN;
 
   private static class AppInventorLocationSensorAdapter implements IMyLocationProvider,
       LocationSensor.LocationSensorListener {
@@ -383,8 +385,14 @@ class NativeOpenStreetMapController implements MapController, MapListener {
     }
     if (compass != null) {
       if (enabled) {
-        compass.enableCompass();
+        if (compass.getOrientationProvider() != null) {
+          compass.enableCompass();
+        } else {
+          compass.enableCompass(new InternalCompassOrientationProvider(view.getContext()));
+        }
+        compass.onOrientationChanged(lastAzimuth, null);
       } else {
+        lastAzimuth = compass.getOrientation();
         compass.disableCompass();
       }
     }
@@ -392,7 +400,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   @Override
   public boolean isCompassEnabled() {
-    return compass != null && compass.isEnabled();
+    return compass != null && compass.isCompassEnabled();
   }
 
   @Override

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/MapTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/MapTest.java
@@ -5,6 +5,8 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.content.Context;
+import android.hardware.Sensor;
 import com.google.appinventor.components.runtime.shadows.ShadowAsynchUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.GeometryUtil;
@@ -13,7 +15,9 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.osmdroid.util.GeoPoint;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowSensorManager;
 import org.robolectric.shadows.ShadowView;
 
 import java.io.IOException;
@@ -121,6 +125,12 @@ public class MapTest extends MapTestBase {
 
   @Test
   public void testShowCompass() {
+    /* We need to create a sensor for the orientation type, otherwise compass will fail to enable */
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+    ShadowSensorManager sensorManager = Shadow.extract(context.getSystemService(Context.SENSOR_SERVICE));
+    Sensor s = Shadow.newInstanceOf(Sensor.class);
+    sensorManager.addSensor(Sensor.TYPE_ORIENTATION, s);
+    /* end setup */
     map.ShowCompass(true);
     assertTrue(map.ShowCompass());
   }


### PR DESCRIPTION
So there were two problems resulting in #1277.

1. When `disableCompass` is called it clears out the old orientation listener. When `enableCompass` is called, it will try to start the now nulled listener, resulting in the observed NPE.
2. There is a delay in drawing the compass until a new orientation is reported by the hardware, i.e. until a new sample is received the compass won't draw.

We now save the old value and call `onOrientationChange` immediately after enabling with the old value. This may result in a little "lag" before a new sample is available from the hardware, but it makes the compass appear immediately when `ShowCompass` is set to true. I also needed to update the tests because I changed from using `isEnabled` to `isCompassEnabled`, which is a function of the orientation sensor.

Fixes #1277 

Change-Id: I86ad3e3f63315d7b78765f59d1b5763b4f63104c