### PR TITLE
Force MockCircle default position to (0, 0)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircle.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircle.java
@@ -134,7 +134,10 @@ public class MockCircle extends MockMapFeatureBaseWithFill {
   // JSNI Methods
   private native void initCircle()/*-{
     this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::feature =
-      top.L.circle([], @com.google.appinventor.components.common.ComponentConstants::CIRCLE_PREFERRED_RADIUS, {
+      // Fix for https://github.com/mit-cml/appinventor-sources/issues/1379: Initial coordinate
+      // should match default property values for Latitude and Longitude (i.e., (0, 0)) otherwise
+      // Leaflet throws an exception when we later add the Circle to the Map.
+      top.L.circle([0, 0], @com.google.appinventor.components.common.ComponentConstants::CIRCLE_PREFERRED_RADIUS, {
         className: 'leaflet-interactive',
         weight: 1,
         color: '#000',


### PR DESCRIPTION
MockCircle's position in the typical workflow will be populated by its Latitude and Longitude properties. However, if one manually sets Latitude and Longitude to 0 (which is the default), then App Inventor won't serialize this and restore it on load. The result is that MockCircle will be initialized without a position, which later causes an exception when it is added to the map. This change sets the center to 0, 0 so that it is valid in the case of the default.

Fixes #1379
