### PR TITLE
Fixed empty dropdown

### DIFF
--- a/appinventor/blocklyeditor/src/field_lexical_variable.js
+++ b/appinventor/blocklyeditor/src/field_lexical_variable.js
@@ -332,7 +332,7 @@ Blockly.FieldLexicalVariable.getLexicalNamesInScope = function (block) {
  */
 Blockly.FieldLexicalVariable.dropdownCreate = function() {
   var variableList = this.getNamesInScope(); // [lyn, 11/10/12] Get all global, parameter, and local names
-  return variableList.length == 0 ? [" ", " "] : variableList;
+  return variableList.length == 0 ? [[" ", " "]] : variableList;
 };
 
 /**


### PR DESCRIPTION
Currently a empty variable dropdown contains two empty string items

![image](https://user-images.githubusercontent.com/22613139/62413264-e1983b80-b650-11e9-987b-c46720510327.png)
