### PR TITLE
Fix export projects in oneProject mode

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -509,9 +509,9 @@ public class TopToolbar extends Composite {
   private static class ExportProjectAction implements Command {
     @Override
     public void execute() {
-      List<Project> selectedProjects =
-          ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
       if (Ode.getInstance().getCurrentView() == Ode.PROJECTS) {
+        List<Project> selectedProjects =
+          ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
         //If we are in the projects view
         if (selectedProjects.size() == 1) {
           exportProject(selectedProjects.get(0));


### PR DESCRIPTION
Change the scope of the “selectedProjects” variable so we do not call
“getProjectList()” when we are not on the PROJECTS tab. This fixes an
issue with “oneproject” mode (which isn’t in this source tree).

Change-Id: I515a9c25fad12339810712b1f5b995c3a8a3855b