### PR TITLE
Remove back/forward check

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -317,9 +317,7 @@ public final class WebViewer extends AndroidViewComponent {
       description = "Go back to the previous page in the history list.  " +
           "Does nothing if there is no previous page.")
   public void GoBack() {
-    if (webview.canGoBack()) {
-      webview.goBack();
-    }
+    webview.goBack();
   }
 
   /**
@@ -329,9 +327,7 @@ public final class WebViewer extends AndroidViewComponent {
       description = "Go forward to the next page in the history list.   " +
           "Does nothing if there is no next page.")
   public void GoForward() {
-    if (webview.canGoForward()) {
-      webview.goForward();
-    }
+    webview.goForward();
   }
 
   /**


### PR DESCRIPTION
> The canGoBack() method returns true if there is actually web page history for the user to visit. Likewise, you can use canGoForward() to check whether there is a forward history. **If you don't perform this check, then once the user reaches the end of the history, goBack() or goForward() _does nothing._**

> From https://developer.android.com/guide/webapps/webview