### PR TITLE
Add HTMLContent property to Label

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1104,6 +1104,9 @@ public final class YoungAndroidFormUpgrader {
       componentProperties.put("HasMargins", new ClientJsonString("False"));
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1649,7 +1649,9 @@ Blockly.Versioning.AllUpgradeMaps =
     3: "noUpgrade",
 
     // AI2: Add HTMLFormat property
-    4: "noUpgrade"
+    4: "noUpgrade",
+
+    5: "noUpgrade"
 
   }, // End Label upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -873,8 +873,10 @@ public class YaVersion {
   // - The HasMargins property was added
   // For LABEL_COMPONENT_VERSION 4:
   // - The HTML format is defined.
+  // For LABEL_COMPONENT_VERSION 5:
+  // - The HTMLContent property is defined.
 
-  public static final int LABEL_COMPONENT_VERSION = 4;
+  public static final int LABEL_COMPONENT_VERSION = 5;
 
   // For LINESTRING_COMPONENT_VERSION 1:
   // - Initial LineString implementation for Maps

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -465,8 +465,10 @@ public class YaVersion {
   // - HYGROMETER_COMPONENT_VERSION was initialized to 1
   // - LIGHTSENSOR_COMPONENT_VERSION was initialized to 1
   // - THERMOMETER_COMPONENT_VERSION was initialized to 1
+  // For YOUNG_ANDROID_VERSION 188:
+  // - Label component version incremented to 5
 
-  public static final int YOUNG_ANDROID_VERSION = 187;
+  public static final int YOUNG_ANDROID_VERSION = 188;
 
   // ............................... Blocks Language Version Number ...............................
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
@@ -71,6 +71,9 @@ public final class Label extends AndroidViewComponent {
   // Label Format
   private boolean htmlFormat;
 
+  // HTML content of the label
+  private String htmlContent;
+
   /**
    * Creates a new Label component.
    *
@@ -364,6 +367,22 @@ private void setLabelMargins(boolean hasMargins) {
       TextViewUtil.setTextHTML(view, text);
     } else {
       TextViewUtil.setText(view, text);
+    }
+    htmlContent = text;
+  }
+
+  /**
+   * Returns the content of the Label as HTML. This is only useful if the
+   * HTMLFormat property is true.
+   *
+   * @return the HTML content of the label
+   */
+  @SimpleProperty
+  public String HTMLContent() {
+    if (htmlFormat) {
+      return htmlContent;
+    } else {
+      return TextViewUtil.getText(view);
     }
   }
 

--- a/appinventor/docs/reference/components/userinterface.html
+++ b/appinventor/docs/reference/components/userinterface.html
@@ -702,6 +702,10 @@
                     (left, right, top, bottom) are the same.  This
                     property has no effect in the designer,
                     where labels are always shown with margins.</dd>
+                    <dt> <code> HTMLContent </code> </dt>
+                    <dd> Retrieves the HTML content of the Label if the
+                    HTMLFormat property is true and the Text property was set to
+                    HTML. </dd>
                     <dt> <code> HTMLFormat </code> </dt>
                     <dd> If true, sets text of label to html format else it is plain text format. Note: Not all HTML is supported.</dd>
                     <dt> <code> Height </code> </dt>


### PR DESCRIPTION
Addresses [this issue](https://groups.google.com/d/msg/mitappinventortest/cW34TP6NAAo/NU2Xtj20AgAJ) raised on the forum about the asymmetry of `Label.Text` when `HTMLFormat` is set. Rather than change the semantics of the `Text` property, I opted to add an `HTMLContent` property that returns the HTML (similar to innerText vs innerHTML in the DOM).

Change-Id: I59c74e29d1ba2d339c0df2d88d25b06a143bfc9d