### PR TITLE
Fix empty points, holepoints after polygon drag

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -694,10 +694,8 @@ class NativeOpenStreetMapController implements MapController, MapListener {
           }
           ((MapRectangle) component).updateBounds(north, west, south, east);
         } else {
-          ((MapPolygon) component).updatePoints(Collections.singletonList(polygon.getPoints()));
-          List<List<GeoPoint>> holes = new ArrayList<List<GeoPoint>>();
-          holes.addAll(polygon.getHoles());
-          ((MapPolygon) component).updateHolePoints(Collections.singletonList(holes));
+          ((MapPolygon) component).updatePoints(((MultiPolygon) polygon).getMultiPoints());
+          ((MapPolygon) component).updateHolePoints(((MultiPolygon) polygon).getMultiHoles());
         }
         for (MapEventListener listener : eventListeners) {
           listener.onFeatureStopDrag(component);
@@ -1341,6 +1339,14 @@ class NativeOpenStreetMapController implements MapController, MapListener {
       }
     }
 
+    public List<List<GeoPoint>> getMultiPoints() {
+      List<List<GeoPoint>> result = new ArrayList<>();
+      for (Polygon p : children) {
+        result.add(p.getPoints());
+      }
+      return result;
+    }
+
     public void setMultiPoints(List<List<GeoPoint>> points) {
       Iterator<Polygon> polygonIterator = children.iterator();
       Iterator<List<GeoPoint>> pointIterator = points.iterator();
@@ -1363,6 +1369,15 @@ class NativeOpenStreetMapController implements MapController, MapListener {
         p.setOnDragListener(dragListener);
         children.add(p);
       }
+    }
+
+    @SuppressWarnings("unchecked")  // upcasting nested ArrayList to List
+    public List<List<List<GeoPoint>>> getMultiHoles() {
+      List<List<List<GeoPoint>>> result = new ArrayList<>();
+      for (Polygon p : children) {
+        result.add((List) p.getHoles());
+      }
+      return result;
     }
 
     public void setMultiHoles(List<List<List<GeoPoint>>> holes) {


### PR DESCRIPTION
This one is a mea culpa. When I implemented dragging of polygons,
there only a single polygon was allowed (and I called
getPoints/getHoles to access its data). However, when we started
loading more complex forms using GeoJSON (e.g., the US states map), we
needed to support MultiPolygons, so I implemented a class to do
so. This class was really a proxy class that grouped calls to its
underlying children. The issue here is that its getPoints and getHoles
methods then report empty lists because it holds no state. This change
adds methods getMultiPoints and getMultiHoles to access its
content. Different methods are needed because the Java language
doesn't allow the same method to return different types before type
erasure.

Fixes #1897 

Change-Id: Ic56b10d6ca1df949a2bbf342b4bc7d3d473a6342