### PR TITLE
Update Closure Library to fix typeblocking autocomplete

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/mit-cml/blockly.git
 [submodule "appinventor/lib/closure-library"]
 	path = appinventor/lib/closure-library
-	url = https://github.com/google/closure-library.git
+	url = https://github.com/mit-cml/closure-library.git

--- a/appinventor/blocklyeditor/src/typeblock.js
+++ b/appinventor/blocklyeditor/src/typeblock.js
@@ -170,6 +170,10 @@ Blockly.TypeBlock.prototype.handleKey = function(e){
       case 34:  // Page Down
       case 35:  // Shift
       case 36:  // End
+      case 37:  // Left Arrow
+      case 38:  // Up Arrow
+      case 39:  // Right Arrow
+      case 40:  // Down Arrow
       case 45:  // Ins
       case 91:  // Meta
       case 112: // F1
@@ -197,8 +201,12 @@ Blockly.TypeBlock.prototype.handleKey = function(e){
       // Can't seem to make Firefox display first character, so keep all browsers from automatically
       // displaying the first character and add it manually.
       e.preventDefault();
+      if (e.charCode == 0) {
+        // Don't try to render a non-printing character.
+        return;
+      }
       goog.dom.getElement(this.inputText_).value =
-        String.fromCharCode(e.charCode != null ? e.charCode : e.keycode);
+        String.fromCharCode(e.charCode != null ? e.charCode : e.keyCode);
     }
   };
 


### PR DESCRIPTION
Firefox 65 no longer reports keypress events for non-printable keys. This breaks typeblock on master. This change updates the Closure Library to fix key handling in the autocomplete widget that typeblock builds upon. Note that because the autocomplete widget uses ES6 code, I needed to fork closure-library and patch it to be ES5 compatible otherwise it breaks our build because GWT 2.8 doesn't understand ES6.

Fixes #1584 

Change-Id: Ia732cb6a35725ef49bb5605f1ab0bc6a808fe33b