### PR TITLE
Make ScrollView fill viewport on Nougat and higher

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -21,6 +21,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.ActivityCompat;
@@ -998,7 +999,16 @@ public class Form extends AppInventorCompatActivity
     // | ---------------------- |
     // --------------------------
 
-    frameLayout = scrollable ? new ScrollView(this) : new FrameLayout(this);
+    if (scrollable) {
+      frameLayout = new ScrollView(this);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        // Nougat changes how ScrollView handles its content size. Here we force it to fill the viewport
+        // in order to preserve the layout of apps developed prior to N that rely on the old behavior.
+        ((ScrollView) frameLayout).setFillViewport(true);
+      }
+    } else {
+      frameLayout = new FrameLayout(this);
+    }
     frameLayout.addView(viewLayout.getLayoutManager(), new ViewGroup.LayoutParams(
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.MATCH_PARENT));


### PR DESCRIPTION
The semantics of how ScrollView manages its content changed between
SDK 23 and SDK 24. Prior to SDK 24, the content of the ScrollView
would stretch the content bounds of the ScrollView, which resulted in
the height fitting the content. With SDK 24, this relationship isn't
preserved, so children that are supposed to fill the parent no longer
do so or take on a different size.

This change sets a flag so that the ScrollView will allow its content
to fill the viewport on SDK 24 or higher. We retain the old behavior
on Android versions older than 24 to minimize breakage.

Fixes #1344 

Change-Id: I0a4c1f1588cc54a499c5860794fb77ad83fa918d