### PR TITLE
1318 Button behavior pre and post-Lollipop

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -168,7 +168,7 @@ public abstract class ButtonBase extends AndroidViewComponent
       //been consumed. Using this approach, other listeners (e.g. OnClick) can process as normal.
       if (me.getAction() == MotionEvent.ACTION_DOWN) {
         //button pressed, provide visual feedback AND return false
-        if (ShowFeedback() && AppInventorCompatActivity.isClassicMode()) {
+        if (ShowFeedback() && (AppInventorCompatActivity.isClassicMode() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
           view.getBackground().setAlpha(70); // translucent
           view.invalidate();
         }
@@ -176,7 +176,7 @@ public abstract class ButtonBase extends AndroidViewComponent
       } else if (me.getAction() == MotionEvent.ACTION_UP ||
               me.getAction() == MotionEvent.ACTION_CANCEL) {
         //button released, set button back to normal AND return false
-        if (ShowFeedback() && AppInventorCompatActivity.isClassicMode()) {
+        if (ShowFeedback() && (AppInventorCompatActivity.isClassicMode() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
           view.getBackground().setAlpha(255); // opaque
           view.invalidate();
         }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -165,7 +165,7 @@ public abstract class ButtonBase extends AndroidViewComponent
       int test = me.getAction();
         if (me.getAction() == MotionEvent.ACTION_DOWN) {
             //button pressed, provide visual feedback AND return false
-            if (ShowFeedback() && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+            if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                view.getBackground().setAlpha(70); // translucent
                view.invalidate();
             }
@@ -173,7 +173,7 @@ public abstract class ButtonBase extends AndroidViewComponent
         } else if (me.getAction() == MotionEvent.ACTION_UP ||
             me.getAction() == MotionEvent.ACTION_CANCEL) {
             //button released, set button back to normal AND return false
-            if (ShowFeedback() && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+            if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                view.getBackground().setAlpha(255); // opaque
                view.invalidate();
             }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -445,15 +445,22 @@ public abstract class ButtonBase extends AndroidViewComponent
         throw new IllegalArgumentException();
     }
 
-    // Set drawable to the background of the button.ß
+    // Set drawable to the background of the button.
     if (!AppInventorCompatActivity.isClassicMode() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       ViewUtil.setBackgroundDrawable(view, new RippleDrawable(createRippleState(), drawable, drawable));
-    } else ViewUtil.setBackgroundDrawable(view, drawable);
+    } else {
+      ViewUtil.setBackgroundDrawable(view, drawable);
+    }
 
-    if (backgroundColor == Component.COLOR_NONE)
+    if (backgroundColor == Component.COLOR_NONE) {
       view.getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.CLEAR);
-    else
+    }
+    else if (backgroundColor == Component.COLOR_DEFAULT) {
+      view.getBackground().setColorFilter(SHAPED_DEFAULT_BACKGROUND_COLOR, PorterDuff.Mode.SRC_ATOP);
+    }
+    else {
       view.getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.SRC_ATOP);
+    }
 
     view.invalidate();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -384,9 +384,6 @@ public abstract class ButtonBase extends AndroidViewComponent
           // If there is no background image and color is default,
           // restore original 3D bevel appearance.
           ViewUtil.setBackgroundDrawable(view, defaultButtonDrawable);
-//        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && backgroundColor == Component.COLOR_NONE) {
-//          RippleDrawable fred = new RippleDrawable(getPressedColorSelector(backgroundColor), new ColorDrawable(backgroundColor), defaultButtonDrawable);
-//          view.setBackgroundDrawable(fred);
         } else if (backgroundColor == Component.COLOR_NONE) {
           // Clear the background image.
           ViewUtil.setBackgroundDrawable(view, null);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -6,7 +6,10 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
@@ -14,7 +17,11 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.PropertyTypeConstants;
-import com.google.appinventor.components.runtime.util.*;
+import com.google.appinventor.components.runtime.util.IceCreamSandwichUtil;
+import com.google.appinventor.components.runtime.util.KitkatUtil;
+import com.google.appinventor.components.runtime.util.MediaUtil;
+import com.google.appinventor.components.runtime.util.TextViewUtil;
+import com.google.appinventor.components.runtime.util.ViewUtil;
 import android.view.MotionEvent;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
@@ -431,8 +438,15 @@ public abstract class ButtonBase extends AndroidViewComponent
       default:
         throw new IllegalArgumentException();
     }
+    int[][] states = new int[][] { new int[] { android.R.attr.state_enabled} };
+    int[] colors = new int[] { Component.COLOR_BLUE }; // sets the ripple color to blue
+
+    ColorStateList colorStateList = new ColorStateList(states, colors);
+    RippleDrawable ripBK = new RippleDrawable(colorStateList, drawable, drawable);
+
     // Set drawable to the background of the button.
-    view.setBackgroundDrawable(drawable);
+//    view.setBackgroundDrawable(drawable);
+    view.setBackgroundDrawable(ripBK);
     view.invalidate();
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -158,29 +158,27 @@ public abstract class ButtonBase extends AndroidViewComponent
      * release when not-pressed.
      */
     @Override
-    public boolean onTouch(View view, MotionEvent me)
-    {
-        //NOTE: We ALWAYS return false because we want to indicate that this listener has not
-        //been consumed. Using this approach, other listeners (e.g. OnClick) can process as normal.
-      int test = me.getAction();
-        if (me.getAction() == MotionEvent.ACTION_DOWN) {
-            //button pressed, provide visual feedback AND return false
-            if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-               view.getBackground().setAlpha(70); // translucent
-               view.invalidate();
-            }
-            TouchDown();
-        } else if (me.getAction() == MotionEvent.ACTION_UP ||
-            me.getAction() == MotionEvent.ACTION_CANCEL) {
-            //button released, set button back to normal AND return false
-            if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-               view.getBackground().setAlpha(255); // opaque
-               view.invalidate();
-            }
-            TouchUp();
+    public boolean onTouch(View view, MotionEvent me) {
+      //NOTE: We ALWAYS return false because we want to indicate that this listener has not
+      //been consumed. Using this approach, other listeners (e.g. OnClick) can process as normal.
+      if (me.getAction() == MotionEvent.ACTION_DOWN) {
+        //button pressed, provide visual feedback AND return false
+        if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+          view.getBackground().setAlpha(70); // translucent
+          view.invalidate();
         }
+        TouchDown();
+      } else if (me.getAction() == MotionEvent.ACTION_UP ||
+              me.getAction() == MotionEvent.ACTION_CANCEL) {
+        //button released, set button back to normal AND return false
+        if (ShowFeedback() && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+          view.getBackground().setAlpha(255); // opaque
+          view.invalidate();
+        }
+        TouchUp();
+      }
 
-        return false;
+      return false;
     }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -6,6 +6,7 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.os.Build;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
