### PR TITLE
Fix order of call-Initialize-of-components in REPL

### DIFF
--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -131,11 +131,6 @@ Blockly.Yail.getFormYail = function(formJson, packageName, forRepl, workspace) {
   }
     
   var componentMap = workspace.buildComponentMap([], [], false, false);
-  
-  for (var comp in componentMap.components)
-    if (componentMap.components.hasOwnProperty(comp))
-      componentNames.push(comp);
-
   var globalBlocks = componentMap.globals;
   for (var i = 0, block; block = globalBlocks[i]; i++) {
     code.push(Blockly.Yail.blockToCode(block));

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -125,8 +125,6 @@ Blockly.ReplMgr.buildYail = function(workspace) {
     }
     var componentMap = Blockly.mainWorkspace.buildComponentMap([], [], false, false);
     var componentNames = [];
-    for (var comp in componentMap.components)
-        componentNames.push(comp);
     if (formProperties) {
         if (formName != 'Screen1')
             code.push(Blockly.Yail.getComponentRenameString("Screen1", formName));


### PR DESCRIPTION
Due to an optimization that reused the component references in blocks
to determine the names of components, components with event handlers
would have their init-thunks called before components without
events. This would result in different initialization paths between
the REPL and compiled apps. This change makes the ordering of
init-thunks consistent by always using the order created by walking
the Form's JSON description.

Fixes #1279

Change-Id: I5ea1070df17a1dd96923cff2f0adfd6889a987b2