### PR TITLE
Support fill-opacity/stroke-opacity for map features

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -358,8 +358,16 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradePedometerProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("Map")) {
         srcCompVersion = upgradeMapProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("Circle")) {
+        srcCompVersion = upgradeCircleProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("LineString")) {
+        srcCompVersion = upgradeLineStringProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("Marker")) {
         srcCompVersion = upgradeMarkerProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("Polygon")) {
+        srcCompVersion = upgradePolygonProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("Rectangle")) {
+        srcCompVersion = upgradeRectangleProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("FeatureCollection")) {
         srcCompVersion = upgradeFeatureCollection(componentProperties, srcCompVersion);
       }
@@ -1631,14 +1639,56 @@ public final class YoungAndroidFormUpgrader {
     }
     return srcCompVersion;
   }
+  
+  private static int upgradeCircleProperties(Map<String, JSONValue> componentProperties,
+    int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Verison 2
+      // The FillOpacity and StrokeOpacity properties were added
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeLineStringProperties(Map<String, JSONValue> componentProperties,
+    int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Verison 2
+      // The StrokeOpacity property was added
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
 
   private static int upgradeMarkerProperties(Map<String, JSONValue> componentProperties,
     int srcCompVersion) {
-    if (srcCompVersion < 2) {
+    if (srcCompVersion < 3) {
       // The ShowShadow property was removed.
       if (componentProperties.containsKey("ShowShadow")) {
         componentProperties.remove("ShowShadow");
       }
+      // Verison 3
+      // The FillOpacity and StrokeOpacity properties were added
+      srcCompVersion = 3;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradePolygonProperties(Map<String, JSONValue> componentProperties,
+    int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Verison 2
+      // The FillOpacity and StrokeOpacity properties were added
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeRectangleProperties(Map<String, JSONValue> componentProperties,
+    int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Verison 2
+      // The FillOpacity and StrokeOpacity properties were added
       srcCompVersion = 2;
     }
     return srcCompVersion;

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1897,11 +1897,39 @@ Blockly.Versioning.AllUpgradeMaps =
 
   }, // End Map upgraders
 
+  "Circle": {
+    // AI2:
+    // - The FillOpacity and StrokeOpacity properties were added
+    2: "noUpgrade"
+  }, // End Circle upgraders
+
+  "LineString": {
+    // AI2:
+    // - The StrokeOpacity property was added
+    2: "noUpgrade"
+  }, // End LineString upgraders
+
   "Marker": {
     // AI2:
     // - The ShowShadow property was removed
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // AI2:
+    // - The FillOpacity and StrokeOpacity properties were added
+    3: "noUpgrade"
   }, // End Marker upgraders
+  
+  "Polygon": {
+    // AI2:
+    // - The FillOpacity and StrokeOpacity properties were added
+    2: "noUpgrade"
+  }, // End Polygon upgraders
+
+  "Rectangle": {
+    // AI2:
+    // - The FillOpacity and StrokeOpacity properties were added
+    2: "noUpgrade"
+  }, // End Rectangle upgraders
 
   "NearField": {
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -714,7 +714,9 @@ public class YaVersion {
 
   // For CIRCLE_COMPONENT_VERSION 1:
   // - Initial implementation of Circle for Maps
-  public static final int CIRCLE_COMPONENT_VERSION = 1;
+  // For CIRCLE_COMPONENT_VERSION 2:
+  // - Added fill and stroke opacity properties
+  public static final int CIRCLE_COMPONENT_VERSION = 2;
 
   // For CLOCK_COMPONENT_VERSION 2:
   // - The pattern parameter was added to the FormatDate and FormatDateTime.
@@ -896,7 +898,9 @@ public class YaVersion {
 
   // For LINESTRING_COMPONENT_VERSION 1:
   // - Initial LineString implementation for Maps
-  public static final int LINESTRING_COMPONENT_VERSION = 1;
+  // For LINESTRING_COMPONENT_VERSION 2:
+  // - Added fill and stroke opacity properties
+  public static final int LINESTRING_COMPONENT_VERSION = 2;
 
   // For LISTPICKER_COMPONENT_VERSION 2:
   // - The Alignment property was renamed to TextAlignment.
@@ -956,7 +960,9 @@ public class YaVersion {
   // - Initial Marker implementation using OpenStreetMap
   // For MARKER_COMPONENT_VERSION 2:
   // - The ShowShadow property was removed
-  public static final int MARKER_COMPONENT_VERSION = 2;
+  // For MARKER_COMPONENT_VERSION 3:
+  // - Added fill and stroke opacity properties
+  public static final int MARKER_COMPONENT_VERSION = 3;
 
   // For NEARFIELD_COMPONENT_VERSION 1:
   public static final int NEARFIELD_COMPONENT_VERSION = 1;
@@ -1059,11 +1065,15 @@ public class YaVersion {
 
   // For POLYGON_COMPONENT_VERSION 1:
   // - Initial Polygon implementation for Maps
-  public static final int POLYGON_COMPONENT_VERSION = 1;
+  // For POLYGON_COMPONENT_VERSION 2:
+  // - Added fill and stroke opacity properties
+  public static final int POLYGON_COMPONENT_VERSION = 2;
 
   // For RECTANGLE_COMPONENT_VERSION 1:
   // - Initial Rectangle implementation for Maps
-  public static final int RECTANGLE_COMPONENT_VERSION = 1;
+  // For RECTANGLE_COMPONENT_VERSION 2:
+  // - Added fill and stroke opacity properties
+  public static final int RECTANGLE_COMPONENT_VERSION = 2;
 
   public static final int SHARING_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
@@ -161,7 +161,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   @SimpleProperty
   public void StrokeOpacity(float opacity) {
     strokeOpacity = opacity;
-    strokeColor = strokeColor & 0x00FFFFFF + Math.round(0xFF * opacity) << 24;
+    strokeColor = (strokeColor & 0x00FFFFFF) | (Math.round(0xFF * opacity) << 24);
     map.getController().updateFeatureStroke(this);
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
@@ -33,6 +33,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   protected Map map = null;
   private boolean visible = true;
   private int strokeColor = COLOR_BLACK;
+  private float strokeOpacity = 1;
   private int strokeWidth = 1;
   private String title = "";
   private String description = "";
@@ -99,6 +100,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
     Draggable(false);
     EnableInfobox(false);
     StrokeColor(COLOR_BLACK);
+    StrokeOpacity(1);
     StrokeWidth(1);
     Title("");
     Visible(true);
@@ -151,6 +153,23 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
       description = "The paint color used to outline the %type%.")
   public int StrokeColor() {
     return strokeColor;
+  }
+
+  @Override
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
+      defaultValue = "1.0")
+  @SimpleProperty
+  public void StrokeOpacity(float opacity) {
+    strokeOpacity = opacity;
+    strokeColor = strokeColor & 0x00FFFFFF + Math.round(0xFF * opacity) << 24;
+    map.getController().updateFeatureStroke(this);
+  }
+
+  @Override
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+    description = "The opacity of the stroke used to outline the map feature.")
+  public float StrokeOpacity() {
+    return strokeOpacity;
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBaseWithFill.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBaseWithFill.java
@@ -18,11 +18,13 @@ import com.google.appinventor.components.runtime.util.MapFactory.MapFeatureVisit
 @SimpleObject
 public abstract class MapFeatureBaseWithFill extends MapFeatureBase implements HasFill {
   private int fillColor = COLOR_RED;
+  private float fillOpacity = 1;
 
   public MapFeatureBaseWithFill(MapFactory.MapFeatureContainer container,
       MapFeatureVisitor<Double> distanceComputation) {
     super(container, distanceComputation);
     FillColor(Color.RED);
+    FillOpacity(1);
   }
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
@@ -39,5 +41,22 @@ public abstract class MapFeatureBaseWithFill extends MapFeatureBase implements H
   @Override
   public int FillColor() {
     return fillColor;
+  }
+
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
+      defaultValue = "1.0")
+  @SimpleProperty
+  @Override
+  public void FillOpacity(float opacity) {
+    fillOpacity = opacity;
+    fillColor = (fillColor & 0x00FFFFFF) | (Math.round(0xFF * opacity) << 24);
+    map.getController().updateFeatureFill(this);
+  }
+
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+      description = "The opacity of the interior of the map feature.")
+  @Override
+  public float FillOpacity() {
+    return fillOpacity;
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureContainerBase.java
@@ -201,8 +201,10 @@ public abstract class MapFeatureContainerBase extends AndroidViewComponent imple
    * draggable becomes Draggable;
    * infobox becomes EnableInfobox;
    * fill becomes FillColor;
+   * fill-opacity becomes FillOpacity;
    * image becomes ImageAsset;
    * stroke becomes StrokeColor;
+   * stroke-opacity becomes StrokeOpacity;
    * stroke-width becomes StrokeWidth;
    * title becomes Title;
    * visible becomes Visible

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/GeoJSONUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/GeoJSONUtil.java
@@ -53,10 +53,12 @@ public final class GeoJSONUtil {
   private static final String PROPERTY_DESCRIPTION = "description";
   private static final String PROPERTY_DRAGGABLE = "draggable";
   private static final String PROPERTY_FILL = "fill";
+  private static final String PROPERTY_FILL_OPACITY = "fill-opacity";
   private static final String PROPERTY_HEIGHT = "height";
   private static final String PROPERTY_IMAGE = "image";
   private static final String PROPERTY_INFOBOX = "infobox";
   private static final String PROPERTY_STROKE = "stroke";
+  private static final String PROPERTY_STROKE_OPACITY = "stroke-opacity";
   private static final String PROPERTY_STROKE_WIDTH = "stroke-width";
   private static final String PROPERTY_TITLE = "title";
   private static final String PROPERTY_WIDTH = "width";
@@ -126,6 +128,14 @@ public final class GeoJSONUtil {
         }
       }
     });
+    SUPPORTED_PROPERTIES.put(PROPERTY_FILL_OPACITY, new PropertyApplication() {
+      @Override
+      public void apply(MapFeature feature, Object value) {
+        if (feature instanceof HasFill) {
+          ((HasFill) feature).FillOpacity(parseFloatOrString(value));
+        }
+      }
+    });
     SUPPORTED_PROPERTIES.put(PROPERTY_HEIGHT, new PropertyApplication() {
       @Override
       public void apply(MapFeature feature, Object value) {
@@ -154,6 +164,14 @@ public final class GeoJSONUtil {
         if (feature instanceof HasStroke) {
           ((HasStroke) feature).StrokeColor(value instanceof Number ? ((Number) value).intValue() :
               parseColor(value.toString()));
+        }
+      }
+    });
+    SUPPORTED_PROPERTIES.put(PROPERTY_STROKE_OPACITY, new PropertyApplication() {
+      @Override
+      public void apply(MapFeature feature, Object value) {
+        if (feature instanceof HasStroke) {
+          ((HasStroke) feature).StrokeOpacity(parseFloatOrString(value));
         }
       }
     });
@@ -411,6 +429,19 @@ public final class GeoJSONUtil {
     }
   }
 
+  @VisibleForTesting
+  static float parseFloatOrString(Object value) {
+    if (value instanceof Number) {
+      return ((Number) value).floatValue();
+    } else if (value instanceof String) {
+      return Float.parseFloat((String) value);
+    } else if (value instanceof FString) {
+      return Float.parseFloat(value.toString());
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
   private static final class FeatureWriter implements MapFactory.MapFeatureVisitor<Void> {
 
     private final PrintStream out;
@@ -483,11 +514,13 @@ public final class GeoJSONUtil {
 
     private void writeProperties(HasStroke feature) {
       writeColorProperty(PROPERTY_STROKE, feature.StrokeColor());
+      writeProperty(PROPERTY_STROKE_OPACITY, feature.StrokeOpacity());
       writeProperty(PROPERTY_STROKE_WIDTH, feature.StrokeWidth());
     }
 
     private void writeProperties(HasFill feature) {
       writeColorProperty(PROPERTY_FILL, feature.FillColor());
+      writeProperty(PROPERTY_FILL_OPACITY, feature.FillOpacity());
     }
 
     private void writePoints(List<GeoPoint> points) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
@@ -897,6 +897,18 @@ public final class MapFactory {
      * @return the fill paint color
      */
     int FillColor();
+
+    /**
+     * Sets the opacity of the interior of the feature
+     * @param opacity the fill opacity
+     */
+    void FillOpacity(float opacity);
+
+    /**
+     * Gets the opacity of the interior of the feature
+     * @return the fill opacity
+     */
+    float FillOpacity();
   }
 
   /**
@@ -916,6 +928,18 @@ public final class MapFactory {
      * @return the outline paint color
      */
     int StrokeColor();
+
+    /**
+     * Sets the opacity of the outline of the feature
+     * @param opacity the stroke opacity
+     */
+    void StrokeOpacity(float opacity);
+
+    /**
+     * Gets the opacity of the outline of the feature
+     * @return the stroke opacity
+     */
+    float StrokeOpacity();
 
     /**
      * Sets the width of the outline of the feature

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -1000,6 +1000,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
       @Override
       public void onSuccess(BitmapDrawable result) {
+        result.setAlpha((int) Math.round(aiMarker.FillOpacity() * 255.0f));
         callback.onSuccess(result);
       }
     });
@@ -1052,6 +1053,7 @@ class NativeOpenStreetMapController implements MapController, MapListener {
         path.baseStyle.stroke = new SVG.Colour(strokePaint.getColor());
         path.baseStyle.strokeOpacity = strokePaint.getAlpha()/255.0f;
         path.baseStyle.strokeWidth = strokeWidth;
+        path.baseStyle.specifiedFlags = 0x3d;
         if (path.style != null) {
           if ((path.style.specifiedFlags & SPECIFIED_FILL) == 0) {
             path.style.fill = new SVG.Colour(fillPaint.getColor());

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
@@ -403,14 +403,14 @@ public class GeoJSONUtilTest extends MapTestBase {
 
   private static void assertTestProperties(MapFeatureBaseWithFill feature) {
     assertEquals(COLOR_BLUE, feature.FillColor() | 0xFF000000);
-    assertEquals(0.4, feature.FillOpacity(), 1e-8);
+    assertEquals(0.4, feature.FillOpacity(), 1e-6);
     assertEquals(Math.round(0.4 * 255), feature.FillColor() >>> 24);
     assertTestProperties((MapFeatureBase) feature);
   }
 
   private static void assertTestProperties(MapFeatureBase feature) {
     assertEquals(COLOR_GREEN, feature.StrokeColor() | 0xFF000000);
-    assertEquals(0.7, feature.StrokeOpacity(), 1e-8);
+    assertEquals(0.7, feature.StrokeOpacity(), 1e-6);
     assertEquals(Math.round(0.7 * 255), feature.StrokeColor() >>> 24);
     assertEquals(3, feature.StrokeWidth());
     assertTestProperties((MapFeature) feature);

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
@@ -403,14 +403,14 @@ public class GeoJSONUtilTest extends MapTestBase {
 
   private static void assertTestProperties(MapFeatureBaseWithFill feature) {
     assertEquals(COLOR_BLUE, feature.FillColor() | 0xFF000000);
-    assertEquals(0.4, feature.FillOpacity(), 1e-15);
+    assertEquals(0.4, feature.FillOpacity(), 1e-8);
     assertEquals(Math.round(0.4 * 255), feature.FillColor() >>> 24);
     assertTestProperties((MapFeatureBase) feature);
   }
 
   private static void assertTestProperties(MapFeatureBase feature) {
     assertEquals(COLOR_GREEN, feature.StrokeColor() | 0xFF000000);
-    assertEquals(0.7, feature.StrokeOpacity(), 1e-15);
+    assertEquals(0.7, feature.StrokeOpacity(), 1e-8);
     assertEquals(Math.round(0.7 * 255), feature.StrokeColor() >>> 24);
     assertEquals(3, feature.StrokeWidth());
     assertTestProperties((MapFeature) feature);

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
@@ -402,14 +402,14 @@ public class GeoJSONUtilTest extends MapTestBase {
   }
 
   private static void assertTestProperties(MapFeatureBaseWithFill feature) {
-    assertEquals(COLOR_BLUE, feature.FillColor());
+    assertEquals(COLOR_BLUE, feature.FillColor() | 0xFF000000);
     assertEquals(0.4, feature.FillOpacity());
     assertEquals(Math.round(0.4 * 255), feature.FillColor() >>> 24);
     assertTestProperties((MapFeatureBase) feature);
   }
 
   private static void assertTestProperties(MapFeatureBase feature) {
-    assertEquals(COLOR_GREEN, feature.StrokeColor());
+    assertEquals(COLOR_GREEN, feature.StrokeColor() | 0xFF000000);
     assertEquals(0.7, feature.StrokeOpacity());
     assertEquals(Math.round(0.7 * 255), feature.StrokeColor() >>> 24);
     assertEquals(3, feature.StrokeWidth());

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
@@ -377,9 +377,11 @@ public class GeoJSONUtilTest extends MapTestBase {
         "description", TEST_DESCRIPTION,
         "draggable", true,
         "fill", "blue",
+        "fill-opacity", 0.4,
         "image", "",
         "infobox", false,
         "stroke", "green",
+        "stroke-opacity", 0.7,
         "stroke-width", 3,
         "title", TEST_TITLE,
         "visible", true,
@@ -401,11 +403,15 @@ public class GeoJSONUtilTest extends MapTestBase {
 
   private static void assertTestProperties(MapFeatureBaseWithFill feature) {
     assertEquals(COLOR_BLUE, feature.FillColor());
+    assertEquals(0.4, feature.FillOpacity());
+    assertEquals(Math.round(0.4 * 255), feature.FillColor() >>> 24);
     assertTestProperties((MapFeatureBase) feature);
   }
 
   private static void assertTestProperties(MapFeatureBase feature) {
     assertEquals(COLOR_GREEN, feature.StrokeColor());
+    assertEquals(0.7, feature.StrokeOpacity());
+    assertEquals(Math.round(0.7 * 255), feature.StrokeColor() >>> 24);
     assertEquals(3, feature.StrokeWidth());
     assertTestProperties((MapFeature) feature);
   }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/GeoJSONUtilTest.java
@@ -403,14 +403,14 @@ public class GeoJSONUtilTest extends MapTestBase {
 
   private static void assertTestProperties(MapFeatureBaseWithFill feature) {
     assertEquals(COLOR_BLUE, feature.FillColor() | 0xFF000000);
-    assertEquals(0.4, feature.FillOpacity());
+    assertEquals(0.4, feature.FillOpacity(), 1e-15);
     assertEquals(Math.round(0.4 * 255), feature.FillColor() >>> 24);
     assertTestProperties((MapFeatureBase) feature);
   }
 
   private static void assertTestProperties(MapFeatureBase feature) {
     assertEquals(COLOR_GREEN, feature.StrokeColor() | 0xFF000000);
-    assertEquals(0.7, feature.StrokeOpacity());
+    assertEquals(0.7, feature.StrokeOpacity(), 1e-15);
     assertEquals(Math.round(0.7 * 255), feature.StrokeColor() >>> 24);
     assertEquals(3, feature.StrokeWidth());
     assertTestProperties((MapFeature) feature);

--- a/appinventor/docs/reference/components/maps.html
+++ b/appinventor/docs/reference/components/maps.html
@@ -517,7 +517,7 @@
                    <dt class="color" id="Circle.FillColor">FillColor<i></i></dt>
                    <dd>Sets or gets the color used to fill in the circle.</dd>
                    <dt class="color" id="Circle.FillOpacity">FillOpacity<i></i></dt>
-                    <dd>Sets or gets the opacity of the interior of the circle.</dd>
+                    <dd>Sets or gets the opacity of the interior of the circle on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                    <dt class="number" id="Circle.Latitude">Latitude<i></i></dt>
                    <dd>Sets or gets the latitude of the center of the circle, in degrees. Positive values representing
                      north of the equator and negative values representing south of the equator. To update the latitude
@@ -533,7 +533,7 @@
                    <dt class="color" id="Circle.StrokeColor">StrokeColor<i></i></dt>
                    <dd>Sets or gets the color used to outline the circle.</dd>
                    <dt class="number" id="Circle.StrokeOpacity">StrokeOpacity<i></i></dt>
-                   <dd>Sets or gets the opacity of the outline of the circle.</dd>
+                   <dd>Sets or gets the opacity of the outline of the circle on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                    <dt class="number" id="Circle.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>Sets or gets the width of the stroke used to outline the circle.</dd>
                    <dt class="text" id="Circle.Title">Title<i></i></dt>
@@ -692,7 +692,7 @@
                    <dt class="color" id="LineString.StrokeColor">StrokeColor<i></i></dt>
                    <dd>The paint color used to outline the map feature.</dd>
                    <dt class="float" id="LineString.StrokeOpacity">StrokeOpacity<i></i></dt>
-                   <dd>The opacity of the stroke used to outline the map feature.</dd>
+                   <dd>The opacity of the stroke used to outline the map feature on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                    <dt class="number" id="LineString.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>The width of the stroke used to outline the map feature.</dd>
                    <dt class="text" id="LineString.Title">Title<i></i></dt>
@@ -947,7 +947,7 @@
                    <dd>Sets or gets the color used to fill in the marker. This property only applies for markers using
                      vector image assets, including the default icon.</dd>
                    <dt class="number" id="Marker.FillOpacity">FillOpacity<i></i></dt>
-                   <dd>Sets or gets the opacity of the interior of the marker. This property only applies for markers using
+                   <dd>Sets or gets the opacity of the interior of the marker on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid. This property only applies for markers using
                      vector image assets, including the default icon.</dd>
                    <dt class="number" id="Marker.Height">Height<i></i></dt>
                    <dd>Sets or gets the height of the marker, in pixels.</dd>
@@ -969,7 +969,7 @@
                    <dt class="color" id="Marker.StrokeColor">StrokeColor<i></i></dt>
                    <dd>Sets or gets the color used to outline the marker.</dd>
                    <dt class="number" id="Marker.StrokeOpacity">StrokeOpacity<i></i></dt>
-                   <dd>Sets or gets the opacity of the outline of the marker.</dd>
+                   <dd>Sets or gets the opacity of the outline of the marker on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                    <dt class="number" id="Marker.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>Sets or gets the width of the stroke used to outline the marker.</dd>
                    <dt class="text" id="Marker.Title">Title<i></i></dt>
@@ -1051,7 +1051,7 @@
                     <dt class="color" id="Polygon.FillColor">FillColor<i></i></dt>
                     <dd>Sets or gets the color used to fill in the polygon.</dd>
                     <dt class="color" id="Polygon.FillOpacity">FillOpacity<i></i></dt>
-                    <dd>Sets or gets the opacity of the interior of the polygon.</dd>
+                    <dd>Sets or gets the opacity of the interior of the polygon on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                     <dt class="list" id="Polygon.HolePoints">HolePoints<i></i></dt>
                     <dd>Sets or gets the lists of points that comprise the polygon's holes. Points are given as <code>(Latitude Longitude)</code> pairs and should be given counterclockwise.</dd>
                     <dt class="text wo" id="Polygon.HolePointsFromString">HolePointsFromString<i></i></dt>
@@ -1131,7 +1131,7 @@
                     <dt class="color" id="Rectangle.FillColor">FillColor<i></i></dt>
                     <dd>Sets or gets the color used to fill in the rectangle.</dd>
                     <dt class="color" id="Rectangle.FillOpacity">FillOpacity<i></i></dt>
-                    <dd>Sets or gets the opacity of the interior of the rectangle.</dd>
+                    <dd>Sets or gets the opacity of the interior of the rectangle on a 0 to 1 scale. 0 is completely transparent. 1 is completely solid.</dd>
                     <dt class="number" id="Rectangle.NorthLatitude">NorthLatitude<i></i></dt>
                     <dd>Sets or gets the latitude, in degrees, bounding the rectangle on the north. Range: [-90, 90]</dd>
                     <dt class="number" id="Rectangle.SouthLatitude">SouthLatitude<i></i></dt>

--- a/appinventor/docs/reference/components/maps.html
+++ b/appinventor/docs/reference/components/maps.html
@@ -516,6 +516,8 @@
                    <dd>Enables or disables the infobox window display when the user taps the circle.</dd>
                    <dt class="color" id="Circle.FillColor">FillColor<i></i></dt>
                    <dd>Sets or gets the color used to fill in the circle.</dd>
+                   <dt class="color" id="Circle.FillOpacity">FillOpacity<i></i></dt>
+                    <dd>Sets or gets the opacity of the interior of the circle.</dd>
                    <dt class="number" id="Circle.Latitude">Latitude<i></i></dt>
                    <dd>Sets or gets the latitude of the center of the circle, in degrees. Positive values representing
                      north of the equator and negative values representing south of the equator. To update the latitude
@@ -530,6 +532,8 @@
                    <dd>Sets or gets the radius of the circle, in meters.</dd>
                    <dt class="color" id="Circle.StrokeColor">StrokeColor<i></i></dt>
                    <dd>Sets or gets the color used to outline the circle.</dd>
+                   <dt class="number" id="Circle.StrokeOpacity">StrokeOpacity<i></i></dt>
+                   <dd>Sets or gets the opacity of the outline of the circle.</dd>
                    <dt class="number" id="Circle.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>Sets or gets the width of the stroke used to outline the circle.</dd>
                    <dt class="text" id="Circle.Title">Title<i></i></dt>
@@ -647,8 +651,10 @@
                        <li>draggable &rarr; Draggable</li>
                        <li>infobox &rarr; EnableInfobox</li>
                        <li>fill &rarr; FillColor</li>
+                       <li>fill-opacity &rarr; FillOpacity</li>
                        <li>image &rarr; ImageAsset</li>
                        <li>stroke &rarr; StrokeColor</li>
+                       <li>stroke-opacity &rarr; StrokeOpacity</li>
                        <li>stroke-width &rarr; StrokeWidth</li>
                        <li>title &rarr; Title</li>
                        <li>visible &rarr; Visible</li>
@@ -685,6 +691,8 @@
                      designer will update this property.</dd>
                    <dt class="color" id="LineString.StrokeColor">StrokeColor<i></i></dt>
                    <dd>The paint color used to outline the map feature.</dd>
+                   <dt class="float" id="LineString.StrokeOpacity">StrokeOpacity<i></i></dt>
+                   <dd>The opacity of the stroke used to outline the map feature.</dd>
                    <dt class="number" id="LineString.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>The width of the stroke used to outline the map feature.</dd>
                    <dt class="text" id="LineString.Title">Title<i></i></dt>
@@ -938,6 +946,9 @@
                    <dt class="color" id="Marker.FillColor">FillColor<i></i></dt>
                    <dd>Sets or gets the color used to fill in the marker. This property only applies for markers using
                      vector image assets, including the default icon.</dd>
+                   <dt class="number" id="Marker.FillOpacity">FillOpacity<i></i></dt>
+                   <dd>Sets or gets the opacity of the interior of the marker. This property only applies for markers using
+                     vector image assets, including the default icon.</dd>
                    <dt class="number" id="Marker.Height">Height<i></i></dt>
                    <dd>Sets or gets the height of the marker, in pixels.</dd>
                    <dt class="number wo bo" id="Marker.HeightPercent">HeightPercent<i></i></dt>
@@ -957,6 +968,8 @@
                      the <a href="#Marker.SetLocation"><code>SetLocation</code></a> method.</dd>
                    <dt class="color" id="Marker.StrokeColor">StrokeColor<i></i></dt>
                    <dd>Sets or gets the color used to outline the marker.</dd>
+                   <dt class="number" id="Marker.StrokeOpacity">StrokeOpacity<i></i></dt>
+                   <dd>Sets or gets the opacity of the outline of the marker.</dd>
                    <dt class="number" id="Marker.StrokeWidth">StrokeWidth<i></i></dt>
                    <dd>Sets or gets the width of the stroke used to outline the marker.</dd>
                    <dt class="text" id="Marker.Title">Title<i></i></dt>
@@ -1037,6 +1050,8 @@
                     <dd>Enables or disables the infobox window display when the user taps the polygon.</dd>
                     <dt class="color" id="Polygon.FillColor">FillColor<i></i></dt>
                     <dd>Sets or gets the color used to fill in the polygon.</dd>
+                    <dt class="color" id="Polygon.FillOpacity">FillOpacity<i></i></dt>
+                    <dd>Sets or gets the opacity of the interior of the polygon.</dd>
                     <dt class="list" id="Polygon.HolePoints">HolePoints<i></i></dt>
                     <dd>Sets or gets the lists of points that comprise the polygon's holes. Points are given as <code>(Latitude Longitude)</code> pairs and should be given counterclockwise.</dd>
                     <dt class="text wo" id="Polygon.HolePointsFromString">HolePointsFromString<i></i></dt>
@@ -1115,6 +1130,8 @@
                     <dd>Enables or disables the infobox window display when the user taps the rectangle.</dd>
                     <dt class="color" id="Rectangle.FillColor">FillColor<i></i></dt>
                     <dd>Sets or gets the color used to fill in the rectangle.</dd>
+                    <dt class="color" id="Rectangle.FillOpacity">FillOpacity<i></i></dt>
+                    <dd>Sets or gets the opacity of the interior of the rectangle.</dd>
                     <dt class="number" id="Rectangle.NorthLatitude">NorthLatitude<i></i></dt>
                     <dd>Sets or gets the latitude, in degrees, bounding the rectangle on the north. Range: [-90, 90]</dd>
                     <dt class="number" id="Rectangle.SouthLatitude">SouthLatitude<i></i></dt>


### PR DESCRIPTION
Adds support for fill-opacity and stroke-opacity as properties for map features. #1745 