### PR TITLE
JsonComponentDescription is needed for buildserver

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -48,7 +48,8 @@
        the jars needed to compile the build server classes.
        ===================================================================== -->
   <target name="BuildServer"
-          depends="init,CopyToRunLibDir,components_AndroidRuntime,components_Barcode,components_ComponentList">
+          depends="init,CopyToRunLibDir,components_AndroidRuntime,components_Barcode,components_ComponentList,
+                                        components_JsonComponentDescription">
     <property name="BuildServer-class.dir" location="${class.dir}/BuildServer" />
     <mkdir dir="${BuildServer-class.dir}" />
 


### PR DESCRIPTION
I was running some tests on appinventor-sources, when I encountered this error:

```
Jan 17, 2020 6:04:40 PM com.google.appinventor.buildserver.ProjectBuilder extractProjectFiles
INFO: extracting C:\Users\DIEGOB~1\AppData\Local\Temp\1579280680360_0.9328654067156685-0\youngandroidproject\project.properties from input zip
java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:191)
	at com.google.common.io.Resources$UrlByteSource.<init>(Resources.java:77)
	at com.google.common.io.Resources$UrlByteSource.<init>(Resources.java:72)
	at com.google.common.io.Resources.asByteSource(Resources.java:66)
	at com.google.common.io.Resources.asCharSource(Resources.java:111)
	at com.google.common.io.Resources.toString(Resources.java:136)
	at com.google.appinventor.buildserver.ProjectBuilder.createNameTypeMap(ProjectBuilder.java:318)
	at com.google.appinventor.buildserver.ProjectBuilder.getComponentTypes(ProjectBuilder.java:248)
	at com.google.appinventor.buildserver.ProjectBuilder.build(ProjectBuilder.java:157)
	at com.google.appinventor.buildserver.Main.main(Main.java:100)
C:\Github\appinventor-sources\appinventor\buildserver\build.xml:189: Java returned: 1
C:\Github\appinventor-sources\appinventor\buildserver\build.xml:189: Java returned: 1
C:\Github\appinventor-sources\appinventor\build.xml:59: The following error occurred while executing this line:
C:\Github\appinventor-sources\appinventor\build.xml:59: The following error occurred while executing this line:
C:\Github\appinventor-sources\appinventor\build.xml:59: The following error occurred while executing this line:

Ant build completed with 5 errors and 52 warnings in 48s at 17/01/2020 18:04
```

Then, after checking the backtrace, I saw the error was because this line was returning `null`.
https://github.com/mit-cml/appinventor-sources/blob/master/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java#L319

So then realized that "simple_components.json" was needed to run the buildserver. However, the ant target was not dependent on the target that builds it.
The \*funny\* thing about this is that I discovered it playing with companion, not with buildserver itself. Time ago, I encountered some errors on buildserver that it was returning NPE when building apps. But I didn't give importance, and "mysteriously" found that they don't happen if I first run `ant noplay` and then `ant RunLocalBuildServer`. Today I saw that it was because I was running `ant RunLocalBuildServer` without having previously generated the "simple_components.json" file.

**This PR fixes both `ant PlayApp` and `ant RunLocalBuildServer` when they are executed on a clean build.**

---

TESTED

- Before this change, executing `ant clean` and then `ant PlayApp` fails
- After this change, executing `ant clean` and then `ant PlayApp` works