### PR TITLE
Fix blocks PNG export in Webkit

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -181,7 +181,7 @@ goog.require('goog.Timer');
 
           var a = document.createElement('a');
           a.download = name;
-          a.target = "_blank";
+          a.target = '_self';
           if (canvas.toBlob === undefined) {
             var src = canvas.toDataURL('image/png');
             a.href = src;


### PR DESCRIPTION
A [bug in Webkit](https://bugs.webkit.org/show_bug.cgi?id=190351) prevents the Download Blocks as PNG menu item from working. It's been fixed in macOS 10.14.4, but may prevent people using macOS 10.14-10.14.3 from being able to use this feature. This change implements the suggested workaround.

I have tested on Chrome, Firefox, and Safari on macOS to check that this doesn't impact the other browsers, but it would be good to also have people test on Linux and Windows.

Change-Id: I25a6e14773fb75a43a556bee57d49e8aa292d036