### PR TITLE
Add early escape when selecting the same component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -919,6 +919,11 @@ public final class MockForm extends MockContainer {
     YaFormEditor formEditor = (YaFormEditor) editor;
     boolean shouldSelectMultipleComponents = formEditor.getShouldSelectMultipleComponents();
     List<MockComponent> selectedComponents = formEditor.getSelectedComponents();
+    if (selectedComponents.size() == 1 && selectedComponents.contains(newSelectedComponent)) {
+      // Attempting to change the selection from old to new when they are the same breaks
+      // Marker drag. See https://github.com/mit-cml/appinventor-sources/issues/1936
+      return;
+    }
     if (shouldSelectMultipleComponents && selectedComponents.size() > 1 && formEditor.isSelectedComponent(newSelectedComponent)) {
       int index = selectedComponents.indexOf(newSelectedComponent);
       selectedComponent = selectedComponents.get((index == 0) ? 1 : index - 1);


### PR DESCRIPTION
Change-Id: I2fca8de2941613c938eaa0e9be0d391fa67c48f5