### PR TITLE
De-Bounce the “Connect To” Button in the Companion

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
@@ -175,7 +175,7 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
 
   // This method is declared static, with an explicit activity input, so that other
   // components can use it
-  public static void oneButtonAlert(Activity activity,String message, String title, String buttonText) {
+  public static void oneButtonAlert(Activity activity,String message, String title, String buttonText, final Runnable callBack) {
     Log.i(LOG_TAG, "One button alert " + message);
     AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
     alertDialog.setTitle(title);
@@ -185,8 +185,18 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
     alertDialog.setButton(DialogInterface.BUTTON_NEUTRAL,
         buttonText, new DialogInterface.OnClickListener() {
       public void onClick(DialogInterface dialog, int which) {
+        if (callBack != null) {
+          callBack.run();
+        }
       }});
     alertDialog.show();
+  }
+
+  // A version of oneButtonAlert that doesn't accept a callback. We provide this
+  // for backwards compatibility in case extensions out there are using this (older)
+  // version which didn't accept a callback
+  public static void oneButtonAlert(Activity activity,String message, String title, String buttonText) {
+    oneButtonAlert(activity, message, title, buttonText, null);
   }
 
   // converts a string that includes HTML tags to a spannable string that can


### PR DESCRIPTION
The Companion's design is to setup communications with the user's
browser and get to work. Once this process starts, enough things are in
motion that it is best to quit the Companion and start a fresh copy if a
different code is needed.

If the same code is entered more then once, we just ignore the second
attempt. This often happens when someone scans a QR Code and then
presses the "Connect" Button because they do not know that they don't
have to do that. Effectively we are "de-bouncing"

Change-Id: I06b20c5d9cdb07999a380d9f877edd111e0357c5