### PR TITLE
Added Sponsor Button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://crowdfund.mit.edu/project/8152/donate

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://crowdfund.mit.edu/project/8152/donate
+custom: https://giving.mit.edu/give/to?fundId=3832320


### PR DESCRIPTION
Github introduced some months ago Sponsor button in repositories, to help open-source projects get funding through donations (https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository)
This (simple) PR adds such button linking to the MIT donation page