### PR TITLE
Emit disable event code only if no active handler exists

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -180,13 +180,38 @@ Blockly.ReplMgr.buildYail = function(workspace) {
         this.block.replError = message;
         this.block.workspace.getWarningHandler().checkAllBlocksForWarningsAndErrors();
     };
+    var componentEventMap = {};
+    var componentGenericEventMap = {};
+
+    function willEmitEvent(block) {
+        if (block.isGeneric) {
+            if (!componentGenericEventMap[block.typeName]) {
+                componentGenericEventMap[block.typeName] = {};
+            }
+            componentGenericEventMap[block.typeName][block.eventName] = true;
+        } else {
+            if (!componentEventMap[block.instanceName]) {
+                componentEventMap[block.instanceName] = {};
+            }
+            componentEventMap[block.instanceName][block.eventName] = true;
+        }
+    }
+
+    function didEmitEvent(block) {
+        if (block.isGeneric && componentGenericEventMap[block.typeName] &&
+          componentGenericEventMap[block.typeName][block.eventName]) {
+            return true;
+        }
+        if (!block.isGeneric && componentEventMap[block.instanceName] &&
+          componentEventMap[block.instanceName][block.eventName]) {
+            return true;
+        }
+        return false;
+    }
 
     for (var x = 0; (block = blocks[x]); x++) {
-        if (!block.category || (block.hasError && !block.replError)) { // Don't send blocks with
-            continue;           // Errors, unless they were errors signaled by the repl
-        }
         if (block.disabled) {
-            if (block.type == 'component_event') {
+            if (block.type == 'component_event' && !didEmitEvent(block)) {
                 // We do need do remove disabled event handlers, though
                 var code = Blockly.Yail.disabledEventBlockToCode(block);
                 if (phoneState.blockYail[block.id] != code) {
@@ -197,11 +222,17 @@ Blockly.ReplMgr.buildYail = function(workspace) {
             // Skip normal code generation for disabled blocks
             continue;
         }
+        if (!block.category || (block.hasError && !block.replError)) { // Don't send blocks with
+            continue;           // Errors, unless they were errors signaled by the repl
+        }
         if (block.blockType != "event" &&
             block.type != "global_declaration" &&
             block.type != "procedures_defnoreturn" &&
             block.type != "procedures_defreturn")
             continue;
+        if (block.type == 'component_event') {
+            willEmitEvent(block);
+        }
         var tempyail = Blockly.Yail.blockToCode(block);
         if (phoneState.blockYail[block.id] != tempyail) { // Only send changed yail
             this.putYail(tempyail, block, success, failure);


### PR DESCRIPTION
The change that produced calls to EventDispatcher's unregister method
for disabled blocks did not account for the scenario where both an
active and inactive event handler exist for the same component-event
combination. This change makes it so that unregister calls are only
output if there isn't a matching active event handler.

Fixes #1918 

Change-Id: If33b577f5af03c64f7abb8fe5b587d576886889b