### PR TITLE
[WIP] Build time optimization without -Ddebug

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -474,6 +474,9 @@
           description="GWT compile to JavaScript"
           depends="common_CommonUtils,common_CommonVersion,components_CommonConstants,AiClientLib,AiRebindLib,CheckYaClientApp"
           unless="YaClientApp.uptodate">
+    <condition property="compiler.extra.args" value="-logLevel INFO -extra ${build.extra.dir} -style pretty" else="-logLevel INFO -extra ${build.extra.dir} -style pretty -optimize 9 -localWorkers 4">
+      <isset property="debug" />
+    </condition>
     <mkdir dir="${build.extra.dir}" />
     <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler">
       <classpath>
@@ -505,7 +508,7 @@
       <jvmarg value="-Dfile.encoding=UTF-8" />
       <arg line="-war"/>
       <arg value="${build.war.dir}"/>
-      <arg line="-logLevel INFO -extra ${build.extra.dir} -style pretty"/>
+      <arg line="${compiler.extra.args}" />
       <arg value="com.google.appinventor.YaClient"/>
     </java>
   </target>


### PR DESCRIPTION
This PR includes GWT optimization depending on `-Ddebug` flag, which was already defined in `build-common.xml`.

Another non-included potential change is setting "mode" to either "RAW" or "SIMPLE" in [ploverConfig.js](https://github.com/mit-cml/appinventor-sources/blob/db6b27ebe1b39bd586ed88a62426880110071d2f/appinventor/blocklyeditor/ploverConfig.js#L189). I would like to avoid sed hassle, so I leave some options to go here:
- Distinguish by `ploverConfig.debug.js` and `ploverConfig.release.js`
- Leave it as it is
- Some Ant or plovr magic that I don't know about