### PR TITLE
Responsive Sizing as Default

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -973,6 +973,19 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 24;
     }
 
+    if (srcCompVersion < 25) {
+      // Sizing default value changed to Responsive
+      if (componentProperties.containsKey("Sizing")) {
+        String value = ((ClientJsonString)componentProperties.get("Sizing")).getString();
+        if (value.equals("Responsive")) {
+          componentProperties.remove("Sizing");
+        }
+      } else {
+        componentProperties.put("Sizing", new ClientJsonString("Fixed"));
+      }
+      srcCompVersion = 25;
+    }
+
     return srcCompVersion;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -974,7 +974,7 @@ public final class YoungAndroidFormUpgrader {
     }
 
     if (srcCompVersion < 25) {
-      // Sizing default value changed to Responsive
+      // Sizing default value changed from Fixed to Responsive
       if (componentProperties.containsKey("Sizing")) {
         String value = ((ClientJsonString)componentProperties.get("Sizing")).getString();
         if (value.equals("Responsive")) {

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2265,7 +2265,11 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // For FORM_COMPONENT_VERSION 24:
     // - The AskForPermissions method, PermissionDenied event, and PermissionGranted event were added. No blocks need to be changed.
-    24: "noUpgrade"
+    24: "noUpgrade",
+
+    // For FORM_COMPONENT_VERSION 25:
+    // - Sizing default value changed from Fixed to Responsive
+    25: "noUpgrade"
 
 
   }, // End Screen

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -793,7 +793,9 @@ public class YaVersion {
   // - Added the AskForPermission method
   // - Added the PermissionDenied event
   // - Added the PermissionGranted event
-  public static final int FORM_COMPONENT_VERSION = 24;
+  // For FORM_COMOPONENT_VERSION 25:
+  // - Sizing default value changed from Fixed to Responsive
+  public static final int FORM_COMPONENT_VERSION = 25;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:
   // - The Fusiontables API was migrated from SQL to V1

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -441,7 +441,7 @@ public class Form extends AppInventorCompatActivity
       ActionBar(themeHelper.hasActionBar());
     }
     Scrollable(false);       // frameLayout is created in Scrollable()
-    Sizing("Fixed");         // Note: Only the Screen1 value is used as this is per-project
+    Sizing("Responsive");    // Note: Only the Screen1 value is used as this is per-project
     BackgroundImage("");
     AboutScreen("");
     BackgroundImage("");
@@ -1699,7 +1699,7 @@ public class Form extends AppInventorCompatActivity
    * @param
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_SIZING,
-      defaultValue = "Fixed")
+      defaultValue = "Responsive", alwaysSend = true)
   @SimpleProperty(userVisible = false,
   // This desc won't apprear as a tooltip, since there's no block, but we'll keep it with the source.
   description = "If set to fixed,  screen layouts will be created for a single fixed-size screen and autoscaled. " +


### PR DESCRIPTION
Corresponds to #1024 

One thing I was quite unsure of was the defaultPropertyValues() method in Form.java. Specifically, the line Sizing("Fixing"). For now, I have changed that to Sizing("Responsive"), but would that not break previous versions/other AppInventor repos?