### PR TITLE
Add %type% as a token in component descriptions

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
@@ -51,7 +51,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   public abstract View getView();
 
   /**
-   * Returns true iff the component is visible.
+   * Returns true iff the %type% is visible.
    * @return  true iff the component is visible
    */
   @SimpleProperty(
@@ -67,8 +67,8 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VISIBILITY,
       defaultValue = "True")
-  @SimpleProperty(description = "Specifies whether the component should be visible on the screen. "
-      + "Value is true if the component is showing and false if hidden.")
+  @SimpleProperty(description = "Specifies whether the %type% should be visible on the screen. "
+      + "Value is true if the %type% is showing and false if hidden.")
   public void Visible(boolean visibility) {
     // The principle of least astonishment suggests we not offer the
     // Android option INVISIBLE.
@@ -76,7 +76,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   }
 
   /**
-   * Returns the component's horizontal width, measured in pixels.
+   * Returns the horizontal width of the %type%, measured in pixels.
    *
    * @return  width in pixels
    */
@@ -89,12 +89,12 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   }
 
   /**
-   * Specifies the component's horizontal width, measured in pixels.
+   * Specifies the horizontal width of the %type%, measured in pixels.
    *
    * @param  width in pixels
    */
   @Override
-  @SimpleProperty(description = "Specifies the component's horizontal width, measured in pixels.")
+  @SimpleProperty(description = "Specifies the horizontal width of the %type%, measured in pixels.")
   public void Width(int width) {
     container.setChildWidth(this, width);
     lastSetWidth = width;
@@ -106,14 +106,15 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   }
 
   /**
-   * Specifies the component's horizontal width as a percentage
-   * of the Width of its parent Component.
+   * Specifies the horizontal width of the %type% as a percentage
+   * of the Width of the Screen.
    *
-   * @param width in percent
+   * @param pCent width in percent
    */
 
   @Override
