### PR TITLE
Remove BOM from GeoJSON files

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
@@ -178,6 +178,7 @@ public class MockFeatureCollection extends MockContainer implements MockMapFeatu
     if (collection) {
       var self = this;
       map.removeLayer(collection);
+      if (geojson.charCodeAt = 0xFEFF) geojson = geojson.substr(1);  // strip byte order marker, if present
       collection = top.L.geoJson(JSON.parse(geojson), {
         pointToLayer: function(feature, latlng) {
           for (var key in feature.properties) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
@@ -355,7 +355,7 @@ public abstract class MapFeatureContainerBase extends AndroidViewComponent imple
 
   @SuppressWarnings("WeakerAccess")
   protected void processGeoJSON(final String url, final String content) throws JSONException {
-    JSONObject parsedData = new JSONObject(content);
+    JSONObject parsedData = new JSONObject(stripBOM(content));
     String type = parsedData.optString(GEOJSON_TYPE);
     if (!GEOJSON_FEATURECOLLECTION.equals(type) && !GEOJSON_GEOMETRYCOLLECTION.equals(type)) {
       $form().runOnUiThread(new Runnable() {
@@ -423,6 +423,14 @@ public abstract class MapFeatureContainerBase extends AndroidViewComponent imple
       }
     }
     return YailList.makeList(items);
+  }
+
+  private static String stripBOM(String content) {
+    if (content.charAt(0) == '\uFEFF') {
+      return content.substring(1);
+    } else {
+      return content;
+    }
   }
 
 }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/FeatureCollectionTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/FeatureCollectionTest.java
@@ -201,6 +201,18 @@ public class FeatureCollectionTest extends MapTestBase {
     assertEquals(getMap(), collection.getMap());
   }
 
+  /**
+   * Tests that the FeatureCollection can load a GeoJSON file with an invalid BOM. Technically, BOM is not allowed
+   * by the JSON RFC, but who needs standards anyway?
+   */
+  @Test
+  public void testGeoJSONWithBOM() {
+    ShadowEventDispatcher.clearEvents();
+    collection.FeaturesFromGeoJSON("\uFEFF{\"type\":\"FeatureCollection\",\"features\":[]}");
+    runAllEvents();
+    assertEventFiredAny(collection, "GotFeatures");
+  }
+
   private void testFeatureListSetter(MapFeature feature) {
     ShadowView view = Shadow.extract(getMap().getView());
     view.clearWasInvalidated();


### PR DESCRIPTION
While GeoJSON files should not have a BOM per the spec, sometimes
systems will include the UTF byte order marker (BOM). This breaks the
JSON parsing on both in the web client and app. This change will check
for and strip out the BOM before passing the JSON string along for
further processing.

Fixes #1407 

Change-Id: I9452871e19b3985f9beea48b30cf49b60e4835cb