### PR TITLE
Fix ill-encoding of UriBuilder class

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/util/UriBuilder.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/util/UriBuilder.java
@@ -11,6 +11,8 @@
 
 package com.google.appinventor.server.util;
 
+import java.net.URLEncoder;
+
 public class UriBuilder {
   private StringBuilder sb = new StringBuilder();
   private boolean first = true;
@@ -30,7 +32,7 @@ public class UriBuilder {
     } else {
       sb.append("&");
     }
-    sb.append(key + "=" + value);
+    sb.append(URLEncoder.encode(key) + "=" + URLEncoder.encode(value));
     return this;
   }
 


### PR DESCRIPTION
This patch was a split from #1570. While previous PR is still the queue of review, I consider this one is related to security issue.

UriBuilder class misses URLEncode.encode() encapsulation, which leaves the danger of URL injection. For example, suppose parameter `k=v`, we can set k = `user=a&pass=n&nonce`, It turns out `user=a&pass=n&nonce=v` and totally changes the semantics.