### PR TITLE
Fix automatic sizing of mock toggle components

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
@@ -1,15 +1,13 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2018 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.editor.simple.components;
 
 import com.google.appinventor.client.editor.simple.SimpleEditor;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Widget;
 
 /**
  * Mock CheckBox component, inherited from MockToggleBase
@@ -32,27 +30,6 @@ public final class MockCheckBox extends MockToggleBase<CheckBox> {
     super(editor, TYPE, images.checkbox());
     toggleWidget = new CheckBox();
     initWrapper(toggleWidget);
-  }
-
-  /**
-   * Class that extends CheckBox so we can use a protected constructor.
-   *
-   * <p/>The purpose of this class is to create a clone of the CheckBox
-   * passed to the constructor. It will be used to determine the preferred size
-   * of the CheckBox, without having the size constrained by its parent,
-   * since the cloned CheckBox won't have a parent.
-   */
-  static class ClonedCheckBox extends CheckBox {
-    ClonedCheckBox(CheckBox ptb) {
-      // Get the Element from the CheckBox.
-      // Call DOM.clone to make a deep clone of that element.
-      // Pass that cloned element to the super constructor.
-      super(DOM.clone(ptb.getElement().getFirstChildElement(), true));
-    }
-  }
-
-  protected Widget createClonedWidget() {
-    return new ClonedCheckBox(toggleWidget);
   }
 
   /*

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
@@ -1,14 +1,11 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2017 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.client.editor.simple.components;
 
-// import com.google.gwt.event.dom.client.LoadEvent;
-// import com.google.gwt.event.dom.client.LoadHandler;
-import com.google.gwt.event.shared.GwtEvent.Type;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Timer;
@@ -280,7 +277,10 @@ public final class MockComponentsUtil {
    *         0 and height at index 1.
    */
   static String[] clearSizeStyle(Widget w) {
-    Element element = w.getElement();
+    return clearSizeStyle(w.getElement());
+  }
+
+  static String[] clearSizeStyle(Element element) {
     String widthStyle = DOM.getStyleAttribute(element, "width");
     String heightStyle = DOM.getStyleAttribute(element, "height");
     String lineHeightStyle = DOM.getStyleAttribute(element, "lineHeight");
@@ -304,7 +304,10 @@ public final class MockComponentsUtil {
    *        and height at index 1.
    */
   static void restoreSizeStyle(Widget w, String[] style) {
-    Element element = w.getElement();
+    restoreSizeStyle(w.getElement(), style);
+  }
+
+  static void restoreSizeStyle(Element element, String[] style) {
     if (style[0] != null) {
       DOM.setStyleAttribute(element, "width", style[0]);
     }
@@ -365,6 +368,30 @@ public final class MockComponentsUtil {
     // Detach the widget from the DOM before returning
     RootPanel.get().remove(w);
 
+    return new int[] { width, height };
+  }
+
+  /**
+   * Returns the preferred size of the specified DOM element in an array of the
+   * form {@code [width, height]}.
+   *
+   * @see #getPreferredSizeOfDetachedWidget(Widget)
+   * @param element the DOM element to compute the size for
+   * @return the natural width and height of the element
+   */
+  public static int[] getPreferredSizeOfElement(Element element) {
+    Element root = RootPanel.get().getElement();
+    root.appendChild(element);
+
+    String[] style = clearSizeStyle(element);
+    int width = element.getOffsetWidth() + 4;
+    int height = element.getOffsetHeight() + 6;
+    if (height < 26) {
+      height = 26;
+    }
+    restoreSizeStyle(element, style);
+
+    root.removeChild(element);
     return new int[] { width, height };
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2018 MIT, All rights reserved
+// Copyright 2018-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -12,7 +12,6 @@ import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.InlineHTML;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Widget;
 
 /**
  * Mock Switch component, inherited from MockToggleBase
@@ -52,26 +51,6 @@ public final class MockSwitch extends MockToggleBase<HorizontalPanel> {
     isInitialized = false;
     initWrapper(toggleWidget);
   }
-
-  /**
-   * Class that extends Widget so we can use a protected constructor.
-   *
-   * <p/>The purpose of this class is to create a clone of the Switch
-   * passed to the constructor. It will be used to determine the preferred size
-   * of the Switch, without having the size constrained by its parent,
-   * since the cloned Switch won't have a parent.
-   */
-  static class ClonedSwitch extends InlineHTML {
-    ClonedSwitch(HorizontalPanel ptb) {
-      super(DOM.clone(ptb.getWidget(0).getElement(), true));
-    }
-  }
-
-  @Override
-  protected Widget createClonedWidget() {
-    return new ClonedSwitch(toggleWidget);
-  }
-
 
   /**
    * Draw the SVG graphic of the toggle switch. It can be drawn in either checked or

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2016-2018 MIT, All rights reserved
+// Copyright 2016-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -7,6 +7,7 @@ package com.google.appinventor.client.editor.simple.components;
 
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
@@ -25,7 +26,10 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper {
     super(editor, type, icon);
   }
 
-  abstract protected Widget createClonedWidget();
+  protected final Widget createClonedWidget() {
+    // We override updatePreferredSize directly, so this shouldn't be called.
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   public void onCreateFromPalette() {
@@ -135,5 +139,10 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper {
     } else if (propertyName.equals(PROPERTY_NAME_TEXTCOLOR)) {
       setTextColorProperty(newValue);
     }
+  }
+
+  protected void updatePreferredSize() {
+    preferredSize = MockComponentsUtil
+        .getPreferredSizeOfElement(DOM.clone(toggleWidget.getElement(), true));
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockWrapper.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockWrapper.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -26,7 +26,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 abstract class MockWrapper extends MockVisibleComponent {
   private final SimplePanel wrapper;
-  private int[] preferredSize;
+  protected int[] preferredSize;
 
   MockWrapper(SimpleEditor editor, String type, ImageResource icon) {
     super(editor, type, icon);
@@ -55,7 +55,7 @@ abstract class MockWrapper extends MockVisibleComponent {
    */
   protected abstract Widget createClonedWidget();
 
-  protected final void updatePreferredSize() {
+  protected void updatePreferredSize() {
     preferredSize = MockComponentsUtil.getPreferredSizeOfDetachedWidget(createClonedWidget());
   }
 


### PR DESCRIPTION
The fix that I made in #1984 caused the sizing algorithm of the CheckBox and Switch components to break. This change corrects that. Rather than needing to create a cloned widget, I've modified it so that we can pass (clones of) DOM elements directly to compute the size.

NB: This also reveals an ugly underside of App Inventor which is that we create a copy of a component every time you change a property and then immediately throw it away. A problem for a different day.

Tested in Chrome, Firefox, and Safari on macOS. Tested in standard dev server, super dev mode server, and with optimizations turned on.

Change-Id: If974657cfe9b5d44768779a465580a29034f352a