### PR TITLE
Fix logic bug when property value is the empty string

### DIFF
--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -345,6 +345,15 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
         info.setPropertyList.push(property.name);
       }
     }
+    // Copy the designer property information to the block information
+    for (j = 0; property = componentInfo.properties[j]; ++j) {
+      var target = info.properties[property['name']];
+      // All designer properties should have setters, but if not...
+      if (!target) continue;
+      Object.keys(property).forEach(function(k) {
+        target[k] = property[k];
+      });
+    }
   }
 };
 

--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -400,8 +400,12 @@ Blockly.Yail.getPropertySettersLines = function(componentJson, componentName, co
   propsToSend.forEach(function(prop) {
     var info = type['properties'][prop];
     if (shouldSendProperty(prop, info)) {
+      var value = componentJson[prop];
+      if (!Boolean(value) && value !== '') {
+        value = info['defaultValue'];
+      }
       code.push(Blockly.Yail.getPropertySetterString(componentName, componentJson['$Type'], prop,
-        componentJson[prop] || info['defaultValue'], componentDb));
+        value, componentDb));
     }
   });
   return code;


### PR DESCRIPTION
The conditional properties change added the ability to use a default
value when a property isn't specified. However, there is a logic bug
due to the fact that the empty string is falsey in JavaScript. This
fix also checks specifically for the empty string as well so that the
default value will be sent.