### PR TITLE
Added context menu items to enable and disable all blocks

### DIFF
--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -89,6 +89,8 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.DISABLE_GRID = 'Disable Workspace Grid';
     Blockly.Msg.ENABLE_SNAPPING = 'Enable Snap to Grid';
     Blockly.Msg.DISABLE_SNAPPING = 'Disable Snap to Grid';
+    Blockly.Msg.DISABLE_ALL_BLOCKS = 'Disable All Blocks';
+    Blockly.Msg.ENABLE_ALL_BLOCKS = 'Enable All Blocks';
 
 // Variable renaming.
     Blockly.MSG_CHANGE_VALUE_TITLE = 'Change value:';

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -714,9 +714,11 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
   enableAll.text = Blockly.Msg.ENABLE_ALL_BLOCKS;
   enableAll.callback = function() {
     var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    Blockly.Events.setGroup(true);
     for (var x = 0, block; block = allBlocks[x]; x++) {
       block.setDisabled(false);
     }
+    Blockly.Events.setGroup(false);
   };
   menuOptions.push(enableAll);
 
@@ -725,9 +727,11 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
   disableAll.text = Blockly.Msg.DISABLE_ALL_BLOCKS;
   disableAll.callback = function() {
     var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    Blockly.Events.setGroup(true);
     for (var x = 0, block; block = allBlocks[x]; x++) {
       block.setDisabled(true);
     }
+    Blockly.Events.setGroup(false);
   };
   menuOptions.push(disableAll);
 

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -709,6 +709,28 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
       arrangeOptionV.callback(opt_type);
   }
 
+  // Enable all blocks
+  var enableAll = {enabled: true};
+  enableAll.text = Blockly.Msg.ENABLE_ALL_BLOCKS;
+  enableAll.callback = function() {
+    var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    for (var x = 0, block; block = allBlocks[x]; x++) {
+      block.setDisabled(false);
+    }
+  };
+  menuOptions.push(enableAll);
+
+  // Disable all blocks
+  var disableAll = {enabled: true};
+  disableAll.text = Blockly.Msg.DISABLE_ALL_BLOCKS;
+  disableAll.callback = function() {
+    var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    for (var x = 0, block; block = allBlocks[x]; x++) {
+      block.setDisabled(true);
+    }
+  };
+  menuOptions.push(disableAll);
+
   // Retrieve from backpack option.
   var backpackRetrieve = {enabled: true};
   backpackRetrieve.text = Blockly.Msg.BACKPACK_GET + " (" +


### PR DESCRIPTION
This commit adds two new items to the context menu of the blocks editor. The first one is "Enable All Blocks" which enables all blocks on the workspace. The second option is "Disable All Blocks" which disables all of the blocks on the workspace.

Resolves #1091 