### PR TITLE
Add Javadoc extraction for property descriptions

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1096,8 +1096,19 @@ public abstract class ComponentProcessor extends AbstractProcessor {
                                  propertyName);
     }
 
+    // Use Javadoc for property unless description is set to a non-empty string.
+    String description = elementUtils.getDocComment(element);
+    if (!simpleProperty.description().isEmpty()) {
+      description = simpleProperty.description();
+    }
+    if (description == null) {
+      description = "";
+    }
+    // Read only until the first javadoc parameter
+    description = description.split("[^\\\\][@{]")[0].trim();
+
     Property property = new Property(propertyName,
-                                     simpleProperty.description(),
+                                     description,
                                      simpleProperty.category(),
                                      simpleProperty.userVisible(),
                                      elementUtils.isDeprecated(element));


### PR DESCRIPTION
While testing #1795 I noticed that the tooltips for some of the properties were not correct. It turns out that if we don't specify a description in `@SimpleProperty` then the `ComponentProcessor` never tries to extract the description from the Javadoc. It does do this for classes, events, and methods. This change makes it so that when we create a property object, we also consider the Javadoc as a source of last resort for the property description.

Change-Id: I7fdc2d77430473420ed2d0e17d798a485ea16325