### PR TITLE
Add Stop method to VideoPlayer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1397,10 +1397,15 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 4;
     }
     if (srcCompVersion < 5) {
-        // The Volume property (setter only) was created.
-        // No properties need to be modified to upgrade to version 4.
-        srcCompVersion = 5;
-      }
+      // The Volume property (setter only) was created.
+      // No properties need to be modified to upgrade to version 5.
+      srcCompVersion = 5;
+    }
+    if (srcCompVersion < 6) {
+      // The Stop method was created.
+      // No properties need to be modified to upgrade to version 6.
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2509,7 +2509,10 @@ Blockly.Versioning.AllUpgradeMaps =
     4: "noUpgrade",
 
     // AI2: The Volume property (setter only) was added to the VideoPlayer.
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // AI2: Stop method was added to the VideoPlayer.
+    6: "noUpgrade"
 
   }, // End VideoPlayer upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -444,10 +444,12 @@ public class YaVersion {
   // - NOTIFIER_COMPONENT_VERSION was incremented to 6
   // For YOUNG_ANDROID_VERSION 178:
   // - CLOCK_COMPONENT_VERSION was incremented to 4
-  // For YOUNG_ANDROID_VERISON 179:
+  // For YOUNG_ANDROID_VERSION 179:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 24
+  // For YOUNG_ANDROID_VERSION 180:
+  // - VIDEOPLAYER_COMPONENT_VERSION was incremented to 6
 
-  public static final int YOUNG_ANDROID_VERSION = 179;
+  public static final int YOUNG_ANDROID_VERSION = 180;
 
   // ............................... Blocks Language Version Number ...............................
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1156,7 +1156,9 @@ public class YaVersion {
   // - The FullScreen property was added to the VideoPlayer.
   // For VIDEOPLAYER_COMPONENT_VERSION 5:
   // - The Volume property (setter only) was added to the VideoPlayer.
-  public static final int VIDEOPLAYER_COMPONENT_VERSION = 5;
+  // For VIDEOPLAYER_COMPONENT_VERSION 6:
+  // - The Stop method was added to the VideoPlayer.
+  public static final int VIDEOPLAYER_COMPONENT_VERSION = 6;
 
   public static final int VOTING_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -284,6 +284,16 @@ public final class VideoPlayer extends AndroidViewComponent implements
   }
 
   @SimpleFunction(
+      description = "Resets to start of video and pauses it if video was playing.")
+  public void Stop() {
+    Log.i("VideoPlayer", "Calling Stop");
+    // Call start() to ensure frame shown is updated
+    Start();
+    SeekTo(0);
+    Pause();
+  }
+
+  @SimpleFunction(
       description = "Seeks to the requested time (specified in milliseconds) in the video. " +
       "If the video is paused, the frame shown will not be updated by the seek. " +
       "The player can jump only to key frames in the video, so seeking to times that " +

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -287,7 +287,9 @@ public final class VideoPlayer extends AndroidViewComponent implements
       description = "Resets to start of video and pauses it if video was playing.")
   public void Stop() {
     Log.i("VideoPlayer", "Calling Stop");
-    // Call start() to ensure frame shown is updated
+    // Call start() to ensure frame shown is updated;
+    // Otherwise stopping while a video is on pause will not refresh its view
+    // until video is started again.
     Start();
     SeekTo(0);
     Pause();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
@@ -103,50 +103,27 @@ public class FullScreenVideoUtil implements OnCompletionListener,
     mForm = form;
     mHandler = handler;
 
-    if (SdkLevel.getLevel() > SdkLevel.LEVEL_DONUT) {
-      mFullScreenVideoDialog = new Dialog(mForm,
-          R.style.Theme_NoTitleBar_Fullscreen) {
-          public void onBackPressed() {
-            // Allows the user to force exiting full-screen.
-            Bundle values = new Bundle();
-            values.putInt(VIDEOPLAYER_POSITION,
-              mFullScreenVideoView.getCurrentPosition());
-            values.putBoolean(VIDEOPLAYER_PLAYING,
-              mFullScreenVideoView.isPlaying());
-            values.putString(VIDEOPLAYER_SOURCE,
-              mFullScreenVideoBundle.getString(VIDEOPLAYER_SOURCE));
-            mFullScreenPlayer.fullScreenKilled(values);
-              super.onBackPressed();
-          }
+    mFullScreenVideoDialog = new Dialog(mForm,
+        R.style.Theme_NoTitleBar_Fullscreen) {
+        public void onBackPressed() {
+          // Allows the user to force exiting full-screen.
+          Bundle values = new Bundle();
+          values.putInt(VIDEOPLAYER_POSITION,
+            mFullScreenVideoView.getCurrentPosition());
+          values.putBoolean(VIDEOPLAYER_PLAYING,
+            mFullScreenVideoView.isPlaying());
+          values.putString(VIDEOPLAYER_SOURCE,
+            mFullScreenVideoBundle.getString(VIDEOPLAYER_SOURCE));
+          mFullScreenPlayer.fullScreenKilled(values);
+            super.onBackPressed();
+        }
 
-          public void onStart() {
-            super.onStart();
-            // Prepare the Dialog media.
-            startDialog();
-          }
-        };
-    } else {
-      mFullScreenVideoDialog = new Dialog(mForm,
-          R.style.Theme_NoTitleBar_Fullscreen) {
-          protected void onStop() {
-            Bundle values = new Bundle();
-            values.putInt(VIDEOPLAYER_POSITION,
-              mFullScreenVideoView.getCurrentPosition());
-            values.putBoolean(VIDEOPLAYER_PLAYING,
-              mFullScreenVideoView.isPlaying());
-            values.putString(VIDEOPLAYER_SOURCE,
-             mFullScreenVideoBundle.getString(VIDEOPLAYER_SOURCE));
-            mFullScreenPlayer.fullScreenKilled(values);
-            super.onStop();
-          }
-
-          public void onStart() {
-            super.onStart();
-            // Prepare the Dialog media.
-            startDialog();
-          }
-        };
-    }
+        public void onStart() {
+          super.onStart();
+          // Prepare the Dialog media.
+          startDialog();
+        }
+      };
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FullScreenVideoUtil.java
@@ -115,7 +115,7 @@ public class FullScreenVideoUtil implements OnCompletionListener,
           values.putString(VIDEOPLAYER_SOURCE,
             mFullScreenVideoBundle.getString(VIDEOPLAYER_SOURCE));
           mFullScreenPlayer.fullScreenKilled(values);
-            super.onBackPressed();
+          super.onBackPressed();
         }
 
         public void onStart() {


### PR DESCRIPTION
Fix issue #1345 
Add a Stop method to VideoPlayer that stops it from playing and rewinds the video view back to the beginning. VideoPlayer version number is bumped.
Also simplify the logic in FullScreenVideoUtil to target Eclair or higher versions of Android.