### PR TITLE
Miscellaneous blocks editor fixes

### DIFF
--- a/appinventor/blocklyeditor/src/backpack.js
+++ b/appinventor/blocklyeditor/src/backpack.js
@@ -479,6 +479,7 @@ Blockly.Backpack.prototype.openBackpack = function(e) {
       for (var i = 0; i < len; i++) {
         newBackpack[i] = Blockly.Xml.textToDom(backpack[i]).firstChild;
       }
+      Blockly.hideChaff();
       p.flyout_.show(newBackpack);
     });
   }

--- a/appinventor/blocklyeditor/src/block_svg.js
+++ b/appinventor/blocklyeditor/src/block_svg.js
@@ -66,9 +66,14 @@ Blockly.BlockSvg.prototype.onMouseDown_ = (function(func) {
         workspace.getParentSvg().parentNode.focus();
       }
       if (Blockly.FieldFlydown.openFieldFlydown_) {
-        if (goog.dom.contains(Blockly.getMainWorkspace().flydown_.svgGroup_, this.svgGroup_)) {
-          //prevent hiding the flyout if a child block is the target
-          Blockly.getMainWorkspace().flydown_.shouldHide = false;
+        var flydown = Blockly.getMainWorkspace().getFlydown();
+        if (flydown) {
+          if (goog.dom.contains(flydown.svgGroup_, this.svgGroup_)) {
+            //prevent hiding the flyout if a child block is the target
+            flydown.shouldHide = false;
+          }
+        } else {
+          console.warn('openFieldFlydown_ was set but flydown_ was undefined!');
         }
       }
       var retval = func.call(this, e);

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -591,6 +591,9 @@ Blockly.Blocks.component_method = {
       var mode = this.typeName === "Form" ? "Screen" : this.typeName;
       return Blockly.ComponentBlock.METHODS_HELPURLS[mode];
   },
+  init: function() {
+    this.genericComponentInput = Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_METHOD_TITLE_FOR_COMPONENT;
+  },
 
   mutationToDom : function() {
 
@@ -745,7 +748,8 @@ Blockly.Blocks.component_method = {
       this.setNextStatement(true);
     }
 
-    this.errors = [{name:"checkIfUndefinedBlock"},{name:"checkIsInDefinition"},{name:"checkComponentNotExistsError"}];
+    this.errors = [{name:"checkIfUndefinedBlock"}, {name:"checkIsInDefinition"},
+      {name:"checkComponentNotExistsError"}, {name: "checkGenericComponentSocket"}];
 
     // mark the block bad if the method isn't defined or is marked deprecated
     var method = this.getMethodTypeObject();
@@ -939,6 +943,7 @@ Blockly.Blocks.component_set_get = {
 
   init: function() {
     this.componentDropDown = Blockly.ComponentBlock.createComponentDropDown(this);
+    this.genericComponentInput = Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_SETTER_TITLE_OF_COMPONENT;
   },
 
   mutationToDom : function() {
@@ -1085,7 +1090,9 @@ Blockly.Blocks.component_set_get = {
 
     this.setTooltip(tooltipDescription);
 
-    this.errors = [{name:"checkIfUndefinedBlock"},{name:"checkIsInDefinition"},{name:"checkComponentNotExistsError"}];
+    this.errors = [{name:"checkIfUndefinedBlock"}, {name:"checkIsInDefinition"},
+      {name:"checkComponentNotExistsError"}, {name: 'checkGenericComponentSocket'},
+      {name: 'checkEmptySetterSocket'}];
 
     if (thisBlock.propertyObject && this.propertyObject.deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
       // [lyn, 2015/12/27] mark deprecated properties as bad

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -152,6 +152,7 @@ Blockly.Drawer.prototype.showBuiltin = function(drawerName) {
   if (!blockSet) {
     throw "no such drawer: " + drawerName;
   }
+  Blockly.hideChaff();
   var xmlList = this.blockListToXMLArray(blockSet);
   this.flyout_.show(xmlList);
 };
@@ -164,7 +165,7 @@ Blockly.Drawer.prototype.showBuiltin = function(drawerName) {
 Blockly.Drawer.prototype.showComponent = function(instanceName) {
   var component = this.workspace_.getComponentDatabase().getInstance(instanceName);
   if (component) {
-    this.flyout_.hide();
+    Blockly.hideChaff();
     this.flyout_.show(this.instanceRecordToXMLArray(component));
     this.lastComponent = instanceName;
   } else {
@@ -182,8 +183,7 @@ Blockly.Drawer.prototype.showComponent = function(instanceName) {
  */
 Blockly.Drawer.prototype.showGeneric = function(typeName) {
   if (this.workspace_.getComponentDatabase().hasType(typeName)) {
-    this.flyout_.hide();
-
+    Blockly.hideChaff();
     var xmlList = this.componentTypeToXMLArray(typeName);
     this.flyout_.show(xmlList);
   } else {

--- a/appinventor/blocklyeditor/src/field_flydown.js
+++ b/appinventor/blocklyeditor/src/field_flydown.js
@@ -153,7 +153,6 @@ Blockly.FieldFlydown.prototype.showFlydown_ = function() {
   // much of the code in Blockly.Flydown.prototype.show.
   // alert("FieldFlydown show Flydown");
   Blockly.hideChaff(); // Hide open context menus, dropDowns, flyouts, and other flydowns
-  Blockly.FieldFlydown.openFieldFlydown_ = this; // Remember field to which flydown is attached
   var flydown = Blockly.getMainWorkspace().getFlydown();
   // Add flydown to top-level svg, *not* to main workspace svg
   // This is essential for correct positioning of flydown via translation
@@ -178,6 +177,7 @@ Blockly.FieldFlydown.prototype.showFlydown_ = function() {
     x = x + borderBBox.width * flydown.workspace_.scale;
   }
   flydown.showAt(blocksXMLList, x, y);
+  Blockly.FieldFlydown.openFieldFlydown_ = this; // Remember field to which flydown is attached
 };
 
 /**

--- a/appinventor/blocklyeditor/src/field_flydown.js
+++ b/appinventor/blocklyeditor/src/field_flydown.js
@@ -133,10 +133,14 @@ Blockly.FieldFlydown.prototype.onMouseOut_ = function(e) {
 Blockly.FieldFlydown.prototype.showFlydownMaker_ = function() {
   var field = this; // Name receiver in variable so can close over this variable in returned thunk
   return function() {
-    if (Blockly.FieldFlydown.showPid_ != 0) {
-      field.showFlydown_();
-      Blockly.FieldFlydown.showPid_ = 0;
+    if (Blockly.FieldFlydown.showPid_ !== 0 && Blockly.dragMode_ === Blockly.DRAG_NONE) {
+      try {
+        field.showFlydown_();
+      } catch (e) {
+        console.error('Failed to show flydown', e);
+      }
     }
+    Blockly.FieldFlydown.showPid_ = 0;
   };
 };
 

--- a/appinventor/blocklyeditor/src/flydown.js
+++ b/appinventor/blocklyeditor/src/flydown.js
@@ -231,7 +231,7 @@ Blockly.Flydown.prototype.shouldHide = true;
 Blockly.Flydown.prototype.hide = function() {
   if (this.shouldHide) {
     Blockly.Flyout.prototype.hide.call(this);
-    Blockly.FieldDropdown.openFieldFlydown_ = null;
+    Blockly.FieldFlydown.openFieldFlydown_ = null;
   }
   this.shouldHide = true;
 }

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1397,6 +1397,8 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.HIDE_WARNINGS = "Hide Warnings";
     Blockly.Msg.MISSING_SOCKETS_WARNINGS = "You should fill all of the sockets with blocks";
     Blockly.Msg.WRONG_TYPE_BLOCK_WARINGS = "This block should be connected to an event block or a procedure definition";
+    Blockly.Msg.ERROR_PROPERTY_SETTER_NEEDS_VALUE = 'This block needs a value block connected to its socket.';
+    Blockly.Msg.ERROR_GENERIC_NEEDS_COMPONENT = 'You need to provide a valid component to this block\'s "%1" socket.';
 
 // Messages from replmgr.js
     Blockly.Msg.REPL_ERROR_FROM_COMPANION = "Error from Companion";

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -604,6 +604,29 @@ Blockly.WarningHandler.prototype.checkDisposedBlock = function(block){
   }
 };
 
+Blockly.WarningHandler.prototype['checkEmptySetterSocket'] = function(block) {
+  if (block.setOrGet === 'set') {
+    var value = block.getInputTargetBlock('VALUE');
+    if (!value) {
+      block.setErrorIconText(Blockly.Msg.ERROR_PROPERTY_SETTER_NEEDS_VALUE);
+      return true;
+    }
+  }
+  return false;
+};
+
+Blockly.WarningHandler.prototype['checkGenericComponentSocket'] = function(block) {
+  if (block.isGeneric) {
+    var value = block.getInputTargetBlock('COMPONENT');
+    if (!value) {
+      block.setErrorIconText(Blockly.Msg.ERROR_GENERIC_NEEDS_COMPONENT
+        .replace(/%1/, block.genericComponentInput));
+      return true;
+    }
+  }
+  return false;
+};
+
 //Warnings
 
 //Warnings indicate that there is a problem with the project, but it will not run

--- a/appinventor/blocklyeditor/src/warningIndicator.js
+++ b/appinventor/blocklyeditor/src/warningIndicator.js
@@ -257,20 +257,26 @@ Blockly.WarningIndicator.prototype.updateWarningToggleText = function() {
  *
  */
 Blockly.WarningIndicator.prototype.onclickWarningToggle = function() {
+  Blockly.hideChaff();
   window.parent.BlocklyPanel_callToggleWarning();
-}
+};
 
 Blockly.WarningIndicator.prototype.onclickWarningNavPrevious = function() {
+  Blockly.hideChaff();
   this.workspace_.getWarningHandler().previousWarning();
-}
-Blockly.WarningIndicator.prototype.onclickWarningNavNext = function() {
-  this.workspace_.getWarningHandler().nextWarning();
-}
+};
 
+Blockly.WarningIndicator.prototype.onclickWarningNavNext = function() {
+  Blockly.hideChaff();
+  this.workspace_.getWarningHandler().nextWarning();
+};
 
 Blockly.WarningIndicator.prototype.onclickErrorNavPrevious = function() {
+  Blockly.hideChaff();
   this.workspace_.getWarningHandler().previousError();
-}
+};
+
 Blockly.WarningIndicator.prototype.onclickErrorNavNext = function() {
+  Blockly.hideChaff();
   this.workspace_.getWarningHandler().nextError();
-}
+};


### PR DESCRIPTION
This PR includes 4 bug fixes.

1. Only call `showFlydown()` if we aren't currently in a drag, and if we are and an error is thrown, log the error to the console and just not end up showing the flydown.
2. In rare instances, the `flydown_` field on the main workspace can be null. I haven't been able to replicate this myself (it was reported on the forum), but I added some additional checks to catch when it happens and log a warning to the browser console.
3. In one location, we set a field `openFieldFlydown_` on the `Blockly.FieldDropdown` class, which is not correct. I've corrected the reference to `Blockly.FieldFlydown`.
4. Corrected an issue in Blockly core where an icon's bubble is associated with its icon's location. However, in the case of a collapsed block the icon might not have a position, which results in attempting to set the bubble on `undefined`. This change (in the submodule) checks that the location is defined first. If not, no harm in not tracking it since it isn't rendered anyway.

I'd like to keep these as separate changes if possible, since they could each be independently reverted. Please rebase and merge if approved.

Fixes #1894 