### PR TITLE
added comments to PNG capture of blocks.

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -78,19 +78,12 @@ goog.require('goog.Timer');
     var clone = el.cloneNode(true);
     var width, height;
     if(el.tagName == 'svg') {
-      var box = el.getBoundingClientRect();
-      width = box.width ||
-        parseInt(clone.getAttribute('width') ||
-          clone.style.width ||
-          out$.getComputedStyle(el).getPropertyValue('width'));
-      height = box.height ||
-        parseInt(clone.getAttribute('height') ||
-          clone.style.height ||
-          out$.getComputedStyle(el).getPropertyValue('height'));
       var left = (parseFloat(optmetrics.contentLeft) - parseFloat(optmetrics.viewLeft)).toString();
       var top = (parseFloat(optmetrics.contentTop) - parseFloat(optmetrics.viewTop)).toString();
       var right = (parseFloat(optmetrics.contentWidth)).toString();
       var bottom = (parseFloat(optmetrics.contentHeight)).toString();
+      width = right;
+      height = bottom;
       clone.setAttribute("viewBox", left + " " + top + " " + right + " " + bottom);
     } else {
       var matrix = el.getScreenCTM();
@@ -213,7 +206,7 @@ goog.require('goog.Timer');
  *
  */
 Blockly.ExportBlocksImage.onclickExportBlocks = function(metrics, opt_workspace) {
-  saveSvgAsPng((opt_workspace || Blockly.getMainWorkspace()).svgBlockCanvas_, "blocks.png", metrics);
+  saveSvgAsPng((opt_workspace || Blockly.getMainWorkspace()).getParentSvg(), "blocks.png", metrics);
 }
 
 


### PR DESCRIPTION
Fixed capturing blocks as PNG to include any open comment bubbles also with a whitespace margin as discussed in the [google forum](https://groups.google.com/forum/#!topic/app-inventor-open-source-dev/gbGT8zDfvcI). I was not able to obtain a tight fit for the margins for the time being due to the way the main workspace parent svg structures and fits its contents.

Note: After further testing, I noticed that depending on how zoomed in the user is in the blocks workspace, the resolution of the PNG changes significantly (likely due to changes in the parent svg based on how zoomed in the user is?). This wasn't a problem when using just the blocks canvas.