### PR TITLE
Fix performance issue in project list

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectList.java
@@ -68,6 +68,8 @@ public class ProjectList extends Composite implements ProjectManagerEventListene
   private SortField sortField;
   private SortOrder sortOrder;
 
+  private boolean projectListLoading = true;
+
   // UI elements
   private final Grid table;
   private final Label nameSortIndicator;
@@ -373,8 +375,11 @@ public class ProjectList extends Composite implements ProjectManagerEventListene
   public void onProjectAdded(Project project) {
     projects.add(project);
     projectWidgets.put(project, new ProjectWidgets(project));
-    refreshTable(true);
+    if (!projectListLoading) {
+      refreshTable(true);
+    }
   }
+
   @Override
   public void onProjectRemoved(Project project) {
     projects.remove(project);
@@ -388,7 +393,8 @@ public class ProjectList extends Composite implements ProjectManagerEventListene
 
   @Override
   public void onProjectsLoaded() {
-    // This can be empty
+    projectListLoading = false;
+    refreshTable(true);
   }
   public void onProjectPublishedOrUnpublished() {
     refreshTable(false);


### PR DESCRIPTION
The onProjectAdded method of ProjectList will sort and refresh the
table, which is an `O(n log n)` operation. However, when we load the
list of projects initially, this will get called `O(n)` times,
resulting in `O(n^2 log n)` performance. For many users, the number of
projects might be small and this load time may appear
negligible. However, for more prolific users with hunders of projects,
this may result in multiple seconds wait time while the list is first
loaded. This fix defers sorting the list until all projects have been
added.

Change-Id: I50332dd8f2993883428c79e8dafbebbe32e2c1fa