### PR TITLE
Bugfix to AARLibrary

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
@@ -246,6 +246,12 @@ public class AARLibrary {
           throw new IOException("Unable to create directory " + path.getAbsolutePath());
         } else if (!entry.isDirectory()) {
           try {
+            // Need to make sure the parent directory is present. Files can appear
+            // in a ZIP (AAR) file without an explicit directory object
+            File parentDir = target.getParentFile();
+            if (!parentDir.exists()) {
+              parentDir.mkdirs();
+            }
             output = new FileOutputStream(target);
             input = zip.getInputStream(entry);
             IOUtils.copy(input, output);


### PR DESCRIPTION
Some aar files do not have an explicit directory entry for every
object. Make sure we create the needed directories.

Change-Id: Ic79d8852b6cc48f2399794c4087507e8f9c3bbaf