-  @SimpleProperty(description = "Specifies the component's horizontal width as a percentage of the Width of its parent Component.")
+  @SimpleProperty(description = "Specifies the horizontal width of the %type% as a percentage of "
+      + "the width of the Screen.")
   public void WidthPercent(int pCent) {
     if (pCent < 0 || pCent > 100) {
       container.$form().dispatchErrorOccurredEvent(this, "WidthPercent",
@@ -183,7 +184,7 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    * @param  height in pixels
    */
   @Override
-  @SimpleProperty(description = "Specifies the component's vertical height, measured in pixels.")
+  @SimpleProperty(description = "Specifies the vertical height of the %type%, measured in pixels.")
   public void Height(int height) {
     container.setChildHeight(this, height);
     lastSetHeight = height;
@@ -198,11 +199,12 @@ public abstract class AndroidViewComponent extends VisibleComponent {
    * Specifies the component's vertical height as a percentage
    * of the height of its parent Component.
    *
-   * @param height in percent
+   * @param pCent height in percent
    */
 
   @Override
-  @SimpleProperty(description = "Specifies the component's vertical height as a percentage of the height of its parent Component.")
+  @SimpleProperty(description = "Specifies the vertical height of the %type% as a percentage of "
+      + "the height of the Screen.")
   public void HeightPercent(int pCent) {
     if (pCent < 0 || pCent > 100) {
       container.$form().dispatchErrorOccurredEvent(this, "HeightPercent",

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -194,7 +194,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   /**
    * Indicates when a button is touch down
    */
-  @SimpleEvent(description = "Indicates that the button was pressed down.")
+  @SimpleEvent(description = "Indicates that the %type% was pressed down.")
   public void TouchDown() {
     EventDispatcher.dispatchEvent(this, "TouchDown");
   }
@@ -202,7 +202,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   /**
    * Indicates when a button touch ends
    */
-  @SimpleEvent(description = "Indicates that a button has been released.")
+  @SimpleEvent(description = "Indicates that the %type% has been released.")
   public void TouchUp() {
     EventDispatcher.dispatchEvent(this, "TouchUp");
   }
@@ -211,7 +211,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    * Indicates the cursor moved over the button so it is now possible
    * to click it.
    */
-  @SimpleEvent(description = "Indicates the cursor moved over the button so " +
+  @SimpleEvent(description = "Indicates the cursor moved over the %type% so " +
       "it is now possible to click it.")
   public void GotFocus() {
     EventDispatcher.dispatchEvent(this, "GotFocus");
@@ -222,7 +222,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    * longer possible to click it.
    */
   @SimpleEvent(description = "Indicates the cursor moved away from " +
-      "the button so it is now no longer possible to click it.")
+      "the %type% so it is now no longer possible to click it.")
   public void LostFocus() {
     EventDispatcher.dispatchEvent(this, "LostFocus");
   }
@@ -288,7 +288,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BUTTON_SHAPE,
       defaultValue = Component.BUTTON_SHAPE_DEFAULT + "")
-  @SimpleProperty(description = "Specifies the button's shape (default, rounded," +
+  @SimpleProperty(description = "Specifies the shape of the %type% (default, rounded," +
       " rectangular, oval). The shape will not be visible if an Image is being displayed.",
       userVisible = false)
   public void Shape(int shape) {
@@ -318,7 +318,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
-  @SimpleProperty(description = "Specifies the path of the button's image.  " +
+  @SimpleProperty(description = "Specifies the path of the image of the %type%.  " +
       "If there is both an Image and a BackgroundColor, only the Image will be " +
       "visible.")
   public void Image(String path) {
@@ -371,7 +371,7 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
                     defaultValue = Component.DEFAULT_VALUE_COLOR_DEFAULT)
-  @SimpleProperty(description = "Specifies the button's background color. " +
+  @SimpleProperty(description = "Specifies the background color of the %type%. " +
       "The background color will not be visible if an Image is being displayed.")
   public void BackgroundColor(int argb) {
     backgroundColor = argb;
@@ -466,19 +466,19 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns true if the button is active and clickable.
+   * Returns true if the %type% is active and clickable.
    *
    * @return  {@code true} indicates enabled, {@code false} disabled
    */
   @SimpleProperty(
       category = PropertyCategory.BEHAVIOR,
-      description = "If set, user can tap check box to cause action.")
+      description = "If set, user can tap %type% to cause action.")
   public boolean Enabled() {
     return TextViewUtil.isEnabled(view);
   }
 
   /**
-   * Specifies whether the button should be active and clickable.
+   * Specifies whether the %type% should be active and clickable.
    *
    * @param enabled  {@code true} for enabled, {@code false} disabled
    */
@@ -490,7 +490,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns true if the button's text should be bold.
+   * Returns true if the text of the %type% should be bold.
    * If bold has been requested, this property will return true, even if the
    * font does not support bold.
    *
@@ -498,13 +498,13 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "If set, button text is displayed in bold.")
+      description = "If set, %type% text is displayed in bold.")
   public boolean FontBold() {
     return bold;
   }
 
   /**
-   * Specifies whether the button's text should be bold.
+   * Specifies whether the text of the %type% should be bold.
    * Some fonts do not support bold.
    *
    * @param bold  {@code true} indicates bold, {@code false} normal
@@ -519,7 +519,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies if a visual feedback should be shown when a button with an assigned image
+   * Specifies if a visual feedback should be shown when a %type% with an assigned image
    * is pressed.
    *
    * @param showFeedback  {@code true} enables showing feedback,
@@ -528,14 +528,14 @@ public abstract class ButtonBase extends AndroidViewComponent
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
           defaultValue = "True")
   @SimpleProperty(description = "Specifies if a visual feedback should be shown " +
-          " for a button that as an image as background.")
+          " for a %type% that as an image as background.")
 
   public void ShowFeedback(boolean showFeedback) {
     this.showFeedback =showFeedback;
   }
 
     /**
-     * Returns true if the button's text should be bold.
+     * Returns true if the text of the %type% should be bold.
      * If bold has been requested, this property will return true, even if the
      * font does not support bold.
      *
@@ -544,13 +544,13 @@ public abstract class ButtonBase extends AndroidViewComponent
      */
     @SimpleProperty(
             category = PropertyCategory.APPEARANCE,
-            description = "Returns the button's visual feedback state")
+            description = "Returns the visual feedback state of the %type%")
     public boolean ShowFeedback() {
         return showFeedback;
     }
 
     /**
-   * Returns true if the button's text should be italic.
+   * Returns true if the text of the %type% should be italic.
    * If italic has been requested, this property will return true, even if the
    * font does not support italic.
    *
@@ -558,13 +558,13 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "If set, button text is displayed in italics.")
+      description = "If set, %type% text is displayed in italics.")
   public boolean FontItalic() {
     return italic;
   }
 
   /**
-   * Specifies whether the button's text should be italic.
+   * Specifies whether the text of the %type% should be italic.
    * Some fonts do not support italic.
    *
    * @param italic  {@code true} indicates italic, {@code false} normal
@@ -579,19 +579,19 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the button's text's font size, measured in sp(scale-independent pixels).
+   * Returns the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @return  font size in sp(scale-independent pixels).
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "Point size for button text.")
+      description = "Point size for %type% text.")
   public float FontSize() {
     return TextViewUtil.getFontSize(view, container.$context());
   }
 
   /**
-   * Specifies the button's text's font size, measured in sp(scale-independent pixels).
+   * Specifies the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @param size  font size in sp(scale-independent pixels)
    */
@@ -604,7 +604,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the button's text's font face as default, serif, sans
+   * Returns the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @return  one of {@link Component#TYPEFACE_DEFAULT},
@@ -614,14 +614,14 @@ public abstract class ButtonBase extends AndroidViewComponent
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "Font family for button text.",
+      description = "Font family for %type% text.",
       userVisible = false)
   public int FontTypeface() {
     return fontTypeface;
   }
 
   /**
-   * Specifies the button's text's font face as default, serif, sans
+   * Specifies the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @param typeface  one of {@link Component#TYPEFACE_DEFAULT},
@@ -639,13 +639,13 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the text displayed by the button.
+   * Returns the text displayed by the %type%.
    *
    * @return  button caption
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "Text to display on button.")
+      description = "Text to display on %type%.")
   public String Text() {
     return TextViewUtil.getText(view);
   }
@@ -663,7 +663,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the button's text color as an alpha-red-green-blue
+   * Returns the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @return  text RGB color with alpha
@@ -676,7 +676,7 @@ public abstract class ButtonBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the button's text color as an alpha-red-green-blue
+   * Specifies the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @param argb  text RGB color with alpha

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -36,10 +36,6 @@ import com.google.appinventor.components.runtime.util.ViewUtil;
 
 import java.io.IOException;
 
-import java.util.ArrayList;
-import java.util.List;
-
-
 /**
  * A container for components that arranges them linearly, either
  * horizontally or vertically.
@@ -217,12 +213,12 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   // The numeric encodings are defined Component Constants
 
   /**
-   * Returns a number that encodes how contents of the arrangement are aligned horizontally.
+   * Returns a number that encodes how contents of the %type% are aligned horizontally.
    * The choices are: 1 = left aligned, 2 = right aligned, 3 = horizontally centered
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "A number that encodes how contents of the arrangement are aligned " +
+      description = "A number that encodes how contents of the %type% are aligned " +
           " horizontally. The choices are: 1 = left aligned, 2 = right aligned, " +
           " 3 = horizontally centered.  Alignment has no effect if the arrangement's width is " +
           "automatic.")
@@ -251,13 +247,13 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   }
 
   /**
-   * Returns a number that encodes how contents of the arrangement are aligned vertically.
+   * Returns a number that encodes how contents of the %type% are aligned vertically.
    * The choices are: 1 = aligned at the top, 2 = vertically centered, 3 = aligned at the bottom.
    * Alignment has no effect if the arrangement's height is automatic.
    */
    @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "A number that encodes how the contents of the arrangement are aligned " +
+      description = "A number that encodes how the contents of the %type% are aligned " +
           " vertically. The choices are: 1 = aligned at the top, 2 = vertically centered, " +
           "3 = aligned at the bottom.  Alignment has no effect if the arrangement's height " +
           "is automatic.")
@@ -286,19 +282,19 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   }
 
     /**
-     * Returns the component's background color as an alpha-red-green-blue
+     * Returns the background color of the %type% as an alpha-red-green-blue
      * integer.
      *
      * @return  background RGB color with alpha
      */
     @SimpleProperty(category = PropertyCategory.APPEARANCE,
-            description = "Returns the component's background color")
+            description = "Returns the background color of the %type%")
     public int BackgroundColor() {
         return backgroundColor;
     }
 
     /**
-     * Specifies the button's background color as an alpha-red-green-blue
+     * Specifies the background color of the %type% as an alpha-red-green-blue
      * integer.  If the parameter is {@link Component#COLOR_DEFAULT}, the
      * original beveling is restored.  If an Image has been set, the color
      * change will not be visible until the Image is removed.
@@ -307,7 +303,7 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
      */
     @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
             defaultValue = Component.DEFAULT_VALUE_COLOR_DEFAULT)
-    @SimpleProperty(description = "Specifies the component's background color. " +
+    @SimpleProperty(description = "Specifies the background color of the %type%. " +
             "The background color will not be visible if an Image is being displayed.")
     public void BackgroundColor(int argb) {
         backgroundColor = argb;
@@ -317,9 +313,9 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     }
 
     /**
-     * Returns the path of the button's image.
+     * Returns the path of the background image of the %type%.
      *
-     * @return  the path of the button's image
+     * @return  the path of the background image
      */
     @SimpleProperty(
             category = PropertyCategory.APPEARANCE)
@@ -328,15 +324,15 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     }
 
     /**
-     * Specifies the path of the button's image.
+     * Specifies the path of the background image of the %type%.
      *
      * <p/>See {@link com.google.appinventor.components.runtime.util.MediaUtil#determineMediaSource} for information about what
      * a path can be.
      *
-     * @param path  the path of the button's image
+     * @param path  the path of the background image
      */
     @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET, defaultValue = "")
-    @SimpleProperty(description = "Specifies the path of the component's image.  " +
+    @SimpleProperty(description = "Specifies the path of the background image for the %type%.  " +
             "If there is both an Image and a BackgroundColor, only the Image will be visible.")
     public void Image(String path) {
         // If it's the same as on the prior call and the prior load was successful,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
@@ -131,7 +131,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   }
 
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "Specifies whether the component should be visible on the screen. "
+      description = "Specifies whether the %type% should be visible on the screen. "
           + "Value is true if the component is showing and false if hidden.")
   public boolean Visible() {
     return visible;
@@ -148,7 +148,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
 
   @Override
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "The paint color used to outline the map feature.")
+      description = "The paint color used to outline the %type%.")
   public int StrokeColor() {
     return strokeColor;
   }
@@ -164,7 +164,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
 
   @Override
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "The width of the stroke used to outline the map feature.")
+      description = "The width of the stroke used to outline the %type%.")
   public int StrokeWidth() {
     return strokeWidth;
   }
@@ -180,7 +180,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
 
   @Override
   @SimpleProperty(description = "The Draggable property is used to set whether or not the user " +
-      "can drag the Marker by long-pressing and then dragging the marker to a new location.")
+      "can drag the %type% by long-pressing and then dragging the %type% to a new location.")
   public boolean Draggable() {
     return this.draggable;
   }
