### PR TITLE
Simplify AndroidRuntime classpath further

### DIFF
--- a/appinventor/components/build.xml
+++ b/appinventor/components/build.xml
@@ -181,19 +181,24 @@
     <copy toFile="${public.deps.dir}/android.jar" file="${lib.dir}/android/android-26/android.jar" />
     <copy toFile="${public.deps.dir}/dx.jar" file="${lib.dir}/android/tools/dx.jar" />
     <copy toFile="${public.deps.dir}/CommonVersion.jar" file="${build.dir}/common/CommonVersion.jar" />
+
+    <!-- Add extension libraries here -->
+    <!-- Example: <copy toFile"${public.deps.dir}/my-dependency.jar" file="${lib.dir}/my-dependency/my-dependency-1.0.0.jar" /> -->
+    <!-- Remember to include my-dependency.jar in the @UsesLibraries annotation in the extension -->
   </target>
+
+  <path id="AndroidRuntime.path">
+    <fileset dir="${public.deps.dir}">
+      <include name="*.jar" />
+      <exclude name="android.jar" /> <!-- Needs to be excluded for testing classpath consistency -->
+    </fileset>
+    <pathelement location="${local.build.dir}/HtmlEntities.jar" />
+    <pathelement location="${public.build.dir}/CommonConstants.jar" />
+  </path>
 
   <!-- =====================================================================
        AndroidRuntime: library providing runtime support for components
        ===================================================================== -->
-  <path id="AndroidSupportLibs.path">
-    <fileset dir="${lib.dir}/android/support">
-      <include name="*.jar"/>
-      <exclude name="testing-support-R-classes.jar"/>
-    </fileset>
-    <pathelement location="${lib.dir}/android/legacy/org.apache.http.legacy.jar" />
-  </path>
-
   <property name="AndroidRuntime-class.dir" location="${class.dir}/AndroidRuntime" />
   <target name="AndroidRuntime"
           description="Generate runtime library implementing components"
@@ -208,36 +213,8 @@
       <!--<include name="${components.pkg}/annotations/*.java" /> -->
       <!--<include name="${components.pkg}/runtime/**/*.java" /> -->
       <classpath>
-        <pathelement location="${local.build.dir}/HtmlEntities.jar" />
-        <pathelement location="${public.build.dir}/CommonConstants.jar" />
-        <pathelement location="${build.dir}/common/CommonVersion.jar" />
-        <pathelement location="${lib.dir}/android/android-26/android.jar" />
-        <path refid="AndroidSupportLibs.path" />
-        <pathelement location="${lib.dir}/kawa/kawa-1.11-modified.jar" />
-        <pathelement location="${lib.dir}/acra/acra-4.4.0.jar" />
-        <pathelement location="${lib.dir}/guava/guava-14.0.1.jar" />
-        <!-- Native WebRTC Support -->
-        <pathelement location="${lib.dir}/webrtc/webrtc.jar" />
-        <!-- Conditionally included libraries -->
-        <pathelement location="${lib.dir}/twitter/twitter4j-core-3.0.5.jar" />
-        <pathelement location="${lib.dir}/twitter/twitter4j-media-support-3.0.5.jar" />
-        <pathelement location="${lib.dir}/apache-http/httpcore-4.3.2.jar" />
-        <pathelement location="${lib.dir}/apache-http/httpmime-4.3.4.jar" />
-        <pathelement location="${lib.dir}/fusiontables/fusiontables.jar" />
-        <pathelement location="${lib.dir}/firebase/firebase-client-android-2.5.0.jar" />
-        <pathelement location="${lib.dir}/oauth/google-api-client-1.10.3-beta.jar" />
-        <pathelement location="${lib.dir}/oauth/google-api-client-android2-1.10.3-beta.jar" />
-        <pathelement location="${lib.dir}/oauth/google-http-client-1.10.3-beta.jar" />
-        <pathelement location="${lib.dir}/oauth/google-http-client-android2-1.10.3-beta.jar" />
-        <pathelement location="${lib.dir}/oauth/google-http-client-android3-1.10.3-beta.jar" />
-        <pathelement location="${lib.dir}/oauth/google-oauth-client-1.10.1-beta.jar" />
-        <pathelement location="${lib.dir}/jedis/jedis-3.0.0-SNAPSHOT-jar-with-dependencies.jar" />
-        <pathelement location="${lib.dir}/commons-pool/commons-pool2-2.0.jar" />
-        <pathelement location="${lib.dir}/gson/gson-2.1.jar" />
-        <pathelement location="${lib.dir}/json/json.jar" />
-        <pathelement location="${lib.dir}/osmdroid/osmdroid-5.6.6.jar" />
-        <pathelement location="${lib.dir}/jts/jts-core-1.15.0-20170823.040415-301.jar" />
-        <pathelement location="${lib.dir}/androidsvg/androidsvg-d4ec6d8.jar" />
+        <path refid="AndroidRuntime.path" />
+        <pathelement location="${public.deps.dir}/android.jar" />
       </classpath>
     </ai.javac>
 
@@ -255,23 +232,15 @@
 
   <path id="libsForAndroidRuntimeTests.path">
     <pathelement location="${public.build.dir}/AndroidRuntime.jar" />
