### PR TITLE
Fix potential resource leak in JsonUtil

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/JsonUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/JsonUtil.java
@@ -296,6 +296,7 @@ public class JsonUtil {
    * @return the name of the created file
    */
   private static String writeFile(String input, String fileExtension) {
+    FileOutputStream outStream = null;
     try {
       if (fileExtension.length() != 3 && fileExtension.length() != 4) {
         throw new YailRuntimeError("File Extension must be three or four characters", "Write Error");
@@ -305,14 +306,15 @@ public class JsonUtil {
       File destDirectory = new File(fullDirName);
       destDirectory.mkdirs();
       File dest = File.createTempFile("BinFile", "." + fileExtension, destDirectory);
-      FileOutputStream outStream = new FileOutputStream(dest);
+      outStream = new FileOutputStream(dest);
       outStream.write(content);
-      outStream.close();
       String retval = dest.toURI().toASCIIString();
       trimDirectory(20, destDirectory);
       return retval;
     } catch (Exception e) {
       throw new YailRuntimeError(e.getMessage(), "Write");
+    } finally {
+      IOUtils.closeQuietly(LOG_TAG, outStream);
     }
   }
 


### PR DESCRIPTION
While working on dictionaries I noticed that in the JsonUtil class we create a file and don't close it as part of a `finally` block. If an `IOException` is thrown when trying to write, this may end up with the file handle being leaked. Ideally we could use try-with-resources but Android only supports this back to Android 7.0, so I opted to use the traditional try-catch-finally approach.

Change-Id: I222d4df3a05ef7ab0f431d2b53ec65a0c008c38a