### PR TITLE
Implement accept attribute on file inputs

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidGeoJSONPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidGeoJSONPropertyEditor.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2016-2017 MIT, All rights reserved
+// Copyright 2016-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import java.util.Collections;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
 
@@ -91,7 +92,8 @@ public class YoungAndroidGeoJSONPropertyEditor extends AdditionalChoicePropertyE
             closeAdditionalChoiceDialog(true);
           }
         };
-        FileUploadWizard uploader = new FileUploadWizard(assetsFolder, callback);
+        FileUploadWizard uploader = new FileUploadWizard(assetsFolder,
+            Collections.singleton(".geojson"), callback);
         uploader.show();
       }
     });

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/ComponentImportWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/ComponentImportWizard.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2015 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -230,6 +230,7 @@ public class ComponentImportWizard extends Wizard {
   private FileUpload createFileUpload() {
     FileUpload upload = new FileUpload();
     upload.setName(ServerLayout.UPLOAD_COMPONENT_ARCHIVE_FORM_ELEMENT);
+    upload.getElement().setAttribute("accept", COMPONENT_ARCHIVE_EXTENSION);
     return upload;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/ComponentUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/ComponentUploadWizard.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2015 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -30,6 +30,7 @@ public class ComponentUploadWizard extends Wizard {
     super(MESSAGES.componentUploadWizardCaption(), true, false);
 
     final FileUpload uploadWiget = new FileUpload();
+    uploadWiget.getElement().setAttribute("accept", COMPONENT_ARCHIVE_EXTENSION);
     uploadWiget.setName(ServerLayout.UPLOAD_COMPONENT_ARCHIVE_FORM_ELEMENT);
 
     VerticalPanel panel = new VerticalPanel();

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadWizard.java
@@ -1,14 +1,12 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.wizards;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
-
-import java.io.File;
 
 import com.google.appinventor.client.ErrorReporter;
 import com.google.appinventor.client.Ode;
@@ -24,25 +22,17 @@ import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetNode;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.FileUpload;
 import com.google.gwt.user.client.ui.VerticalPanel;
-import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.DialogBox;
-import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HasHorizontalAlignment;
-import com.google.gwt.user.client.ui.HasVerticalAlignment;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.Label;
+import java.util.Collection;
 
 
 /**
@@ -53,7 +43,7 @@ public class FileUploadWizard extends Wizard {
   /**
    * Interface for callback to execute after a file is uploaded.
    */
-  public static interface FileUploadedCallback {
+  public interface FileUploadedCallback {
     /**
      * Will be invoked after a file is uploaded.
      *
@@ -78,12 +68,27 @@ public class FileUploadWizard extends Wizard {
    * @param folderNode the upload destination folder
    * @param fileUploadedCallback callback to be executed after upload
    */
+  public FileUploadWizard(FolderNode folderNode, FileUploadedCallback fileUploadedCallback) {
+    this(folderNode, null, fileUploadedCallback);
+  }
+
+  /**
+   * Creates a new file upload wizard.
+   *
+   * @param folderNode the upload destination folder
+   * @param acceptableTypes a collection of acceptable types, or null.
+   * @param fileUploadedCallback callback to be executed after upload
+   */
   public FileUploadWizard(final FolderNode folderNode,
+      final Collection<String> acceptableTypes,
       final FileUploadedCallback fileUploadedCallback) {
     super(MESSAGES.fileUploadWizardCaption(), true, false);
 
     // Initialize UI
     final FileUpload upload = new FileUpload();
+    if (acceptableTypes != null) {
+      upload.getElement().setAttribute("accept", String.join(",", acceptableTypes));
+    }
     upload.setName(ServerLayout.UPLOAD_FILE_FORM_ELEMENT);
     setStylePrimaryName("ode-DialogBox");
     VerticalPanel panel = new VerticalPanel();
@@ -100,11 +105,11 @@ public class FileUploadWizard extends Wizard {
           final String filename = makeValidFilename(uploadFilename);
           if(!TextValidators.isValidCharFilename(filename)){
             createErrorDialog(MESSAGES.malformedFilenameTitle(), MESSAGES.malformedFilename(),
-              Error.NOFILESELECETED, folderNode, fileUploadedCallback);
+              Error.NOFILESELECETED, folderNode, acceptableTypes, fileUploadedCallback);
             return;
           } else if (!TextValidators.isValidLengthFilename(filename)){
             createErrorDialog(MESSAGES.filenameBadSizeTitle(), MESSAGES.filenameBadSize(),
-              Error.FILENAMEBADSIZE, folderNode, fileUploadedCallback);
+              Error.FILENAMEBADSIZE, folderNode, acceptableTypes, fileUploadedCallback);
             return;
           }
           int nameLength = uploadFilename.length();
@@ -112,7 +117,7 @@ public class FileUploadWizard extends Wizard {
 
           if (".aia".equals(fileEnd.toLowerCase())) {
             createErrorDialog(MESSAGES.aiaMediaAssetTitle(), MESSAGES.aiaMediaAsset(),
-              Error.AIAMEDIAASSET, folderNode, fileUploadedCallback);
+              Error.AIAMEDIAASSET, folderNode, acceptableTypes, fileUploadedCallback);
             return;
           }
           String fn = conflictingExistingFile(folderNode, filename);
@@ -172,7 +177,7 @@ public class FileUploadWizard extends Wizard {
           });
         } else {
           createErrorDialog(MESSAGES.noFileSelectedTitle(), MESSAGES.noFileSelected(),
-              Error.NOFILESELECETED, folderNode, fileUploadedCallback);
+              Error.NOFILESELECETED, folderNode, acceptableTypes, fileUploadedCallback);
         }
       }
     });
