### PR TITLE
Add scroll arrangement functionality with their non scrollable counterpart.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -34,6 +34,7 @@ import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 
+import javax.swing.*;
 import java.io.IOException;
 
 /**
@@ -86,7 +87,6 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     context = container.$context();
 
     this.orientation = orientation;
-    this.scrollable = scrollable;
     viewLayout = new LinearLayout(context, orientation,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT);
@@ -98,33 +98,8 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     alignmentSetter.setHorizontalAlignment(horizontalAlignment);
     alignmentSetter.setVerticalAlignment(verticalAlignment);
 
-    if (scrollable) {
-      switch (orientation) {
-      case LAYOUT_ORIENTATION_VERTICAL:
-        Log.d(LOG_TAG, "Setting up frameContainer = ScrollView()");
-        frameContainer = new ScrollView(context);
-        break;
-      case LAYOUT_ORIENTATION_HORIZONTAL:
-        Log.d(LOG_TAG, "Setting up frameContainer = HorizontalScrollView()");
-        frameContainer = new HorizontalScrollView(context);
-        break;
-      }
-    } else {
-      Log.d(LOG_TAG, "Setting up frameContainer = FrameLayout()");
-      frameContainer = new FrameLayout(context);
-    }
-
-    frameContainer.setLayoutParams(new ViewGroup.LayoutParams(ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH, ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT));
-    frameContainer.addView(viewLayout.getLayoutManager(), new ViewGroup.LayoutParams(
-        ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT));
-
-      // Save the default values in case the user wants them back later.
-    defaultButtonDrawable = getView().getBackground();
-
-    container.$add(this);
+    Scrollable(false);
     BackgroundColor(Component.COLOR_DEFAULT);
-
   }
 
 
@@ -365,6 +340,66 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
         // Update the appearance based on the new value of backgroundImageDrawable.
         updateAppearance();
     }
+
+  /**
+   * Scrollable Property Getter method
+   *
+   * @return true if the frameContainer is scrollable.
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+          description = "When checked, the horizontal/vertical view will be scrollable."
+                  + "i.e the height/width of the view can exceed the physical height/width of"
+                  + "the device. When unchecked, the view's height/width is constrained to the"
+                  + "height/width of the device.")
+  public boolean Scrollable() {
+    return scrollable;
+  }
+
+  /**
+   * Scrollable property setter method.
+   *
+   * @param scrollable  true if the view should be scrollable
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+          defaultValue = "False")
+  @SimpleProperty
+  public void Scrollable(boolean scrollable) {
+    this.scrollable = scrollable;
+    recomputeLayout();
+  }
+
+  private void recomputeLayout() {
+    if(frameContainer != null) {
+      frameContainer.removeAllViews();
+    }
+
+    if (scrollable) {
+      switch (orientation) {
+        case LAYOUT_ORIENTATION_VERTICAL:
+          Log.d(LOG_TAG, "Setting up frameContainer = ScrollView()");
+          frameContainer = new ScrollView(context);
+          break;
+        case LAYOUT_ORIENTATION_HORIZONTAL:
+          Log.d(LOG_TAG, "Setting up frameContainer = HorizontalScrollView()");
+          frameContainer = new HorizontalScrollView(context);
+          break;
+      }
+    } else {
+      Log.d(LOG_TAG, "Setting up frameContainer = FrameLayout()");
+      frameContainer = new FrameLayout(context);
+    }
+
+    frameContainer.setLayoutParams(new ViewGroup.LayoutParams(ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH, ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT));
+    frameContainer.addView(viewLayout.getLayoutManager(), new ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT));
+
+    // Save the default values in case the user wants them back later.
+    defaultButtonDrawable = getView().getBackground();
+
+    container.$add(this);
+  }
+
 
 
   // Update appearance based on values of backgroundImageDrawable, backgroundColor and shape.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
@@ -18,6 +18,7 @@ import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.PermissionException;
+import com.google.appinventor.components.runtime.util.BulkPermissionRequest;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
 import android.Manifest;
@@ -158,26 +159,22 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
    */
   @SimpleFunction
   public void Start() {
-      // Need to check if we have RECORD_AUDIO permission
+    // Need to check if we have RECORD_AUDIO and WRITE_EXTERNAL permissions
     if (!havePermission) {
       final SoundRecorder me = this;
       form.runOnUiThread(new Runnable() {
-          @Override
-          public void run() {
-            form.askPermission(Manifest.permission.RECORD_AUDIO,
-              new PermissionResultHandler() {
-                @Override
-                public void HandlePermissionResponse(String permission, boolean granted) {
-                  if (granted) {
-                    me.havePermission = true;
-                    me.Start();
-                  } else {
-                    form.dispatchPermissionDeniedEvent(me, "Start", Manifest.permission.RECORD_AUDIO);
-                  }
-                }
-              });
-          }
-        });
+        @Override
+        public void run() {
+          form.askPermission(new BulkPermissionRequest(me, "AudioRecord",
+                  Manifest.permission.RECORD_AUDIO, Manifest.permission.WRITE_EXTERNAL_STORAGE) {
+            @Override
+            public void onGranted() {
+              me.havePermission = true;
+              me.Start();
+            }
+          });
+        }
+      });
       return;
     }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SoundRecorder.java
@@ -165,7 +165,7 @@ public final class SoundRecorder extends AndroidNonvisibleComponent
       form.runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          form.askPermission(new BulkPermissionRequest(me, "AudioRecord",
+          form.askPermission(new BulkPermissionRequest(me, "Start",
                   Manifest.permission.RECORD_AUDIO, Manifest.permission.WRITE_EXTERNAL_STORAGE) {
             @Override
             public void onGranted() {


### PR DESCRIPTION
@ewpatton I've added the scrollable property to HVArrangement. Kindle review.
Solves #1106 
During testing, I'm facing an issue. Whenever we switch the scrollable property, a new instance of the respective view group is created and added at the end of the Component Container. For this, we need to have a method that would replace the view group at the same index in the component container.
Can you please help me out with the same? 
I've attached below a couple of screenshots. The first one of them is before checking the scrollable property and the other one is after checking the scrollable property.
![WhatsApp Image 2020-02-25 at 7 44 09 PM](https://user-images.githubusercontent.com/49081775/75255205-9077b100-5807-11ea-9d3c-9ca835963941.jpeg)

Thank you.