@@ -196,7 +196,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   @Override
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       description = "The title displayed in the info window that appears when the user clicks " +
-      "on the map feature.")
+      "on the %type%.")
   public String Title() {
     return title;
   }
@@ -212,7 +212,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   @Override
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       description = "The description displayed in the info window that appears when the user " +
-      "clicks on the map feature.")
+      "clicks on the %type%.")
   public String Description() {
     return description;
   }
@@ -228,14 +228,14 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
 
   @Override
   @SimpleProperty(category = PropertyCategory.BEHAVIOR,
-  description = "Enable or disable the infobox window display when the user taps the feature.")
+  description = "Enable or disable the infobox window display when the user taps the %type%.")
   public boolean EnableInfobox() {
     return infobox;
   }
 
   @Override
-  @SimpleFunction(description = "Show the infobox for the feature. This will show the infobox " +
-      "even if {@link #EnableInfobox} is set to false.")
+  @SimpleFunction(description = "Show the infobox for the %type%. This will show the infobox " +
+      "even if EnableInfobox is set to false.")
   public void ShowInfobox() {
     map.getController().showInfobox(this);
   }
@@ -253,7 +253,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   }
 
   @SuppressWarnings("squid:S00100")
-  @SimpleFunction(description = "Compute the distance, in meters, between a map feature and a " +
+  @SimpleFunction(description = "Compute the distance, in meters, between a %type% and a " +
       "latitude, longitude point.")
   public double DistanceToPoint(double latitude, double longitude, boolean centroid) {
     return accept(distanceToPoint, new GeoPoint(latitude, longitude), centroid);
@@ -267,14 +267,14 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
 
   // Component Events
   @Override
-  @SimpleEvent(description = "The user clicked on the feature.")
+  @SimpleEvent(description = "The user clicked on the %type%.")
   public void Click() {
     EventDispatcher.dispatchEvent(this, "Click");
     container.FeatureClick(this);
   }
 
   @Override
-  @SimpleEvent(description = "The user long-pressed on the feature. This event will only " +
+  @SimpleEvent(description = "The user long-pressed on the %type%. This event will only " +
       "trigger if Draggable is false.")
   public void LongClick() {
     EventDispatcher.dispatchEvent(this, "LongClick");
@@ -289,7 +289,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   }
 
   @Override
-  @SimpleEvent(description = "The user dragged the map feature.")
+  @SimpleEvent(description = "The user dragged the %type%.")
   public void Drag() {
     EventDispatcher.dispatchEvent(this, "Drag");
     container.FeatureDrag(this);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBaseWithFill.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBaseWithFill.java
@@ -35,7 +35,7 @@ public abstract class MapFeatureBaseWithFill extends MapFeatureBase implements H
   }
 
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "The paint color used to fill in the map feature.")
+      description = "The paint color used to fill in the %type%.")
   @Override
   public int FillColor() {
     return fillColor;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
@@ -123,7 +123,7 @@ public abstract class MapFeatureContainerBase extends AndroidViewComponent imple
    * @return A YailList of map features, e.g., Marker, LineString
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
-      description = "The list of features placed on this map. This list also includes any " +
+      description = "The list of features placed on this %type%. This list also includes any " +
           "features created by calls to FeatureFromDescription")
   public YailList Features() {
     return YailList.makeList(features);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
@@ -377,7 +377,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   }
 
   @SuppressWarnings("squid:S00100")
-  @SimpleFunction(description = "Compute the distance, in meters, between a map feature and a " +
+  @SimpleFunction(description = "Compute the distance, in meters, between a Marker and a " +
       "latitude, longitude point.")
   public double DistanceToPoint(double latitude, double longitude) {
     return GeometryUtil.distanceBetween(this, new GeoPoint(latitude, longitude));

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Picker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Picker.java
@@ -48,7 +48,7 @@ public abstract class Picker extends ButtonBase implements ActivityResultListene
   // Functions
 
   /**
-   * Opens the picker, as though the user clicked on it.
+   * Opens the %type%, as though the user clicked on it.
    */
   @SimpleFunction(description = "Opens the picker, as though the user clicked on it.")
   public void Open() {
@@ -58,7 +58,7 @@ public abstract class Picker extends ButtonBase implements ActivityResultListene
   // Events
 
   /**
-   * Event to raise when the button of the component is clicked or the list is shown
+   * Event to raise when the %type% is clicked or the list is shown
    * using the Open block.  This event occurs before the list of items is displayed, and 
    * can be used to prepare the list before it is shown.
    */

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
@@ -119,7 +119,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Event raised when this component is selected for input, such as by
+   * Event raised when the %type% is selected for input, such as by
    * the user touching it.
    */
   @SimpleEvent
@@ -128,7 +128,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Event raised when this component is no longer selected for input, such
+   * Event raised when the %type% is no longer selected for input, such
    * as if the user touches a different text box.
    */
   @SimpleEvent
@@ -183,7 +183,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the textbox's background color as an alpha-red-green-blue
+   * Returns the background color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @return  background RGB color with alpha
@@ -198,7 +198,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the textbox's background color as an alpha-red-green-blue
+   * Specifies the background color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @param argb  background RGB color with alpha
@@ -216,20 +216,20 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns true if the textbox is active and useable.
+   * Returns true if the %type% is active and useable.
    *
    * @return  {@code true} indicates enabled, {@code false} disabled
    */
   @SimpleProperty(
       category = PropertyCategory.BEHAVIOR,
-      description = "Whether the user can enter text into this input box.  " +
+      description = "Whether the user can enter text into the %type%.  " +
       "By default, this is true.")
   public boolean Enabled() {
     return TextViewUtil.isEnabled(view);
   }
 
   /**
-   * Specifies whether the textbox should be active and useable.
+   * Specifies whether the %type% should be active and usable.
    *
    * @param enabled  {@code true} for enabled, {@code false} disabled
    */
@@ -241,7 +241,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns true if the textbox's text should be bold.
+   * Returns true if the text of the %type% should be bold.
    * If bold has been requested, this property will return true, even if the
    * font does not support bold.
    *
@@ -257,7 +257,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies whether the textbox's text should be bold.
+   * Specifies whether the text of the %type% should be bold.
    * Some fonts do not support bold.
    *
    * @param bold  {@code true} indicates bold, {@code false} normal
@@ -272,7 +272,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns true if the textbox's text should be italic.
+   * Returns true if the text of the %type% should be italic.
    * If italic has been requested, this property will return true, even if the
    * font does not support italic.
    *
@@ -288,7 +288,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies whether the textbox's text should be italic.
+   * Specifies whether the text of the %type% should be italic.
    * Some fonts do not support italic.
    *
    * @param italic  {@code true} indicates italic, {@code false} normal
@@ -302,7 +302,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the textbox's text's font size, measured in sp(scale-independent pixels).
+   * Returns the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @return  font size in sp(scale-independent pixels).
    */
@@ -315,7 +315,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the textbox's text's font size, measured in sp(scale-independent pixels).
+   * Specifies the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @param size  font size in pixel
    */
@@ -327,7 +327,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the textbox's text's font face as default, serif, sans
+   * Returns the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @return  one of {@link Component#TYPEFACE_DEFAULT},
@@ -345,7 +345,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the textbox's text's font face as default, serif, sans
+   * Specifies the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @param typeface  one of {@link Component#TYPEFACE_DEFAULT},
@@ -369,7 +369,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
-      description = "Text that should appear faintly in the input box to " +
+      description = "Text that should appear faintly in the %type% to " +
       "provide a hint as to what the user should enter.  This can only be " +
       "seen if the <code>Text</code> property is empty.")
   public String Hint() {
@@ -401,7 +401,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the textbox contents.
+   * Specifies the %type% contents.
    *
    * @param text  new text in text box
    */
@@ -410,7 +410,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   @SimpleProperty(
       // This kind of breaks the appearance/behavior dichotomy
       category = PropertyCategory.BEHAVIOR,
-      description = "The text in the input box, which can be set by the " +
+      description = "The text in the %type%, which can be set by the " +
       "programmer in the Designer or Blocks Editor, or it can be entered by " +
       "the user (unless the <code>Enabled</code> property is false).")
   public void Text(String text) {
@@ -418,7 +418,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Returns the textbox's text color as an alpha-red-green-blue
+   * Returns the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @return  text RGB color with alpha
@@ -433,7 +433,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Specifies the textbox's text color as an alpha-red-green-blue
+   * Specifies the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @param argb  text RGB color with alpha
@@ -451,10 +451,10 @@ public abstract class TextBoxBase extends AndroidViewComponent
   }
 
   /**
-   * Request focus to current textbox.
+   * Request focus to current %type%.
    */
   @SimpleFunction(
-    description = "Sets the textbox active.")
+    description = "Sets the %type% active.")
   public void RequestFocus() {
     view.requestFocus();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ToggleBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ToggleBase.java
@@ -6,15 +6,12 @@
 
 package com.google.appinventor.components.runtime;
 
-import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
-import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
-import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 
 import android.view.View;
@@ -23,15 +20,10 @@ import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 /**
- * Check box with the ability to detect initialization, focus
+ * Abstract base class for toggleable items with the ability to detect initialization, focus
  * change (mousing on or off of it), and user clicks.
  *
  */
-@DesignerComponent(version = YaVersion.CHECKBOX_COMPONENT_VERSION,
-        description = "Checkbox that raises an event when the user clicks on it. " +
-                "There are many properties affecting its appearance that can be set in " +
-                "the Designer or Blocks Editor.",
-        category = ComponentCategory.USERINTERFACE)
 @SimpleObject
 public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewComponent
         implements OnCheckedChangeListener, OnFocusChangeListener {
@@ -54,14 +46,16 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   private int textColor;
 
   /**
-   * Creates a new CheckBox component.
+   * Creates a new ToggleBase component.
    *
    * @param container  container, component will be placed in
    */
+  @SuppressWarnings("WeakerAccess")  // Could be used by extensions
   public ToggleBase(ComponentContainer container) {
     super(container);
   }
 
+  @SuppressWarnings("WeakerAccess")  // Could be used by extensions
   protected void initToggle() {
     // Listen to focus changes
     view.setOnFocusChangeListener(this);
@@ -109,7 +103,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns the checkbox's background color as an alpha-red-green-blue
+   * Returns the background color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @return  background RGB color with alpha
@@ -121,7 +115,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies the checkbox's background color as an alpha-red-green-blue
+   * Specifies the background color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @param argb  background RGB color with alpha
@@ -139,7 +133,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns true if the checkbox is active and clickable.
+   * Returns true if the %type% is active and clickable.
    *
    * @return  {@code true} indicates enabled, {@code false} disabled
    */
@@ -150,7 +144,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies whether the checkbox should be active and clickable.
+   * Specifies whether the %type% should be active and clickable.
    *
    * @param enabled  {@code true} for enabled, {@code false} disabled
    */
@@ -162,7 +156,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns true if the checkbox's text should be bold.
+   * Returns true if the text of the %type% should be bold.
    * If bold has been requested, this property will return true, even if the
    * font does not support bold.
    *
@@ -176,7 +170,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies whether the checkbox's text should be bold.
+   * Specifies whether the text of the %type% should be bold.
    * Some fonts do not support bold.
    *
    * @param bold  {@code true} indicates bold, {@code false} normal
@@ -191,7 +185,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns true if the checkbox's text should be italic.
+   * Returns true if the text of the %type% should be italic.
    * If italic has been requested, this property will return true, even if the
    * font does not support italic.
    *
@@ -205,7 +199,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies whether the checkbox's text should be italic.
+   * Specifies whether the text of the %type% should be italic.
    * Some fonts do not support italic.
    *
    * @param italic  {@code true} indicates italic, {@code false} normal
@@ -220,7 +214,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns the checkbox's text's font size, measured in sp(scale-independent pixels).
+   * Returns the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @return  font size in sp (scale-independent pixels)
    */
@@ -231,7 +225,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies the checkbox's text's font size, measured in sp(scale-independent pixels).
+   * Specifies the text font size of the %type%, measured in sp(scale-independent pixels).
    *
    * @param size  font size in sp(scale-independent pixels)
    */
@@ -243,7 +237,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns the checkbox's text's font face as default, serif, sans
+   * Returns the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @return  one of {@link Component#TYPEFACE_DEFAULT},
@@ -259,7 +253,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies the checkbox's text's font face as default, serif, sans
+   * Specifies the text font face of the %type% as default, serif, sans
    * serif, or monospace.
    *
    * @param typeface  one of {@link Component#TYPEFACE_DEFAULT},
@@ -277,9 +271,9 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Returns the text displayed by the checkbox.
+   * Returns the text displayed by the %type%.
    *
-   * @return  checkbox caption
+   * @return  toggle's caption
    */
   @SimpleProperty(
           category = PropertyCategory.APPEARANCE)
@@ -288,19 +282,18 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies the text displayed by the checkbox.
+   * Specifies the text displayed by the %type%.
    *
-   * @param text  new caption for checkbox
+   * @param text  new caption for toggleable button
    */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
-          defaultValue = "")
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING)
   @SimpleProperty
   public void Text(String text) {
     TextViewUtil.setText(view, text);
   }
 
   /**
-   * Returns the checkbox's text color as an alpha-red-green-blue
+   * Returns the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @return  text RGB color with alpha
@@ -312,7 +305,7 @@ public abstract class ToggleBase<T extends CompoundButton> extends AndroidViewCo
   }
 
   /**
-   * Specifies the checkbox's text color as an alpha-red-green-blue
+   * Specifies the text color of the %type% as an alpha-red-green-blue
    * integer.
    *
    * @param argb  text RGB color with alpha

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -146,6 +146,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
   // Must match buildserver.compiler.X86_64_SUFFIX
   private static final String X86_64_SUFFIX = "-x8a";
 
+  private static final String TYPE_PLACEHOLDER = "%type%";
+
   // The next two fields are set in init().
   /**
    * A handle allowing access to facilities provided by the annotation
@@ -897,9 +899,9 @@ public abstract class ComponentProcessor extends AbstractProcessor {
      * superclass.
      */
   private void processComponent(Element element) {
+    boolean isForDesigner = element.getAnnotation(DesignerComponent.class) != null;
     // If the element is not a component (e.g., Float), return early.
-    if (element.getAnnotation(SimpleObject.class) == null &&
-        element.getAnnotation(DesignerComponent.class) == null) {
+    if (element.getAnnotation(SimpleObject.class) == null && !isForDesigner) {
       return;
     }
 
@@ -1078,8 +1080,27 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     // Build up method information.
     processMethods(componentInfo, element);
 
+    if (isForDesigner) {
+      processDescriptions(componentInfo);
+    }
+
     // Add it to our components map.
     components.put(longComponentName, componentInfo);
+  }
+
+  private void processDescriptions(ComponentInfo info) {
+    final String name = info.displayName;
+    info.description = info.description.replaceAll(TYPE_PLACEHOLDER, name);
+    info.helpUrl = info.description.replaceAll(TYPE_PLACEHOLDER, name);
+    for (Property property : info.properties.values()) {
+      property.description = property.description.replaceAll(TYPE_PLACEHOLDER, name);
+    }
+    for (Event event : info.events.values()) {
+      event.description = event.description.replaceAll(TYPE_PLACEHOLDER, name);
+    }
+    for (Method method : info.methods.values()) {
+      method.description = method.description.replaceAll(TYPE_PLACEHOLDER, name);
+    }
   }
 
   private boolean isPublicMethod(Element element) {
@@ -1371,7 +1392,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
           }
 
           // Merge newProperty into priorProperty, which is already in the properties map.
-          if (priorProperty.description.isEmpty() && !newProperty.description.isEmpty()) {
+          if ((priorProperty.description.isEmpty() || element.getAnnotation(Override.class) != null)
+              && !newProperty.description.isEmpty()) {
             priorProperty.description = newProperty.description;
           }
           if (priorProperty.propertyCategory == PropertyCategory.UNSET) {


### PR DESCRIPTION
App Inventor doesn't present a type hierarchy even though internally
it makes sense for objects to have shared methods defined in super
classes. However, the documentation for the properties, methods, and
events of an App Inventor component shared in this way must typically
be written generic enough so that they make sense when shown on
concrete classes. This can lead to either awkward/generic sounding
documentation or requires that the component author override all of
the relevant features on the component to provide component-specific
descriptions.

This change makes it so that descriptions of components, properties,
methods, and events can contain one or more %type% tokens that can be
substituted with the name of the concrete representation shown to the
App Inventor user. This allows for documentation to be shared at the
super class level while still making it sound specific to the
individual component type.

Change-Id: Ida4eb22bec12b2e33ac73de2bb5706d1683b227a