### PR TITLE
Fix MockSwitch sizing and positioning interactions with FontSize

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
@@ -9,6 +9,7 @@ import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.appinventor.client.editor.simple.components.utils.SVGPanel;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.InlineHTML;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -84,7 +85,7 @@ public final class MockSwitch extends MockToggleBase<HorizontalPanel> {
       isInitialized = true;
     }
     switchGraphic = new SVGPanel();
-    int switchHeight = Math.round(Float.parseFloat(getPropertyValue(MockVisibleComponent.PROPERTY_NAME_FONTSIZE)));
+    int switchHeight = 14;  // pixels (Android asset is 28 px at 160 dpi)
 
     int switchWidth = (int) Math.round(switchHeight * 2);
     switchGraphic.setWidth(switchWidth + "px");
@@ -98,6 +99,7 @@ public final class MockSwitch extends MockToggleBase<HorizontalPanel> {
     panel.add(switchGraphic);
     panel.setCellWidth(switchGraphic, switchWidth + "px");
     panel.setCellHorizontalAlignment(switchGraphic, HasHorizontalAlignment.ALIGN_RIGHT);
+    panel.setCellVerticalAlignment(switchGraphic, HasVerticalAlignment.ALIGN_MIDDLE);
     toggleWidget = panel;
     refreshForm();
   }


### PR DESCRIPTION
The MockSwitch scaled the size of the switch in the designer based on the font size, but this doesn't actually happen on the device (the switch is always the same size). This PR reflects this change and also vertically aligns the switch in the middle of its label.

Fixes #1630 