### PR TITLE
Address lexical variable internationalization issues

### DIFF
--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -156,7 +156,6 @@ Blockly.usePrefixInYail = false;
      + maybe index variables have prefix "index", or maybe instead they are treated as "param"
 */
 
-Blockly.globalNamePrefix = "global"; // For names introduced by global variable declarations
 Blockly.procedureParameterPrefix = "input"; // For names introduced by procedure/function declarations
 Blockly.handlerParameterPrefix = "input"; // For names introduced by event handlers
 Blockly.localNamePrefix = "local"; // For names introduced by local variable declarations
@@ -183,14 +182,14 @@ function (prefix) {
 };
 
 Blockly.prefixGlobalMenuName = function (name) {
-  return Blockly.globalNamePrefix + Blockly.menuSeparator + name;
+  return Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator + name;
 };
 
 // Return a list of (1) prefix (if it exists, "" if not) and (2) unprefixed name
 Blockly.unprefixName = function (name) {
-  if (name.indexOf(Blockly.globalNamePrefix + Blockly.menuSeparator) == 0) {
+  if (name.indexOf(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator) == 0) {
     // Globals always have prefix, regardless of flags. Handle these specially
-    return [Blockly.globalNamePrefix, name.substring(Blockly.globalNamePrefix.length + Blockly.menuSeparator.length)];
+    return [Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX, name.substring(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX.length + Blockly.menuSeparator.length)];
   } else if (!Blockly.showPrefixToUser) {
     return ["", name];
   } else {

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -440,7 +440,22 @@ Blockly.Blocks.component_event = {
   },
 
   declaredNames: function() { // [lyn, 10/13/13] Interface with Blockly.LexicalVariable.renameParam
-    return this.getVars();
+    var names = [];
+    for (var i = 0, param; param = this.getField('VAR' + i); i++) {
+      names.push(param.getText());
+      if (param.eventparam && param.eventparam != param.getText()) {
+        names.push(param.eventparam);
+      }
+    }
+    return names;
+  },
+
+  declaredVariables: function() {
+    var names = [];
+    for (var i = 0, param; param = this.getField('VAR' + i); i++) {
+      names.push(param.getText());
+    }
+    return names;
   },
 
   blocksInScope: function() { // [lyn, 10/13/13] Interface with Blockly.LexicalVariable.renameParam

--- a/appinventor/blocklyeditor/src/blocks/lexical-variables.js
+++ b/appinventor/blocklyeditor/src/blocks/lexical-variables.js
@@ -145,7 +145,7 @@ Blockly.Blocks['lexical_variable_get'] = {
     var prefixPair = Blockly.unprefixName(this.getFieldValue('VAR'));
     var prefix = prefixPair[0];
     // Only rename lexical (nonglobal) names
-    if (prefix !== Blockly.globalNamePrefix) {
+    if (prefix !== Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
       var oldName = prefixPair[1];
       var newName = freeSubstitution.apply(oldName);
       if (newName !== oldName) {
@@ -157,7 +157,7 @@ Blockly.Blocks['lexical_variable_get'] = {
     var prefixPair = Blockly.unprefixName(this.getFieldValue('VAR'));
     var prefix = prefixPair[0];
     // Only return lexical (nonglobal) names
-    if (prefix !== Blockly.globalNamePrefix) {
+    if (prefix !== Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
       var oldName = prefixPair[1];
       return new Blockly.NameSet([oldName])
     } else {
@@ -202,7 +202,7 @@ Blockly.Blocks['lexical_variable_set'] = {
     var prefixPair = Blockly.unprefixName(this.getFieldValue('VAR'));
     var prefix = prefixPair[0];
     // Only rename lexical (nonglobal) names
-    if (prefix !== Blockly.globalNamePrefix) {
+    if (prefix !== Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
       var oldName = prefixPair[1];
       var newName = freeSubstitution.apply(oldName);
       if (newName !== oldName) {
@@ -219,7 +219,7 @@ Blockly.Blocks['lexical_variable_set'] = {
     var prefixPair = Blockly.unprefixName(this.getFieldValue('VAR'));
     var prefix = prefixPair[0];
     // Only return lexical (nonglobal) names
-    if (prefix !== Blockly.globalNamePrefix) {
+    if (prefix !== Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
       var oldName = prefixPair[1];
       result.insert(oldName);
     }

--- a/appinventor/blocklyeditor/src/blocks/lexical-variables.js
+++ b/appinventor/blocklyeditor/src/blocks/lexical-variables.js
@@ -96,10 +96,11 @@ Blockly.Blocks['global_declaration'] = {
     this.setTooltip(Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_TOOLTIP);
   },
   getVars: function() {
-    return [this.getFieldValue('NAME')];
+    var field = this.getField('NAME');
+    return field ? [field.getText()] : [];
   },
   renameVar: function(oldName, newName) {
-    if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
+    if (Blockly.Names.equals(oldName, this.getFieldValue('NAME'))) {
       this.setFieldValue(newName, 'NAME');
     }
   },
@@ -131,7 +132,7 @@ Blockly.Blocks['lexical_variable_get'] = {
     Blockly.LexicalVariable.eventParamDomToMutation(this, xmlElement);
   },
   getVars: function() {
-    return [this.getFieldValue('VAR')];
+    return this.getFieldValue('VAR');
   },
   renameLexicalVar: function(oldName, newName) {
     // console.log("Renaming lexical variable from " + oldName + " to " + newName);
@@ -193,7 +194,7 @@ Blockly.Blocks['lexical_variable_set'] = {
     Blockly.LexicalVariable.eventParamDomToMutation(this, xmlElement);
   },
   getVars: function() {
-    return [this.getFieldValue('VAR')];
+    return this.getFieldValue('VAR');
   },
   renameLexicalVar: Blockly.Blocks.lexical_variable_get.renameLexicalVar,
   renameFree: function (freeSubstitution) {
@@ -453,12 +454,15 @@ Blockly.Blocks['local_declaration_statement'] = {
   },
   getVars: function() {
     var varList = [];
-    for (var i = 0, input; input = this.getFieldValue('VAR' + i); i++) {
-      varList.push(input);
+    for (var i = 0, input; input = this.getField('VAR' + i); i++) {
+      varList.push(input.getText());
     }
     return varList;
   },
   declaredNames: function () { // Interface with Blockly.LexicalVariable.renameParam
+    return this.getVars();
+  },
+  declaredVariables: function () {
     return this.getVars();
   },
   initializerConnections: function() { // [lyn, 11/16/13 ] Return all the initializer connections
@@ -588,6 +592,7 @@ Blockly.Blocks['local_declaration_expression'] = {
   saveConnections: Blockly.Blocks.local_declaration_statement.saveConnections,
   getVars: Blockly.Blocks.local_declaration_statement.getVars,
   declaredNames: Blockly.Blocks.local_declaration_statement.declaredNames,
+  declaredVariables: Blockly.Blocks.local_declaration_statement.declaredVariables,
   renameVar: Blockly.Blocks.local_declaration_statement.renameVar,
   renameVars: Blockly.Blocks.local_declaration_statement.renameVars,
   renameBound: Blockly.Blocks.local_declaration_statement.renameBound,

--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -413,6 +413,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
   declaredNames: function() { // [lyn, 10/11/13] return the names of all parameters of this procedure
      return this.getVars();
   },
+  declaredVariables: function() {
+    return this.getVars();
+  },
   renameVar: function(oldName, newName) {
     this.renameVars(Blockly.Substitution.simpleSubstitution(oldName,newName));
   },
@@ -506,6 +509,7 @@ Blockly.Blocks['procedures_defreturn'] = {
   getProcedureDef: Blockly.Blocks.procedures_defnoreturn.getProcedureDef,
   getVars: Blockly.Blocks.procedures_defnoreturn.getVars,
   declaredNames: Blockly.Blocks.procedures_defnoreturn.declaredNames,
+  declaredVariables: Blockly.Blocks.procedures_defnoreturn.declaredVariables,
   renameVar: Blockly.Blocks.procedures_defnoreturn.renameVar,
   renameVars: Blockly.Blocks.procedures_defnoreturn.renameVars,
   renameBound: Blockly.Blocks.procedures_defnoreturn.renameBound,

--- a/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
+++ b/appinventor/blocklyeditor/src/demos/yail/yail_testing_index.html
@@ -53,7 +53,6 @@ function start() {
   Blockly.showPrefixToUser = true;
   Blockly.usePrefixInYail = false;
 
-  Blockly.globalNamePrefix = "global"; // For names introduced by global variable declarations
   Blockly.procedureParameterPrefix = "input"; // For names introduced by procedure/function declarations
   Blockly.handlerParameterPrefix = "input"; // For names introduced by event handlers
   Blockly.localNamePrefix = "local"; // For names introduced by local variable declarations
@@ -79,14 +78,16 @@ function start() {
     };
 
   Blockly.prefixGlobalMenuName = function (name) {
-    return Blockly.globalNamePrefix + Blockly.menuSeparator + name;
+    return Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator + name;
   };
 
   // Return a list of (1) prefix (if it exists, "" if not) and (2) unprefixed name
   Blockly.unprefixName = function (name) {
-    if (name.indexOf(Blockly.globalNamePrefix + Blockly.menuSeparator) == 0) {
+    if (name.indexOf(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator) == 0) {
       // Globals always have prefix, regardless of flags. Handle these specially
-      return [Blockly.globalNamePrefix, name.substring(Blockly.globalNamePrefix.length + Blockly.menuSeparator.length)];
+      return [Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX,
+              name.substring(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX.length +
+                      Blockly.menuSeparator.length)];
     } else if (!Blockly.showPrefixToUser) {
       return ["", name];
     } else {

--- a/appinventor/blocklyeditor/src/field_global_flydown.js
+++ b/appinventor/blocklyeditor/src/field_global_flydown.js
@@ -37,7 +37,7 @@ Blockly.FieldGlobalFlydown.prototype.flyoutCSSClassName = 'blocklyFieldParameter
  *  @return {!Array.<string>} List of two XML elements.
  **/
 Blockly.FieldGlobalFlydown.prototype.flydownBlocksXML_ = function() {
-  var name = Blockly.globalNamePrefix + " " + this.getText(); // global name for this parameter field.
+  var name = Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + " " + this.getText(); // global name for this parameter field.
   var getterSetterXML =
       '<xml>' +
         '<block type="lexical_variable_get">' +

--- a/appinventor/blocklyeditor/src/field_lexical_variable.js
+++ b/appinventor/blocklyeditor/src/field_lexical_variable.js
@@ -87,7 +87,7 @@ Blockly.FieldLexicalVariable.prototype.setValue = function(text) {
  * Update the eventparam mutation associated with the field's source block.
  */
 Blockly.FieldLexicalVariable.prototype.updateMutation = function() {
-  var text = this.getValue();
+  var text = this.getText();
   if (this.sourceBlock_ && this.sourceBlock_.getParent()) {
     this.sourceBlock_.eventparam = undefined;
     if (text.indexOf(Blockly.globalNamePrefix + ' ') === 0) {
@@ -96,7 +96,7 @@ Blockly.FieldLexicalVariable.prototype.updateMutation = function() {
     }
     var i, parent = this.sourceBlock_.getParent();
     while (parent) {
-      var variables = parent.getVars();
+      var variables = parent.declaredVariables ? parent.declaredVariables() : [];
       if (parent.type != 'component_event') {
         for (i = 0; i < variables.length; i++) {
           if (variables[i] == text) {
@@ -205,22 +205,25 @@ Blockly.FieldLexicalVariable.prototype.getNamesInScope = function () {
 
 /**
  * @param block
- * @returns {list} A list of all global and lexical names in scope at the given block.
- *   Global names are listed in sorted order before lexical names in sorted order.
+ * @returns {Array.<Array.<string>>} A list of pairs representing the translated
+ * and untranslated name of every variable in the scope of the current block.
  */
 // [lyn, 11/15/13] Refactored to work on any block
 Blockly.FieldLexicalVariable.getNamesInScope = function (block) {
   var globalNames = Blockly.FieldLexicalVariable.getGlobalNames(); // from global variable declarations
   // [lyn, 11/24/12] Sort and remove duplicates from namespaces
   globalNames = Blockly.LexicalVariable.sortAndRemoveDuplicates(globalNames);
+  globalNames = globalNames.map(Blockly.prefixGlobalMenuName).map(function(name) {
+    return [name, name];
+  });
   var allLexicalNames = Blockly.FieldLexicalVariable.getLexicalNamesInScope(block);
   // Return a list of all names in scope: global names followed by lexical ones.
-  return globalNames.map( Blockly.prefixGlobalMenuName ).concat(allLexicalNames);
+  return globalNames.concat(allLexicalNames);
 }
 
 /**
  * @param block
- * @returns {list} A list of all lexical names (in sorted order) in scope at the point of the given block
+ * @returns {Array.<Array.<string>>} A list of all lexical names (in sorted order) in scope at the point of the given block
  *   If Blockly.usePrefixInYail is true, returns names prefixed with labels like "param", "local", "index";
  *   otherwise returns unprefixed names.
  */
@@ -257,9 +260,9 @@ Blockly.FieldLexicalVariable.getLexicalNamesInScope = function (block) {
             for (i = 0; i < params.length; i++) {
               rememberName(params[i], procedureParamNames, Blockly.procedureParameterPrefix);
             }
-          } else if (parent.category === "Component" && parent.getEventTypeObject && parent.declaredNames) {
+          } else if (parent.category === "Component" && parent.getEventTypeObject && parent.getParameters) {
             // Parameter names in event handlers
-            params = parent.declaredNames();
+            params = parent.getParameters().map(function(entry) { return entry['name'] });
             for (var j = 0; j < params.length; j++) {
               rememberName(params[j], handlerParamNames, Blockly.handlerParameterPrefix);
             }
@@ -290,8 +293,7 @@ Blockly.FieldLexicalVariable.getLexicalNamesInScope = function (block) {
   }
 
   if(!Blockly.usePrefixInYail){ // Only a single namespace
-    allLexicalNames = procedureParamNames.concat(handlerParamNames)
-                                         .concat(loopNames)
+    allLexicalNames = procedureParamNames.concat(loopNames)
                                          .concat(rangeNames)
                                          .concat(localNames);
     allLexicalNames = Blockly.LexicalVariable.sortAndRemoveDuplicates(allLexicalNames);
@@ -306,13 +308,21 @@ Blockly.FieldLexicalVariable.getLexicalNamesInScope = function (block) {
            // note: correctly handles case where some prefixes are the same
     allLexicalNames = 
        procedureParamNames.map( Blockly.possiblyPrefixMenuNameWith(Blockly.procedureParameterPrefix) )
-       .concat(handlerParamNames.map( Blockly.possiblyPrefixMenuNameWith(Blockly.handlerParameterPrefix) ))
        .concat(loopNames.map( Blockly.possiblyPrefixMenuNameWith(Blockly.loopParameterPrefix) ))
        .concat(rangeNames.map( Blockly.possiblyPrefixMenuNameWith(Blockly.loopRangeParameterPrefix) ))
        .concat(localNames.map( Blockly.possiblyPrefixMenuNameWith(Blockly.localNamePrefix) ));
     allLexicalNames = Blockly.LexicalVariable.sortAndRemoveDuplicates(allLexicalNames);
   }
-  return allLexicalNames;
+  return allLexicalNames.map(function(name) {
+    return [name, name]
+  }).concat(
+    handlerParamNames.map(function(name) {
+      var translatedName = block.workspace.getTopWorkspace().getComponentDatabase()
+        .getInternationalizedParameterName(name);
+      var prefix = Blockly.usePrefixInYail ? Blockly.handlerParameterPrefix : innermostPrefix[name];
+      return [Blockly.possiblyPrefixMenuNameWith(prefix)(translatedName), name];
+    })
+  );
 }
 
 /**
@@ -322,15 +332,7 @@ Blockly.FieldLexicalVariable.getLexicalNamesInScope = function (block) {
  */
 Blockly.FieldLexicalVariable.dropdownCreate = function() {
   var variableList = this.getNamesInScope(); // [lyn, 11/10/12] Get all global, parameter, and local names
-  // Variables are not language-specific, use the name as both the user-facing
-  // text and the internal representation.
-  var options = [];
-  // [lyn, 11/10/12] Ensure variable list isn't empty
-  if (variableList.length == 0) variableList = [" "];
-  for (var x = 0; x < variableList.length; x++) {
-    options[x] = [variableList[x], variableList[x]];
-  }
-  return options;
+  return variableList.length == 0 ? [" ", " "] : variableList;
 };
 
 /**
@@ -561,7 +563,15 @@ Blockly.LexicalVariable.renameParamRenamingCapturables = function (sourceBlock, 
       throw "Blockly.LexicalVariable.renamingCapturables: oldName " + oldName +
           " is not in declarations {" + namesDeclaredHere.join(',') + "}";
     }
-    var namesDeclaredAbove = Blockly.FieldLexicalVariable.getNamesInScope(sourceBlock);
+    var namesDeclaredAbove = [];
+    Blockly.FieldLexicalVariable.getNamesInScope(sourceBlock)
+      .map(function(pair) {
+        if (pair[0] == pair[1]) {
+          namesDeclaredAbove.push(pair[0]);
+        } else {
+          namesDeclaredAbove.push(pair[0], pair[1]);
+        }
+      });  // uses translated param names
     var declaredNames = namesDeclaredHere.concat(namesDeclaredAbove);
     // Should really check which forbidden names are free vars in the body of declBlock.
     if (declaredNames.indexOf(newName) != -1) {
@@ -890,7 +900,7 @@ Blockly.LexicalVariable.referenceResult = function (block, name, prefix, env) {
   }
   // Base case: getters/setters is where all the interesting action occurs
   if ((block.type === "lexical_variable_get") || (block.type === "lexical_variable_set")) {
-    var possiblyPrefixedReferenceName = block.getFieldValue('VAR');
+    var possiblyPrefixedReferenceName = block.getField('VAR').getText();
     var unprefixedPair = Blockly.unprefixName(possiblyPrefixedReferenceName);
     var referencePrefix = unprefixedPair[0];
     var referenceName = unprefixedPair[1];
@@ -917,6 +927,9 @@ Blockly.LexicalVariable.referenceResult = function (block, name, prefix, env) {
         // When Blockly.usePrefixInYail is true, only consider names with same prefix to be capturable
         capturables.push(referenceName);
       }
+    }
+    if (block.eventparam) {  // also capture untranslated param names
+      capturables.push(block.eventparam);
     }
   }
   /* console.log("referenceResult from block of type " + block.type + 
@@ -1043,7 +1056,7 @@ Blockly.LexicalVariable.getEventParam = function (block) {
           || ( parent.type === "local_declaration_statement"
           && parent.getInputTargetBlock('STACK') == child ) // only body is in scope of names
            ) {
-          var params = parent.declaredNames(); // [lyn, 10/13/13] Names from block, not localNames_ instance var
+          var params = parent.getVars(); // [lyn, 10/13/13] Names from block, not localNames_ instance var
           if (params.indexOf(name) != -1) {
             return null; // Name is locally bound, not an event parameter.
           }
@@ -1076,6 +1089,16 @@ Blockly.LexicalVariable.eventParamDomToMutation = function (block, xmlElement) {
     if (childNode.nodeName.toLowerCase() == 'eventparam') {
       var untranslatedEventName = childNode.getAttribute('name');
       block.eventparam = untranslatedEventName; // special property viewed by Blockly.LexicalVariable.eventParameterDict
+      if (!Blockly.Events.isEnabled() && !block.isInFlyout) {  // Loading or flyout
+        setTimeout(function() {
+          Blockly.Events.disable();  // we don't want to save this change since it is visual
+          block.fieldVar_.setValue(untranslatedEventName);
+          block.fieldVar_.setText(block.workspace.getTopWorkspace().getComponentDatabase().getInternationalizedParameterName(untranslatedEventName));
+          block.eventparam = untranslatedEventName;
+          block.workspace.requestErrorChecking(block);
+          Blockly.Events.enable();
+        }, 0);
+      }
     }
   }
 }

--- a/appinventor/blocklyeditor/src/field_lexical_variable.js
+++ b/appinventor/blocklyeditor/src/field_lexical_variable.js
@@ -90,7 +90,7 @@ Blockly.FieldLexicalVariable.prototype.updateMutation = function() {
   var text = this.getText();
   if (this.sourceBlock_ && this.sourceBlock_.getParent()) {
     this.sourceBlock_.eventparam = undefined;
-    if (text.indexOf(Blockly.globalNamePrefix + ' ') === 0) {
+    if (text.indexOf(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + ' ') === 0) {
       this.sourceBlock_.eventparam = null;
       return;
     }
@@ -459,8 +459,8 @@ Blockly.LexicalVariable.renameGlobal = function (newName) {
         var renamingFunction = block.renameLexicalVar;
         if (renamingFunction) {
             renamingFunction.call(block,
-                                  Blockly.globalNamePrefix + Blockly.menuSeparator + oldName,
-                                  Blockly.globalNamePrefix + Blockly.menuSeparator + newName);
+                                  Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator + oldName,
+                                  Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator + newName);
         }
       }
     }
@@ -906,7 +906,7 @@ Blockly.LexicalVariable.referenceResult = function (block, name, prefix, env) {
     var referenceName = unprefixedPair[1];
     var referenceNotInEnv = ((Blockly.usePrefixInYail && (env.indexOf(possiblyPrefixedReferenceName) == -1))
                              || ((!Blockly.usePrefixInYail) && (env.indexOf(referenceName) == -1)))
-    if (!(referencePrefix === Blockly.globalNamePrefix)) {
+    if (!(referencePrefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX)) {
       if ((referenceName === name) && referenceNotInEnv) {
         // if referenceName refers to name and not some intervening declaration, it's a reference to be renamed:
         blocksToRename.push(block);
@@ -1032,7 +1032,7 @@ Blockly.LexicalVariable.getEventParam = function (block) {
                                 // evaluated it.
   var prefixPair = Blockly.unprefixName(block.getFieldValue("VAR"));
   var prefix = prefixPair[0];
-  if (prefix !== Blockly.globalNamePrefix) {
+  if (prefix !== Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
     var name = prefixPair[1];
     var child = block;
     var parent = block.getParent();

--- a/appinventor/blocklyeditor/src/field_parameter_flydown.js
+++ b/appinventor/blocklyeditor/src/field_parameter_flydown.js
@@ -92,14 +92,14 @@ Blockly.FieldParameterFlydown.prototype.flydownBlocksXML_ = function() {
   var getterSetterXML =
        '<xml>' +
          '<block type="lexical_variable_get">' + mutation +
-           '<title name="VAR">' +
+           '<field name="VAR">' +
              name +
-           '</title>' +
+           '</field>' +
          '</block>' +
          '<block type="lexical_variable_set">' + mutation +
-           '<title name="VAR">' +
+           '<field name="VAR">' +
              name +
-           '</title>' +
+           '</field>' +
          '</block>' +
        '</xml>';
   return getterSetterXML;

--- a/appinventor/blocklyeditor/src/generators/yail/variables.js
+++ b/appinventor/blocklyeditor/src/generators/yail/variables.js
@@ -90,7 +90,7 @@ Blockly.Yail['getVariableCommandAndName'] = function(name){
   var pair = Blockly.unprefixName(name);
   var prefix = pair[0];
   var unprefixedName = pair[1];
-  if (prefix === Blockly.globalNamePrefix) {
+  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
     name = Blockly.Yail.YAIL_GLOBAL_VAR_TAG + unprefixedName;
     command = Blockly.Yail.YAIL_GET_VARIABLE;
   } else {
@@ -106,7 +106,7 @@ Blockly.Yail['setVariableCommandAndName'] = function(name){
   var pair = Blockly.unprefixName(name);
   var prefix = pair[0];
   var unprefixedName = pair[1];
-  if (prefix === Blockly.globalNamePrefix) {
+  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
     name = Blockly.Yail.YAIL_GLOBAL_VAR_TAG + unprefixedName;
     command = Blockly.Yail.YAIL_SET_VARIABLE;
   } else {

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -941,6 +941,7 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_TO = 'to';
     Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_COLLAPSED_TEXT = 'global';
     Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_TOOLTIP = 'Creates a global variable and gives it the value of the attached blocks.';
+    Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX = 'global';
 
     Blockly.Msg.LANG_VARIABLES_GET_HELPURL = '/reference/blocks/variables.html#get';
     Blockly.Msg.LANG_VARIABLES_GET_TITLE_GET = 'get';


### PR DESCRIPTION
This PR addresses two issues. First, event parameters are not properly internationalized when switching between projects. Second, while testing the first change I noticed that the 'global' keyword in variable names isn't internationalized, so I took care of that. There will be a separate PR that addresses some larger issues I also encountered.

Fixes #708