### PR TITLE
Fix permissions handling on older Android versions

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -2472,8 +2472,7 @@ public class Form extends AppInventorCompatActivity
    */
   public void askPermission(final String permission, final PermissionResultHandler responseRequestor) {
     final Form form = this;
-    if (ContextCompat.checkSelfPermission(form, permission) ==
-        PackageManager.PERMISSION_GRANTED) {
+    if (!isDeniedPermission(permission)) {
       // We already have permission, so no need to ask
       responseRequestor.HandlePermissionResponse(permission, true);
       return;


### PR DESCRIPTION
On versions of Android < 4.0, the ContextCompat code for testing for permissions gets optimized away in a way that doesn't work correctly given how our code is structured. This prevents components such as File from working correctly. This change switches to checking `isPermissionDenied(String)`, which also includes an Android SDK version check. Therefore, we always assume that permissions are granted on Android < 6.0, which is the default behavior on most Android distributions of that era excepting Cyanogenmod (and maybe others).

Change-Id: If93a3e452908781c35e577c5d72df88eb028ade8