### PR TITLE
Map empty URL to none for background-image CSS

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
@@ -59,7 +59,11 @@ public final class MockComponentsUtil {
    * @param image  URL
    */
   static void setWidgetBackgroundImage(Widget widget, String image) {
-    DOM.setStyleAttribute(widget.getElement(), "backgroundImage", "url(" + image + ')');
+    if (image.isEmpty()) {
+      DOM.setStyleAttribute(widget.getElement(), "backgroundImage", "none");
+    } else {
+      DOM.setStyleAttribute(widget.getElement(), "backgroundImage", "url(" + image + ')');
+    }
     DOM.setStyleAttribute(widget.getElement(), "backgroundRepeat", "no-repeat");
     DOM.setStyleAttribute(widget.getElement(), "backgroundPosition", "center");
     DOM.setStyleAttribute(widget.getElement(), "backgroundSize", "100% 100%");


### PR DESCRIPTION
When dragging a button or other component with an image from the
palette, its Image property is set, and when it is dropped, the
property is set again. This property is empty by default. In the
network devtools one can observe that this results in a request to the
root of the web server tagged as "img". This is because the
background-image CSS set in response to the Image property uses an
empty string URL, which will resolve against the base URL of the
page. This results in every new button created causing the browser to
fetch index.html twice. In production, we don't cache index.html so
that means every new button created by an App Inventor user causes
them to download ~6 kB of HTML that can't even be used. This fix
switches to setting background-image to none, which foregoes the
unnecessary network requests.

Change-Id: Ifc1165833b2c4aa9d412b0a929dca47381a0cfe8