### PR TITLE
Use border box sizing for MockTextBox

### DIFF
--- a/appinventor/appengine/war/gwt.css
+++ b/appinventor/appengine/war/gwt.css
@@ -918,6 +918,7 @@ a, a:visited, a:hover {
 
 .gwt-TextBox {
   padding: 2px;
+  box-sizing: border-box;
 }
 .gwt-TextBox-readonly {
   color: #888;


### PR DESCRIPTION
I was building a sample app with some fill-parent text boxes. Because of how the CSS is set up, the mock textbox will overflow its parent (companion preview is fine). This is a small fix to change the CSS box sizing model so that the mock textbox better reflects how it appears on the screen.

Change-Id: Ic374dbabd9fad57c06b1b070ab3d84a63ba0b4e6