### PR TITLE
Palette not shows up on deleting screen in Blocks

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
@@ -204,6 +204,7 @@ public abstract class ProjectEditor extends Composite {
       fileIds.remove(index);
       deckPanel.remove(fileEditor);
       if (selectedFileEditor == fileEditor) {
+        selectedFileEditor.onHide();
         selectedFileEditor = null;
       }
       fileEditor.onClose();


### PR DESCRIPTION
When working with multiple screens in the 'Blocks' section, on deleting a screen, it takes us to the 'Designer' section, but the 'Palette Panel' not shows up. Also, components/media panels end up below the 'Blocks Panel', which is wrong.

This PR fixes the issue mentioned above.
#1603 