### PR TITLE
Convert \n in browser designer page

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -100,9 +100,18 @@ public final class MockLabel extends MockVisibleComponent {
   private void setTextProperty(String text) {
     savedText = text;
     if (getPropertyValue(PROPERTY_NAME_HTMLFORMAT).equals("True")) {
-      labelWidget.setHTML(SimpleHtmlSanitizer.sanitizeHtml(text).asString());
+      String sanitizedText = SimpleHtmlSanitizer.sanitizeHtml(text).asString();
+      labelWidget.setHTML(
+        (sanitizedText == null) ? 
+        sanitizedText : 
+        sanitizedText.replaceAll("\\\\n", "<br>")
+      );
     } else {
-      labelWidget.setText(text);
+      labelWidget.setText(
+        (text == null) ?
+        text :
+        text.replaceAll("\\\\n", "<br>")
+      );
     }
   }
 
@@ -140,6 +149,7 @@ public final class MockLabel extends MockVisibleComponent {
       setFontTypefaceProperty(newValue);
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TEXT)) {
+      Ode.CLog("case 1");
       setTextProperty(newValue);
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TEXTCOLOR)) {
@@ -147,6 +157,7 @@ public final class MockLabel extends MockVisibleComponent {
     } else if (propertyName.equals(PROPERTY_NAME_HTMLFORMAT)) {
       // Just need to re-set the saved text so it is displayed
       // either as HTML or text as appropriate
+      Ode.CLog("case 2");
       setTextProperty(savedText);
       refreshForm();
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -104,10 +104,10 @@ public final class MockLabel extends MockVisibleComponent {
       labelWidget.setHTML(
         (sanitizedText == null) ? 
         sanitizedText : 
-        sanitizedText.replaceAll("\\\\n", "<br>")
+        sanitizedText.replaceAll("\\n", "")
       );
     } else {
-      labelWidget.setText(
+      labelWidget.setHTML(
         (text == null) ?
         text :
         text.replaceAll("\\\\n", "<br>")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -104,7 +104,7 @@ public final class MockLabel extends MockVisibleComponent {
       labelWidget.setHTML(
         (sanitizedText == null) ? 
         sanitizedText : 
-        sanitizedText.replaceAll("\\n", "")
+        sanitizedText.replaceAll("\\\\n", " ")
       );
     } else {
       labelWidget.setHTML(

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -149,7 +149,6 @@ public final class MockLabel extends MockVisibleComponent {
       setFontTypefaceProperty(newValue);
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TEXT)) {
-      Ode.CLog("case 1");
       setTextProperty(newValue);
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TEXTCOLOR)) {
@@ -157,7 +156,6 @@ public final class MockLabel extends MockVisibleComponent {
     } else if (propertyName.equals(PROPERTY_NAME_HTMLFORMAT)) {
       // Just need to re-set the saved text so it is displayed
       // either as HTML or text as appropriate
-      Ode.CLog("case 2");
       setTextProperty(savedText);
       refreshForm();
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -99,8 +99,8 @@ public final class MockLabel extends MockVisibleComponent {
    */
   private void setTextProperty(String text) {
     savedText = text;
+    String sanitizedText = SimpleHtmlSanitizer.sanitizeHtml(text).asString();
     if (getPropertyValue(PROPERTY_NAME_HTMLFORMAT).equals("True")) {
-      String sanitizedText = SimpleHtmlSanitizer.sanitizeHtml(text).asString();
       labelWidget.setHTML(
         (sanitizedText == null) ? 
         sanitizedText : 
@@ -108,9 +108,9 @@ public final class MockLabel extends MockVisibleComponent {
       );
     } else {
       labelWidget.setHTML(
-        (text == null) ?
-        text :
-        text.replaceAll("\\\\n", "<br>")
+        (sanitizedText == null) ?
+        sanitizedText :
+        sanitizedText.replaceAll("\\\\n", "<br>")
       );
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -25,9 +25,9 @@ public final class MockLabel extends MockVisibleComponent {
   // GWT label widget used to mock a Simple Label
   private InlineHTML labelWidget;
 
-  private String savedText;     // Saved text, so if we change from
-                                // text to/from html we have the text
-                                // to set
+  private String savedText = "";     // Saved text, so if we change from
+                                     // text to/from html we have the text
+                                     // to set
 
   /**
    * Creates a new MockLabel component.
@@ -99,18 +99,15 @@ public final class MockLabel extends MockVisibleComponent {
    */
   private void setTextProperty(String text) {
     savedText = text;
-    String sanitizedText = SimpleHtmlSanitizer.sanitizeHtml(text).asString();
     if (getPropertyValue(PROPERTY_NAME_HTMLFORMAT).equals("True")) {
-      labelWidget.setHTML(
-        (sanitizedText == null) ? 
-        sanitizedText : 
-        sanitizedText.replaceAll("\\\\n", " ")
-      );
+      String sanitizedText = SimpleHtmlSanitizer.sanitizeHtml(text).asString();
+      if (sanitizedText != null) {
+        sanitizedText = sanitizedText.replaceAll("\\\\n", " ");
+      }
+      labelWidget.setHTML(sanitizedText);
     } else {
-      labelWidget.setHTML(
-        (sanitizedText == null) ?
-        sanitizedText :
-        sanitizedText.replaceAll("\\\\n", "<br>")
+      labelWidget.setHTML(text.replaceAll("&", "&amp;").replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;").replaceAll("\\\\n", "<br>")
       );
     }
   }


### PR DESCRIPTION
This PR renders line breaks for label components in the designer page when the user enters `\n` characters in the label text property. This addresses https://github.com/mit-cml/appinventor-sources/issues/1099.