### PR TITLE
Create a Connection Progress Bar

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/AssetManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/AssetManager.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2018 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -242,9 +242,13 @@ public final class AssetManager implements ProjectChangeListener {
         }
       }
     }
-    // If no assets are in the project, perform the callback immediately.
-    if (assets.values().size() == 0 && assetsTransferredCallback != null) {
-      doCallBack(assetsTransferredCallback);
+    // If no assets are in the project, close the Progress Bar and
+    // perform the callback immediately.
+    if (assets.values().size() == 0) {
+      ConnectProgressBar.hide();
+      if (assetsTransferredCallback != null) {
+        doCallBack(assetsTransferredCallback);
+      }
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
@@ -28,81 +28,82 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 public final class ConnectProgressBar {
 
-    private static ConnectProgressBar INSTANCE = new ConnectProgressBar();
-    private ProgressBarDialogBox progressBar;
-    private boolean shouldShow = false;
+  private static ConnectProgressBar INSTANCE = new ConnectProgressBar();
+  private ProgressBarDialogBox progressBar;
+  private boolean shouldShow = false;
 
-    private ConnectProgressBar() {
-      exportMethodsToJavascript();
+  private ConnectProgressBar() {
+    exportMethodsToJavascript();
+  }
+
+  public static ConnectProgressBar getInstance() {
+    return INSTANCE;
+  }
+
+  public static void start() {
+    INSTANCE.start1();
+  }
+
+  private void start1() {
+    Ode ode = Ode.getInstance();
+    Project currentProject = ode.getProjectManager().getProject(ode.getCurrentYoungAndroidProjectId());
+    if (progressBar == null) {
+      progressBar = new ProgressBarDialogBox("ConnectProgressBar", currentProject.getRootNode());
+      progressBar.show();
+      progressBar.center();
+      progressBar.setProgress(0, MESSAGES.startingConnectionDialog());
+      progressBar.showDismissButton();
+    } else if (!progressBar.isShowing() && progressBar.getProgressBarShow() < 2) {
+      progressBar.show();
+      progressBar.center();
     }
+  }
 
-    public static ConnectProgressBar getInstance() {
-      return INSTANCE;
+  public static void setProgress(int progress, String message) {
+    INSTANCE.setProgress1(progress, message);
+  }
+
+  private void setProgress1(int progress, String message) {
+    if (progressBar != null && progressBar.isShowing()) {
+      progressBar.setProgress(progress, message);
     }
+  }
 
-    public static void start() {
-      INSTANCE.start1();
+  public static void hide() {
+    INSTANCE.hide1();
+  }
+
+  private void hide1() {
+    if (progressBar != null && progressBar.isShowing()) {
+      progressBar.hide(true);
     }
+    progressBar = null;
+  }
 
-    private void start1() {
-      Ode ode = Ode.getInstance();
-      Project currentProject = ode.getProjectManager().getProject(ode.getCurrentYoungAndroidProjectId());
-      if (progressBar == null) {
-          progressBar = new ProgressBarDialogBox("ConnectProgressBar", currentProject.getRootNode());
-          progressBar.show();
-          progressBar.center();
-          progressBar.setProgress(0, MESSAGES.startingConnectionDialog());
-          progressBar.showDismissButton();
-      } else if (!progressBar.isShowing() && progressBar.getProgressBarShow() < 2) {
-          progressBar.show();
-          progressBar.center();
+  public static void tempHide(boolean hide) {
+    INSTANCE.tempHide1(hide);
+  }
+
+  private void tempHide1(boolean hide) {
+    if (progressBar == null) {
+      return;                 // Nothing to do
+    }
+    if (hide) {
+      shouldShow = progressBar.isShowing();
+      if (shouldShow) {
+        progressBar.hide(true);
       }
+    } else if (shouldShow) {
+      progressBar.show();
+      progressBar.center();
     }
+  }
 
-    public static void setProgress(int progress, String message) {
-      INSTANCE.setProgress1(progress, message);
-    }
+  private static native void exportMethodsToJavascript() /*-{
+    $wnd.ConnectProgressBar_start =
+      $entry(@com.google.appinventor.client.ConnectProgressBar::start());
+    $wnd.ConnectProgressBar_setProgress =
+      $entry(@com.google.appinventor.client.ConnectProgressBar::setProgress(ILjava/lang/String;));
+  }-*/;
 
-    private void setProgress1(int progress, String message) {
-      if (progressBar != null && progressBar.isShowing()) {
-          progressBar.setProgress(progress, message);
-      }
-    }
-
-    public static void hide() {
-      INSTANCE.hide1();
-    }
-
-    private void hide1() {
-      if (progressBar != null && progressBar.isShowing()) {
-          progressBar.hide(true);
-      }
-      progressBar = null;
-    }
-
-    public static void tempHide(boolean hide) {
-      INSTANCE.tempHide1(hide);
-    }
-
-    private void tempHide1(boolean hide) {
-      if (progressBar == null) {
-        return;                 // Nothing to do
-      }
-      if (hide) {
-        shouldShow = progressBar.isShowing();
-        if (shouldShow) {
-          progressBar.hide(true);
-        }
-      } else if (shouldShow) {
-        progressBar.show();
-        progressBar.center();
-      }
-    }
-
-    private static native void exportMethodsToJavascript() /*-{
-      $wnd.ConnectProgressBar_start =
-        $entry(@com.google.appinventor.client.ConnectProgressBar::start());
-      $wnd.ConnectProgressBar_setProgress =
-        $entry(@com.google.appinventor.client.ConnectProgressBar::setProgress(ILjava/lang/String;));
-    }-*/;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
@@ -15,7 +15,7 @@ import static com.google.appinventor.client.Ode.MESSAGES;
  * Show a Progress Bar during connection from the Browser to the Companion.
  * We are designed by be used from a static context. This facilitates calls
  * from both the Java (GWT) side of things and the Javascript (blockly) side
- * of thing.
+ * of things.
  *
  * Javascript starts the progress bar when we learn the connection information
  * we need from the Rendezvous server. After a connection to the Companion is complete
@@ -29,8 +29,8 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 public final class ConnectProgressBar {
 
     private static ConnectProgressBar INSTANCE = new ConnectProgressBar();
-    private Project currentProject;
     private ProgressBarDialogBox progressBar;
+    private boolean shouldShow = false;
 
     private ConnectProgressBar() {
       exportMethodsToJavascript();
@@ -46,7 +46,7 @@ public final class ConnectProgressBar {
 
     private void start1() {
       Ode ode = Ode.getInstance();
-      currentProject = ode.getProjectManager().getProject(ode.getCurrentYoungAndroidProjectId());
+      Project currentProject = ode.getProjectManager().getProject(ode.getCurrentYoungAndroidProjectId());
       if (progressBar == null) {
           progressBar = new ProgressBarDialogBox("ConnectProgressBar", currentProject.getRootNode());
           progressBar.show();
@@ -63,7 +63,7 @@ public final class ConnectProgressBar {
       INSTANCE.setProgress1(progress, message);
     }
 
-    public void setProgress1(int progress, String message) {
+    private void setProgress1(int progress, String message) {
       if (progressBar != null && progressBar.isShowing()) {
           progressBar.setProgress(progress, message);
       }
@@ -73,11 +73,30 @@ public final class ConnectProgressBar {
       INSTANCE.hide1();
     }
 
-    public void hide1() {
+    private void hide1() {
       if (progressBar != null && progressBar.isShowing()) {
           progressBar.hide(true);
       }
       progressBar = null;
+    }
+
+    public static void tempHide(boolean hide) {
+      INSTANCE.tempHide1(hide);
+    }
+
+    private void tempHide1(boolean hide) {
+      if (progressBar == null) {
+        return;                 // Nothing to do
+      }
+      if (hide) {
+        shouldShow = progressBar.isShowing();
+        if (shouldShow) {
+          progressBar.hide(true);
+        }
+      } else if (shouldShow) {
+        progressBar.show();
+        progressBar.center();
+      }
     }
 
     private static native void exportMethodsToJavascript() /*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
@@ -1,0 +1,89 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2019 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client;
+
+import com.google.appinventor.client.explorer.dialogs.ProgressBarDialogBox;
+
+import com.google.appinventor.client.explorer.project.Project;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+/**
+ * Show a Progress Bar during connection from the Browser to the Companion.
+ * We are designed by be used from a static context. This facilitates calls
+ * from both the Java (GWT) side of things and the Javascript (blockly) side
+ * of thing.
+ *
+ * Javascript starts the progress bar when we learn the connection information
+ * we need from the Rendezvous server. After a connection to the Companion is complete
+ * we hand control over to the AssetManager (in GWT land).
+ *
+ * @author jis@mit.edu (Jeffrey I. Schiller)
+ *
+ */
+
+
+public final class ConnectProgressBar {
+
+    private static ConnectProgressBar INSTANCE = new ConnectProgressBar();
+    private Project currentProject;
+    private ProgressBarDialogBox progressBar;
+
+    private ConnectProgressBar() {
+      exportMethodsToJavascript();
+    }
+
+    public static ConnectProgressBar getInstance() {
+      return INSTANCE;
+    }
+
+    public static void start() {
+      INSTANCE.start1();
+    }
+
+    private void start1() {
+      Ode ode = Ode.getInstance();
+      currentProject = ode.getProjectManager().getProject(ode.getCurrentYoungAndroidProjectId());
+      if (progressBar == null) {
+          progressBar = new ProgressBarDialogBox("ConnectProgressBar", currentProject.getRootNode());
+          progressBar.show();
+          progressBar.center();
+          progressBar.setProgress(0, MESSAGES.startingConnectionDialog());
+          progressBar.showDismissButton();
+      } else if (!progressBar.isShowing() && progressBar.getProgressBarShow() < 2) {
+          progressBar.show();
+          progressBar.center();
+      }
+    }
+
+    public static void setProgress(int progress, String message) {
+      INSTANCE.setProgress1(progress, message);
+    }
+
+    public void setProgress1(int progress, String message) {
+      if (progressBar != null && progressBar.isShowing()) {
+          progressBar.setProgress(progress, message);
+      }
+    }
+
+    public static void hide() {
+      INSTANCE.hide1();
+    }
+
+    public void hide1() {
+      if (progressBar != null && progressBar.isShowing()) {
+          progressBar.hide(true);
+      }
+      progressBar = null;
+    }
+
+    private static native void exportMethodsToJavascript() /*-{
+      $wnd.ConnectProgressBar_start =
+        $entry(@com.google.appinventor.client.ConnectProgressBar::start());
+      $wnd.ConnectProgressBar_setProgress =
+        $entry(@com.google.appinventor.client.ConnectProgressBar::setProgress(ILjava/lang/String;));
+    }-*/;
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -739,6 +739,9 @@ public class Ode implements EntryPoint {
       galleryIdLoadingFlag = true;
     }
 
+    // We call this below to initialize the ConnectProgressBar
+    ConnectProgressBar.getInstance();
+
     // Get user information.
     OdeAsyncCallback<Config> callback = new OdeAsyncCallback<Config>(
         // failure message

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2227,9 +2227,9 @@ public interface OdeMessages extends Messages {
   @Description("Text messages are always received, and a notification is shown if the App is in the background.")
   String textReceivingChoiceAlways();
 
-  @DefaultMessage("Starting asset transfer to companion...")
-  @Description("Message to display at the start of an asset transfer before any assets are sent")
-  String startingAssetTransfer();
+  @DefaultMessage("0 Starting Up")
+  @Description("")
+  String startingConnectionDialog();
 
   @DefaultMessage("Downloading {0} from the App Inventor server...")
   @Description("Message to display when an asset is being downloaded from the server")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -1,12 +1,13 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright © 2009-2011 Google, All Rights reserved
-// Copyright © 2011-2016 Massachusetts Institute of Technology, All rights reserved
+// Copyright © 2011-2019 Massachusetts Institute of Technology, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.editor.youngandroid;
 
 import com.google.appinventor.client.ComponentsTranslation;
+import com.google.appinventor.client.ConnectProgressBar;
 import com.google.appinventor.client.DesignToolbar;
 import com.google.appinventor.client.ErrorReporter;
 import com.google.appinventor.client.Ode;
@@ -381,6 +382,7 @@ public class BlocklyPanel extends HTMLPanel {
     DialogBoxContents.add(holder);
     dialogBox.setWidget(DialogBoxContents);
     terminateDrag();  // cancel a drag before showing the modal dialog
+    ConnectProgressBar.tempHide(true); // Hide any connection progress bar
     dialogBox.show();
     return dialogBox;
   }
@@ -394,6 +396,7 @@ public class BlocklyPanel extends HTMLPanel {
    */
 
   public static void HideDialog(DialogBox dialog) {
+    ConnectProgressBar.tempHide(false); // unhide the progress bar if it was hidden
     dialog.hide();
   }
 

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1445,6 +1445,12 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.TIME_MINUTES = "Minutes";
     Blockly.Msg.TIME_SECONDS = "Seconds";
     Blockly.Msg.TIME_DURATION = "Duration";
+
+// Connection Dialog Messages
+    Blockly.Msg.DIALOG_SECURE_ESTABLISHING = "20 Establishing Secure Connection";
+    Blockly.Msg.DIALOG_SECURE_ESTABLISHED = "30 Secure Connection Established";
+    Blockly.Msg.DIALOG_FOUND_COMPANION = "10 Found the Companion";
+
   }
 };
 

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -256,6 +256,7 @@ Blockly.ReplMgr.putYail = (function() {
     var conn;                   // XMLHttpRequest Object sending to Phone
     var rxhr;                   // XMLHttpRequest Object listening for returns
     var context;
+    var upatedProgressDialog = false;
     var phonereceiving = false;
     var webrtcstarting = false;
     var webrtcrunning = false;
@@ -336,6 +337,7 @@ Blockly.ReplMgr.putYail = (function() {
             var haveoffer = false;
             webrtcisopen = false;
             webrtcforcestop = false;
+            top.ConnectProgressBar_setProgress(20, Blockly.Msg.DIALOG_SECURE_ESTABLISHING);
             var poll = function() {
                 var xhr = new XMLHttpRequest();
                 xhr.open('GET', webrtcrendezvous + key + '-r', true);
@@ -399,6 +401,7 @@ Blockly.ReplMgr.putYail = (function() {
             webrtcdata = webrtcpeer.createDataChannel('data');
             webrtcdata.onopen = function() {
                 webrtcisopen = true;
+                top.ConnectProgressBar_setProgress(30, Blockly.Msg.DIALOG_SECURE_ESTABLISHED);
                 console.log('webrtc data connection open!');
                 webrtcdata.onmessage = function(ev) {
                     console.log("webrtc(onmessage): " + ev.data);
@@ -1353,6 +1356,9 @@ Blockly.ReplMgr.getFromRendezvous = function() {
                     return;
                 }
                 rs.dialog.hide(); // Take down the QRCode dialog
+                // Keep the user informed about the connection
+                top.ConnectProgressBar_start();
+                top.ConnectProgressBar_setProgress(10, Blockly.Msg.DIALOG_FOUND_COMPANION);
                 var json = goog.json.parse(xmlhttp.response);
                 rs.url = 'http://' + json.ipaddr + ':8001/_newblocks';
                 rs.rurl = 'http://' + json.ipaddr + ':8001/_values';


### PR DESCRIPTION
WebRTC Connections can take a while to negotiate. This change gives the
user some feedback while negotiation is taking place.

We remove the ProgressBarDialog functionality from AssetManager and
place it in a new module which is called from AssetManager and from
replmgr.js. This permits us to put up the progress dialog at connection
attempt time instead of at asset download time.

Change-Id: I28772eb92a49b8ed2aa9af9ab84b1ea10d915bcc