### PR TITLE
Merge scroll arrangement functionality with their non-scrollable counterparts

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1054,6 +1054,10 @@ public final class YoungAndroidFormUpgrader {
       // - Added background color & image
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // - The Scrollable property was added.
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 
@@ -1409,6 +1413,10 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 3) {
       // - Added background color & image
       srcCompVersion = 3;
+    }
+    if (srcCompVersion < 4) {
+      // - The Scrollable property was added.
+      srcCompVersion = 4;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1559,7 +1559,11 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // - Added background color & image
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // - The Scrollable property was added
+    // No blocks need to be modified to upgrade to version 4.
+    4: "noUpgrade"
 
   }, // End HorizontalArrangement upgraders
 
@@ -2546,7 +2550,11 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // - Added background color & image
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // - The Scrollable property was added
+    // No blocks need to be modified to upgrade to version 4.
+    4: "noUpgrade"
 
   }, // End VerticalArrangement upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -491,8 +491,12 @@ public class YaVersion {
   // For YOUNG_ANDROID_VERSION 197:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 28
   // - WEB_COMPONENT_VERSION was incremented to 7
+  // For YOUNG_ANDROID_VERSION 198:
+  // - HORIZONTALARRANGEMENT_COMPONENT_VERSION was incremented to 4
+  // - VERTICALARRANGEMENT_COMPONENT_VERSION was incremented to 4
 
-  public static final int YOUNG_ANDROID_VERSION = 197;
+
+  public static final int YOUNG_ANDROID_VERSION = 198;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -866,7 +870,9 @@ public class YaVersion {
   // - The AlignVertical property was added
   // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 3:
   // - Added background color & image
-  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 3;
+  // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 4:
+  // - The Scrollable property was added
+  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 4;
 
   public static final int HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION = 1;
 
@@ -1232,7 +1238,9 @@ public class YaVersion {
   // - The AlignVertical property was added
   // For VERTICALARRANGEMENT_COMPONENT_VERSION 3:
   // - Added background color & image
-  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 3;
+  // For VERTICALARRANGEMENT_COMPONENT_VERSION 4:
+  // - The Scrollable property was added
+  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 4;
 
   public static final int VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION = 1;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -86,7 +86,6 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     context = container.$context();
 
     this.orientation = orientation;
-    this.scrollable = scrollable;
     viewLayout = new LinearLayout(context, orientation,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH,
         ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT);
@@ -98,31 +97,7 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     alignmentSetter.setHorizontalAlignment(horizontalAlignment);
     alignmentSetter.setVerticalAlignment(verticalAlignment);
 
-    if (scrollable) {
-      switch (orientation) {
-      case LAYOUT_ORIENTATION_VERTICAL:
-        Log.d(LOG_TAG, "Setting up frameContainer = ScrollView()");
-        frameContainer = new ScrollView(context);
-        break;
-      case LAYOUT_ORIENTATION_HORIZONTAL:
-        Log.d(LOG_TAG, "Setting up frameContainer = HorizontalScrollView()");
-        frameContainer = new HorizontalScrollView(context);
-        break;
-      }
-    } else {
-      Log.d(LOG_TAG, "Setting up frameContainer = FrameLayout()");
-      frameContainer = new FrameLayout(context);
-    }
-
-    frameContainer.setLayoutParams(new ViewGroup.LayoutParams(ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH, ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT));
-    frameContainer.addView(viewLayout.getLayoutManager(), new ViewGroup.LayoutParams(
-        ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT));
-
-      // Save the default values in case the user wants them back later.
-    defaultButtonDrawable = getView().getBackground();
-
-    container.$add(this);
+    Scrollable(false);
     BackgroundColor(Component.COLOR_DEFAULT);
 
   }
@@ -365,6 +340,65 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
         // Update the appearance based on the new value of backgroundImageDrawable.
         updateAppearance();
     }
