### PR TITLE
Add internationalization to component block tooltips in Blocks Editor

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -280,10 +280,10 @@ Blockly.Blocks.component_event = {
     this.setParameterOrientation(horizParams);
     var tooltipDescription;
     if (eventType) {
-      tooltipDescription = eventType.description;
+      tooltipDescription = componentDb.getInternationalizedEventDescription(eventType.name);
     }
     else {
-      tooltipDescription = Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP;
+      tooltipDescription = componentDb.getInternationalizedEventDescription(this.eventName);
     }
     this.setTooltip(tooltipDescription);
     this.setPreviousStatement(false, null);
@@ -563,9 +563,6 @@ Blockly.Blocks.component_event = {
 
     if (isDefined) {
       this.notBadBlock();
-      if (this.getEventTypeObject()) {
-        this.setTooltip(this.getEventTypeObject().description); // update the tooltipDescription, if block is defined
-      }
     } else {
       this.badBlock();
     }
@@ -711,9 +708,9 @@ Blockly.Blocks.component_method = {
 
     var tooltipDescription;
     if (methodTypeObject) {
-      tooltipDescription = methodTypeObject.description;
+      tooltipDescription = componentDb.getInternationalizedMethodDescription(methodTypeObject.name);
     } else {
-      tooltipDescription = Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP;
+      tooltipDescription = componentDb.getInternationalizedMethodDescription(this.typeName);
     }
     this.setTooltip(tooltipDescription);
 
@@ -912,9 +909,6 @@ Blockly.Blocks.component_method = {
     var isDefined = validate.call(this);
     if (isDefined) {
       this.notBadBlock();
-      if (this.getMethodTypeObject()) {
-        this.setTooltip(this.getMethodTypeObject().description); // update the tooltipDescription, if block is defined
-      }
     } else {
       this.badBlock();
     }
@@ -1000,8 +994,8 @@ Blockly.Blocks.component_set_get = {
       this.setColour(Blockly.ComponentBlock.COLOUR_GET);
     }
     var tooltipDescription;
-    if (this.propertyObject) {
-      tooltipDescription = this.propertyObject.description;
+    if (this.propertyName) {
+      tooltipDescription = componentDb.getInternationalizedPropertyDescription(this.propertyName);
     } else {
       tooltipDescription = Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP;
     }
@@ -1016,8 +1010,8 @@ Blockly.Blocks.component_set_get = {
         thisBlock.propertyName = selection;
         thisBlock.propertyObject = thisBlock.getPropertyObject(selection);
         thisBlock.setTypeCheck();
-        if (thisBlock.propertyObject) {
-          thisBlock.setTooltip(thisBlock.propertyObject.description);
+        if (thisBlock.propertyName) {
+          thisBlock.setTooltip(componentDb.getInternationalizedPropertyDescription(thisBlock.propertyName));
         } else {
           thisBlock.setTooltip(Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP);
         }
@@ -1251,9 +1245,6 @@ Blockly.Blocks.component_set_get = {
     var isDefined = validate.call(this);
     if (isDefined) {
       this.notBadBlock();
-      if (this.propertyObject) {
-        this.setTooltip(this.propertyObject.description); // update the tooltipDescription, if block is defined
-      }
     } else {
       this.badBlock(true);
     }

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -104,9 +104,12 @@ Blockly.ComponentDatabase = function() {
   // Internationalization support
   this.i18nComponentTypes_ = {};
   this.i18nEventNames_ = {};
+  this.i18nEventDescriptions_ = {};
   this.i18nMethodNames_ = {};
+  this.i18nMethodDescriptions_ = {};
   this.i18nParamNames_ = {};
   this.i18nPropertyNames_ = {};
+  this.i18nPropertyDescriptions_ = {};
 };
 
 /**
@@ -375,6 +378,12 @@ Blockly.ComponentDatabase.prototype.populateTranslations = function(translations
         this.i18nMethodNames_[parts[1]] = translations[key];
       } else if (parts[0] == 'PARAM') {
         this.i18nParamNames_[parts[1]] = translations[key];
+      } else if (parts[0] == 'EVENTDESC') {
+        this.i18nEventDescriptions_[parts[1]] = translations[key];
+      } else if (parts[0] == 'METHDESC') {
+        this.i18nMethodDescriptions_[parts[1]] = translations[key];
+      } else if (parts[0] == 'PROPDESC') {
+        this.i18nPropertyDescriptions_[parts[1]] = translations[key];
       }
     }
   }
@@ -505,12 +514,30 @@ Blockly.ComponentDatabase.prototype.getInternationalizedEventName = function(nam
 };
 
 /**
+ * Get the internationalized string for the given event description tooltip.
+ * @param {!string} name String naming a component event
+ * @returns {string} The localized string if available, otherwise the unlocalized name.
+ */
+Blockly.ComponentDatabase.prototype.getInternationalizedEventDescription = function(name) {
+  return this.i18nEventDescriptions_[name] || name;
+};
+
+/**
  * Get the internationalized string for the given method name.
  * @param {!string} name String naming a component method
  * @returns {string} The localized string if available, otherwise the unlocalized name.
  */
 Blockly.ComponentDatabase.prototype.getInternationalizedMethodName = function(name) {
   return this.i18nMethodNames_[name] || name;
+};
+
+/**
+ * Get the internationalized string for the given method name.
+ * @param {!string} name String naming a component method
+ * @returns {string} The localized string if available, otherwise the unlocalized name.
+ */
+Blockly.ComponentDatabase.prototype.getInternationalizedMethodDescription = function(name) {
+  return this.i18nMethodDescriptions_[name] || name;
 };
 
 /**
@@ -529,4 +556,13 @@ Blockly.ComponentDatabase.prototype.getInternationalizedParameterName = function
  */
 Blockly.ComponentDatabase.prototype.getInternationalizedPropertyName = function(name) {
   return this.i18nPropertyNames_[name] || name;
+};
+
+/**
+ * Get the internationalized string for the given property description tooltip.
+ * @param {!string} name String naming a component property
+ * @returns {string} The localized string if available, otherwise the unlocalized name.
+ */
+Blockly.ComponentDatabase.prototype.getInternationalizedPropertyDescription = function(name) {
+  return this.i18nPropertyDescriptions_[name] || name;
 };


### PR DESCRIPTION
We currently allow translations of component block tooltips (Method/Event/Property Descriptions in the OdeMessages file), but the blocks editor doesn't display the internationalized strings. This PR fixes that bug.