### PR TITLE
Address issue with userVisible annotation param

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -284,7 +284,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append(", \"type\": \"");
     sb.append(javaTypeToYailType(prop.getType()));
     sb.append("\", \"rw\": \"");
-    sb.append(prop.isUserVisible() ? prop.getRwString() : "invisible");
+    sb.append(prop.isUserVisible() ? prop.getRwString() : "read-only");
     // [lyn, 2015/12/20] Added deprecated field to JSON.
     // If we want to save space in simple-components.json,
     // we could include this field only when it is "true"


### PR DESCRIPTION
Getter block not showing. Since this code affects all components, needs further discussion / testing:

![image](https://user-images.githubusercontent.com/8935543/75193777-da3b9b00-5724-11ea-9a4c-fd69d2141e4b.png)

According to annotation, getter block should be visible:
![image](https://user-images.githubusercontent.com/8935543/75193832-048d5880-5725-11ea-9a62-7f9f48176e8c.png)
