### PR TITLE
Add missing annotation for setWebViewString

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -467,6 +467,7 @@ public final class WebViewer extends AndroidViewComponent {
     /**
      * Sets the web view string
      */
+    @JavascriptInterface
     public void setWebViewString(String newString) {
       webViewString = newString;
     }


### PR DESCRIPTION
When we update App Inventor to a later Android API, the requirement that
webview interface have the annotation will be enforced. This one was
missing

Change-Id: I61dca27b000fb7b9166fe75bdd34ba00f2077841