### PR TITLE
Add ReadOnly property to TextBox component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1517,7 +1517,7 @@ public final class YoungAndroidFormUpgrader {
       // RequestFocus method was added
       srcCompVersion = 5;
     }
-    if (scrCompVersion < 6) {
+    if (srcCompVersion < 6) {
       // ReadOnly property was added
       srcCompVersion = 6;
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1517,6 +1517,10 @@ public final class YoungAndroidFormUpgrader {
       // RequestFocus method was added
       srcCompVersion = 5;
     }
+    if (scrCompVersion < 6) {
+      // ReadOnly property was added
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2369,7 +2369,10 @@ Blockly.Versioning.AllUpgradeMaps =
     4: "noUpgrade",
 
     // AI2: Added RequestFocus method
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // AI3: Added ReadOnly property
+    6: "noUpgrade"
 
   }, // End TextBox upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1097,7 +1097,9 @@ public class YaVersion {
   // - The MultiLine property was added.
   // For TEXTBOX_COMPONENT_VERSION 5:
   // - RequestFocus method was added
-  public static final int TEXTBOX_COMPONENT_VERSION = 5;
+  // For TEXTBOX_COMPONENT_VERSION 6:
+  // - ReadOnly property was added
+  public static final int TEXTBOX_COMPONENT_VERSION = 6;
 
   // For TEXTING_COMPONENT_VERSION 2:
   // Texting over Wifi was implemented using Google Voice

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBox.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBox.java
@@ -79,6 +79,9 @@ public final class TextBox extends TextBoxBase {
   // If true, then text box is multiline
   private boolean multiLine;
 
+  // If true, then text box is read-only
+  private boolean readOnly;
+
   /**
    * Creates a new TextBox component.
    *
@@ -88,6 +91,7 @@ public final class TextBox extends TextBoxBase {
     super(container, new EditText(container.$context()));
     NumbersOnly(false);
     MultiLine(false);
+    ReadOnly(false);
 
     // We need to set the IME options here.  Otherwise, Android's default
     // behavior is that the action button will be Done or Next, depending on
@@ -181,6 +185,24 @@ public final class TextBox extends TextBoxBase {
   public void MultiLine(boolean multiLine) {
     this.multiLine = multiLine;
     view.setSingleLine(!multiLine);
+  }
+
+  @SimpleProperty(
+    category = PropertyCategory.BEHAVIOR,
+    description = "Whether the %type% is read-only. By default, this is true."
+  )
+  public boolean ReadOnly() {
+    return readOnly;
+  }
+
+  @DesignerProperty(
+    editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+    defaultValue = "False"
+  )
+  @SimpleProperty
+  public void ReadOnly(boolean readOnly) {
+    this.readOnly = readOnly;
+    view.setEnabled(!readOnly);
   }
 
   // TODO(halabelson): We might also want a method to show the keyboard.


### PR DESCRIPTION
This PR adds a property `ReadOnly` to the `TextBox` component. This addresses issue https://github.com/mit-cml/appinventor-sources/issues/1841.