### PR TITLE
Align labeled text boxes in the middle

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
@@ -38,6 +38,7 @@ public class LabeledTextBox extends Composite {
     panel.add(label);
     panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
+    textbox.setStylePrimaryName("ode-LabeledTextBox");
     textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(label, "40%");
@@ -62,6 +63,7 @@ public class LabeledTextBox extends Composite {
     panel.add(label);
     panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
+    textbox.setStylePrimaryName("ode-LabeledTextBox");
     defaultTextBoxColor = textbox.getElement().getStyle().getBorderColor();
     textbox.setWidth("100%");
     panel.add(textbox);

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
@@ -1,12 +1,13 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.widgets;
 
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
@@ -35,10 +36,12 @@ public class LabeledTextBox extends Composite {
     HorizontalPanel panel = new HorizontalPanel();
     Label label = new Label(caption);
     panel.add(label);
+    panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
     textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(label, "40%");
+    panel.setCellVerticalAlignment(textbox, HasVerticalAlignment.ALIGN_MIDDLE);
 
     initWidget(panel);
 
@@ -57,11 +60,13 @@ public class LabeledTextBox extends Composite {
     HorizontalPanel panel = new HorizontalPanel();
     Label label = new Label(caption);
     panel.add(label);
+    panel.setCellVerticalAlignment(label, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
     defaultTextBoxColor = textbox.getElement().getStyle().getBorderColor();
     textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(label, "40%");
+    panel.setCellVerticalAlignment(textbox, HasVerticalAlignment.ALIGN_MIDDLE);
 
     HorizontalPanel errorPanel = new HorizontalPanel();
     errorLabel = new Label("");

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1340,6 +1340,10 @@ path.ode-SimpleMockMapFeature-selected {
   width: 100%;
 }
 
+.ode-DialogBox .ode-LabeledTextBox {
+  margin-bottom: 0;
+}
+
 /* AI2 Extensions Styles */
 
 a.ode-ExtensionAnchor {

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1475,6 +1475,7 @@ input[type="color"],
   display: inline-block;
   height: 20px;
   padding: 2px 6px;
+  margin-bottom: 4px;
   font-size: 12px;
   line-height: 20px;
   color: #555555;

--- a/appinventor/appengine/war/Ya.css
+++ b/appinventor/appengine/war/Ya.css
@@ -1475,7 +1475,6 @@ input[type="color"],
   display: inline-block;
   height: 20px;
   padding: 2px 6px;
-  margin-bottom: 4px;
   font-size: 12px;
   line-height: 20px;
   color: #555555;


### PR DESCRIPTION
The first commit removes the bottom margin in order to perfectly align labeled text boxes vertically in the middle

### Before
<img width="368" alt="screen shot 2018-11-12 at 9 48 27 am" src="https://user-images.githubusercontent.com/43410941/48322030-61fcb380-e660-11e8-98b4-c0003c50e061.png">

### After
<img width="371" alt="screen shot 2018-11-12 at 9 46 17 am" src="https://user-images.githubusercontent.com/43410941/48322039-6c1eb200-e660-11e8-8054-98b75c93d2fe.png">
