### PR TITLE
Fix GeoJSON parsing in MockFeatureCollection

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockFeatureCollection.java
@@ -180,7 +180,7 @@ public class MockFeatureCollection extends MockContainer implements MockMapFeatu
     if (collection) {
       var self = this;
       map.removeLayer(collection);
-      if (geojson.charCodeAt = 0xFEFF) geojson = geojson.substr(1);  // strip byte order marker, if present
+      if (geojson.charCodeAt(0) == 0xFEFF) geojson = geojson.substr(1);  // strip byte order marker, if present
       collection = top.L.geoJson(JSON.parse(geojson), {
         pointToLayer: function(feature, latlng) {
           for (var key in feature.properties) {


### PR DESCRIPTION
I'm not sure what I was thinking when I wrote this code for #1407, but clearly it is wrong. We didn't catch the regression because we only tested the case that was previously failing, and not any successful files that actually broke with the previous change.

Fixes #1456 

Change-Id: Ifd5cd24c006bac1acc996fcb7d3763c58c54dd84