### PR TITLE
FIX: Little typo on Javadoc

### DIFF
--- a/appinventor/build.xml
+++ b/appinventor/build.xml
@@ -144,7 +144,6 @@
         <!-- app engine libs -->
         <pathelement location="lib/appengine/appengine-java-sdk-1.9.17/lib/user/appengine-api-1.0-sdk-1.9.17.jar"/>
         <pathelement location="lib/gcs/appengine-gcs-client-0.4.3.jar"/>
-        -->
         <pathelement location="lib/appengine/appengine-java-sdk-1.9.17/lib/testing/appengine-testing.jar"/>
         <pathelement location="lib/appengine/appengine-java-sdk-1.9.17/lib/impl/appengine-api-stubs.jar"/>
         <pathelement location="lib/appengine/appengine-java-sdk-1.9.17/lib/user/orm/geronimo-jpa_3.0_spec-1.1.1.jar"/>


### PR DESCRIPTION
I have just fixed a little issue on Javadoc target at build.xml
It was raising an error, but it was easy to fix it