### PR TITLE
Add syntax rule for old define-form form

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -288,6 +288,8 @@
 
 (define-syntax define-form
   (syntax-rules ()
+    ((_ class-name form-name)
+     (define-form-internal class-name form-name 'com.google.appinventor.components.runtime.Form #f #t))
     ((_ class-name form-name classic-theme)
      (define-form-internal class-name form-name 'com.google.appinventor.components.runtime.Form #f classic-theme))))
 


### PR DESCRIPTION
The change to fix themes on SDK 26 is a hard switchover from the old
2-parameter define-form to a 3-parameter define-form. This means that
when we deploy a buildserver people who build with an out-of-date App
Inventor client will get an error about no matching syntax rule for
_. This change adds a 2-parameter version that assumes a default of #t
for whether Classic theme is needed.

Note: This fix is not ideal because if the built app has a non-Classic
theme its ActionBar will disappear. After reloading App Inventor they
will get the new 3-parameter define-form, which will work correctly.

Change-Id: I8390fa51c789aca449bdaa3e93c7f79b2b0a9a12