### PR TITLE
Remove extra loop from polygonFromGeoJSON

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/GeoJSONUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/GeoJSONUtil.java
@@ -341,12 +341,8 @@ public final class GeoJSONUtil {
   private static MapPolygon polygonFromGeoJSON(final MapFeatureContainer container,
       final YailList coordinates) {
     Polygon polygon = new Polygon(container);
-    Iterator i = coordinates.iterator();
-    i.next();
-    polygon.Points(swapCoordinates((YailList) i.next()));
-    if (i.hasNext()) {
-      polygon.HolePoints(YailList.makeList(swapNestedCoordinates((LList) ((Pair)coordinates.getCdr()).getCdr())));
-    }
+    polygon.Points(swapCoordinates((YailList) coordinates.get(1)));
+    polygon.HolePoints(YailList.makeList(swapNestedCoordinates((LList) ((Pair) coordinates.getCdr()).getCdr())));
     return polygon;
   }
 


### PR DESCRIPTION
This corrects the generation of map polygons from GeoJSON. FeatureFromDescription block for Map and FeatureCollection should now correctly parse the coordinates for a polygon.

Basically, the code to load polygons and multipolygons was the same, but the polygon code assumed a single entry. Multipolygon coordinates are actually nested one level deeper than polygon coordinates, so the polygon builder was iterating itself into oblivion.

This should become more relevant with PR #1500 , which makes it much more straightforward to load map features at runtime

A test project demonstrating the bug is attached to the Issue.

Fixes #1503 

Change-Id: I1a0a04c4d8ffb1190f1e33a6897004fab4b01146