### PR TITLE
Fix null pointer when logging before user info available

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/output/OdeLog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/output/OdeLog.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -83,7 +83,8 @@ public final class OdeLog extends Composite {
    * @return  logging availability
    */
   public static final boolean isLogAvailable() {
-    return AppInventorFeatures.hasDebuggingView() && Ode.getInstance().getUser().getIsAdmin();
+    return AppInventorFeatures.hasDebuggingView() &&
+      (Ode.getInstance().getUser() == null || Ode.getInstance().getUser().getIsAdmin());
   }
 
   /**


### PR DESCRIPTION
Fixes #1446 by assuming the user will be able to see logs until we know otherwise. 

Change-Id: Ie39c3a9e0e35c58a97a9307db8cd31a086e602b5