+
+  /**
+   * Scrollable Property Getter method
+   *
+   * @return true if the frameContainer is scrollable.
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+          description = "When checked, the horizontal/vertical view will be scrollable."
+                  + "i.e the height/width of the view can exceed the physical height/width of"
+                  + "the device. When unchecked, the view's height/width is constrained to the"
+                  + "height/width of the device.")
+  public boolean Scrollable() {
+    return scrollable;
+  }
+
+  /**
+   * Scrollable property setter method.
+   *
+   * @param scrollable  true if the view should be scrollable
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+          defaultValue = "False")
+  @SimpleProperty
+  public void Scrollable(boolean scrollable) {
+    this.scrollable = scrollable;
+    recomputeLayout();
+  }
+
+  private void recomputeLayout() {
+    if(frameContainer != null) {
+      frameContainer.removeAllViews();
+    }
+
+    if (scrollable) {
+      switch (orientation) {
+        case LAYOUT_ORIENTATION_VERTICAL:
+          Log.d(LOG_TAG, "Setting up frameContainer = ScrollView()");
+          frameContainer = new ScrollView(context);
+          break;
+        case LAYOUT_ORIENTATION_HORIZONTAL:
+          Log.d(LOG_TAG, "Setting up frameContainer = HorizontalScrollView()");
+          frameContainer = new HorizontalScrollView(context);
+          break;
+      }
+    } else {
+      Log.d(LOG_TAG, "Setting up frameContainer = FrameLayout()");
+      frameContainer = new FrameLayout(context);
+    }
+
+    frameContainer.setLayoutParams(new ViewGroup.LayoutParams(ComponentConstants.EMPTY_HV_ARRANGEMENT_WIDTH, ComponentConstants.EMPTY_HV_ARRANGEMENT_HEIGHT));
+    frameContainer.addView(viewLayout.getLayoutManager(), new ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT));
+
+    // Save the default values in case the user wants them back later.
+    defaultButtonDrawable = getView().getBackground();
+
+    container.$add(this);
+  }
 
 
   // Update appearance based on values of backgroundImageDrawable, backgroundColor and shape.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -97,7 +97,7 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     alignmentSetter.setHorizontalAlignment(horizontalAlignment);
     alignmentSetter.setVerticalAlignment(verticalAlignment);
 
-    Scrollable(false);
+    Scrollable(scrollable);
     BackgroundColor(Component.COLOR_DEFAULT);
 
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HorizontalScrollArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HorizontalScrollArrangement.java
@@ -6,9 +6,12 @@
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
+import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 
 /**
@@ -34,6 +37,14 @@ public class HorizontalScrollArrangement extends HVArrangement {
   public HorizontalScrollArrangement(ComponentContainer container) {
     super(container, ComponentConstants.LAYOUT_ORIENTATION_HORIZONTAL,
       ComponentConstants.SCROLLABLE_ARRANGEMENT);
+  }
+
+  @Override
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+          defaultValue = "True")
+  @SimpleProperty
+  public void Scrollable(boolean scrollable) {
+    super.Scrollable(scrollable);
   }
 
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VerticalScrollArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VerticalScrollArrangement.java
@@ -6,9 +6,12 @@
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
+import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 
 /**
@@ -37,6 +40,14 @@ public class VerticalScrollArrangement extends HVArrangement {
   public VerticalScrollArrangement(ComponentContainer container) {
     super(container, ComponentConstants.LAYOUT_ORIENTATION_VERTICAL,
       ComponentConstants.SCROLLABLE_ARRANGEMENT);
+  }
+
+  @Override
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+          defaultValue = "True")
+  @SimpleProperty
+  public void Scrollable(boolean scrollable) {
+    super.Scrollable(scrollable);
   }
 
 }


### PR DESCRIPTION
@ewpatton I've added the scrollable property to HVArrangement. Kindle review.
Solves #1106 
During testing, I'm facing an issue. Whenever we switch the scrollable property, a new instance of the respective view group is created and added at the end of the Component Container. For this, we need to have a method that would replace the view group at the same index in the component container.
Can you please help me out with the same? 
I've attached below a couple of screenshots. The first one of them is before checking the scrollable property and the other one is after checking the scrollable property.
![WhatsApp Image 2020-02-25 at 7 44 09 PM](https://user-images.githubusercontent.com/49081775/75255205-9077b100-5807-11ea-9d3c-9ca835963941.jpeg)

Thank you.