@@ -244,7 +249,8 @@ public class FileUploadWizard extends Wizard {
   }
 
   private void createErrorDialog(String title, String body, Error e,
-      final FolderNode folderNode, final FileUploadedCallback fileUploadedCallback) {
+      final FolderNode folderNode, final Collection<String> acceptableTypes,
+      final FileUploadedCallback fileUploadedCallback) {
     final DialogBox dialogBox = new DialogBox(false,true);
     HTML message;
     dialogBox.setStylePrimaryName("ode-DialogBox");
@@ -259,7 +265,7 @@ public class FileUploadWizard extends Wizard {
     ok.addClickListener(new ClickListener() {
       public void onClick(Widget sender) {
         dialogBox.hide();
-        new FileUploadWizard(folderNode, fileUploadedCallback).show();
+        new FileUploadWizard(folderNode, acceptableTypes, fileUploadedCallback).show();
       }
     });
     holder.add(ok);

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/KeystoreUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/KeystoreUploadWizard.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -37,6 +37,7 @@ public class KeystoreUploadWizard extends Wizard {
     // Initialize UI
     final FileUpload upload = new FileUpload();
     upload.setName(ServerLayout.UPLOAD_USERFILE_FORM_ELEMENT);
+    upload.getElement().setAttribute("accept", KEYSTORE_EXTENSION);
     setStylePrimaryName("ode-DialogBox");
     VerticalPanel panel = new VerticalPanel();
     panel.setVerticalAlignment(VerticalPanel.ALIGN_MIDDLE);

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/ProjectUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/ProjectUploadWizard.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -39,6 +39,7 @@ public class ProjectUploadWizard extends Wizard {
     // Initialize UI
     final FileUpload upload = new FileUpload();
     upload.setName(ServerLayout.UPLOAD_PROJECT_ARCHIVE_FORM_ELEMENT);
+    upload.getElement().setAttribute("accept", PROJECT_ARCHIVE_EXTENSION);
     setStylePrimaryName("ode-DialogBox");
     VerticalPanel panel = new VerticalPanel();
     panel.setVerticalAlignment(VerticalPanel.ALIGN_MIDDLE);


### PR DESCRIPTION
This PR is a minor usability improvement on newer browsers that understand the accept attribute on file input elements. It sets the accept attribute to the relevant extension for different file upload wizards to prevent accidental selection of invalid file types.

Change-Id: Id9052e79785ed1a53f5654970a46c7002df350de