### PR TITLE
Set webViewString directly to bypass event from blocks

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -153,7 +153,7 @@ public final class WebViewer extends AndroidViewComponent {
    */
   @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void WebViewString(String newString) {
-    wvInterface.setWebViewString(newString);
+    wvInterface.setWebViewStringFromBlocks(newString);
   }
 
   @Override
@@ -482,6 +482,10 @@ public final class WebViewer extends AndroidViewComponent {
           WebViewStringChange(newString);
         }
       });
+    }
+
+    public void setWebViewStringFromBlocks(final String newString) {
+      webViewString = newString;
     }
 
   }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/WebViewerTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/WebViewerTest.java
@@ -1,0 +1,36 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright © 2018 Massachusetts Institute of Technology, All rights reserved.
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime;
+
+import com.google.appinventor.components.runtime.shadows.ShadowEventDispatcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebViewerTest extends RobolectricTestBase {
+
+  private WebViewer webViewer;
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    webViewer = new WebViewer(getForm());
+  }
+
+  /**
+   * Tests that setting a WebViewer's WebViewString property does not cause
+   */
+  @Test
+  public void testWebViewStringChange() {
+    final String TEST_STRING = "teststring";
+    webViewer.WebViewString(TEST_STRING);
+    runAllEvents();
+    ShadowEventDispatcher.assertEventNotFired(webViewer, "WebViewStringChange");
+    assertEquals(TEST_STRING, webViewer.WebViewString());
+  }
+
+}

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/shadows/ShadowEventDispatcher.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/shadows/ShadowEventDispatcher.java
@@ -7,7 +7,7 @@ package com.google.appinventor.components.runtime.shadows;
 
 import com.google.appinventor.components.runtime.Component;
 import com.google.appinventor.components.runtime.EventDispatcher;
-import org.easymock.internal.AssertionErrorWrapper;
+import org.junit.Assert;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -58,6 +58,23 @@ public class ShadowEventDispatcher {
     }
     // the event didn't fire, assertion failed.
     throw new AssertionError(String.format("Component %s did not receive event %s", component, eventName));
+  }
+
+  /**
+   * Checks whether or not the given {@code eventName} has fired for {@code component}. If so, the
+   * test fails.
+   * @param component The component to check for events
+   * @param eventName An event name to check that should not have fired
+   */
+  public static void assertEventNotFired(Component component, String eventName) {
+    Set<EventWithArgs> events = firedEvents.get(component);
+    if (events != null) {
+      for (EventWithArgs e : events) {
+        if (e.eventName.equals(eventName)) {
+          Assert.fail("Expected " + eventName + " of " + component + " to not fire, but it did.");
+        }
+      }
+    }
   }
 
   public static void assertEventFiredAny(Component component, String eventName) {


### PR DESCRIPTION
Setting the WebViewString from blocks will also trigger a
WebViewStringChange event. This forces users to have to work around
the extra change event when they are typically expecting the change
from within JavaScript code only. This change sets the internal value
directly to bypass firing the event.

Fixes #1319

Change-Id: Ic8f38bfb34faad1f67ee0bcc29289417ef780eb3