### PR TITLE
Fire permission granted without posting runnable if we have permission

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -2315,15 +2315,15 @@ public class Form extends AppInventorCompatActivity
 
   public void askPermission(final String permission, final PermissionResultHandler responseRequestor) {
     final Form form = this;
+    if (ContextCompat.checkSelfPermission(form, permission) ==
+        PackageManager.PERMISSION_GRANTED) {
+      // We already have permission, so no need to ask
+      responseRequestor.HandlePermissionResponse(permission, true);
+      return;
+    }
     androidUIHandler.post(new Runnable() {
         @Override
         public void run() {
-          if (ContextCompat.checkSelfPermission(form, permission) ==
-            PackageManager.PERMISSION_GRANTED) {
-            // We already have permission, so no need to ask
-            responseRequestor.HandlePermissionResponse(permission, true);
-            return;
-          }
           int nonce = permissionRandom.nextInt(100000);
           Log.d(LOG_TAG, "askPermission: permission = " + permission +
             " requestCode = " + nonce);


### PR DESCRIPTION
Clocks break on SDK 26 due to an order of operations problem that is
introduced by asking for dangerous permissions. The traditional order
of operations would be to call `$define()` as part of `onCreate` and
therefore before `onResume`. With the mechanism for requesting dangerous
permissions, we can end up calling `$define` before `onResume` if the
dialog is shown in response to needing SD card access, or after
`onResume` if we need SD card access but the user has already granted
it. In the latter case, this causes the Clock's `onScreen` field to be
false and prevents the timer from firing. This commit moves the check
for permission to be before posting the runnable so that if we know
permission is grantd the old control flow remains intact.

Fixes #1364 

Change-Id: I01330f8cc373e1c5184dedc7eb208199b74fe8fb