### PR TITLE
Implement number => InstantInTime coercion (and clean up tests)

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -352,11 +352,19 @@
     <fileset dir="${run.lib.dir}" includes="*.jar"/>
     <pathelement location="${build.dir}/common/CommonTestUtils.jar" />
     <pathelement location="${build.dir}/components/AndroidRuntime.jar"/>
+    <fileset dir="${build.dir}/components/deps" includes="*.jar" />
     <pathelement location="${lib.dir}/kawa/kawa-1.11-modified.jar" />
     <pathelement location="${lib.dir}/guava/guava-14.0.1.jar" />
     <pathelement location="${lib.dir}/commons-io/commons-io-2.0.1.jar" />
     <pathelement location="${lib.dir}/json/json.jar" />
     <pathelement location="${lib.dir}/junit/junit-4.8.2.jar" />
+    <pathelement location="${lib.dir}/junit4/tl4j-junit4-1.1.3.jar" />
+    <pathelement location="${lib.dir}/bouncycastle/bcprov-jdk15on-149.jar" />
+    <pathelement location="${lib.dir}/powermock/cglib-nodep-2.2.jar" />
+    <pathelement location="${lib.dir}/powermock/easymock-3.0.jar" />
+    <pathelement location="${lib.dir}/powermock/javassist-3.18.0-GA.jar" />
+    <pathelement location="${lib.dir}/powermock/objenesis-1.2.jar" />
+    <pathelement location="${lib.dir}/powermock/powermock-easymock-1.4.10-full.jar" />
   </path>
 
   <path id="BuildServerTests.path">

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1336,7 +1336,11 @@
 (define (coerce-to-instant arg)
   (cond
    ((instance? arg java.util.Calendar) arg)
-   (else *non-coercible-value*)))
+   (else
+     (let ((as-millis (coerce-to-number arg)))
+       (if (number? as-millis)
+           (com.google.appinventor.components.runtime.Clock:MakeInstantFromMillis as-millis)
+         *non-coercible-value*)))))
 
 (define (coerce-to-component arg)
   (cond

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailAndroidTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailAndroidTest.java
@@ -1,0 +1,59 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2019 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver;
+
+import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.components.runtime.Clock;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import kawa.standard.Scheme;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+public class YailAndroidTest {
+  private Scheme scheme;
+
+  private static final String YAIL_SCHEME_TESTS = TestUtils.APP_INVENTOR_ROOT_DIR +
+      "/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.scm";
+
+  @Before
+  public void setUp() throws Exception {
+    scheme = new Scheme();
+    String yailRuntimeLibrary = Compiler.getResource(Compiler.YAIL_RUNTIME);
+    try {
+      scheme.eval("(load \"" + yailRuntimeLibrary + "\")");
+      scheme.eval("(load \"" + YAIL_SCHEME_TESTS + "\")");
+      scheme.eval("(set! *testing* #t)");
+    } catch (Exception e) {
+      throw e;
+    } catch (Throwable throwable) {
+      throw new RuntimeException(throwable);
+    }
+  }
+
+  @Test
+  public void testFormatDateTime() throws Throwable {
+    // Unfortunately, call-component-method requires an actual component, even though
+    // FormatDateTime method is static. This means we have to mock out a Clock component so that
+    // method lookup can be performed by Kawa.
+    Clock c = PowerMock.createMock(Clock.class);
+    scheme.define("*test-clock*", c);
+    String output = scheme.eval("(begin (add-to-current-form-environment 'Clock1 *test-clock*)"
+        + "(call-component-method 'Clock1 'FormatDateTime"
+        + " (*list-for-runtime* 0  \"MM/dd/yyyy hh:mm:ss a\") '(InstantInTime text)))")
+        .toString();
+    Calendar expected = Calendar.getInstance();
+    expected.setTimeInMillis(0);
+    SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss a");
+    assertEquals(sdf.format(expected.getTime()), output);
+  }
+}

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2019 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -8,10 +8,8 @@ package com.google.appinventor.buildserver;
 
 import com.google.appinventor.common.testutils.TestUtils;
 import com.google.appinventor.components.runtime.errors.YailRuntimeError;
-
 import gnu.math.DFloNum;
 import gnu.math.IntNum;
-import junit.framework.Assert;
 import junit.framework.TestCase;
 import kawa.standard.Scheme;
 
@@ -22,34 +20,19 @@ import kawa.standard.Scheme;
  *
  * @author markf@google.com (Mark Friedman)
  */
-
 public class YailEvalTest extends TestCase {
-  Scheme scheme;
+  private Scheme scheme;
 
   private static final String YAIL_SCHEME_TESTS = TestUtils.APP_INVENTOR_ROOT_DIR +
       "/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.scm";
-
-  private static final String OPEN = "<<";
-  private static final String ID = ":";
-  private static final String TAG = "@@";
-  private static final String RESULT = "==";
-  private static final String CLOSE = ">>";
-  private static final String SUCCESS = "Success";
-  private static final String FAILURE = "Failure";
-
-  private static final String ESCAPE = "&";
-  private static final String ENCODED_ESCAPE = "&0";
-  private static final String ENCODED_OPEN = "&1";
-  private static final String ENCODED_CLOSE = "&2";
 
   @Override
   public void setUp() throws Exception {
     scheme = new Scheme();
     String yailRuntimeLibrary = Compiler.getResource(Compiler.YAIL_RUNTIME);
-    String yailSchemeTests = YAIL_SCHEME_TESTS;
     try {
       scheme.eval("(load \"" + yailRuntimeLibrary + "\")");
-      scheme.eval("(load \"" + yailSchemeTests + "\")");
+      scheme.eval("(load \"" + YAIL_SCHEME_TESTS + "\")");
       scheme.eval("(set! *testing* #t)");
     } catch (Exception e) {
       throw e;
@@ -360,7 +343,7 @@ public class YailEvalTest extends TestCase {
   }
 
 
-  public void deepCopyTest() throws Throwable {
+  public void testDeepCopy() throws Throwable {
     // check that yail-list-copy does a deep copy
     String schemeInputString = "(begin " +
         "(define list1 (make-yail-list (make-yail-list \"a\" \"b\") \"c\" \"d\" ))" +
@@ -1094,15 +1077,9 @@ public class YailEvalTest extends TestCase {
       String expression = "(" + funName + " " + args[i] + ")";
       Object result = scheme.eval(expression);
       if (result instanceof DFloNum) {
-        Assert.assertEquals(expression,
-                            vals[i],
-                            ((DFloNum) result).doubleValue(),
-                            DELTA);
+        assertEquals(expression, vals[i], ((DFloNum) result).doubleValue(), DELTA);
       } else {
-        Assert.assertEquals(expression,
-                            vals[i],
-                            (Double) result,
-                            DELTA);
+        assertEquals(expression, vals[i], (Double) result, DELTA);
       }
     }
   }
@@ -1147,9 +1124,9 @@ public class YailEvalTest extends TestCase {
    }
 
   // These constant definitions make the below tests more readable.
-  static final double PI = Math.PI;
-  static final double PI_2 = PI / 2;
-  static final double PI_4 = PI / 4;
+  private static final double PI = Math.PI;
+  private static final double PI_2 = PI / 2;
+  private static final double PI_4 = PI / 4;
 
   public void testDegreesToRadians() throws Throwable {
     double[] args = {   -45, 0,   45,   90,   270, 360, 720 };
@@ -1170,9 +1147,7 @@ public class YailEvalTest extends TestCase {
       throws Throwable {
     for (int i = 0; i < args1.length; i++) {
       String expression = "(" + funName + " " + args1[i] + " " + args2[i] + ")";
-      Assert.assertEquals(vals[i],
-                          ((DFloNum) scheme.eval(expression)).doubleValue(),
-                          DELTA);
+      assertEquals(vals[i], ((DFloNum) scheme.eval(expression)).doubleValue(), DELTA);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Clock.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Clock.java
@@ -47,7 +47,7 @@ import android.app.TimePickerDialog;
     nonVisible = true,
     iconName = "images/clock.png")
 @SimpleObject
-public final class Clock extends AndroidNonvisibleComponent
+public class Clock extends AndroidNonvisibleComponent
     implements Component, AlarmHandler, OnStopListener, OnResumeListener, OnDestroyListener,
                Deleteable {
   private static final int DEFAULT_INTERVAL = 1000;  // ms


### PR DESCRIPTION
This PR addresses an issue that @kdclang brought to me where it seemed totally obvious and reasonable that Clock1.FormatDateTime(Clock1.SystemTime, ...) should return a string but instead throws a RuntimeError due to the fact that FormatDateTime expects an InstantInTime (java.util.Calendar) but SystemTime returns a long. Rather than try and change the signature of SystemTime, I decided to make it so that coerce-to-instant will also convert numbers to instants. Previously, programs would have thrown an error at this point (resulting in a crash), so this improves the usability of the blocks without requiring the use of the MakeInstantFromMillis block.

Change-Id: If46915890381f0b05165804d802281a4b28c174c