### PR TITLE
Fix PlayApp build on Windows due to wrong slash

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -78,6 +78,7 @@ public final class Compiler {
 
   private static final String SLASH = File.separator;
   private static final String COLON = File.pathSeparator;
+  private static final String ZIPSLASH = "/";
 
   public static final String RUNTIME_FILES_DIR = "/" + "files" + "/";
 
@@ -1719,7 +1720,7 @@ public final class Compiler {
           }
 
           String sourcePath = "";
-          String pathSuffix = RUNTIME_FILES_DIR + sourceDirName + SLASH + lib;
+          String pathSuffix = RUNTIME_FILES_DIR + sourceDirName + ZIPSLASH + lib;
 
           if (simpleCompTypes.contains(type)) {
             sourcePath = getResource(pathSuffix);


### PR DESCRIPTION
In the fix to support adding native libraries to an app, we reference the system-dependent `SLASH` constant, which at first glance seems like the right thing to do. However, the pathname being constructed is going to be used to extract files from BuildServer.jar, and zip entries are always referenced using `/`. On Linux and macOS, this works because the directory separator is the same as in a zip file, but it fails on Windows due to the fact that `SLASH` will be `"\"`, not `"/"`. This change adds `ZIPSLASH` to indicate that the semantics of the slash are for use in ZIP files and sets it to be `"/"`. This way in a future pass through the code we don't accidentally change it back to `SLASH`.

Fixes #1471 

Change-Id: Idbd09280429ee9a786a4c476224fcae0e69f7e6c