### PR TITLE
Permission blocks for Screen

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -3920,6 +3920,10 @@ public interface OdeMessages extends Messages {
   @Description("")
   String functionNameParams();
 
+  @DefaultMessage("permissionName")
+  @Description("The name of the parameter that is used to report the name of a needed permission.")
+  String permissionNameParams();
+
   @DefaultMessage("errorNumber")
   @Description("")
   String errorNumberParams();
@@ -4492,6 +4496,14 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("OtherScreenClosed")
   @Description("")
   String OtherScreenClosedEvents();
+
+  @DefaultMessage("PermissionDenied")
+  @Description("The name of the event handler for when the app is denied a dangerous permission by the user.")
+  String PermissionDeniedEvents();
+
+  @DefaultMessage("PermissionGranted")
+  @Description("The name of the event handler for when the app is granted a dangerous permission by the user.")
+  String PermissionGrantedEvents();
 
   @DefaultMessage("ScreenOrientationChanged")
   @Description("")
@@ -5381,6 +5393,10 @@ public interface OdeMessages extends Messages {
   @DefaultMessage("HideKeyboard")
   @Description("")
   String HideKeyboardMethods();
+
+  @DefaultMessage("AskForPermission")
+  @Description("")
+  String AskForPermissionMethods();
 
   @DefaultMessage("Speak")
   @Description("")

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -959,6 +959,13 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 23;
     }
 
+    if (srcCompVersion < 24) {
+      // The AskForPermissions method was added.
+      // The PermissionDenied event was added.
+      // The PermissionGranted event was added.
+      srcCompVersion = 24;
+    }
+
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright © 2013-2016 MIT, All rights reserved
+// Copyright © 2013-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 /**
@@ -216,7 +216,7 @@ Blockly.Blocks.component_event = {
     }
   },
   helpUrl : function() {
-    var mode = this.typeName;
+    var mode = this.typeName === "Form" ? "Screen" : this.typeName;
     return Blockly.ComponentBlock.EVENTS_HELPURLS[mode];
   },
 