-    <pathelement location="${public.build.dir}/CommonConstants.jar" />
-    <pathelement location="${lib.dir}/json/json.jar" />
+    <path refid="AndroidRuntime.path" />
     <pathelement location="${lib.dir}/junit/junit-4.8.2.jar" />
     <pathelement location="${lib.dir}/junit4/tl4j-junit4-1.1.3.jar" />
-    <pathelement location="${lib.dir}/kawa/kawa-1.11-modified.jar" />
-    <pathelement location="${lib.dir}/acra/acra-4.4.0.jar" />
-    <pathelement location="${lib.dir}/guava/guava-20.0.jar" />
     <pathelement location="${lib.dir}/bouncycastle/bcprov-jdk15on-149.jar" />
-    <pathelement location="${lib.dir}/osmdroid/osmdroid-5.6.6.jar" />
-    <pathelement location="${lib.dir}/jts/jts-core-1.15.0-20170823.040415-301.jar" />
-    <pathelement location="${lib.dir}/androidsvg/androidsvg-d4ec6d8.jar" />
     <pathelement location="${lib.dir}/powermock/cglib-nodep-2.2.jar" />
     <pathelement location="${lib.dir}/powermock/easymock-3.0.jar" />
     <pathelement location="${lib.dir}/powermock/javassist-3.18.0-GA.jar" />
     <pathelement location="${lib.dir}/powermock/objenesis-1.2.jar" />
     <pathelement location="${lib.dir}/powermock/powermock-easymock-1.4.10-full.jar" />
-    <path refid="AndroidSupportLibs.path" />
     <pathelement location="${lib.dir}/android/support/testing-support-R-classes.jar" />
     <!-- android.jar must go last on the classpath list
          so that its junit (or other) stubs don't override the real ones -->
@@ -338,34 +307,9 @@
         <exclude name="${components.pkg}/common/**/*.java" /> <!-- exclude components/common package -->
         <exclude name="${components.pkg}/annotations/**/*.java" /> <!-- exclude components/annotations package -->
         <classpath>
+          <path refid="AndroidRuntime.path" />
           <pathelement location="${public.build.dir}/AndroidRuntime.jar" />
-          <pathelement location="${local.build.dir}/HtmlEntities.jar" />
-          <pathelement location="${public.build.dir}/CommonConstants.jar" />
-          <pathelement location="${lib.dir}/android/android-26/android.jar" />
-          <path refid="AndroidSupportLibs.path" />
-          <pathelement location="${lib.dir}/guava/guava-14.0.1.jar" />
-          <pathelement location="${lib.dir}/gson/gson-2.1.jar" />
-          <pathelement location="${lib.dir}/json/json.jar" />
-          <pathelement location="${lib.dir}/kawa/kawa-1.11-modified.jar" />
-          <pathelement location="${lib.dir}/acra/acra-4.4.0.jar" />
-          <pathelement location="${lib.dir}/twitter/twitter4j-core-3.0.5.jar" />
-          <pathelement location="${lib.dir}/webrtc/webrtc.jar" />
-          <pathelement location="${lib.dir}/twitter/twitter4j-media-support-3.0.5.jar" />
-          <pathelement location="${lib.dir}/apache-http/httpcore-4.3.2.jar" />
-          <pathelement location="${lib.dir}/apache-http/httpmime-4.3.4.jar" />
-          <pathelement location="${lib.dir}/fusiontables/fusiontables.jar" />
-          <pathelement location="${lib.dir}/firebase/firebase-client-android-2.5.0.jar" />
-          <pathelement location="${lib.dir}/oauth/google-api-client-1.10.3-beta.jar" />
-          <pathelement location="${lib.dir}/oauth/google-api-client-android2-1.10.3-beta.jar" />
-          <pathelement location="${lib.dir}/oauth/google-http-client-1.10.3-beta.jar" />
-          <pathelement location="${lib.dir}/oauth/google-http-client-android2-1.10.3-beta.jar" />
-          <pathelement location="${lib.dir}/oauth/google-http-client-android3-1.10.3-beta.jar" />
-          <pathelement location="${lib.dir}/oauth/google-oauth-client-1.10.1-beta.jar" />
-          <pathelement location="${lib.dir}/jedis/jedis-3.0.0-SNAPSHOT-jar-with-dependencies.jar" />
-          <pathelement location="${lib.dir}/commons-pool/commons-pool2-2.0.jar" />
-          <pathelement location="${lib.dir}/osmdroid/osmdroid-5.6.6.jar" />
-          <pathelement location="${lib.dir}/jts/jts-core-1.15.0-20170823.040415-301.jar" />
-          <pathelement location="${lib.dir}/androidsvg/androidsvg-d4ec6d8.jar" />
+          <pathelement location="${public.deps.dir}/android.jar" />
         </classpath>
         <compilerarg line="-processorpath ${local.build.dir}/AnnotationProcessors.jar"/>
         <compilerarg line="-processor @{apt-processor}" />


### PR DESCRIPTION
PR #1605 made components manage parts of the classpath instead of the
buildserver. This move means that all of AndroidRuntime's dependencies
are managed within components/build.xml, and so we can further
simplify the classpath for all of the targets within the components
module. This change introduces an AndroidRuntime.path reference that
is constructed from the dependencies set created by the aforementioned
PR. It becomes a single point to introduce dependencies targetting the
Android platform, including extension writing, and is used both for
compilation and unit test evaluation.