### PR TITLE
Fix mapview invalidation when Marker visibility changed

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -1137,6 +1137,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   protected void showOverlay(OverlayWithIW overlay) {
     view.getOverlayManager().add(overlay);
+    view.invalidate();
   }
 
   @Override
@@ -1146,6 +1147,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   protected void hideOverlay(OverlayWithIW overlay) {
     view.getOverlayManager().remove(overlay);
+    view.invalidate();
   }
 
   @Override

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/MarkerTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/MarkerTest.java
@@ -6,12 +6,15 @@
 package com.google.appinventor.components.runtime;
 
 import android.graphics.Color;
+import android.view.ViewGroup;
 import com.google.appinventor.components.runtime.shadows.ShadowEventDispatcher;
+import com.google.appinventor.components.runtime.shadows.org.osmdroid.views.ShadowMapView;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.osmdroid.util.GeoPoint;
+import org.robolectric.internal.bytecode.ShadowMap;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowView;
 
@@ -271,7 +274,7 @@ public class MarkerTest extends MapTestBase {
 
   @Test
   public void testVisibleNoInvalidate() {
-    ShadowView mapView = Shadow.extract(getMap().getView());
+    ShadowMapView mapView = Shadow.extract(((ViewGroup) getMap().getView()).getChildAt(0));
     Marker marker = new Marker(getMap());
     mapView.clearWasInvalidated();
     marker.Visible(true);
@@ -281,7 +284,7 @@ public class MarkerTest extends MapTestBase {
 
   @Test
   public void testVisibleInvalidate() {
-    ShadowView mapView = Shadow.extract(getMap().getView());
+    ShadowMapView mapView = Shadow.extract(((ViewGroup) getMap().getView()).getChildAt(0));
     Marker marker = new Marker(getMap());
     mapView.clearWasInvalidated();
     marker.Visible(true);


### PR DESCRIPTION
To test: Add a marker to a map with a button to toggle its visibility. On versions before 2.47, this worked correctly. Starting with 2.47 it does not. This change fixes the problem and updates the tests, which were broken because of a view hierarchy change related to using our own zoom controls rather than the (deprecated) built-in ones.

Fixes #1521 

Change-Id: Iea7872a0896e39c30353cd89d950c6d3779370bf