@@ -355,7 +355,7 @@ Blockly.Blocks.component_event = {
 Blockly.Blocks.component_method = {
   category : 'Component',
   helpUrl : function() {
-      var mode = this.typeName;
+      var mode = this.typeName === "Form" ? "Screen" : this.typeName;
       return Blockly.ComponentBlock.METHODS_HELPURLS[mode];
   },
 
@@ -670,9 +670,9 @@ Blockly.Blocks.component_set_get = {
   category : 'Component',
   //this.blockType = 'getter',
   helpUrl : function() {
-    var mode = this.typeName;
+    var mode = this.typeName === "Form" ? "Screen" : this.typeName;
     return Blockly.ComponentBlock.PROPERTIES_HELPURLS[mode];
-  },  // TODO: fix
+  },
 
   mutationToDom : function() {
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2231,7 +2231,11 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // For FORM_COMPONENT_VERSION 23:
     // - The ActionBar designer property was hidden and tied to the Theme property. No blocks need to be changed.
-    23: "noUpgrade"
+    23: "noUpgrade",
+
+    // For FORM_COMPONENT_VERSION 24:
+    // - The AskForPermissions method, PermissionDenied event, and PermissionGranted event were added. No blocks need to be changed.
+    24: "noUpgrade"
 
 
   }, // End Screen

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -431,8 +431,10 @@ public class YaVersion {
   // - FUSIONTABLESCONTROL_COMPONENT_VERSION was incremented to 4
   // For YOUNG_ANDROID_VERSION 172:
   // - WEBVIEWER_COMPONENT_VERSION was incremented to 7
+  // For YOUNG_ANDROID_VERSION 173:
+  // - FORM_COMPONENT_VERSION was incremented to 24
 
-  public static final int YOUNG_ANDROID_VERSION = 172;
+  public static final int YOUNG_ANDROID_VERSION = 173;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -748,7 +750,11 @@ public class YaVersion {
   // - The Classic option for themes was added
   // For FORM_COMPONENT_VERSION 23:
   // - The ActionBar property was deprecated
-  public static final int FORM_COMPONENT_VERSION = 23;
+  // For FORM_COMPONENT_VERSION 24:
+  // - Added the AskForPermission method
+  // - Added the PermissionDenied event
+  // - Added the PermissionGranted event
+  public static final int FORM_COMPONENT_VERSION = 24;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:
   // - The Fusiontables API was migrated from SQL to V1

--- a/appinventor/components/src/com/google/appinventor/components/runtime/BarcodeScanner.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/BarcodeScanner.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -105,10 +105,8 @@ public class BarcodeScanner extends AndroidNonvisibleComponent
                                BarcodeScanner.this.havePermission = true;
                                DoScan();
                              } else {
-                               BarcodeScanner.this
-                                 .container.$form()
-                                 .dispatchErrorOccurredEvent(BarcodeScanner.this, "BarcodeScanner",
-                                                             ErrorMessages.ERROR_NO_CAMERA_PERMISSION, "");
+                               form.dispatchPermissionDeniedEvent(BarcodeScanner.this, "DoScan",
+                                   Manifest.permission.CAMERA);
                              }
                            }
                          });

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camcorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camcorder.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -85,8 +85,8 @@ public class Camcorder extends AndroidNonvisibleComponent
                                      me.havePermission = true;
                                      me.RecordVideo();
                                    } else {
-                                     form.dispatchErrorOccurredEvent(me, "Camcorder",
-                                                                     ErrorMessages.ERROR_NO_CAMERA_PERMISSION);
+                                     form.dispatchPermissionDeniedEvent(me, "RecordVideo",
+                                         Manifest.permission.CAMERA);
                                    }
                                  }
                                });

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -130,8 +130,8 @@ public class Camera extends AndroidNonvisibleComponent
                                      me.havePermission = true;
                                      me.TakePicture();
                                    } else {
-                                     form.dispatchErrorOccurredEvent(me, "Camera",
-                                                                     ErrorMessages.ERROR_NO_CAMERA_PERMISSION);
+                                     form.dispatchPermissionDeniedEvent(me, "TakePicture",
+                                         Manifest.permission.CAMERA);
                                    }
                                  }
                                });

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -21,6 +21,7 @@ import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.collect.Sets;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.BoundingBox;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
@@ -1366,6 +1367,8 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
     try {
       File file = FileUtil.getPictureFile("png");
       return saveFile(file, Bitmap.CompressFormat.PNG, "Save");
+    } catch (PermissionException e) {
+      container.$form().dispatchPermissionDeniedEvent(this, "Save", e);
     } catch (IOException e) {
       container.$form().dispatchErrorOccurredEvent(this, "Save",
           ErrorMessages.ERROR_MEDIA_FILE_ERROR, e.getMessage());
@@ -1406,6 +1409,8 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
     try {
       File file = FileUtil.getExternalFile(fileName);
       return saveFile(file, format, "SaveAs");
+    } catch (PermissionException e) {
+      container.$form().dispatchPermissionDeniedEvent(this, "SaveAs", e);
     } catch (IOException e) {
       container.$form().dispatchErrorOccurredEvent(this, "SaveAs",
           ErrorMessages.ERROR_MEDIA_FILE_ERROR, e.getMessage());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/CloudDB.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/CloudDB.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2017 MIT, All rights reserved
+// Copyright 2017-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -34,12 +34,12 @@ import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.YailRuntimeError;
 
 import com.google.appinventor.components.runtime.util.CloudDBJedisListener;
+import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.JsonUtil;
 import com.google.appinventor.components.runtime.util.YailList;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -1201,18 +1201,8 @@ public final class CloudDB extends AndroidNonvisibleComponent implements Compone
       if (!fileName.startsWith("/")) {
         throw new YailRuntimeError("Invalid fileName, was " + originalFileName, "ReadFrom");
       }
-      File inputFile = new File(fileName);
-      if (!inputFile.isFile()) {
-        throw new YailRuntimeError("Cannot find file", "ReadFrom");
-      }
       String extension = getFileExtension(fileName);
-      FileInputStream inputStream = new FileInputStream(inputFile);
-      byte [] content = new byte[(int)inputFile.length()];
-      int bytesRead = inputStream.read(content);
-      if (bytesRead != inputFile.length()) {
-        throw new YailRuntimeError("Did not read complete file!", "Read");
-      }
-      inputStream.close();
+      byte [] content = FileUtil.readFile(fileName);
       String encodedContent = Base64.encodeToString(content, Base64.DEFAULT);
       Object [] results = new Object[2];
       results[0] = "." + extension;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ContactPicker.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -122,10 +122,8 @@ public class ContactPicker extends Picker implements ActivityResultListener {
                              ContactPicker.this.havePermission = true;
                              ContactPicker.this.click();
                            } else {
-                             ContactPicker
-                               .this.container.$form()
-                               .dispatchErrorOccurredEvent(ContactPicker.this, "ContactPicker",
-                                                           ErrorMessages.ERROR_NO_READ_CONTACTS_PERMISSION, "");
+                             container.$form().dispatchPermissionDeniedEvent(ContactPicker.this,
+                                 "Click", Manifest.permission.READ_CONTACTS);
                            }
                          }
                        });

--- a/appinventor/components/src/com/google/appinventor/components/runtime/EmailPicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/EmailPicker.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -12,9 +12,8 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
-import com.google.appinventor.components.runtime.util.ErrorMessages;
-import com.google.appinventor.components.runtime.util.SdkLevel;
 
