### PR TITLE
Register YaFormEditor and YaBlocksEditor earlier

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1067,7 +1067,6 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   }
 
   public void delete() {
-    OdeLog.log("Got delete component for " + this.getName());
     this.editor.getProjectEditor().clearLocation(getName());
     getForm().select();
     // Pass true to indicate that the component is being permanently deleted.

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -530,6 +530,19 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     // Set loadCompleted to true.
     // From now on, all change events will be taken seriously.
     loadComplete = true;
+
+    // Originally this was done in loadDesigner. However, this resulted in
+    // the form and blocks editor not being registered for events until after
+    // they were opened. This became problematic if the user deleted an extension
+    // prior to opening the screen as they would never trigger a save, resulting
+    // in a corrupt project.
+
+    // Listen to changes on the form.
+    form.addFormChangeListener(this);
+    // Also have the blocks editor listen to changes. Do this here instead
+    // of in the blocks editor so that we don't risk it missing any updates.
+    form.addFormChangeListener(((YaProjectEditor) projectEditor)
+        .getBlocksFileEditor(form.getName()));
   }
 
   public void reloadComponentPalette(String subsetjson) {
@@ -678,14 +691,6 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     propertiesBox.setContent(designProperties);
     updatePropertiesPanel(selectedComponent);
     propertiesBox.setVisible(true);
-
-    // Listen to changes on the form.
-    form.addFormChangeListener(this);
-    // Also have the blocks editor listen to changes. Do this here instead
-    // of in the blocks editor so that we don't risk it missing any updates.
-    OdeLog.log("Adding blocks editor as a listener for " + form.getName());
-    form.addFormChangeListener(((YaProjectEditor) projectEditor)
-        .getBlocksFileEditor(form.getName()));
   }
 
   /*


### PR DESCRIPTION
Prior to this change, YaFormEditor and YaBlocksEditor are registered
in loadDesigner, which is called from onShow. This is problematic
because if the screen hasn't been opened in the current session and
the user deletes an extension, the unopened screens are not notified
of the change. When the project is reloaded, it will fail to load
because the unopened screens still referenced the deleted extension.

This change moves the registration of YaFormEditor and YaBlocksEditor
as FormChangeListeners to the onFileLoaded method so that they are
made aware of project-level changes (like removing an extension) even
if they are never viewed in a session.

Fixes #1818 

Change-Id: I8306ede85f5fb3576d810c9bd213e5e00df938ff