### PR TITLE
Treat 'global' keyword as untranslatable internally

### DIFF
--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -258,6 +258,13 @@ Blockly.usePrefixInYail = false;
      + maybe index variables have prefix "index", or maybe instead they are treated as "param"
 */
 
+/**
+ * The global keyword. Users may be shown a translated keyword instead but this is the internal
+ * token used to identify global variables.
+ * @type {string}
+ * @const
+ */
+Blockly.GLOBAL_KEYWORD = 'global';  // used internally to identify global variables; not translated
 Blockly.procedureParameterPrefix = "input"; // For names introduced by procedure/function declarations
 Blockly.handlerParameterPrefix = "input"; // For names introduced by event handlers
 Blockly.localNamePrefix = "local"; // For names introduced by local variable declarations
@@ -292,6 +299,8 @@ Blockly.unprefixName = function (name) {
   if (name.indexOf(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX + Blockly.menuSeparator) == 0) {
     // Globals always have prefix, regardless of flags. Handle these specially
     return [Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX, name.substring(Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX.length + Blockly.menuSeparator.length)];
+  } else if (name.indexOf(Blockly.GLOBAL_KEYWORD + Blockly.menuSeparator) === 0) {
+    return [Blockly.GLOBAL_KEYWORD, name.substring(6 + Blockly.menuSeparator.length)];
   } else if (!Blockly.showPrefixToUser) {
     return ["", name];
   } else {

--- a/appinventor/blocklyeditor/src/generators/yail/variables.js
+++ b/appinventor/blocklyeditor/src/generators/yail/variables.js
@@ -90,7 +90,7 @@ Blockly.Yail['getVariableCommandAndName'] = function(name){
   var pair = Blockly.unprefixName(name);
   var prefix = pair[0];
   var unprefixedName = pair[1];
-  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
+  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX || prefix === Blockly.GLOBAL_KEYWORD) {
     name = Blockly.Yail.YAIL_GLOBAL_VAR_TAG + unprefixedName;
     command = Blockly.Yail.YAIL_GET_VARIABLE;
   } else {
@@ -106,7 +106,7 @@ Blockly.Yail['setVariableCommandAndName'] = function(name){
   var pair = Blockly.unprefixName(name);
   var prefix = pair[0];
   var unprefixedName = pair[1];
-  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX) {
+  if (prefix === Blockly.Msg.LANG_VARIABLES_GLOBAL_PREFIX || prefix === Blockly.GLOBAL_KEYWORD) {
     name = Blockly.Yail.YAIL_GLOBAL_VAR_TAG + unprefixedName;
     command = Blockly.Yail.YAIL_SET_VARIABLE;
   } else {


### PR DESCRIPTION
In the block name we store globals as 'global foo' where foo is the
variable name. In Korean and Polish, the 'global' keyword has been
translated for the blocks, but interally we still call the variable
'global foo' even though the keyword shown to the user is
translated. However, because the functionality to unprefix names
references the translated name it causes bad code generation for
languages where the global keyword isn't the string 'global'. This
change introduces a GLOBAL_KEYWORD constant that is checked to
identify globals where the user locale may provide a translation.

Change-Id: Id18331206c28592c145bc2a1d915bcecc0799f13