### PR TITLE
Limit Buildserver to not get projects > 32Mb

### DIFF
--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -197,5 +197,6 @@
   <!-- Enable concurrency in the app engine server -->
   <threadsafe>true</threadsafe>
 
+  <url-stream-handler>urlfetch</url-stream-handler>
 
 </appengine-web-app>


### PR DESCRIPTION
Also switch to using URLFetch service for outgoing HttpURLConnections

Change-Id: I67f06fdfbc5624e13fd1e614a1fc931f7394a13f