### PR TITLE
Remove mysterious margin

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
@@ -1,12 +1,13 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.widgets;
 
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
@@ -35,10 +36,12 @@ public class LabeledTextBox extends Composite {
     HorizontalPanel panel = new HorizontalPanel();
     Label label = new Label(caption);
     panel.add(label);
+    panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
     textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(label, "40%");
+    panel.setCellVerticalAlignment(textbox, HasVerticalAlignment.ALIGN_MIDDLE);
 
     initWidget(panel);
 
@@ -57,11 +60,13 @@ public class LabeledTextBox extends Composite {
     HorizontalPanel panel = new HorizontalPanel();
     Label label = new Label(caption);
     panel.add(label);
+    panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
     defaultTextBoxColor = textbox.getElement().getStyle().getBorderColor();
     textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(label, "40%");
+    panel.setCellVerticalAlignment(textbox, HasVerticalAlignment.ALIGN_MIDDLE);
 
     HorizontalPanel errorPanel = new HorizontalPanel();
     errorLabel = new Label("");

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1475,7 +1475,6 @@ input[type="color"],
   display: inline-block;
   height: 20px;
   padding: 2px 6px;
-  margin-bottom: 4px;
   font-size: 12px;
   line-height: 20px;
   color: #555555;


### PR DESCRIPTION
The mysterious margin appears in a lot of places and it makes them asymmetrical and inconsistent. Here are two examples.

### **Before:** 
<img width="225" alt="screen shot 2018-11-12 at 5 49 44 am" src="https://user-images.githubusercontent.com/43410941/48318806-96f90e00-e640-11e8-850b-66983e248408.png"> <img width="366" alt="screen shot 2018-11-12 at 5 53 18 am" src="https://user-images.githubusercontent.com/43410941/48318817-aed09200-e640-11e8-8ff0-88fb15a44124.png"> 

### **After:**
<img width="221" alt="screen shot 2018-11-12 at 5 57 37 am" src="https://user-images.githubusercontent.com/43410941/48318804-8a74b580-e640-11e8-8801-bf554b4733d0.png"> <img width="369" alt="screen shot 2018-11-12 at 5 56 33 am" src="https://user-images.githubusercontent.com/43410941/48318820-b7c16380-e640-11e8-8717-04ef9b00b83a.png">


