### PR TITLE
Added context menu items to show and hide all comments

### DIFF
--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -91,6 +91,8 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.DISABLE_SNAPPING = 'Disable Snap to Grid';
     Blockly.Msg.DISABLE_ALL_BLOCKS = 'Disable All Blocks';
     Blockly.Msg.ENABLE_ALL_BLOCKS = 'Enable All Blocks';
+    Blockly.Msg.HIDE_ALL_COMMENTS = 'Hide All Comments';
+    Blockly.Msg.SHOW_ALL_COMMENTS = 'Show All Comments';
 
 // Variable renaming.
     Blockly.MSG_CHANGE_VALUE_TITLE = 'Change value:';

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -742,7 +742,9 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
     var allBlocks = Blockly.mainWorkspace.getAllBlocks();
     Blockly.Events.setGroup(true);
     for (var x = 0, block; block = allBlocks[x]; x++) {
-      block.comment.setVisible(true);
+      if (block.comment != null) {
+        block.comment.setVisible(true);
+      }
     }
     Blockly.Events.setGroup(false);
   };
@@ -755,7 +757,9 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
     var allBlocks = Blockly.mainWorkspace.getAllBlocks();
     Blockly.Events.setGroup(true);
     for (var x = 0, block; block = allBlocks[x]; x++) {
-      block.comment.setVisible(false);
+      if (block.comment != null) {
+        block.comment.setVisible(false);
+      }
     }
     Blockly.Events.setGroup(false);
   };

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -735,6 +735,32 @@ Blockly.WorkspaceSvg.prototype.customContextMenu = function(menuOptions) {
   };
   menuOptions.push(disableAll);
 
+  // Show all comments
+  var showAll = {enabled: true};
+  showAll.text = Blockly.Msg.SHOW_ALL_COMMENTS;
+  showAll.callback = function() {
+    var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    Blockly.Events.setGroup(true);
+    for (var x = 0, block; block = allBlocks[x]; x++) {
+      block.comment.setVisible(true);
+    }
+    Blockly.Events.setGroup(false);
+  };
+  menuOptions.push(showAll);
+
+  // Hide all comments
+  var hideAll = {enabled: true};
+  hideAll.text = Blockly.Msg.HIDE_ALL_COMMENTS;
+  hideAll.callback = function() {
+    var allBlocks = Blockly.mainWorkspace.getAllBlocks();
+    Blockly.Events.setGroup(true);
+    for (var x = 0, block; block = allBlocks[x]; x++) {
+      block.comment.setVisible(false);
+    }
+    Blockly.Events.setGroup(false);
+  };
+  menuOptions.push(hideAll);
+
   // Retrieve from backpack option.
   var backpackRetrieve = {enabled: true};
   backpackRetrieve.text = Blockly.Msg.BACKPACK_GET + " (" +


### PR DESCRIPTION
This commit adds two new options to the block editor's context menu to show and hide all the comments on the workspace.
Resolves #1422 