### PR TITLE
Added TurnOn Function to BuildServer

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -796,6 +796,9 @@ public class BuildServer {
 
   private ShutdownState getShutdownState() {
     if (shuttingTime == 0 || (System.currentTimeMillis() > turningOnTime && turningOnTime > shuttingTime)) {
+      if (System.currentTimeMillis() > shuttingTime && shuttingTime != 0) {
+        shuttingTime = 0;
+      }
       int max = buildExecutor.getMaxActiveTasks();
       if (max < 10) {           // Only do this scheme if we are not unlimited
                                 // (unlimited == 0) and allow more then 10 max builds
@@ -817,6 +820,9 @@ public class BuildServer {
         return ShutdownState.UP;
       }
     } else if (System.currentTimeMillis() > shuttingTime) {
+      if (System.currentTimeMillis() > turningOnTime && turningOnTime != 0) {
+        turningOnTime = 0;
+      }
       return ShutdownState.DOWN;
     } else {
       return ShutdownState.SHUTTING;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -801,9 +801,6 @@ public class BuildServer {
     }
 
     if (shuttingTime == 0) {
-      if (System.currentTimeMillis() > shuttingTime && shuttingTime != 0) {
-        shuttingTime = 0;
-      }
       int max = buildExecutor.getMaxActiveTasks();
       if (max < 10) {           // Only do this scheme if we are not unlimited
                                 // (unlimited == 0) and allow more then 10 max builds
@@ -825,9 +822,6 @@ public class BuildServer {
         return ShutdownState.UP;
       }
     } else if (System.currentTimeMillis() > shuttingTime) {
-      if (System.currentTimeMillis() > turningOnTime && turningOnTime != 0) {
-        turningOnTime = 0;
-      }
       return ShutdownState.DOWN;
     } else {
       return ShutdownState.SHUTTING;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -368,6 +368,9 @@ public class BuildServer {
     } else if (!token.equals(commandLineOptions.shutdownToken)) {
       return Response.status(Response.Status.FORBIDDEN).type(MediaType.TEXT_PLAIN_TYPE).entity("Invalid Shutdown Token").build();
     } else {
+      if (shuttingTime == 0) {
+        return Response.status(Response.Status.FORBIDDEN).type(MediaType.TEXT_PLAIN_TYPE).entity("Buildserver is not expected to be shutted down").build();
+      }
       long turnonTime = System.currentTimeMillis();
       if (delay != null) {
         try {

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -350,7 +350,7 @@ public class BuildServer {
   }
 
   /**
-   * Indicate that the server is shutting down.
+   * Indicate that the server is turning on.
    *
    * @param token -- secret token used like a password to authenticate the shutdown command
    * @param delay -- the delay in seconds before jobs are no longer accepted

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -795,7 +795,12 @@ public class BuildServer {
   }
 
   private ShutdownState getShutdownState() {
-    if (shuttingTime == 0 || (System.currentTimeMillis() > turningOnTime && turningOnTime > shuttingTime)) {
+    if (turningOnTime != 0 && System.currentTimeMillis() > turningOnTime && turningOnTime > shuttingTime) {
+      turningOnTime = 0;
+      shuttingTime = 0;
+    }
+
+    if (shuttingTime == 0) {
       if (System.currentTimeMillis() > shuttingTime && shuttingTime != 0) {
         shuttingTime = 0;
       }


### PR DESCRIPTION
AI buildserver has a function to turn it off from /buildserver/shutdown, but it does not have a way to turn it on back from the URL
This PR adds /buildserver/turnon to it