### PR TITLE
Restrict the dimensions of AboutScreen for MockForm

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/TextAreaPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/TextAreaPropertyEditor.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -10,11 +10,22 @@ import com.google.gwt.user.client.ui.TextArea;
 
 /**
  * Property editor for long text.  Appears as a scrollable, resizable area.
- *
  */
-public class TextAreaPropertyEditor extends TextPropertyEditorBase{
+public class TextAreaPropertyEditor extends TextPropertyEditorBase {
+
+  /* same as the height set in TextPropertyEditorBase */
+  private static final String MIN_CSS_HEIGHT = "2em";
+
+  /* tightly coupled with the width of properties panel:
+   * 186px == width of properties panel - side paddings and borders of textarea
+   *       == 194px - 8px
+   */
+  private static final String MAX_CSS_WIDTH = "186px";
 
   public TextAreaPropertyEditor() {
    super(new TextArea());
+
+   textEdit.getElement().getStyle().setProperty("min-height", MIN_CSS_HEIGHT);
+   textEdit.getElement().getStyle().setProperty("max-width", MAX_CSS_WIDTH);
   }
 }


### PR DESCRIPTION
The original text area can be resized across the visible region, making the bottom right triangle for resizing unreachable afterwards.

### Before
<img width="230" alt="screen shot 2018-11-14 at 1 35 44 pm" src="https://user-images.githubusercontent.com/43410941/48462309-9a43f380-e812-11e8-8601-e9d4ca47059f.png">

### After
<img width="230" alt="screen shot 2018-11-14 at 1 38 01 pm" src="https://user-images.githubusercontent.com/43410941/48462320-a4fe8880-e812-11e8-8e65-e95d4e4fbcd4.png">
