### PR TITLE
Make annotation processors target Java 7

### DIFF
--- a/appinventor/components/build.xml
+++ b/appinventor/components/build.xml
@@ -254,6 +254,8 @@
       <javac destdir="@{apt-classdir}"
              encoding="utf-8"
              sourcepath=""
+             source="7"
+             target="7"
              srcdir="${src.dir}"
              includeantruntime="false">
         <include name="**/*.java" /> <!-- include all java files -->


### PR DESCRIPTION
Classes under components/ need to be built with an early enough version of Java to work on older devices. However, there is an issue where you clean and build targets in a certain order that can result in the annotation processor compiling classes using the current JDK version rather than targeting Java 7. No problem will be noticed if you run the system on the same version of Java as compiled, but when moving from Java > 7 to running on Java 7 Kawa will fail to compile apps.

Change-Id: Ie2ae31c90304d6278541f22513adfcf731f999a0