### PR TITLE
Make "Display hidden components in Viewer" checkbox screen-dependent

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
@@ -50,6 +50,8 @@ public abstract class ProjectEditor extends Composite {
   private final HashMap<String,String> locationHashMap = new HashMap<String,String>();
   private final DeckPanel deckPanel;
   private FileEditor selectedFileEditor;
+  private HashMap<String, Boolean> screenHashMap = new HashMap<String, Boolean>();
+  private String currentScreen;
 
   /**
    * Creates a {@code ProjectEditor} instance.
@@ -246,6 +248,22 @@ public abstract class ProjectEditor extends Composite {
       }
       ode.getEditorManager().scheduleAutoSave(projectSettings);
     }
+  }
+
+  public final Boolean getScreenComponentVisibility(String screen) {
+    return screenHashMap.get(screen);
+  }
+
+  public final Boolean getCurrentScreenComponentVisibility() {
+    if (currentScreen == null) {
+      return null;
+    }
+    return screenHashMap.get(currentScreen);
+  }
+
+  public final void updateScreenComponentVisiblity(String screen, Boolean showVisibleComponents) {
+    currentScreen = screen;
+    screenHashMap.put(screen, showVisibleComponents);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
@@ -7,6 +7,7 @@
 package com.google.appinventor.client.editor;
 
 import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.output.OdeLog;
 import com.google.appinventor.client.settings.Settings;
@@ -50,8 +51,8 @@ public abstract class ProjectEditor extends Composite {
   private final HashMap<String,String> locationHashMap = new HashMap<String,String>();
   private final DeckPanel deckPanel;
   private FileEditor selectedFileEditor;
-  private HashMap<String, Boolean> screenHashMap = new HashMap<String, Boolean>();
-  private String currentScreen;
+  HashMap<VerticalPanel, Boolean> screenHashMap = new HashMap<VerticalPanel, Boolean>();
+  HashMap<VerticalPanel, List<MockComponent>> componentHashMap = new HashMap<VerticalPanel, List<MockComponent>>();
 
   /**
    * Creates a {@code ProjectEditor} instance.
@@ -250,19 +251,25 @@ public abstract class ProjectEditor extends Composite {
     }
   }
 
-  public final Boolean getScreenComponentVisibility(String screen) {
+  public final VerticalPanel getScreen(MockComponent component) {
+    for (VerticalPanel screen : componentHashMap.keySet()) {
+      List<MockComponent> components = componentHashMap.get(screen);
+      if (components.contains(component)) {
+        return screen;
+      }
+    }
+    return null;
+  }
+
+  public final void setScreen(VerticalPanel screen, List<MockComponent> components) {
+    componentHashMap.put(screen, components);
+  }
+
+  public final Boolean getScreenComponentVisibility(VerticalPanel screen) {
     return screenHashMap.get(screen);
   }
 
-  public final Boolean getCurrentScreenComponentVisibility() {
-    if (currentScreen == null) {
-      return null;
-    }
-    return screenHashMap.get(currentScreen);
-  }
-
-  public final void updateScreenComponentVisiblity(String screen, Boolean showVisibleComponents) {
-    currentScreen = screen;
+  public final void setScreenComponentVisiblity(VerticalPanel screen, Boolean showVisibleComponents) {
     screenHashMap.put(screen, showVisibleComponents);
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
@@ -66,21 +66,24 @@ public final class SimpleVisibleComponentsPanel extends Composite implements Dro
       @Override
       protected void onLoad() {
         // onLoad is called immediately after a widget becomes attached to the browser's document.
-        boolean showHiddenComponents = Boolean.parseBoolean(
-            projectEditor.getProjectSettingsProperty(
-            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-            SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
-        checkboxShowHiddenComponents.setValue(showHiddenComponents);
+        // boolean showHiddenComponents = Boolean.parseBoolean(
+        //     projectEditor.getProjectSettingsProperty(
+        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
+        Boolean isChecked = projectEditor.getScreenComponentVisibility(phoneScreen.getTitle());
+        checkboxShowHiddenComponents.setValue(isChecked == null ? false : isChecked);
       }
     };
     checkboxShowHiddenComponents.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
       @Override
       public void onValueChange(ValueChangeEvent<Boolean> event) {
-        boolean isChecked = event.getValue(); // auto-unbox from Boolean to boolean
-        projectEditor.changeProjectSettingsProperty(
-            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-            SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS,
-            isChecked ? "True" : "False");
+        // boolean isChecked = event.getValue(); // auto-unbox from Boolean to boolean
+        // projectEditor.changeProjectSettingsProperty(
+        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS,
+        //     isChecked ? "True" : "False");
+        Boolean isChecked = event.getValue();
+        projectEditor.updateScreenComponentVisiblity(phoneScreen.getTitle(), isChecked);
         if (form != null) {
           form.refresh();
         }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleVisibleComponentsPanel.java
@@ -10,6 +10,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import static com.google.appinventor.client.Ode.MESSAGES;
 import com.google.appinventor.client.editor.ProjectEditor;
+import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.editor.simple.components.MockForm;
 import com.google.appinventor.client.editor.simple.palette.SimplePaletteItem;
 import com.google.appinventor.client.explorer.project.ComponentDatabaseChangeListener;
@@ -24,7 +25,7 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.user.client.ui.ListBox;
 
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -65,25 +66,20 @@ public final class SimpleVisibleComponentsPanel extends Composite implements Dro
     checkboxShowHiddenComponents = new CheckBox(MESSAGES.showHiddenComponentsCheckbox()) {
       @Override
       protected void onLoad() {
-        // onLoad is called immediately after a widget becomes attached to the browser's document.
-        // boolean showHiddenComponents = Boolean.parseBoolean(
-        //     projectEditor.getProjectSettingsProperty(
-        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
-        Boolean isChecked = projectEditor.getScreenComponentVisibility(phoneScreen.getTitle());
+        Boolean isChecked = projectEditor.getScreenComponentVisibility(phoneScreen);
+        List<MockComponent> components = new ArrayList<MockComponent>(form.getEditor().getComponents().values());
+        projectEditor.setScreen(phoneScreen, components);
+        projectEditor.setScreenComponentVisiblity(phoneScreen, isChecked == null ? false : isChecked);
         checkboxShowHiddenComponents.setValue(isChecked == null ? false : isChecked);
       }
     };
     checkboxShowHiddenComponents.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
       @Override
       public void onValueChange(ValueChangeEvent<Boolean> event) {
-        // boolean isChecked = event.getValue(); // auto-unbox from Boolean to boolean
-        // projectEditor.changeProjectSettingsProperty(
-        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS,
-        //     isChecked ? "True" : "False");
         Boolean isChecked = event.getValue();
-        projectEditor.updateScreenComponentVisiblity(phoneScreen.getTitle(), isChecked);
+        List<MockComponent> components = new ArrayList<MockComponent>(form.getEditor().getComponents().values());
+        projectEditor.setScreen(phoneScreen, components);
+        projectEditor.setScreenComponentVisiblity(phoneScreen, isChecked);
         if (form != null) {
           form.refresh();
         }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -12,6 +12,7 @@ import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
 import com.google.appinventor.client.ComponentsTranslation;
 import com.google.appinventor.client.Images;
 import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.ProjectEditor;
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.appinventor.client.editor.simple.components.utils.PropertiesUtil;
 import com.google.appinventor.client.editor.youngandroid.YaBlocksEditor;
@@ -523,6 +524,10 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     properties.addProperty(name, defaultValue, caption, editor, type);
   }
 
+  public SimpleEditor getEditor() {
+    return editor;
+  }
+
   /**
    * Returns the component name.
    * <p>
@@ -995,13 +1000,10 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       // If this component's visible property is false, we need to check whether to show hidden
       // components.
       if (!visible) {
-        Boolean showHiddenComponents = editor.getProjectEditor().getCurrentScreenComponentVisibility();
+        ProjectEditor projectEditor = editor.getProjectEditor();
+        VerticalPanel screen = projectEditor.getScreen(this);
+        Boolean showHiddenComponents = (screen != null) ? editor.getProjectEditor().getScreenComponentVisibility(screen) : false;
         return (showHiddenComponents != null) ? showHiddenComponents : false;
-        // boolean showHiddenComponents = Boolean.parseBoolean(
-        //     editor.getProjectEditor().getProjectSettingsProperty(
-        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
-        // return showHiddenComponents;
       }
     }
     return true;

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -995,11 +995,13 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       // If this component's visible property is false, we need to check whether to show hidden
       // components.
       if (!visible) {
-        boolean showHiddenComponents = Boolean.parseBoolean(
-            editor.getProjectEditor().getProjectSettingsProperty(
-            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-            SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
-        return showHiddenComponents;
+        Boolean showHiddenComponents = editor.getProjectEditor().getCurrentScreenComponentVisibility();
+        return (showHiddenComponents != null) ? showHiddenComponents : false;
+        // boolean showHiddenComponents = Boolean.parseBoolean(
+        //     editor.getProjectEditor().getProjectSettingsProperty(
+        //     SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+        //     SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_HIDDEN_COMPONENTS));
+        // return showHiddenComponents;
       }
     }
     return true;


### PR DESCRIPTION
This PR allows for the visibility of screen components to be toggled on a screen basis. That is, it adjusts the checkbox so that its state change only affects the current screen, not all screens in the project.