### PR TITLE
Fix tutorial panel sizing

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -2604,6 +2604,7 @@ public class Ode implements EntryPoint {
   private void showTutorials() {
     if (tutorialVisible) {
       tutorialPanel.setVisible(true);
+      overDeckPanel.setCellWidth(tutorialPanel, "300");
     }
   }
 
@@ -2612,6 +2613,7 @@ public class Ode implements EntryPoint {
     if (visible) {
       tutorialPanel.setVisible(true);
       tutorialPanel.setWidth("300px");
+      overDeckPanel.setCellWidth(tutorialPanel, "300");
     } else {
       tutorialPanel.setVisible(false);
       overDeckPanel.setCellWidth(tutorialPanel, "0%");


### PR DESCRIPTION
Forces the `<td>` element containing the tutorial iframe to always be 300px rather than dynamically sized based on the content of the table (because tables are bad for layout, but GWT uses them because of IE, boo).

Change-Id: Ib3142c60ecb389da2b304d96c30308cb08939ebb