@@ -13,11 +14,7 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.PropertyTypeConstants;
-import com.google.appinventor.components.runtime.util.IceCreamSandwichUtil;
-import com.google.appinventor.components.runtime.util.KitkatUtil;
-import com.google.appinventor.components.runtime.util.MediaUtil;
-import com.google.appinventor.components.runtime.util.TextViewUtil;
-import com.google.appinventor.components.runtime.util.ViewUtil;
+import com.google.appinventor.components.runtime.util.*;
 import android.view.MotionEvent;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
@@ -165,9 +162,10 @@ public abstract class ButtonBase extends AndroidViewComponent
     {
         //NOTE: We ALWAYS return false because we want to indicate that this listener has not
         //been consumed. Using this approach, other listeners (e.g. OnClick) can process as normal.
+      int test = me.getAction();
         if (me.getAction() == MotionEvent.ACTION_DOWN) {
             //button pressed, provide visual feedback AND return false
-            if (ShowFeedback()) {
+            if (ShowFeedback() && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
                view.getBackground().setAlpha(70); // translucent
                view.invalidate();
             }
@@ -175,7 +173,7 @@ public abstract class ButtonBase extends AndroidViewComponent
         } else if (me.getAction() == MotionEvent.ACTION_UP ||
             me.getAction() == MotionEvent.ACTION_CANCEL) {
             //button released, set button back to normal AND return false
-            if (ShowFeedback()) {
+            if (ShowFeedback() && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
                view.getBackground().setAlpha(255); // opaque
                view.invalidate();
             }
@@ -388,6 +386,15 @@ public abstract class ButtonBase extends AndroidViewComponent
           // If there is no background image and color is default,
           // restore original 3D bevel appearance.
           ViewUtil.setBackgroundDrawable(view, defaultButtonDrawable);
+//        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && backgroundColor == Component.COLOR_NONE) {
+//          RippleDrawable fred = new RippleDrawable(getPressedColorSelector(backgroundColor), new ColorDrawable(backgroundColor), defaultButtonDrawable);
+//          view.setBackgroundDrawable(fred);
+        } else if (backgroundColor == Component.COLOR_NONE) {
+          // Clear the background image.
+          ViewUtil.setBackgroundDrawable(view, null);
+          //Now we set again the default drawable
+          ViewUtil.setBackgroundDrawable(view, defaultButtonDrawable);
+          view.getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.CLEAR);
         } else {
           // Clear the background image.
           ViewUtil.setBackgroundDrawable(view, null);


### PR DESCRIPTION
This fixes the original bug report about Color None buttons displaying as default.

It also removes the Alpha changes on the Touch event for Lollipop and higher. This allows Material UI buttons to retain their ripple effect, and Classic buttons seem to do the correct thing on press as well (they don't pre-Lollipop, thus the Alpha changes to begin with).

After examining the LollipopUtil class, I'm not clear whether moving the changes Touch event into the util class is the right way to organize, since this is additional code that needs to be run for OLDER versions. 

I'm submitting as is, and we can discuss.

Fixes #1318