### PR TITLE
Remove "Make Generic" button from Form blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -47,7 +47,7 @@ Blockly.ComponentBlock.COMPONENT_SELECTOR = "COMPONENT_SELECTOR";
  * @param {Array.<{enabled,text,callback}>} options the menu options
  */
 Blockly.ComponentBlock.addGenericOption = function(block, options) {
-  if (block.type === 'component_event' && block.isGeneric) {
+  if ((block.type === 'component_event' && block.isGeneric) || block.typeName === 'Form') {
     return;  // Cannot make a generic component_event specific for now...
   }
 


### PR DESCRIPTION
#1928 fixed being able to use the typeblock to create generic blocks for the Form, but they could still be accessed by using the "Make Generic" context menu item.

This commit removes the "Make Generic" button from the Form blocks.