### PR TITLE
Cancel focusing on TreeItems in Tree widgets

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -63,6 +63,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
@@ -739,6 +740,28 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     return container;
   }
 
+  private final Focusable nullFocusable = new Focusable() {
+    @Override
+    public int getTabIndex() {
+      return 0;
+    }
+
+    @Override
+    public void setAccessKey(char key) {
+
+    }
+
+    @Override
+    public void setFocus(boolean focused) {
+
+    }
+
+    @Override
+    public void setTabIndex(int index) {
+
+    }
+  };
+
   /**
    * Constructs a tree item for the component which will be displayed in the
    * source structure explorer.
@@ -751,7 +774,12 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // used to get HTML for the iconImage. AbstractImagePrototype requires
     // an ImageResource, which we don't necessarily have.
     TreeItem itemNode = new TreeItem(
-        new HTML("<span>" + iconImage.getElement().getString() + getName() + "</span>"));
+        new HTML("<span>" + iconImage.getElement().getString() + getName() + "</span>")) {
+      @Override
+      protected Focusable getFocusable() {
+        return nullFocusable;
+      }
+    };
     itemNode.setUserObject(sourceStructureExplorerItem);
     return itemNode;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -37,6 +37,7 @@ public class SourceStructureExplorer extends Composite {
     // Initialize UI elements
     tree = new Tree(Ode.getImageBundle());
     tree.setAnimationEnabled(true);
+    tree.setScrollOnSelectEnabled(false);
     tree.addCloseHandler(new CloseHandler<TreeItem>() {
       @Override
       public void onClose(CloseEvent<TreeItem> event) {

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/project/ProjectNodeContextMenu.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/project/ProjectNodeContextMenu.java
@@ -12,6 +12,7 @@ import com.google.appinventor.client.explorer.commands.ProjectNodeCommand;
 import com.google.appinventor.client.widgets.ContextMenu;
 import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
@@ -31,7 +32,7 @@ public final class ProjectNodeContextMenu {
    * @param node  node for which to show the context menu
    * @param host  widget to anchor context menu to
    */
-  public static void show(final ProjectNode node, Widget host) {
+  public static void show(final ProjectNode node, Widget host, int clientX, int clientY) {
 
     List<CommandRegistry.Entry> entries = Ode.getCommandRegistry().get(node);
     if (entries.isEmpty()) {
@@ -40,8 +41,8 @@ public final class ProjectNodeContextMenu {
 
     final ContextMenu menu = new ContextMenu();
     // Position the context menu to the East of the host widget.
-    menu.setPopupPosition(host.getAbsoluteLeft() + host.getOffsetWidth(),
-        host.getAbsoluteTop());
+    menu.setPopupPosition(Window.getScrollLeft() + clientX,
+        Window.getScrollTop() + clientY);
     for (final CommandRegistry.Entry entry : entries) {
       final ProjectNodeCommand cmd = entry.getCommand();
 

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
@@ -22,8 +22,11 @@ import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjec
 import com.google.appinventor.shared.storage.StorageUtil;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.MouseMoveEvent;
+import com.google.gwt.event.dom.client.MouseMoveHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
@@ -47,6 +50,8 @@ public class AssetList extends Composite implements ProjectChangeListener {
   private long projectId;
   private Project project;
   private YoungAndroidAssetsFolder assetsFolder;
+  private int clientX;
+  private int clientY;
 
   /**
    * Creates a new AssetList
@@ -81,6 +86,15 @@ public class AssetList extends Composite implements ProjectChangeListener {
 
     initWidget(panel);
 
+    assetList.setScrollOnSelectEnabled(false);
+    assetList.sinkEvents(Event.ONMOUSEMOVE);
+    assetList.addMouseMoveHandler(new MouseMoveHandler() {
+      @Override
+      public void onMouseMove(MouseMoveEvent event) {
+        clientX = event.getClientX();
+        clientY = event.getClientY();
+      }
+    });
     assetList.addSelectionHandler(new SelectionHandler<TreeItem>() {
       @Override
       public void onSelection(SelectionEvent<TreeItem> event) {
@@ -88,7 +102,7 @@ public class AssetList extends Composite implements ProjectChangeListener {
         ProjectNode node = (ProjectNode) selected.getUserObject();
         // The actual menu is determined by what is registered for the filenode
         // type in CommandRegistry.java
-        ProjectNodeContextMenu.show(node, selected.getWidget());
+        ProjectNodeContextMenu.show(node, selected.getWidget(), clientX, clientY);
       }});
   }
 


### PR DESCRIPTION
Also makes it so that when we click on an asset in the AssetList (which is a Tree), the menu appears at the cursor rather than to the right of the tree.

Fixes #1749 

Change-Id: Ib3e663aae8135694ddf423611ebcf7a7caffbd39