### PR TITLE
Change Form Initialize ordering to initialize components first

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -904,12 +904,13 @@ public class Form extends AppInventorCompatActivity
           }
           screenInitialized = true;
 
-          EventDispatcher.dispatchEvent(Form.this, "Initialize");
-
           //  Call all apps registered to be notified when Initialize Event is dispatched
           for (OnInitializeListener onInitializeListener : onInitializeListeners) {
             onInitializeListener.onInitialize();
           }
+
+          EventDispatcher.dispatchEvent(Form.this, "Initialize");
+
           if (activeForm instanceof ReplForm) { // We are the Companion
             ((ReplForm)activeForm).HandleReturnValues();
           }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -897,13 +897,14 @@ public class Form extends AppInventorCompatActivity
     androidUIHandler.post(new Runnable() {
       public void run() {
         if (frameLayout != null && frameLayout.getWidth() != 0 && frameLayout.getHeight() != 0) {
-          EventDispatcher.dispatchEvent(Form.this, "Initialize");
           if (sCompatibilityMode) { // Make sure call to setLayout happens
             Sizing("Fixed");
           } else {
             Sizing("Responsive");
           }
           screenInitialized = true;
+
+          EventDispatcher.dispatchEvent(Form.this, "Initialize");
 
           //  Call all apps registered to be notified when Initialize Event is dispatched
           for (OnInitializeListener onInitializeListener : onInitializeListeners) {


### PR DESCRIPTION
**Up for discussion**

Right now in App Inventor, the component onInitialize events get triggered only after the Initialize event is dispatched.

The reason why this might be an issue is that the component onInitialize events (in the future) might set certain states which should be in place before the user accesses the component via blocks. However, in this case, the component's state would only change after the Initialize block, and should the component be accessed in the Initialize block, issues would be caused due to the order.

The following generalized example illustrates the issue:
![Initialization Ordering Issue](https://user-images.githubusercontent.com/34982762/62169396-610fcd00-b328-11e9-95f2-cc26b07c9428.png)
