### PR TITLE
Don't apply ripple when button has background image

### DIFF
--- a/appinventor/build-extension.bat
+++ b/appinventor/build-extension.bat
@@ -1,6 +1,0 @@
-@echo off
-cls
-echo Your build has started, this may take a while
-ant extensions
-cls
-pause

--- a/appinventor/build-extension.bat
+++ b/appinventor/build-extension.bat
@@ -1,0 +1,6 @@
+@echo off
+cls
+echo Your build has started, this may take a while
+ant extensions
+cls
+pause

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -169,16 +169,22 @@ public abstract class ButtonBase extends AndroidViewComponent
       if (me.getAction() == MotionEvent.ACTION_DOWN) {
         //button pressed, provide visual feedback AND return false
         if (ShowFeedback() && (AppInventorCompatActivity.isClassicMode() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
-          view.getBackground().setAlpha(70); // translucent
-          view.invalidate();
+          if (backgroundImageDrawable != null || imagePath != "") {
+            view.getBackground().setAlpha(70); // translucent
+          } else {
+            view.invalidate();
+          }
         }
         TouchDown();
       } else if (me.getAction() == MotionEvent.ACTION_UP ||
               me.getAction() == MotionEvent.ACTION_CANCEL) {
         //button released, set button back to normal AND return false
         if (ShowFeedback() && (AppInventorCompatActivity.isClassicMode() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
-          view.getBackground().setAlpha(255); // opaque
-          view.invalidate();
+          if (backgroundImageDrawable != null || imagePath != "") {
+            view.getBackground().setAlpha(255); // opaque
+          } else {
+            view.invalidate();
+          }
         }
         TouchUp();
       }


### PR DESCRIPTION
Checks if the button has a drawable/image, if so then don't apply ripple. Otherwise, invalidate the ripple, then make it visible.

This implements additional Material Design to apps created with any App Inventor distribution. Also removed build-extension.bat as it's not needed.