### PR TITLE
Fix for null pointer exception | Image Picker

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -130,17 +130,16 @@ public class ImagePicker extends Picker implements ActivityResultListener {
     // copy the picture at the image URI to the temp file
     try {
       tempFile = MediaUtil.copyMediaToTempFile(container.$form(), selectionURI);
+      // copy the temp file to external storage
+      Log.i(LOG_TAG, "temp file path is: " + tempFile.getPath());
+      // Copy file will signal a screen error if the copy fails.
+      copyToExternalStorageAndDeleteSource(tempFile, extension);
     } catch (IOException e) {
       Log.i(LOG_TAG, "copyMediaToTempFile failed: " + e.getMessage());
       container.$form().dispatchErrorOccurredEvent(this, "ImagePicker",
           ErrorMessages.ERROR_CANNOT_COPY_MEDIA, e.getMessage());
       return;
     }
-
-    // copy the temp file to external storage
-    Log.i(LOG_TAG, "temp file path is: " + tempFile.getPath());
-    // Copy file will signal a screen error if the copy fails.
-    copyToExternalStorageAndDeleteSource(tempFile, extension);
   }
 
   private void copyToExternalStorageAndDeleteSource(File source, String extension) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -138,7 +138,6 @@ public class ImagePicker extends Picker implements ActivityResultListener {
       Log.i(LOG_TAG, "copyMediaToTempFile failed: " + e.getMessage());
       container.$form().dispatchErrorOccurredEvent(this, "ImagePicker",
           ErrorMessages.ERROR_CANNOT_COPY_MEDIA, e.getMessage());
-      return;
     }
   }
 


### PR DESCRIPTION
This PR will fix:
`Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.io.File.delete()' on a null object reference at com.google.appinventor.components.runtime.ImagePicker.copyToExternalStorageAndDeleteSource(ImagePicker.java:188) at com.google.appinventor.components.runtime.ImagePicker.saveSelectedImageToExternalStorage(ImagePicker.java:143) at com.google.appinventor.components.runtime.ImagePicker.resultReturned(ImagePicker.java:117)`