### PR TITLE
Fix default background color on SDKs prior to 14

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1765,10 +1765,12 @@ public class Form extends AppInventorCompatActivity
   @SimpleProperty(userVisible = false, description = "Sets the theme used by the application.")
   public void Theme(String theme) {
     if (SdkLevel.getLevel() < SdkLevel.LEVEL_HONEYCOMB) {
+      backgroundColor = Component.COLOR_WHITE;
+      setBackground(frameLayout);
       return;  // Only "Classic" is supported below SDK 11 due to minSDK in AppCompat
     }
     if (usesDefaultBackground) {
-      if (theme.equalsIgnoreCase("AppTheme")) {
+      if (theme.equalsIgnoreCase("AppTheme") && !isClassicMode()) {
         backgroundColor = Component.COLOR_BLACK;
       } else {
         backgroundColor = Component.COLOR_WHITE;


### PR DESCRIPTION
A teacher reported a regression in the emulator (Android 2.1) where the default background color is black instead of white. This is due to the fact that appcompat support went away with the SDK 26 update and I constructed a similar theme. In the fix for SDK 26 so that we could support pre SDK 14 devices, I failed to enforce that that the default background color is white, and so the background ends up black if default is specified.

The easiest way to test this is to build App Inventor, load the companion into the emulator, and load HelloPurr as a project. On older Android versions the background will be black, rather than white. This patch corrects the problem.

Change-Id: I46562b4a2668303862940456bec490fe6c757bdc