### PR TITLE
Raise error when using boxed primitive types in component APIs

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -113,6 +113,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
 
   public static final String MISSING_SIMPLE_PROPERTY_ANNOTATION =
       "Designer property %s does not have a corresponding @SimpleProperty annotation.";
+  public static final String BOXED_TYPE_ERROR =
+      "Found use of boxed type %s. Please use the primitive type %s instead";
 
   // Returned by getSupportedAnnotationTypes()
   private static final Set<String> SUPPORTED_ANNOTATION_TYPES = ImmutableSet.of(
@@ -147,6 +149,19 @@ public abstract class ComponentProcessor extends AbstractProcessor {
   private static final String X86_64_SUFFIX = "-x8a";
 
   private static final String TYPE_PLACEHOLDER = "%type%";
+
+  private static final Map<String, String> BOXED_TYPES = new HashMap<>();
+
+  static {
+    BOXED_TYPES.put("java.lang.Boolean", "boolean");
+    BOXED_TYPES.put("java.lang.Byte", "byte");
+    BOXED_TYPES.put("java.lang.Char", "char");
+    BOXED_TYPES.put("java.lang.Short", "short");
+    BOXED_TYPES.put("java.lang.Integer", "int");
+    BOXED_TYPES.put("java.lang.Long", "long");
+    BOXED_TYPES.put("java.lang.Float", "float");
+    BOXED_TYPES.put("java.lang.Double", "double");
+  }
 
   // The next two fields are set in init().
   /**
@@ -1603,6 +1618,10 @@ public abstract class ComponentProcessor extends AbstractProcessor {
    *         legal return values
    */
   protected final String javaTypeToYailType(String type) {
+    if (BOXED_TYPES.containsKey(type)) {
+      throw new IllegalArgumentException(String.format(BOXED_TYPE_ERROR, type,
+          BOXED_TYPES.get(type)));
+    }
     // boolean -> boolean
     if (type.equals("boolean")) {
       return type;
@@ -1643,8 +1662,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       return "component";
     }
 
-    throw new RuntimeException("Cannot convert Java type '" + type +
-                               "' to Yail type");
+    throw new IllegalArgumentException("Cannot convert Java type '" + type + "' to Yail type");
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -111,9 +111,9 @@ import javax.tools.StandardLocation;
 public abstract class ComponentProcessor extends AbstractProcessor {
   private static final String OUTPUT_PACKAGE = "";
 
-  public static final String MISSING_SIMPLE_PROPERTY_ANNOTATION =
+  private static final String MISSING_SIMPLE_PROPERTY_ANNOTATION =
       "Designer property %s does not have a corresponding @SimpleProperty annotation.";
-  public static final String BOXED_TYPE_ERROR =
+  private static final String BOXED_TYPE_ERROR =
       "Found use of boxed type %s. Please use the primitive type %s instead";
 
   // Returned by getSupportedAnnotationTypes()


### PR DESCRIPTION
This change is in response to a question by @Amerkashi about the use of boxed types in component (extension) APIs. I think it's preferable that we always prefer primitive types over boxed types in these situations. This change reports a more specific issue asking the extension author to convert from the boxed type to the primitive type. Previously, they would have gotten a rather generic "Cannot convert Java type ... to YAIL type" message.

Change-Id: I5b2da0fc9b22c88678d050122eb2d033f395d63b