### PR TITLE
Fix for WebRTC on Safari

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -263,7 +263,7 @@ Blockly.ReplMgr.putYail = (function() {
     var webrtcisopen = false;
     var webrtcforcestop = false;
     // var iceservers = { 'iceServers' : [ { 'urls' : ['stun:stun.l.google.com:19302']}]};
-    var iceservers = { 'iceServers' : [ { 'url' : 'turn:turn.appinventor.mit.edu:3478',
+    var iceservers = { 'iceServers' : [ { 'urls' : ['turn:turn.appinventor.mit.edu:3478'],
                                           'username' : 'oh',
                                           'credential' : 'boy' }]};
     var webrtcrendezvous = 'http://rendezvous.appinventor.mit.edu/rendezvous2/';


### PR DESCRIPTION
Use the “urls” property of ICEServer instead of the deprecated “url”
property.

Change-Id: I391f06eaffd26261a7a106e9fb35eedf2e0d84ee