+import android.Manifest;
 import android.widget.AutoCompleteTextView;
 
 /**
@@ -56,7 +55,20 @@ public class EmailPicker extends TextBoxBase {
   public EmailPicker(ComponentContainer container) {
     super(container, new AutoCompleteTextView(container.$context()));
     addressAdapter = new EmailAddressAdapter(container.$context());
-    ((AutoCompleteTextView) super.view).setAdapter(addressAdapter);
+  }
+
+  @SuppressWarnings("unused")  // Will be called from Scheme
+  public void Initialize() {
+    container.$form().askPermission(Manifest.permission.READ_CONTACTS, new PermissionResultHandler() {
+      @Override
+      public void HandlePermissionResponse(String permission, boolean granted) {
+        if (granted) {
+          ((AutoCompleteTextView) view).setAdapter(addressAdapter);
+        } else {
+          container.$form().dispatchPermissionDeniedEvent(EmailPicker.this, "Initialize", permission);
+        }
+      }
+    });
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/File.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/File.java
@@ -1,39 +1,31 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2014 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
-import com.google.appinventor.components.annotations.DesignerProperty;
-import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
-import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
-import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.AsynchUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
-import com.google.appinventor.components.runtime.Form;
-import com.google.appinventor.components.runtime.ReplForm;
 
 import android.Manifest;
 import android.app.Activity;
-import android.content.Context;
 import android.os.Environment;
 import android.util.Log;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
@@ -133,20 +125,11 @@ public class File extends AndroidNonvisibleComponent implements Component {
     try {
       InputStream inputStream;
       if (fileName.startsWith("//")) {
-        if (isRepl) {
-          form.assertPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
-          inputStream = new FileInputStream(Environment.getExternalStorageDirectory().getPath() +
-              "/AppInventor/assets/" + fileName);
-        } else {
-          inputStream = form.getAssets().open(fileName.substring(2));
-        }
+        inputStream = form.openAsset(fileName.substring(2));
       } else {
         String filepath = AbsoluteFileName(fileName);
-        if (MediaUtil.isExternalFile(filepath)) {
-          form.assertPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
-        }
         Log.d(LOG_TAG, "filepath = " + filepath);
-        inputStream = new FileInputStream(filepath);
+        inputStream = FileUtil.openFile(filepath);
       }
 
       final InputStream asyncInputStream = inputStream;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -60,6 +60,7 @@ import com.google.appinventor.components.runtime.multidex.MultiDex;
 import com.google.appinventor.components.runtime.util.AlignmentUtil;
 import com.google.appinventor.components.runtime.util.AnimationUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
+import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.FullScreenVideoUtil;
 import com.google.appinventor.components.runtime.util.JsonUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
@@ -70,8 +71,6 @@ import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import org.json.JSONException;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -2531,7 +2530,7 @@ public class Form extends AppInventorCompatActivity
       final AssetManager am = getAssets();
       return am.open(path.substring(ASSETS_PREFIX.length()));
     } else {
-      return new FileInputStream(new File(URI.create(path)));
+      return FileUtil.openFile(URI.create(path));
     }
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -1,6 +1,6 @@
 // -*- Mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Intent;
@@ -120,6 +121,12 @@ public class ImagePicker extends Picker implements ActivityResultListener {
   }
 
   private void saveSelectedImageToExternalStorage(String extension) {
+    if (container.$form().isDeniedPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      container.$form().dispatchPermissionDeniedEvent(this, "ImagePicker",
+          Manifest.permission.WRITE_EXTERNAL_STORAGE);
+      return;
+
+    }
     // clear imageFile for new save attempt
     // This will be the stored picture
     selectionSavedImage = "";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -67,6 +67,9 @@ public class ImagePicker extends Picker implements ActivityResultListener {
   // The path to the saved image
   private String selectionSavedImage = "";
 
+  // Flag to indicate whether we have permission to write imgaes to external storage
+  private boolean havePermission = false;
+
   /**
    * Create a new ImagePicker component.
    *
@@ -88,6 +91,27 @@ public class ImagePicker extends Picker implements ActivityResultListener {
   @Override
   protected Intent getIntent() {
     return new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI);
+  }
+
+  @Override
+  public void click() {
+    if (!havePermission) {
+      container.$form().askPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE,
+          new PermissionResultHandler() {
+            @Override
+            public void HandlePermissionResponse(String permission, boolean granted) {
+              if (granted) {
+                havePermission = true;
+                click();
+              } else {
+                container.$form().dispatchPermissionDeniedEvent(ImagePicker.this, "Click",
+                    permission);
+              }
+            }
+          });
+      return;
+    }
+    super.click();
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImagePicker.java
@@ -7,11 +7,7 @@
 package com.google.appinventor.components.runtime;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -33,6 +29,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
+import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 
 /**
@@ -153,8 +150,6 @@ public class ImagePicker extends Picker implements ActivityResultListener {
   private void copyToExternalStorageAndDeleteSource(File source, String extension) {
 
     File dest = null;
-    InputStream inStream = null;
-    OutputStream outStream = null;
 
     String fullDirname = Environment.getExternalStorageDirectory() + imagePickerDirectoryName;
     File destDirectory = new File(fullDirname);
@@ -168,19 +163,8 @@ public class ImagePicker extends Picker implements ActivityResultListener {
       // dest.deleteOnExit();
       Log.i(LOG_TAG, "saved file path is: " + selectionSavedImage);
 
-      inStream = new FileInputStream(source);
-      outStream = new FileOutputStream(dest);
+      FileUtil.copyFile(source.getAbsolutePath(), dest.getAbsolutePath());
 
-      byte[] buffer = new byte[1024];
-
-      int length;
-      // copy the file content in bytes
-      while ((length = inStream.read(buffer)) > 0){
-        outStream.write(buffer, 0, length);
-      }
-
-      inStream.close();
-      outStream.close();
       Log.i(LOG_TAG, "Image was copied to " + selectionSavedImage);
       // this can be uncommented to show the alert, but the alert
       // is pretty annoying

--- a/appinventor/components/src/com/google/appinventor/components/runtime/NxtDirectCommands.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/NxtDirectCommands.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -13,6 +13,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
+import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.YailList;
 
@@ -20,7 +21,6 @@ import android.util.Log;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -606,7 +606,7 @@ public class NxtDirectCommands extends LegoMindstormsNxtBase {
     try {
       File tempFile = MediaUtil.copyMediaToTempFile(form, source);
       try {
-        InputStream in = new BufferedInputStream(new FileInputStream(tempFile), 1024);
+        InputStream in = new BufferedInputStream(FileUtil.openFile(tempFile), 1024);
         try {
           long fileSize = tempFile.length();
           Integer handle = (destination.endsWith(".rxe") || destination.endsWith(".ric"))

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -75,7 +75,21 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
     form.registerForOnDestroy(this);
     PhoneNumber("");
     callStateReceiver = new CallStateReceiver();
-    registerCallStateMonitor();
+  }
+
+  @SuppressWarnings({"unused"})
+  public void Initialize() {
+    form.askPermission(Manifest.permission.PROCESS_OUTGOING_CALLS, new PermissionResultHandler() {
+      @Override
+      public void HandlePermissionResponse(String permission, boolean granted) {
+        if (granted) {
+          registerCallStateMonitor();
+        } else {
+          form.dispatchPermissionDeniedEvent(PhoneCall.this, "Initialize",
+              Manifest.permission.PROCESS_OUTGOING_CALLS);
+        }
+      }
+    });
   }
 
   /**
@@ -114,9 +128,8 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
               PhoneCall.this.havePermission = true;
               PhoneCall.this.MakePhoneCall();
             } else {
-              PhoneCall.this.form
-                .dispatchErrorOccurredEvent(PhoneCall.this, "PhoneCall",
-                  ErrorMessages.ERROR_NO_CALL_PERMISSION, "");
+              form.dispatchPermissionDeniedEvent(PhoneCall.this, "MakePhoneCall",
+                  Manifest.permission.READ_EXTERNAL_STORAGE);
             }
           }
         });

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2014 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -18,6 +18,7 @@ import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.IllegalArgumentError;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FroyoUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
@@ -181,6 +182,11 @@ public final class Player extends AndroidNonvisibleComponent
       try {
         MediaUtil.loadMediaPlayer(player, form, sourcePath);
 
+      } catch (PermissionException e) {
+        player.release();
+        player = null;
+        form.dispatchPermissionDeniedEvent(this, "Source", e);
+        return;
       } catch (IOException e) {
         player.release();
         player = null;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
@@ -335,6 +335,11 @@ public class ReplForm extends Form {
   }
 
   @Override
+  public String getAssetPath(String asset) {
+    return REPL_ASSET_DIR + asset;
+  }
+
+  @Override
   public String getAssetPathForExtension(Component component, String asset) throws FileNotFoundException {
     // For testing extensions, we allow external = false, but still compile the assets into the
     // companion for testing. When external = true, we are assuming this is an extension loaded

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sound.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sound.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 /// Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,6 +17,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
@@ -189,6 +190,8 @@ public class Sound extends AndroidNonvisibleComponent
             form.dispatchErrorOccurredEvent(this, "Source",
                 ErrorMessages.ERROR_UNABLE_TO_LOAD_MEDIA, sourcePath);
           }
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(this, "Source", e);
         } catch (IOException e) {
           form.dispatchErrorOccurredEvent(this, "Source",
               ErrorMessages.ERROR_UNABLE_TO_LOAD_MEDIA, sourcePath);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,6 +17,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
 import android.Manifest;
@@ -166,8 +167,7 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
                     me.havePermission = true;
                     me.Start();
                   } else {
-                    form.dispatchErrorOccurredEvent(me, "SoundRecorder",
-                      ErrorMessages.ERROR_SOUND_NO_PERMISSION);
+                    form.dispatchPermissionDeniedEvent(me, "Start", Manifest.permission.RECORD_AUDIO);
                   }
                 }
               });
@@ -188,6 +188,9 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
     }
     try {
       controller = new RecordingController(savedRecording);
+    } catch (PermissionException e) {
+      form.dispatchPermissionDeniedEvent(this, "Start", e);
+      return;
     } catch (Throwable t) {
       form.dispatchErrorOccurredEvent(
           this, "Start", ErrorMessages.ERROR_SOUND_RECORDER_CANNOT_CREATE, t.getMessage());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -7,7 +7,6 @@
 package com.google.appinventor.components.runtime;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -29,6 +28,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import java.util.ArrayList;
 
+import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.OAuth2Helper;
 import com.google.appinventor.components.runtime.util.OnInitializeListener;
 import com.google.appinventor.components.runtime.util.SdkLevel;
@@ -576,16 +576,8 @@ public class Texting extends AndroidNonvisibleComponent
     Log.i(TAG, "Retrieving cached messages");
     String cache = "";
     try {
-      FileInputStream fis = activity.openFileInput(CACHE_FILE);
-      byte[] bytes = new byte[8192];
-      if (fis == null) {
-        Log.e(TAG, "Null file stream returned from openFileInput");
-        return null;
-      }
-      int n = fis.read(bytes);
-      Log.i(TAG, "Read " + n + " bytes from " + CACHE_FILE);
-      cache = new String(bytes, 0, n);
-      fis.close();
+      byte[] bytes = FileUtil.readFile(CACHE_FILE);
+      cache = new String(bytes);
       activity.deleteFile(CACHE_FILE);
       messagesCached = 0;
       Log.i(TAG, "Retrieved cache " + cache);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -18,6 +18,7 @@ import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FullScreenVideoUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
@@ -198,6 +199,9 @@ public final class VideoPlayer extends AndroidViewComponent implements
         try {
           mediaReady = false;
           MediaUtil.loadVideoView(videoView, container.$form(), sourcePath);
+        } catch (PermissionException e) {
+          container.$form().dispatchPermissionDeniedEvent(this, "Source", e);
+          return;
         } catch (IOException e) {
           container.$form().dispatchErrorOccurredEvent(this, "Source",
               ErrorMessages.ERROR_UNABLE_TO_LOAD_MEDIA, sourcePath);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -21,6 +21,7 @@ import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.collect.Lists;
 import com.google.appinventor.components.runtime.collect.Maps;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.AsynchUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
@@ -345,8 +346,9 @@ public class Web extends AndroidNonvisibleComponent implements Component {
    */
   @SimpleFunction
   public void Get() {
+    final String METHOD = "Get";
     // Capture property values in local variables before running asynchronously.
-    final CapturedProperties webProps = capturePropertyValues("Get");
+    final CapturedProperties webProps = capturePropertyValues(METHOD);
     if (webProps == null) {
       // capturePropertyValues has already called form.dispatchErrorOccurredEvent
       return;
@@ -357,12 +359,14 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       public void run() {
         try {
           performRequest(webProps, null, null, "GET");
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(Web.this, METHOD, e);
         } catch (FileUtil.FileException e) {
-          form.dispatchErrorOccurredEvent(Web.this, "Get",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               e.getErrorMessageNumber());
         } catch (Exception e) {
           Log.e(LOG_TAG, "ERROR_UNABLE_TO_GET", e);
-          form.dispatchErrorOccurredEvent(Web.this, "Get",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               ErrorMessages.ERROR_WEB_UNABLE_TO_GET, webProps.urlString);
         }
       }
@@ -416,8 +420,9 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       "the name of the file.<br>" +
       "If the SaveResponse property is false, the GotText event will be triggered.")
   public void PostFile(final String path) {
+    final String METHOD = "PostFile";
     // Capture property values before running asynchronously.
-    final CapturedProperties webProps = capturePropertyValues("PostFile");
+    final CapturedProperties webProps = capturePropertyValues(METHOD);
     if (webProps == null) {
       // capturePropertyValues has already called form.dispatchErrorOccurredEvent
       return;
@@ -428,11 +433,13 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       public void run() {
         try {
           performRequest(webProps, null, path, "POST");
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(Web.this, METHOD, e);
         } catch (FileUtil.FileException e) {
-          form.dispatchErrorOccurredEvent(Web.this, "PostFile",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               e.getErrorMessageNumber());
         } catch (Exception e) {
-          form.dispatchErrorOccurredEvent(Web.this, "PostFile",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT_FILE, path, webProps.urlString);
         }
       }
@@ -486,8 +493,9 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       "the name of the file.<br>" +
       "If the SaveResponse property is false, the GotText event will be triggered.")
   public void PutFile(final String path) {
+    final String METHOD = "PutFile";
     // Capture property values before running asynchronously.
-    final CapturedProperties webProps = capturePropertyValues("PutFile");
+    final CapturedProperties webProps = capturePropertyValues(METHOD);
     if (webProps == null) {
       // capturePropertyValues has already called form.dispatchErrorOccurredEvent
       return;
@@ -498,11 +506,13 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       public void run() {
         try {
           performRequest(webProps, null, path, "PUT");
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(Web.this, METHOD, e);
         } catch (FileUtil.FileException e) {
-          form.dispatchErrorOccurredEvent(Web.this, "PutFile",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               e.getErrorMessageNumber());
         } catch (Exception e) {
-          form.dispatchErrorOccurredEvent(Web.this, "PutFile",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT_FILE, path, webProps.urlString);
         }
       }
@@ -520,8 +530,9 @@ public class Web extends AndroidNonvisibleComponent implements Component {
    */
   @SimpleFunction
   public void Delete() {
+    final String METHOD = "Delete";
     // Capture property values in local variables before running asynchronously.
-    final CapturedProperties webProps = capturePropertyValues("Delete");
+    final CapturedProperties webProps = capturePropertyValues(METHOD);
     if (webProps == null) {
       // capturePropertyValues has already called form.dispatchErrorOccurredEvent
       return;
@@ -532,11 +543,13 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       public void run() {
         try {
           performRequest(webProps, null, null, "DELETE");
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(Web.this, METHOD, e);
         } catch (FileUtil.FileException e) {
-          form.dispatchErrorOccurredEvent(Web.this, "Delete",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               e.getErrorMessageNumber());
         } catch (Exception e) {
-          form.dispatchErrorOccurredEvent(Web.this, "Delete",
+          form.dispatchErrorOccurredEvent(Web.this, METHOD,
               ErrorMessages.ERROR_WEB_UNABLE_TO_DELETE, webProps.urlString);
         }
       }
@@ -587,6 +600,8 @@ public class Web extends AndroidNonvisibleComponent implements Component {
 
         try {
           performRequest(webProps, requestData, null, httpVerb);
+        } catch (PermissionException e) {
+          form.dispatchPermissionDeniedEvent(Web.this, functionName, e);
         } catch (FileUtil.FileException e) {
           form.dispatchErrorOccurredEvent(Web.this, functionName,
               e.getErrorMessageNumber());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -1,11 +1,12 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.components.runtime;
 
+import android.Manifest;
 import android.content.Context;
 import android.webkit.JavascriptInterface;
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -22,11 +23,8 @@ import com.google.appinventor.components.common.YaVersion;
 
 import com.google.appinventor.components.runtime.util.EclairUtil;
 import com.google.appinventor.components.runtime.util.FroyoUtil;
+import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
-
-import android.app.Activity;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 
 import android.view.MotionEvent;
 import android.view.View;
@@ -219,7 +217,7 @@ public final class WebViewer extends AndroidViewComponent {
     homeUrl = url;
     // clear the history, since changing Home is a kind of reset
     webview.clearHistory();
-    webview.loadUrl(homeUrl);
+    loadUrl("HomeUrl", homeUrl);
   }
 
   /**
@@ -307,7 +305,7 @@ public final class WebViewer extends AndroidViewComponent {
       description = "Loads the home URL page.  This happens automatically when " +
           "the home URL is changed.")
   public void GoHome() {
-    webview.loadUrl(homeUrl);
+    loadUrl("GoHome", homeUrl);
   }
 
   /**
@@ -360,7 +358,7 @@ public final class WebViewer extends AndroidViewComponent {
   @SimpleFunction(
       description = "Load the page at the given URL.")
   public void GoToUrl(String url) {
-    webview.loadUrl(url);
+    loadUrl("GoToUrl", url);
   }
 
   /**
@@ -444,6 +442,16 @@ public final class WebViewer extends AndroidViewComponent {
   @SimpleEvent(description = "When the JavaScript calls AppInventor.setWebViewString this event is run.")
   public void WebViewStringChange(String value) {
     EventDispatcher.dispatchEvent(this, "WebViewStringChange", value);
+  }
+
+  private void loadUrl(String caller, String url) {
+    if (MediaUtil.isExternalFileUrl(url)) {
+      if (container.$form().isDeniedPermission(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+        container.$form().dispatchPermissionDeniedEvent(this, caller, Manifest.permission.READ_EXTERNAL_STORAGE);
+        return;
+      }
+    }
+    webview.loadUrl(url);
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/errors/PermissionException.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/errors/PermissionException.java
@@ -1,0 +1,40 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright © 2018 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.errors;
+
+/**
+ * PermissionException is thrown when App Inventor needs a certain permission granted by the user but does not
+ * have that permissions according to the Android permissions API.
+ *
+ * This exception will only be thrown on SDK 23 (Android 6.0 Marshmallow) or higher.
+ *
+ * @author ewpatton@mit.edu (Evan W. Patton)
+ */
+public class PermissionException extends RuntimeException {
+
+  private final String permissionNeeded;
+
+  /**
+   * Construct a new PermissionException to report that the given permission is needed.
+   * @param permissionNeeded The permission needed at the point the exception is thrown.
+   */
+  public PermissionException(String permissionNeeded) {
+    this.permissionNeeded = permissionNeeded;
+  }
+
+  /**
+   * Get the name of the needed permission.
+   * @return The permission name, e.g. android.permission.WRITE_EXTERNAL_STORAGE
+   */
+  public String getPermissionNeeded() {
+    return permissionNeeded;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Unable to complete the operation because the user denied permission: " + permissionNeeded;
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2017 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -116,6 +116,7 @@ public final class ErrorMessages {
   public static final int ERROR_SCREEN_INVALID_ANIMATION = 905;
   public static final int ERROR_NO_FOCUSABLE_VIEW_FOUND = 906;
   public static final int ERROR_ACTIONBAR_NOT_SUPPORTED = 907;
+  public static final int ERROR_PERMISSION_DENIED = 908;
   // Canvas errors
   public static final int ERROR_CANVAS_BITMAP_ERROR = 1001;
   public static final int ERROR_CANVAS_WIDTH_ERROR = 1002;
@@ -446,6 +447,8 @@ public final class ErrorMessages {
         "No Focusable View Found");
     errorMessages.put(ERROR_ACTIONBAR_NOT_SUPPORTED,
         "ActionBar is not supported on this device.");
+    errorMessages.put(ERROR_PERMISSION_DENIED,
+        "The permission %s has been denied. Please enable it in the Settings app.");
     // Canvas errors
     errorMessages.put(ERROR_CANVAS_BITMAP_ERROR, "Error getting Canvas contents to save");
     errorMessages.put(ERROR_CANVAS_WIDTH_ERROR, "Canvas width cannot be set to non-positive number");

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FileUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FileUtil.java
@@ -1,25 +1,28 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.components.runtime.util;
 
+import com.google.appinventor.components.runtime.Form;
 import com.google.appinventor.components.runtime.errors.RuntimeError;
+import com.google.appinventor.components.runtime.errors.YailRuntimeError;
 
+import android.Manifest;
 import android.os.Environment;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -65,14 +68,82 @@ public class FileUtil {
    * @return the file's contents as a byte array
    */
   public static byte[] readFile(String inputFileName) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    InputStream in = new FileInputStream(inputFileName);
-    try {
-      copy(in, out);
-    } finally {
-      in.close();
+    File inputFile = new File(inputFileName);
+    if (!inputFile.isFile()) {
+      throw new YailRuntimeError("Cannot find file", "Read");
     }
-    return out.toByteArray();
+    FileInputStream inputStream = null;
+    byte[] content = null;
+    try {
+      inputStream = openFile(inputFileName);
+      content = new byte[(int)inputFile.length()];
+      int bytesRead = inputStream.read(content);
+      if (bytesRead != inputFile.length()) {
+        throw new YailRuntimeError("Did not read complete file!", "Read");
+      }
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
+    }
+    return content;
+  }
+
+  /**
+   * Opens the file at the given file name.
+   *
+   * If the file is an external file and the app is running on a version of Android at SDK level 23
+   * or higher, then the READ_EXTERNAL_STORAGE permission will be checked. If the app does not have
+   * permission to read the external file, a PermissionException will be thrown.
+   *
+   * @param fileName The file path to open.
+   * @return An open FileInputStream on success
+   * @throws IOException If the file cannot be opened
+   * @throws com.google.appinventor.components.runtime.errors.PermissionException If the app does
+   * not have permission to read external files and the pathname looks to be external.
+   */
+  public static FileInputStream openFile(String fileName) throws IOException {
+    if (MediaUtil.isExternalFile(fileName)) {
+      Form.getActiveForm().assertPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+    return new FileInputStream(fileName);
+  }
+
+  /**
+   * Opens the file identified by the given File object.
+   *
+   * If the file is an external file and the app is running on a version of Android at SDK level 23
+   * or higher, then the READ_EXTERNAL_STORAGE permission will be checked. If the app does not have
+   * permission to read the external file, a PermissionException will be thrown.
+   *
+   * @param file The file to open.
+   * @return An open FileInputStream on success
+   * @throws IOException If the file cannot be opened
+   * @throws com.google.appinventor.components.runtime.errors.PermissionException If the app does
+   * not have permission to read external files and the pathname looks to be external.
+   */
+  public static FileInputStream openFile(File file) throws IOException {
+    return openFile(file.getAbsolutePath());
+  }
+
+  /**
+   * Opens the file at the given file URI.
+   *
+   * If the file is an external file and the app is running on a version of Android at SDK level 23
+   * or higher, then the READ_EXTERNAL_STORAGE permission will be checked. If the app does not have
+   * permission to read the external file, a PermissionException will be thrown.
+   *
+   * @param fileUri The file URI to open.
+   * @return An open FileInputStream on success
+   * @throws IOException If the file cannot be opened
+   * @throws com.google.appinventor.components.runtime.errors.PermissionException If the app does
+   * not have permission to read external files and the pathname looks to be external.
+   */
+  public static FileInputStream openFile(URI fileUri) throws IOException {
+    if (MediaUtil.isExternalFileUrl(fileUri.toString())) {
+      Form.getActiveForm().assertPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+    return new FileInputStream(new File(fileUri));
   }
 
   /**
@@ -246,10 +317,13 @@ public class FileUtil {
    * @throws FileException if the external storage is not writeable.
    */
   public static File getExternalFile(String fileName)
-    throws IOException, FileException {
+    throws IOException, FileException, SecurityException {
     checkExternalStorageWriteable();
     File file = new File(Environment.getExternalStorageDirectory(), fileName);
     File directory = file.getParentFile();
+    if (Form.getActiveForm() != null) {
+      Form.getActiveForm().assertPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    }
     if (!directory.exists() && !directory.mkdirs()) {
       throw new IOException("Unable to create directory " + directory.getAbsolutePath());
     }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -8,6 +8,7 @@ package com.google.appinventor.components.runtime.util;
 
 import com.google.appinventor.components.runtime.Form;
 import com.google.appinventor.components.runtime.VideoPlayer;
+import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 
 import android.R;
@@ -407,6 +408,9 @@ public class FullScreenVideoUtil implements OnCompletionListener,
       mFullScreenVideoBundle.putString(VIDEOPLAYER_SOURCE,
           source);
       return true;
+    } catch (PermissionException e) {
+      mForm.dispatchPermissionDeniedEvent(mFullScreenPlayer, "Source", e);
+      return false;
     } catch (IOException e) {
       mForm.dispatchErrorOccurredEvent(mFullScreenPlayer, "Source",
           ErrorMessages.ERROR_UNABLE_TO_LOAD_MEDIA, source);
@@ -459,6 +463,8 @@ public class FullScreenVideoUtil implements OnCompletionListener,
       MediaUtil.loadVideoView(mFullScreenVideoView, mForm,
           mFullScreenVideoBundle
               .getString(VIDEOPLAYER_SOURCE));
+    } catch (PermissionException e) {
+      mForm.dispatchPermissionDeniedEvent(mFullScreenPlayer, "Source", e);
     } catch (IOException e) {
       mForm.dispatchErrorOccurredEvent(mFullScreenPlayer, "Source",
           ErrorMessages.ERROR_UNABLE_TO_LOAD_MEDIA, mFullScreenVideoBundle

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -946,7 +946,7 @@ none
 
 <p>Top-level component containing all other components in the program</p>
 
-<h3>Properties</h3>
+<h3><a name="screenproperties"></a>Properties</h3>
 <dl>
   <dt><code>AboutScreen</code></dt>
   <dd>Information about the screen.  It appears when "About this Application" is selected from the system menu. Use it to tell users about your app.  In multiple screen apps, each screen has its own AboutScreen info.</dd>
@@ -1002,7 +1002,7 @@ none
   <dt><code>ShowListsAsJson</code> (designer only)</dt>
   <dd>
     If false, lists will be converted to strings using Lisp notation,
-    i.e., as symbols separated by spaces, e.g., (a 1 b2 (c d). If true,
+    i.e., as symbols separated by spaces, e.g., (a 1 b2 (c d)). If true,
     lists will appear as in Json or Python, e.g.  ["a", 1, "b", 2, ["c",
     "d"]].  This property appears only in Screen 1, and the value for
     Screen 1 determines the behavior for all screens. The property
@@ -1050,7 +1050,7 @@ none
   <dd>Screen width (x-size).</dd>
 </dl>
 
-<h3>Events</h3>
+<h3><a name="screenevents"></a>Events</h3>
 <dl>
   <dt><code>BackPressed()</code></dt>
   <dd>Device back button pressed.</dd>
@@ -1064,8 +1064,11 @@ none
   <dd>Screen orientation changed</dd>
 </dl>
 
-<h3>Methods</h3>
-none
+<h3><a name="screenmethods"></a>Methods</h3>
+<dl>
+  <dt><code>HideKeyboard()</code></dt>
+  <dd>Hide the onscreen soft keyboard.</dd>
+</dl>
 
 
 <h2 id="Slider">Slider</h2>

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -1060,12 +1060,25 @@ none
   <dd>Screen starting</dd>
   <dt><code>OtherScreenClosed(text otherScreenName, any result)</code></dt>
   <dd>Event raised when another screen has closed and control has returned to this screen.</dd>
+  <dt><code>PermissionDenied(component component, text functionName, text permissionName)</code></dt>
+  <dd>Event run to handle when the app user has denied a needed permission.</dd>
+  <dt><code>PermissionGranted(text permissionName)</code></dt>
+  <dd>Event to handle when the app user has granted a needed
+   permission. This event is only run when permission is granted in
+   response to the AskForPermission method.</dd>
   <dt><code>ScreenOrientationChanged()</code></dt>
   <dd>Screen orientation changed</dd>
 </dl>
 
 <h3><a name="screenmethods"></a>Methods</h3>
 <dl>
+  <dt><code><a name="AskForPermission"></a>AskForPermission(text permissionName)</code></dt>
+  <dd>Ask the user to grant access to a sensitive permission, such as
+    ACCESS_FINE_LOCATION. This block is typically used as part of
+    a <code>PermissionDenied</code> event to ask for permission. If
+    the user grants permission, the <code>PermissionGranted</code>
+    event will be run. If the user denies permission,
+    the <code>PermissionDenied</code> event will be run.</dd>
   <dt><code>HideKeyboard()</code></dt>
   <dd>Hide the onscreen soft keyboard.</dd>
 </dl>


### PR DESCRIPTION
This PR adds three new blocks for the Screen to help app inventors manage permissions on SDK 23 and higher. These blocks are:

1. method AskForPermission - Prompts the user for permission if it hasn't been granted. Either PermissionDenied or PermissionGranted will be run
2. event PermissionDenied - A permission was denied by the user. This is also run if a component attempts an action that requires a dangerous permission and that permission has been previously denied.
3. event PermissionGranted - A permission was granted by the user. This is only called in response to a successful AskForPermission action. Grants made in response to component requests are silently acknowledged and the component will continue its behavior that required the permission.

The PR also has the following changes:

* Builds on top of #1462 for documentation.
* Adds new helper methods to Form and FileUtil for files.
* Moves all components to use Form/FileUtil so that we minimize the number of places we ask for permission, especially w.r.t. READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE.
