### PR TITLE
Use built-in (rejection algorithm) random sampling

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/WebRTCNativeMgr.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/WebRTCNativeMgr.java
@@ -141,7 +141,7 @@ public class WebRTCNativeMgr {
           Log.d(LOG_TAG, "IceCandidate = " + iceCandidate.toString());
           /* Send to Peer */
           JSONObject response = new JSONObject();
-          response.put("nonce", random.nextInt() % 100000);
+          response.put("nonce", random.nextInt(100000));
           JSONObject jsonCandidate = new JSONObject();
           jsonCandidate.put("candidate", iceCandidate.sdp);
           jsonCandidate.put("sdpMLineIndex", iceCandidate.sdpMLineIndex);


### PR DESCRIPTION
The original method, uniform integer modulo 100000, is biased in
distribution. Now it's replaced by built-in sampling method.

Java 7 API has comments on random.nextInt(int n):
https://docs.oracle.com/javase/7/docs/api/java/util/Random.html#nextInt(int)