### PR TITLE
Added experimental components link

### DIFF
--- a/appinventor/docs/reference/components/index.html
+++ b/appinventor/docs/reference/components/index.html
@@ -464,6 +464,7 @@
                       <li> <a href="storage.html"> Storage components </a> </li>
                       <li> <a href="connectivity.html"> Connectivity components </a> </li>
                       <li> <a href="legomindstorms.html"> LEGO® MINDSTORMS® components </a> </li>
+                      <li> <a href="experimental.html"> Experimental components </a> </li>
                     </ul>
                     <p> LEGO and MINDSTORMS are registered trademarks of the LEGO Group.</p>
                   </div>


### PR DESCRIPTION
The components reference page was missing a link to the Experimental component category.