### PR TITLE
Reset min size of button with images

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -14,6 +14,7 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.runtime.util.IceCreamSandwichUtil;
+import com.google.appinventor.components.runtime.util.KitkatUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
@@ -123,8 +124,8 @@ public abstract class ButtonBase extends AndroidViewComponent
     // Save the default values in case the user wants them back later.
     defaultButtonDrawable = view.getBackground();
     defaultColorStateList = view.getTextColors();
-    defaultButtonMinWidth = view.getMinWidth();
-    defaultButtonMinHeight = view.getMinHeight();
+    defaultButtonMinWidth = KitkatUtil.getMinWidth(view);
+    defaultButtonMinHeight = KitkatUtil.getMinHeight(view);
 
     // Adds the component to its designated container
     container.$add(this);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -98,6 +98,20 @@ public abstract class ButtonBase extends AndroidViewComponent
   private Drawable backgroundImageDrawable;
 
   /**
+   * The minimum width of a button for the current theme.
+   *
+   * We store this statically because it should be constant across all buttons in the app.
+   */
+  private static int defaultButtonMinWidth = 0;
+
+  /**
+   * The minimum height of a button for the current theme.
+   *
+   * We store this statically because it should be constant across all buttons in the app.
+   */
+  private static int defaultButtonMinHeight = 0;
+
+  /**
    * Creates a new ButtonBase component.
    *
    * @param container  container, component will be placed in
@@ -109,6 +123,8 @@ public abstract class ButtonBase extends AndroidViewComponent
     // Save the default values in case the user wants them back later.
     defaultButtonDrawable = view.getBackground();
     defaultColorStateList = view.getTextColors();
+    defaultButtonMinWidth = view.getMinWidth();
+    defaultButtonMinHeight = view.getMinHeight();
 
     // Adds the component to its designated container
     container.$add(this);
@@ -384,9 +400,11 @@ public abstract class ButtonBase extends AndroidViewComponent
         // create a drawable with the appropriate shape and color.
         setShape();
       }
+      TextViewUtil.setMinSize(view, defaultButtonMinWidth, defaultButtonMinHeight);
     } else {
       // If there is a background image
       ViewUtil.setBackgroundImage(view, backgroundImageDrawable);
+      TextViewUtil.setMinSize(view, 0, 0);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/KitkatUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/KitkatUtil.java
@@ -10,8 +10,10 @@ import java.util.Collections;
 import java.util.List;
 
 import android.content.Intent;
+import android.os.Build;
 import android.provider.Telephony.Sms.Intents;
 import android.telephony.SmsMessage;
+import android.widget.TextView;
 
 /**
  * Helper methods for calling APIs added in KITKAT (4.4, API level 19)
@@ -38,5 +40,33 @@ public final class KitkatUtil {
       Collections.addAll(result, messages);
     }
     return result;
+  }
+
+  /**
+   * Get the minimum width of the view. On versions prior to Kitkat, getMinWidth is undefined so we return the
+   * width of the component. Therefore, this method should be called before the component is manipulated.
+   * @param view The text view of which to get the minimum width
+   * @return The "minimum" allowable width of the view
+   */
+  public static int getMinWidth(TextView view) {
+    if (Build.VERSION.SDK_INT >= 16) {
+      return view.getMinWidth();
+    } else {
+      return view.getWidth();
+    }
+  }
+
+  /**
+   * Get the minimum height of the view. On versions prior to Kitkat, getMinHeight is undefined so we return the
+   * height of the component. Therefore, this method should be called before the component is manipulated.
+   * @param view The text view of which to get the minimum height
+   * @return The "minimum" allowable height of the view
+   */
+  public static int getMinHeight(TextView view) {
+    if (Build.VERSION.SDK_INT >= 16) {
+      return view.getMinHeight();
+    } else {
+      return view.getHeight();
+    }
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/TextViewUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/TextViewUtil.java
@@ -215,4 +215,42 @@ public class TextViewUtil {
   public static void setTextColors(TextView textview, ColorStateList colorStateList) {
     textview.setTextColor(colorStateList);
   }
+
+  /**
+   * Sets the minimum width of a text view.
+   *
+   * @param textview text view instance
+   * @param minWidth minimum width of the text view in pixels
+   */
+  public static void setMinWidth(TextView textview, int minWidth) {
+    // According to https://developer.android.com/reference/android/widget/TextView.html#setMinWidth(int), the minimum
+    // width of TextView is the maximum of setMinWidth and setMinimumWidth. Talk about NIH syndrome!
+    textview.setMinWidth(minWidth);
+    textview.setMinimumWidth(minWidth);
+  }
+
+  /**
+   * Sets the minimum height of a text view.
+   *
+   * @param textview text view instance
+   * @param minHeight minimum height of the text view in pixels
+   */
+  public static void setMinHeight(TextView textview, int minHeight) {
+    // According to https://developer.android.com/reference/android/widget/TextView.html#setMinHeight(int), the minimum
+    // height of TextView is the maximum of setMinHeight and setMinimumHeight. Talk about NIH syndrome!
+    textview.setMinHeight(minHeight);
+    textview.setMinimumHeight(minHeight);
+  }
+
+  /**
+   * Sets the minimum size for a text view.
+   *
+   * @param textview text view instance
+   * @param minWidth minimum width of the text view in pixels
+   * @param minHeight minimum height of the text view in pixels
+   */
+  public static void setMinSize(TextView textview, int minWidth, int minHeight) {
+    TextViewUtil.setMinWidth(textview, minWidth);
+    TextViewUtil.setMinHeight(textview, minHeight);
+  }
 }


### PR DESCRIPTION
If someone sets an image on a button in a non-Classic theme, the
minimum width/height settings in the theme will force the button to
sometimes resize the image arbitrarily to fit the minimum constraints
rather than allowing the button to assume the shape of the image like
it would in the Classic theme. This fix sets the minimum size of a
button to 0x0 so that it can take on the image size regardless of what
the platform's default dimensions for a button.

Change-Id: I590eb1bec860cda221e821c663c03c5cd81a65fe