### PR TITLE
Limit Certain Permissions

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -8,6 +8,7 @@ package com.google.appinventor.buildserver;
 
 import com.google.appinventor.buildserver.util.AARLibraries;
 import com.google.appinventor.buildserver.util.AARLibrary;
+import com.google.appinventor.common.version.AppInventorFeatures;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
@@ -806,6 +807,14 @@ public final class Compiler {
       Set<String> permissions = Sets.newHashSet();
       for (Set<String> compPermissions : permissionsNeeded.values()) {
         permissions.addAll(compPermissions);
+      }
+
+      // Remove Google's Forbidden Permissions
+      // This code is crude because we had to do this on short notice
+      if (isForCompanion && AppInventorFeatures.limitPermissions()) {
+        permissions.remove("android.permission.RECEIVE_SMS");
+        permissions.remove("android.permission.SEND_SMS");
+        permissions.remove("android.permission.PROCESS_OUTGOING_CALLS");
       }
 
       for (String permission : permissions) {

--- a/appinventor/common/src/com/google/appinventor/common/version/AppInventorFeatures.java
+++ b/appinventor/common/src/com/google/appinventor/common/version/AppInventorFeatures.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -122,6 +122,18 @@ public final class AppInventorFeatures {
    */
   public static boolean doCompanionSplashScreen() {
     return false;
+  }
+
+  /** limitPermissions -- Remove Google defined "dangerous" permissions when
+   *                      building the MIT AI2 Companion. These include:
+   *                      android.permission.RECEIVE_SMS
+   *                      android.permission.SEND_SMS
+   *                      android.permission.PROCESS_OUTGOING_CALLS
+   *
+   * @return true to limit permissions in the Companion
+   */
+  public static boolean limitPermissions() {
+    return true;
   }
 
 }


### PR DESCRIPTION
Google has defined a set of permissions that they consider “dangerous”
and can only be used in an application under certain specific
circumstances and then only with special permission from Google. This is
enforced when an application is submitted to the Google Play Store, not
on a device.

This change causes these permissions to not be included in the MIT AI2
Companion. However it is controlled by the “limitPermissions()” flag in
the AppInventor features module. Change the return value to “false” to
give the Companion these permissions.

Change-Id: I0fa3b2e928e7aa53c70cd339f50ed11008fe1876