### PR TITLE
Make FormPropertiesAnalyzer handle Windows line endings

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/shared/youngandroid/YoungAndroidSourceAnalyzer.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/youngandroid/YoungAndroidSourceAnalyzer.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -57,6 +57,7 @@ public class YoungAndroidSourceAnalyzer {
    * @return the properties as a JSONObject
    */
   public static JSONObject parseSourceFile(String source, JSONParser jsonParser) {
+    source = source.replaceAll("\r\n", "\n");
     // First, locate the beginning of the $JSON section.
     // Older files have a $Properties before the $JSON section and we need to make sure we skip
     // that.

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/FormPropertiesAnalyzer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/FormPropertiesAnalyzer.java
@@ -53,6 +53,7 @@ public class FormPropertiesAnalyzer {
    * @return the properties as a JSONObject
    */
   public static JSONObject parseSourceFile(String source) {
+    source = source.replaceAll("\r\n", "\n");
     // First, locate the beginning of the $JSON section.
     // Older files have a $Properties before the $JSON section and we need to make sure we skip
     // that.
@@ -64,7 +65,7 @@ public class FormPropertiesAnalyzer {
     }
     beginningOfJsonSection += jsonSectionPrefix.length();
 
-    // Then, locate the end of the $JSON section;
+    // Then, locate the end of the $JSON section
     String jsonSectionSuffix = FORM_PROPERTIES_SUFFIX;
     int endOfJsonSection = source.lastIndexOf(jsonSectionSuffix);
     if (endOfJsonSection == -1) {

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/FormPropertiesAnalyzerTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/FormPropertiesAnalyzerTest.java
@@ -1,0 +1,60 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright © 2019 Massachusetts Institute of Technology, All rights reserved.
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver;
+
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FormPropertiesAnalyzerTest {
+
+  private static final String TEST_DATA =
+      "#|\n$JSON\n{\"Properties\":{\"$Type\":\"Form\",\"$Components\":[]}}\n|#\n";
+
+  @Test
+  public void testParseSourceFileValid() {
+    JSONObject data = FormPropertiesAnalyzer.parseSourceFile(TEST_DATA);
+    assertNotNull(data.optJSONObject("Properties"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseSourceFileMissingHeader() {
+    FormPropertiesAnalyzer.parseSourceFile("\n|#\n");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseSourceFileMissingFooter() {
+    FormPropertiesAnalyzer.parseSourceFile("#|\n$JSON\n");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseSourceFileInvalidJSON() {
+    FormPropertiesAnalyzer.parseSourceFile("#|\n$JSON\n{]\n|#\n");
+  }
+
+  @Test
+  public void testParseSourceFileWindowsLineEndings() {
+    JSONObject data = FormPropertiesAnalyzer.parseSourceFile(TEST_DATA.replaceAll("\n", "\r\n"));
+    assertNotNull(data.optJSONObject("Properties"));
+  }
+
+  @Test
+  public void testGetComponentTypesFromFormFile() {
+    Set<String> result = FormPropertiesAnalyzer.getComponentTypesFromFormFile(TEST_DATA);
+    assertEquals(1, result.size());
+    assertTrue(result.contains("Form"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetComponentTypesFromFormFileThrows() {
+    FormPropertiesAnalyzer.getComponentTypesFromFormFile("#|\n$JSON\n{}\n|$\n");
+  }
+}


### PR DESCRIPTION
Fixes #1531 by adapting the tools that process the .scm files to be able to support Windows-style line endings as well as Unix-style.

The change for conditional permissions added parsing of the .scm file to the build server, but it did not take into account that checkouts might change the line endings (i.e., it fails on Windows to build the companion). We ran into this issue when doing a hackathon this weekend. This change makes it so that the functions that parse the .scm file can handle both \n and \r\n in .scm files.

Change-Id: Id58ad71b23a4132db983e8a2c9d8dce6919c4433