### PR TITLE
update community joining link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ The automated tests depend on [Phantomjs](http://phantomjs.org/). Make sure you 
     $ ant tests
 
 ## Need help?
-Contact us through our [Google Group](https://groups.google.com/forum/#!forum/app-inventor-open-source-dev).
+Join [our community](https://community.appinventor.mit.edu/).


### PR DESCRIPTION
the old link was directing to the google group which is not active anymore and it took me a while to join the community via new link. I hope this new link will minimise the confusion and will help other new contributors too.