### PR TITLE
Clone default button background drawable if needed

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -92,6 +92,8 @@ public abstract class ButtonBase extends AndroidViewComponent
   // This is our handle on Android's nice 3-d default button.
   private Drawable defaultButtonDrawable;
 
+  private Drawable myBackgroundDrawable = null;
+
   // This is our handle in Android's default button color states;
   private ColorStateList defaultColorStateList;
 
@@ -393,13 +395,13 @@ public abstract class ButtonBase extends AndroidViewComponent
           // Clear the background image.
           ViewUtil.setBackgroundDrawable(view, null);
           //Now we set again the default drawable
-          ViewUtil.setBackgroundDrawable(view, defaultButtonDrawable);
+          ViewUtil.setBackgroundDrawable(view, getSafeBackgroundDrawable());
           view.getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.CLEAR);
         } else {
           // Clear the background image.
           ViewUtil.setBackgroundDrawable(view, null);
           //Now we set again the default drawable
-          ViewUtil.setBackgroundDrawable(view, defaultButtonDrawable);
+          ViewUtil.setBackgroundDrawable(view, getSafeBackgroundDrawable());
           //@Author NMD (Next Mobile Development) [nmdofficialhelp@gmail.com]
           view.getBackground().setColorFilter(backgroundColor, PorterDuff.Mode.SRC_ATOP);
         }
@@ -414,6 +416,19 @@ public abstract class ButtonBase extends AndroidViewComponent
       ViewUtil.setBackgroundImage(view, backgroundImageDrawable);
       TextViewUtil.setMinSize(view, 0, 0);
     }
+  }
+
+  private Drawable getSafeBackgroundDrawable() {
+    if (myBackgroundDrawable == null) {
+      Drawable.ConstantState state = defaultButtonDrawable.getConstantState();
+      if (state != null) {
+        myBackgroundDrawable = state.newDrawable().mutate();
+      } else {
+        // Since we can't make a copy of the default we'll just use it directly
+        myBackgroundDrawable = defaultButtonDrawable;
+      }
+    }
+    return myBackgroundDrawable;
   }
 
   private ColorStateList createRippleState () {


### PR DESCRIPTION
When we apply colors to buttons, we apply a filter to the background
drawable. However, the default drawable is cached and reused across
all buttons. This causes problems when mixing buttons of the different
colors with buttons using the "default" color.

This change addresses the problem by making a copy of the background
drawable and applying the color to the copy so that the currently
rendered button doesn't adversely affect buttons that come after it in
the view hierarchy. This copy is done lazily at the time the color is
changed from "Default" to something else so that we can still benefit
from the reusability of the default button background drawable.

Fixes #1412 

Change-Id: I2be3b15df32b76a59a29f1e2aed41054f5bdd975