### PR TITLE
Fix HELPURL for Screen component selector block

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -971,7 +971,7 @@ Blockly.Blocks.component_component_block = {
   category : 'Component',
 
   helpUrl : function() {
-    var mode = this.typeName;
+    var mode = this.typeName === "Form" ? "Screen" : this.typeName;
     return Blockly.ComponentBlock.HELPURLS[mode];
   },  // TODO: fix
 


### PR DESCRIPTION
PR #1426 fixed the "Help" button for the Screen's Event, Property and Method blocks but didn't fix the component selector block.

Before:
![image](https://user-images.githubusercontent.com/25845449/50726631-bf186100-1107-11e9-8255-5b3a8f184fa0.png)

After:
![image](https://user-images.githubusercontent.com/25845449/50726647-e8d18800-1107-11e9-9783-45dc3c4366e4.png)