### PR TITLE
Add ant flag force.builddocs

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -90,17 +90,19 @@
        ===================================================================== -->
   <target name="BuildDocs" depends="components_Markdown,CheckDocs"
           unless="Docs.uptodate">
+    <!-- Jenkins will pass -Dforce.builddocs=true to ensure docs build correctly -->
+    <property name="force.builddocs" value="false" />
     <!-- We set failifexecutionfails to false so the whole build doesn't fail
          if the developer doesn't have Jekyll set up -->
-    <exec executable="bundle" failonerror="true"
-          failifexecutionfails="false"
+    <exec executable="bundle" failonerror="${force.builddocs}"
+          failifexecutionfails="${force.builddocs}"
           dir="${docs.dir}/markdown" >
       <arg value="install" />
       <arg value="--path" />
       <arg value="vendor/bundle" />
     </exec>
-    <exec executable="bundle" failonerror="true"
-          failifexecutionfails="false"
+    <exec executable="bundle" failonerror="${force.builddocs}"
+          failifexecutionfails="${force.builddocs}"
           dir="${docs.dir}/markdown" >
       <arg value="exec" />
       <arg value="jekyll" />


### PR DESCRIPTION
This change adds a property force.builddocs to the build script that
controls whether a failure to successfully execute Jekyll constitutes
a build failure or not. It defaults to false. In Jenkins we will set
it to true so that builds fail if they cause jekyll to fail. This way
people who do not have Jekyll installed can continue to work with the
sources. Since everything needs to pass Jenkins before being merged,
maintainers can run Jekyll to update the docs prior to merging.

Change-Id: I9fb22eea7582fb5ba5a83069778c23a40c14aaa8