### PR TITLE
Fix a 500 Error

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/BuildOutputServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/BuildOutputServlet.java
@@ -65,6 +65,10 @@ public class BuildOutputServlet extends OdeServlet {
       String uri = req.getRequestURI();
       // First, call split with no limit parameter.
       String[] uriComponents = uri.split("/");
+      if (uriComponents.length < 3) {
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
       nonceValue = uriComponents[2];
 
       storageIo.cleanupNonces(); // This removes expired Nonce objects


### PR DESCRIPTION
Google Search reported this to us. If you go to “/b” you get an
ArrayIndexOutOfBounds exception. This is not a valid URL, normally in
practice a code follows the /b/ which points to the APK to download. So
given that /b is not valid, we turn the error into a 404, which makes
more sense.

Change-Id: Id3ac26a35eb2cb51038a74974850ee401b9fb91c