### PR TITLE
WidthPercent, HeightPercent, Width & Height Tooltips, Documentation

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
@@ -94,7 +94,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    * @param  width in pixels
    */
   @Override
-  @SimpleProperty
+  @SimpleProperty(description = "Specifies the component's horizontal width, measured in pixels.")
   public void Width(int width) {
     container.setChildWidth(this, width);
     lastSetWidth = width;
@@ -110,7 +110,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    */
 
   @Override
-  @SimpleProperty
+  @SimpleProperty(description = "Specifies the component's horizontal width as a percentage of the Width of its parent Component.")
   public void WidthPercent(int pCent) {
     if (pCent < 0 || pCent > 100) {
       container.$form().dispatchErrorOccurredEvent(this, "WidthPercent",
@@ -180,7 +180,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    * @param  height in pixels
    */
   @Override
-  @SimpleProperty
+  @SimpleProperty(description = "Specifies the component's vertical height, measured in pixels.")
   public void Height(int height) {
     container.setChildHeight(this, height);
     lastSetHeight = height;
@@ -196,7 +196,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    */
 
   @Override
-  @SimpleProperty
+  @SimpleProperty(description = "Specifies the component's vertical height as a percentage of the height of its parent Component.")
   public void HeightPercent(int pCent) {
     if (pCent < 0 || pCent > 100) {
       container.$form().dispatchErrorOccurredEvent(this, "HeightPercent",

--- a/appinventor/docs/reference/components/layout.html
+++ b/appinventor/docs/reference/components/layout.html
@@ -528,17 +528,17 @@
                       <dt><code>BackgroundColor</code></dt>
                       <dd>Returns the component's background color</dd>
                       <dt><code>Height</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's vertical height, measured in pixels.</dd>
                       <dt><code>HeightPercent</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's vertical height as a percentage of the height of its parent Component.</dd>
                       <dt><code>Image</code></dt>
                       <dd>Specifies the path of the component's image.  If there is both an Image and a BackgroundColor, only the Image will be visible.</dd>
                       <dt><code>Visible</code></dt>
                       <dd>Specifies whether the component should be visible on the screen. Value is true if the component is showing and false if hidden.</dd>
                       <dt><code>Width</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's horizontal width, measured in pixels.</dd>
                       <dt><code>WidthPercent</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's horizontal width as a percentage of the Width of its parent Component.</dd>
                     </dl>
 
                     <h2 id="TableArrangement"> TableArrangement </h2>
@@ -642,17 +642,17 @@
                       <dt><code>BackgroundColor</code></dt>
                       <dd>Returns the component's background color</dd>
                       <dt><code>Height</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's vertical height, measured in pixels.</dd>
                       <dt><code>HeightPercent</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's vertical height as a percentage of the height of its parent Component.</dd>
                       <dt><code>Image</code></dt>
                       <dd>Specifies the path of the component's image.  If there is both an Image and a BackgroundColor, only the Image will be visible.</dd>
                       <dt><code>Visible</code></dt>
                       <dd>Specifies whether the component should be visible on the screen. Value is true if the component is showing and false if hidden.</dd>
                       <dt><code>Width</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's horizontal width, measured in pixels.</dd>
                       <dt><code>WidthPercent</code></dt>
-                      <dd></dd>
+                      <dd>Specifies the component's horizontal width as a percentage of the Width of its parent Component.</dd>
                     </dl>
                   </div>
                 </div>


### PR DESCRIPTION
WidthPercent, HeightPercent, Width and Height did not previously have tooltips or documentation. This has now been added.

Corresponds to issue #1058 