### PR TITLE
Fix block HELPURL lookup for Screen blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright © 2013-2016 MIT, All rights reserved
+// Copyright © 2013-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 /**
@@ -216,7 +216,7 @@ Blockly.Blocks.component_event = {
     }
   },
   helpUrl : function() {
-    var mode = this.typeName;
+    var mode = this.typeName === "Form" ? "Screen" : this.typeName;
     return Blockly.ComponentBlock.EVENTS_HELPURLS[mode];
   },
 
@@ -355,7 +355,7 @@ Blockly.Blocks.component_event = {
 Blockly.Blocks.component_method = {
   category : 'Component',
   helpUrl : function() {
-      var mode = this.typeName;
+      var mode = this.typeName === "Form" ? "Screen" : this.typeName;
       return Blockly.ComponentBlock.METHODS_HELPURLS[mode];
   },
 
@@ -670,9 +670,9 @@ Blockly.Blocks.component_set_get = {
   category : 'Component',
   //this.blockType = 'getter',
   helpUrl : function() {
-    var mode = this.typeName;
+    var mode = this.typeName === "Form" ? "Screen" : this.typeName;
     return Blockly.ComponentBlock.PROPERTIES_HELPURLS[mode];
-  },  // TODO: fix
+  },
 
   mutationToDom : function() {
 

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -946,7 +946,7 @@ none
 
 <p>Top-level component containing all other components in the program</p>
 
-<h3>Properties</h3>
+<h3><a name="screenproperties"></a>Properties</h3>
 <dl>
   <dt><code>AboutScreen</code></dt>
   <dd>Information about the screen.  It appears when "About this Application" is selected from the system menu. Use it to tell users about your app.  In multiple screen apps, each screen has its own AboutScreen info.</dd>
@@ -1002,7 +1002,7 @@ none
   <dt><code>ShowListsAsJson</code> (designer only)</dt>
   <dd>
     If false, lists will be converted to strings using Lisp notation,
-    i.e., as symbols separated by spaces, e.g., (a 1 b2 (c d). If true,
+    i.e., as symbols separated by spaces, e.g., (a 1 b2 (c d)). If true,
     lists will appear as in Json or Python, e.g.  ["a", 1, "b", 2, ["c",
     "d"]].  This property appears only in Screen 1, and the value for
     Screen 1 determines the behavior for all screens. The property
@@ -1050,7 +1050,7 @@ none
   <dd>Screen width (x-size).</dd>
 </dl>
 
-<h3>Events</h3>
+<h3><a name="screenevents"></a>Events</h3>
 <dl>
   <dt><code>BackPressed()</code></dt>
   <dd>Device back button pressed.</dd>
@@ -1064,8 +1064,11 @@ none
   <dd>Screen orientation changed</dd>
 </dl>
 
-<h3>Methods</h3>
-none
+<h3><a name="screenmethods"></a>Methods</h3>
+<dl>
+  <dt><code>HideKeyboard()</code></dt>
+  <dd>Hide the onscreen soft keyboard.</dd>
+</dl>
 
 
 <h2 id="Slider">Slider</h2>


### PR DESCRIPTION
This is a minor fix for a bug I found when testing the new permission blocks. The Help entry on the context menu for Screen blocks was disabled because we use Form as the component name but the URLs are mapped to Screen. This change will "convert" from Form to Screen so that the Help function works. It also adds a missing description for the HideKeyboard block.

Change-Id: I3cb282631cfaf6e832c454af667f24ee5d70cbcf