### PR TITLE
Fix handling of Map.ZoomLevel when animating changes

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -329,7 +329,9 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   @Override
   public int getZoom() {
-    return (int) view.getZoomLevel(false);
+    // We pass pending as true here so that when a user sets ZoomLevel
+    // and then reads it back it should be reflected.
+    return (int) view.getZoomLevel(true);
   }
 
   @Override


### PR DESCRIPTION
The behavior of how map animation works changed with the SDK 26 update. Technically the test was correct because with minSdk 7 and no targetSdk, Robolectric would simulate SDK 7 for testing. Now, it simulates SDK 26. Inside osmdroid, the animation behavior changes at SDK 11 (Honeycomb), and this breaks the test. This update fixes the behavior of how we report the ZoomLevel from the map so that it always returns the ZoomLevel for after the animation.

Change-Id: If652e6759e95e47884a1324f8dfd203d8b15e65a