### PR TITLE
Pass query string parameters through the TOS

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -856,6 +856,27 @@ public class Ode implements EntryPoint {
         topPanel.showUserEmail(user.getUserEmail());
       }
 
+      private boolean isSet(String str) {
+        return str != null && !str.equals("");
+      }
+
+      private String makeUri(String base) {
+        String[] params = new String[] { "locale", "repo", "galleryId" };
+        String separator = "?";
+        StringBuilder sb = new StringBuilder(base);
+        for (String param : params) {
+          String value = Window.Location.getParameter(param);
+          if (isSet(value)) {
+            sb.append(separator);
+            sb.append(param);
+            sb.append("=");
+            sb.append(value);
+            separator = "&";
+          }
+        }
+        return sb.toString();
+      }
+
       @Override
       public void onFailure(Throwable caught) {
         if (caught instanceof StatusCodeException) {
@@ -870,26 +891,10 @@ public class Ode implements EntryPoint {
               return;
             case Response.SC_FORBIDDEN:
               // forbidden => need tos accept
-              Window.open("/" + ServerLayout.YA_TOS_FORM, "_self", null);
+              Window.open(makeUri("/" + ServerLayout.YA_TOS_FORM), "_self", null);
               return;
             case Response.SC_PRECONDITION_FAILED:
-              String locale = Window.Location.getParameter("locale");
-              String repo = Window.Location.getParameter("repo");
-              galleryId = Window.Location.getParameter("galleryId");
-              String separator = "?";
-              String uri = "/login/";
-              if (locale != null && !locale.equals("")) {
-                uri += separator + "locale=" + locale;
-                separator = "&";
-              }
-              if (repo != null && !repo.equals("")) {
-                uri += separator + "repo=" + repo;
-                separator = "&";
-              }
-              if (galleryId != null && !galleryId.equals("")) {
-                uri += separator + "galleryId=" + galleryId;
-              }
-              Window.Location.replace(uri);
+              Window.Location.replace(makeUri("/login/"));
               return;           // likely not reached
           }
         }

--- a/appinventor/appengine/src/com/google/appinventor/server/TosServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/TosServlet.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -9,6 +9,7 @@ package com.google.appinventor.server;
 import com.google.appinventor.server.flags.Flag;
 import com.google.appinventor.server.storage.StorageIo;
 import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.server.util.UriBuilder;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -35,6 +36,8 @@ public class TosServlet extends OdeServlet {
   private static final Flag<String> initialRedirectionUrl =
       Flag.createFlag("initial.redirection.url", "/");
 
+  private static final String[] PARAMS = new String[] { "locale", "repo", "galleryId" };
+
   @Override
   public void doPost(HttpServletRequest req, HttpServletResponse resp)
       throws IOException {
@@ -42,6 +45,15 @@ public class TosServlet extends OdeServlet {
     storageIo.setTosAccepted(LocalUser.getInstance().getUserId());
 
     // Redirect the user to the initialRedirectionUrl (the 'About' page, by default).
-    resp.sendRedirect(initialRedirectionUrl.get());
+    // Also include parameters passed from the TOS form.
+    UriBuilder builder = new UriBuilder(initialRedirectionUrl.get());
+    for (String param : PARAMS) {
+      String value = req.getParameter(param);
+      if (value != null && !value.isEmpty()) {
+        builder.add(param, value);
+      }
+    }
+
+    resp.sendRedirect(builder.build());
   }
 }

--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -15,6 +15,7 @@
     <include path="/static/**" expiration="1d" />
     <include path="/websiteassets/**" expiration="10s" />
     <include path="/images/*" expiration="365d" />
+    <include path="/js/*" />
     <include path="/Ya_tos_form.html" expiration="1d" />
     <include path="/favicon.ico" expiration="365d" />
     <include path="/gwt.css" expiration="1d" />

--- a/appinventor/appengine/war/Ya_tos_form.html
+++ b/appinventor/appengine/war/Ya_tos_form.html
@@ -3,6 +3,7 @@
     <title>Terms of Service</title>
     <link type="text/css" rel="stylesheet" href="Ya.css">
     <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
+    <script src="js/tos.js"></script>
   </head>
 
 <body>

--- a/appinventor/appengine/war/js/tos.js
+++ b/appinventor/appengine/war/js/tos.js
@@ -1,0 +1,30 @@
+// -*- mode: javascript; js-indent-level: 2; -*-
+// Copyright © 2019 Massachusetts Institute of Technology, All rights reserved.
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+/**
+ * Inspects the query string for any key=value pairs and adds hidden
+ * input elements to the TOS form so that they can be passed through
+ * when the user accepts the terms.
+ */
+function setupForm() {
+  var parts = window.location.href.split('?');
+  if (parts.length === 1) return;
+  var queryString = parts[1];
+  parts = queryString.split('&');
+  if (parts.length === 0) return;
+  var form = document.forms[0];
+  for (var i = 0; i < parts.length; i++) {
+    var keyval = parts[i].split('='),
+      key = keyval[0],
+      val = keyval[1],
+      input = document.createElement('input');
+    input.setAttribute('type', 'hidden');
+    input.setAttribute('name', key);
+    input.setAttribute('value', val);
+    form.appendChild(input);
+  }
+}
+
+window.onload = setupForm;


### PR DESCRIPTION
This change addresses the problem in the onboarding workflow when it involves the use of repo or galleryId in the query string, as observed at the CRLS workshop.

NB: I have not yet tested this with the branding commits, but the workflow appears correct when working with the dev server. We'll also need to test against the external login server code.