### PR TITLE
Hide Progress Dialog on Companion Update

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/ConnectProgressBar.java
@@ -104,6 +104,8 @@ public final class ConnectProgressBar {
       $entry(@com.google.appinventor.client.ConnectProgressBar::start());
     $wnd.ConnectProgressBar_setProgress =
       $entry(@com.google.appinventor.client.ConnectProgressBar::setProgress(ILjava/lang/String;));
+    $wnd.ConnectProgressBar_hide =
+      $entry(@com.google.appinventor.client.ConnectProgressBar::hide());
   }-*/;
 
 }

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1407,6 +1407,7 @@ Blockly.ReplMgr.getFromRendezvous = function() {
                                                              } else {
                                                                  top.ReplState.state = Blockly.ReplMgr.rsState.IDLE;
                                                                  top.BlocklyPanel_indicateDisconnect();
+                                                                 top.ConnectProgressBar_hide();
                                                              }
                                                          });
 


### PR DESCRIPTION
When the “OK” button on the Companion Update dialog is pressed, properly
hide the ConnectProgressBar as we are now no longer connecting.

Change-Id: I4c5f24a5e8979757d6e7066c734ba40078e4a8ce