### PR TITLE
ComponentProcessor should use helpUrl and not description

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1138,7 +1138,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
   private void processDescriptions(ComponentInfo info) {
     final String name = info.displayName;
     info.description = info.description.replaceAll(TYPE_PLACEHOLDER, name);
-    info.helpUrl = info.description.replaceAll(TYPE_PLACEHOLDER, name);
+    info.helpUrl = info.helpUrl.replaceAll(TYPE_PLACEHOLDER, name);
     for (Property property : info.properties.values()) {
       property.description = property.description.replaceAll(TYPE_PLACEHOLDER, name);
     }


### PR DESCRIPTION
Probably a copy-paste error. It has been forgotten to change `description` to `helpUrl`.
Fixes https://community.appinventor.mit.edu/t/bug-in-class-componentprocessor/2718

EDIT: This is the PR number 2000! 🎉 

---

TESTED:
- `ant components_JsonComponentDescription` builds the right _simple\_components.json_ file

---

PENDING:
- Add a regression test