### PR TITLE
Make ScaledFrameLayout only save matrix

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ScaledFrameLayout.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ScaledFrameLayout.java
@@ -58,11 +58,7 @@ public class ScaledFrameLayout extends ViewGroup {
 
   @Override
   protected void dispatchDraw(Canvas canvas) {
-    if (VERSION.SDK_INT < VERSION_CODES.P) {
-      canvas.saveLayer(0, 0, canvas.getWidth(), canvas.getHeight(), null, MATRIX_SAVE_FLAG);
-    } else {
-      canvas.saveLayer(0, 0, canvas.getWidth(), canvas.getHeight(), null);
-    }
+    canvas.save();
     canvas.scale(mScale, mScale);
     super.dispatchDraw(canvas);
     canvas.restore();


### PR DESCRIPTION
Previous versions of ScaledFrameLayout saved the entire layer. This
isn't great for performance reasons, but it also had the side effect
on Android > 8.0 of messing with how WebView draws to the screen since
it is drawing to a back buffer. This change switches to only calling
save(), which saves the various transformations without creating a
secondary buffer. This seems to make the WebView happy again.

Change-Id: I9188e68d943fdc56bca7a57a24d0d17b2f9b49e7