### PR TITLE
Make AWT run in headless mode in buildserver

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -190,6 +190,7 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <jvmarg value="-Djava.awt.headless=true" />
       <arg value="--childProcessRamMb" />
       <arg value="1024" />
       <arg value="--inputZipFile" />
@@ -222,6 +223,7 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <jvmarg value="-Djava.awt.headless=true" />
       <arg value="--childProcessRamMb" />
       <arg value="1024" />
       <arg value="--inputZipFile" />
@@ -259,6 +261,7 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <jvmarg value="-Djava.awt.headless=true" />
       <arg value="--childProcessRamMb" />
       <arg value="1024" />
       <arg value="--inputZipFile" />
@@ -303,6 +306,7 @@
         <fileset dir="${run.lib.dir}" includes="*.jar" />
       </classpath>
       <sysproperty key="file.encoding" value="UTF-8" />
+      <jvmarg value="-Djava.awt.headless=true" />
       <arg value="--dexCacheDir" />
       <arg value="${public.build.dir}/dexCache" />
       <arg value="--shutdownToken" />


### PR DESCRIPTION
On macOS, the application icon preparation step causes Java AWT to
create an app window. This window gains focus, even though the
buildserver is a background process. This really only affects
developers working with the sources on OS X. This change sets a flag
to inform AWT to run in headless mode, which prevents it from creating
the app window.

Change-Id: Ida725b80e67c55777437cdd69392a3fab4dcf00a