### PR TITLE
Fix interaction between EnableZoom and ShowZoom

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -336,6 +336,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
   public void setZoomEnabled(boolean enable) {
     this.zoomEnabled = enable;
     view.setMultiTouchControls(enable);
+    zoomControls.setEnabled(enable);
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/view/ZoomControlView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/view/ZoomControlView.java
@@ -24,6 +24,7 @@ public class ZoomControlView extends LinearLayout {
   private final Button zoomOut;
 
   private float density;
+  private boolean enabled = true;
 
   public ZoomControlView(MapView parent) {
     super(parent.getContext());
@@ -75,8 +76,23 @@ public class ZoomControlView extends LinearLayout {
    */
   @SuppressWarnings("WeakerAccess")
   public final void updateButtons() {
-    zoomIn.setEnabled(parent.canZoomIn());
-    zoomOut.setEnabled(parent.canZoomOut());
+    zoomIn.setEnabled(enabled && parent.canZoomIn());
+    zoomOut.setEnabled(enabled && parent.canZoomOut());
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+    if (enabled) {
+      zoomIn.setEnabled(parent.canZoomIn());
+      zoomOut.setEnabled(parent.canZoomOut());
+    } else {
+      zoomIn.setEnabled(false);
+      zoomOut.setEnabled(false);
+    }
+  }
+
+  public boolean isEnabled() {
+    return enabled;
   }
 
   private void initButton(Button button, String text) {


### PR DESCRIPTION
The new zoom controls do not respect the EnableZoom property of
Map. One can continue to zoom the map using the zoom controls even if
EnableZoom is true. This change ties the zoom control enable state to
the EnableZoom property.

Change-Id: I7a205be5e649cc2599cc83c5b173b93f8dc85644