### PR TITLE
Hide custom colour picker on interaction elsewhere

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ColorChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ColorChoicePropertyEditor.java
@@ -231,6 +231,7 @@ public abstract class ColorChoicePropertyEditor extends PropertyEditor {
 
       advancedPanel = new PopupPanel();
       advancedPanel.add(panel);
+      advancedPanel.setAutoHideEnabled(true);
 
       choices.add(new DropDownItem(WIDGET_NAME, makeCustomHTML(1.0, 255, 0, 0), new Command() {
         @Override


### PR DESCRIPTION
This commit makes sure that the custom colour picker autohides when the user interacts outside of the picker.

Resolves #979