### PR TITLE
Hide deprecated blocks

### DIFF
--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -259,7 +259,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
     //create event blocks
     goog.object.forEach(componentInfo.eventDictionary, function (event, name) {
-      if (event.deprecated != 'true') {
+      if (event.deprecated != 'true' && event.deprecated !== true) {
         Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_event', {
           'component_type': typeName, 'instance_name': instanceRecord.name, 'event_name': name
         }));
@@ -268,7 +268,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
     //create non-generic method blocks
     goog.object.forEach(componentInfo.methodDictionary, function (method, name) {
-      if (method.deprecated != 'true') {
+      if (method.deprecated != 'true' && method.deprecated !== true) {
         Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_method', {
           'component_type': typeName, 'instance_name': instanceRecord.name, 'method_name': name
         }));
@@ -277,7 +277,7 @@ Blockly.Drawer.prototype.instanceRecordToXMLArray = function(instanceRecord) {
 
     //for each property
     goog.object.forEach(componentInfo.properties, function (property, name) {
-      if (property.deprecated != 'true') {
+      if (property.deprecated != 'true' && property.deprecated !== true) {
         var params = {
           'component_type': typeName, 'instance_name': instanceRecord.name,
           'property_name': name


### PR DESCRIPTION
In earlier versions of App Inventor, the deprecated flag was stored as
the string `"true"` or `"false"`. More recently, we made the flag output a
Boolean rather than a string (i.e., `true` or `false`). However, the
code to handle creating the blocks for the drawer wasn't updated to
handle this scenario. Luckily, it was a sensible fallback such that
the block showed, but that means that deprecated blocks show when they
shouldn't. This change fixes this by checking for both the string
version (to support extensions that use the old format) and the
Boolean version.

Change-Id: I6ae272d8e36887ea4259a7948a56badb62f817d6