### PR TITLE
Reference #!null directly instead

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -814,7 +814,7 @@
                    (if ,condition
                        (begin (begin ,body . ,rest)
                               (*yail-loop*))
-                       *the-null-value*)))))
+                       #!null)))))
      (call-with-current-continuation cont)))
 
 ;; Below are hygienic versions of the forrange, foreach and while


### PR DESCRIPTION
Reference #!null directly in the while macro instead of via
the *the-null-value* which apparently isn’t always bound.

Change-Id: I2e178f4c6a0317d4014d115912c16b9689bf1dd5