### PR TITLE
Fix screen names with underscore

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -664,7 +664,7 @@ public class BlocklyPanel extends HTMLPanel {
     Blockly.mainWorkspace = this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
     Blockly.mainWorkspace.refreshBackpack();
     // Trigger a screen switch to send new YAIL.
-    var parts = Blockly.mainWorkspace.formName.split(/_/, 2);
+    var parts = Blockly.mainWorkspace.formName.split(/_(.+)/);  // Split string on first _
     if (Blockly.ReplMgr.isConnected()) {
       Blockly.ReplMgr.pollYail(Blockly.mainWorkspace);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -664,7 +664,7 @@ public class BlocklyPanel extends HTMLPanel {
     Blockly.mainWorkspace = this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
     Blockly.mainWorkspace.refreshBackpack();
     // Trigger a screen switch to send new YAIL.
-    var parts = Blockly.mainWorkspace.formName.split(/_/);
+    var parts = Blockly.mainWorkspace.formName.split(/_/, 2);
     if (Blockly.ReplMgr.isConnected()) {
       Blockly.ReplMgr.pollYail(Blockly.mainWorkspace);
     }

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -397,7 +397,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
 
   var formName = Blockly.mainWorkspace.formName;
-  var screenName = formName.split("_", 1)[1];
+  var screenName = formName.split("_", 2)[1];
   var subsetJsonString;
   if (window.parent.BlocklyPanel_getComponentInstancePropertyValue) {
     subsetJsonString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName, screenName, "BlocksToolkit");

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -93,7 +93,7 @@ Blockly.Drawer.createSubsetBlockInfoArray_ = function() {
     console.log("trying to set subset string");
     var subsetJsonString;
     var formName = Blockly.mainWorkspace.formName;
-    var screenName = formName.split("_")[1];
+    var screenName = formName.split("_", 2)[1];
     if (window.parent.BlocklyPanel_getComponentInstancePropertyValue) {
       subsetJsonString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName, screenName, "BlocksToolkit");
     } else {
@@ -397,7 +397,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
 
   var formName = Blockly.mainWorkspace.formName;
-  var screenName = formName.split("_")[1];
+  var screenName = formName.split("_", 1)[1];
   var subsetJsonString;
   if (window.parent.BlocklyPanel_getComponentInstancePropertyValue) {
     subsetJsonString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName, screenName, "BlocksToolkit");

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -93,7 +93,7 @@ Blockly.Drawer.createSubsetBlockInfoArray_ = function() {
     console.log("trying to set subset string");
     var subsetJsonString;
     var formName = Blockly.mainWorkspace.formName;
-    var screenName = formName.split("_", 2)[1];
+    var screenName = formName.substring(formName.indexOf("_") + 1);
     if (window.parent.BlocklyPanel_getComponentInstancePropertyValue) {
       subsetJsonString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName, screenName, "BlocksToolkit");
     } else {
@@ -397,7 +397,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
 
   var formName = Blockly.mainWorkspace.formName;
-  var screenName = formName.split("_", 2)[1];
+  var screenName = formName.substring(formName.indexOf("_") + 1);
   var subsetJsonString;
   if (window.parent.BlocklyPanel_getComponentInstancePropertyValue) {
     subsetJsonString = window.parent.BlocklyPanel_getComponentInstancePropertyValue(formName, screenName, "BlocksToolkit");


### PR DESCRIPTION
Logic that finds the screen name by removing everything up to the first _ character from the form name broke when the screen name contains an underscore.