### PR TITLE
Chunk large Messages to the Companion

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -441,6 +441,40 @@ Blockly.ReplMgr.putYail = (function() {
             poll();
 
         },
+        'chunker' : (function() {
+            var seq = 0;
+            var gensym = function() {
+                seq += 1;
+                return 'Q' + seq;
+            };
+
+            var chunker = function(input) {
+                var length = input.length;
+                var chunklen = 8192;
+                if (length < chunklen) {
+                    return input;
+                }
+                var chunks = [];
+                while (length > 0) {
+                    var clen = Math.min(length, chunklen);
+                    chunks.push(input.substring(0, clen));
+                    input = input.substring(clen);
+                    length = input.length;
+                }
+                var symbol = gensym();
+                var retval = [];
+                retval.push('(define ' + symbol + ' "")');
+                chunks.forEach(function(item, index) {
+                    item = item.replace(/\\/g, '\\\\');
+                    item = item.replace(/"/g, '\\"');
+                    var code = '(set! ' + symbol + ' (string-append ' + symbol + ' "' + item + '"))';
+                    retval.push(code);
+                });
+                retval.push('(eval (read (open-input-string ' + symbol + ')))');
+                return retval;
+            };
+            return (chunker);
+        })(),
         'pollphone' : function() {
             if (!rs.didversioncheck) {
                 engine.doversioncheck();
@@ -479,7 +513,17 @@ Blockly.ReplMgr.putYail = (function() {
                     sendcode = "(begin (require <com.google.youngandroid.runtime>) (process-repl-input " +
                         blockid + " (begin " + work.code + ")))";
                     console.log(sendcode);
-                    webrtcdata.send(sendcode); // Send the code!
+                    sendcode = engine.chunker(sendcode);
+                    if (typeof(sendcode) == 'string') {
+                        console.log('sending whole');
+                        webrtcdata.send(sendcode); // Send the code!
+                    } else {
+                        console.log('sending chunked');
+                        sendcode.forEach(function(item) {
+                            console.log('Chunk: ' + item);
+                            webrtcdata.send(item);
+                        });
+                    }
                 }
                 if (rs.state == Blockly.ReplMgr.rsState.CONNECTED) {
                     while ((work = rs.phoneState.phoneQueue.shift())) {
@@ -491,7 +535,17 @@ Blockly.ReplMgr.putYail = (function() {
                         sendcode = "(begin (require <com.google.youngandroid.runtime>) (process-repl-input " +
                             blockid + " (begin " + work.code + ")))";
                         console.log(sendcode);
-                        webrtcdata.send(sendcode); // Send the code!
+                        sendcode = engine.chunker(sendcode);
+                        if (typeof(sendcode) == 'string') {
+                            console.log('sending whole');
+                            webrtcdata.send(sendcode); // Send the code!
+                        } else {
+                            console.log('sending chunked');
+                            sendcode.forEach(function(item) {
+                                console.log('Chunk: ' + item);
+                                webrtcdata.send(item);
+                            });
+                        }
                     }
                 }
                 rs.phoneState.ioRunning = false;


### PR DESCRIPTION
WebRTC can only safely send messages of 16K. So we will only send up to
8K characters (ok, a margin of safety). Most projects do not need to
send YAIL forms larger then this, but a few do.

To “chunk” the code into smaller pieces would normally require changes
both on the browser side and the Companion side. However we wish to
avoid changing the Companion at this time. So instead, we break the
large YAIL forms into smaller YAIL forms that can each be evaled on the
device correctly.

Change-Id: I865e39cad3c55ea35b2a56582d50136f8303e90e