### PR TITLE
Fix logic bug in MakePhoneCallDirect

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
@@ -151,7 +151,7 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
           public void HandlePermissionResponse(String permission, boolean granted) {
             if (granted) {
               PhoneCall.this.havePermission = true;
-              PhoneCall.this.MakePhoneCall();
+              PhoneCall.this.MakePhoneCallDirect();
             } else {
               form.dispatchPermissionDeniedEvent(PhoneCall.this, "MakePhoneCall",
                   Manifest.permission.CALL_PHONE);


### PR DESCRIPTION
The `MakePhoneCallDirect` block calls the `MakePhoneCall` method after permission is granted rather than `MakePhoneCallDirect`, resulting in the wrong behavior. This change makes it so that it calls itself so that it can resume where it left off before requesting permission.