### PR TITLE
Trim extraneous whitespace from base64-encoded aia

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
@@ -128,7 +128,7 @@ public class ProjectServiceImpl extends OdeRemoteServiceServlet implements Proje
     // NOTE: GWT's Base64Utils uses a non-standard algorithm.
     // @see:  https://code.google.com/p/google-web-toolkit/issues/detail?id=3880
     byte[] binData = null;
-    binData = Base64Util.decode(zipData);
+    binData = Base64Util.decodeLines(zipData);
 
     // Import the project
     ByteArrayInputStream bais = null;


### PR DESCRIPTION
The base64 utility on macOS writes a carriage return at the end of the
base64 encoded string. When App Inventor attempts to read a project
template with this extra whitespace, it causes an exception to be
thrown since the server's decode() implementation expects a string
with a length multiple of 4. This change switches to using
decodeLines(), which ignores whitespace.

Fixes #1401 

Change-Id: I34f6c7b1ef1fcd12b82eab67c98ffb422bbf5894