### PR TITLE
Ensure Polygon Points and HolePoints invalidate map view

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
@@ -141,6 +141,7 @@ public class Polygon extends PolygonBase implements MapPolygon {
             "Unable to determine the structure of the points argument.");
       }
       clearGeometry();
+      map.getController().updateFeaturePosition(this);
     } catch(DispatchableError e) {
       container.$form().dispatchErrorOccurredEvent(this, "Points", e.getErrorCode(), e.getArguments());
     }
@@ -209,7 +210,7 @@ public class Polygon extends PolygonBase implements MapPolygon {
             "Unable to determine the structure of the points argument.");
       }
       clearGeometry();
-      map.getController().updateFeaturePosition(this);
+      map.getController().updateFeatureHoles(this);
     } catch(DispatchableError e) {
       container.$form().dispatchErrorOccurredEvent(this, "HolePoints",
           e.getErrorCode(), e.getArguments());
@@ -222,18 +223,18 @@ public class Polygon extends PolygonBase implements MapPolygon {
   public void HolePointsFromString(String pointString) {
     if (TextUtils.isEmpty(pointString)) {
       holePoints = new ArrayList<List<List<GeoPoint>>>();  // create a new list in case the user has saved a reference
-      map.getController().updateFeaturePosition(this);
+      map.getController().updateFeatureHoles(this);
       return;
     }
     try {
       JSONArray content = new JSONArray(pointString);
       if (content.length() == 0) {
         holePoints = new ArrayList<List<List<GeoPoint>>>();  // create a new list in case the user has saved a reference
-        map.getController().updateFeaturePosition(this);
+        map.getController().updateFeatureHoles(this);
         return;
       }
       holePoints = GeometryUtil.multiPolygonHolesToList(content);
-      map.getController().updateFeaturePosition(this);
+      map.getController().updateFeatureHoles(this);
       Log.d(TAG, "Points: " + points);
     } catch(JSONException e) {
       Log.e(TAG, "Unable to parse point string", e);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
@@ -230,6 +230,11 @@ class DummyMapController implements MapController {
   }
 
   @Override
+  public void updateFeatureHoles(MapPolygon polygon) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void updateFeaturePosition(MapCircle circle) {
     throw new UnsupportedOperationException();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
@@ -442,6 +442,13 @@ public final class MapFactory {
     void updateFeaturePosition(MapPolygon polygon);
 
     /**
+     * Update the holes in a polygon on the map.
+     *
+     * @param polygon the polygon that needs its holes updated
+     */
+    void updateFeatureHoles(MapPolygon polygon);
+
+    /**
      * Update the position of a circle on the map.
      *
      * @param circle the circle that needs its position updated on the map

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -737,6 +737,14 @@ class NativeOpenStreetMapController implements MapController, MapListener {
     MultiPolygon polygon = (MultiPolygon) featureOverlays.get(aiPolygon);
     if (polygon != null) {
       polygon.setMultiPoints(aiPolygon.getPoints());
+      view.invalidate();
+    }
+  }
+
+  @Override
+  public void updateFeatureHoles(MapPolygon aiPolygon) {
+    MultiPolygon polygon = (MultiPolygon) featureOverlays.get(aiPolygon);
+    if (polygon != null) {
       polygon.setMultiHoles(aiPolygon.getHolePoints());
       view.invalidate();
     }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/MapTestBase.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/MapTestBase.java
@@ -5,6 +5,7 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.view.ViewGroup;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.runtime.shadows.org.osmdroid.tileprovider.modules.ShadowMapTileModuleProviderBase;
 import com.google.appinventor.components.runtime.shadows.org.osmdroid.views.ShadowMapView;
@@ -13,6 +14,7 @@ import com.google.appinventor.components.runtime.util.YailList;
 import org.junit.Before;
 import org.osmdroid.util.GeoPoint;
 import org.robolectric.annotation.Config;
+import org.robolectric.internal.Shadow;
 
 import static com.google.appinventor.components.runtime.util.GeometryUtil.ONE_DEG_IN_METERS;
 
@@ -133,6 +135,10 @@ public class MapTestBase extends RobolectricTestBase {
 
   public Map getMap() {
     return map;
+  }
+
+  public ShadowMapView getMapShadow() {
+    return Shadow.extract(((ViewGroup)map.getView()).getChildAt(0));
   }
 
   @Before

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/PolygonTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/PolygonTest.java
@@ -5,7 +5,9 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.view.ViewGroup;
 import com.google.appinventor.components.runtime.shadows.ShadowEventDispatcher;
+import com.google.appinventor.components.runtime.shadows.org.osmdroid.views.ShadowMapView;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.GeometryUtil;
 import com.google.appinventor.components.runtime.util.YailList;
@@ -13,12 +15,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.robolectric.Shadows;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowView;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the Polygon component.
@@ -111,6 +118,14 @@ public class PolygonTest extends MapTestBase {
   }
 
   @Test
+  public void testPointsInvalidatesView() {
+    ShadowMapView view = getMapShadow();
+    view.clearWasInvalidated();
+    defaultPolygon(polygon);
+    assertTrue(view.wasInvalidated());
+  }
+
+  @Test
   public void testPointsMultipolygon() {
     defaultMultipolygon(polygon);
     YailList points = polygon.Points();
@@ -190,6 +205,22 @@ public class PolygonTest extends MapTestBase {
     YailList holes = polygon.HolePoints();
     assertEquals(1, holes.size());  // one hole in polygon
     assertEquals(3, ((YailList) holes.get(1)).size());  // three points in the hole
+  }
+
+  @Test
+  public void testHolePointsInvalidatesView() {
+    defaultPolygon(polygon);
+    ShadowMapView view = getMapShadow();
+    view.clearWasInvalidated();
+    polygon.HolePoints(YailList.makeList(new Object[] {
+        // First hole
+        YailList.makeList(new Object[] {
+            GeometryUtil.asYailList(new GeoPoint(0.5, 0.5)),
+            GeometryUtil.asYailList(new GeoPoint(0.25, 0.5)),
+            GeometryUtil.asYailList(new GeoPoint(0.5, 0.25))
+        })
+    }));
+    assertTrue(view.wasInvalidated());
   }
 
   @Test

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/DummyMapControllerTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/DummyMapControllerTest.java
@@ -244,6 +244,11 @@ public class DummyMapControllerTest {
   }
 
   @Test(expected = UnsupportedOperationException.class)
+  public void testUpdateFeatureHoles() {
+    mapController.updateFeatureDraggable(null);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
   public void testUpdateFeaturePositionCircle() {
     mapController.updateFeaturePosition((MapCircle) null);
   }


### PR DESCRIPTION
While experimenting with #1504, I noticed that it was sufficient to just remove the if statement guarding the call to `HolePoints` to fix the issue. The deeper problem is that `HolePoints` calls `updateFeaturePosition` that in turn calls `invalidate` on the map view, but `Points` does not trigger this chain of calls. Typically, they would both be called together and it would be fine (e.g., via the designer). So while #1504 would address the issue of loading from a URL, it would leave unresolved a deeper bug where manipulating `Points` without manipulating `HolePoints` never updates the polygon. This affects manipulating the polygon in blocks as well as when loaded from URLs. This change corrects the underlying problem, and therefore should fix #1503 in a more robust way.

As part of this change, I also separated the logic of updating the polygon shell from the polygon holes. The reason for this is because updateFeaturePosition previously updated both, and two calls (one via Points and another via HolePoints) would introduce double the work for every polygon without any benefit. For small polygons this won't be noticeable, but for polygons with 10k or more points one might experience a slowdown on less powerful devices.

Change-Id: I35b143a3dbe3aecdc6c57352468c73e9baf40b72