### PR TITLE
Mock Container delete all child components

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -322,9 +322,6 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
     for (int i = children.size() - 1; i >= 0; --i) {
       MockComponent child = children.get(i);
 
-      // Send event of component removal
-      getForm().fireComponentRemoved(child, true);
-
       // Manually delete child component to ensure that it is
       // completely removed from the Designer.
       child.delete();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -316,8 +316,7 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
   }
 
   @Override
-  public void onRemoved()
-  {
+  public void delete() {
     // Traverse list backwards to make removal easier
     for (int i = children.size() - 1; i >= 0; --i) {
       MockComponent child = children.get(i);
@@ -326,6 +325,8 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
       // completely removed from the Designer.
       child.delete();
     }
+
+    super.delete();
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -318,8 +318,16 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
   @Override
   public void onRemoved()
   {
-    for (MockComponent child : children) {
+    // Traverse list backwards to make removal easier
+    for (int i = children.size() - 1; i >= 0; --i) {
+      MockComponent child = children.get(i);
+
+      // Send event of component removal
       getForm().fireComponentRemoved(child, true);
+
+      // Manually delete child component to ensure that it is
+      // completely removed from the Designer.
+      child.delete();
     }
   }
 


### PR DESCRIPTION
Fixes #1743 by fully deleting child components when deleting a MockContainer.

The fireComponentRemoved event call was preserved.

An alternative could be also overriding the delete() method in MockContainer and handle the onRemoved() functionality there, although it should most likely yield the same result.