### PR TITLE
Fix number block displaying non-number values

### DIFF
--- a/appinventor/blocklyeditor/ploverConfig.js
+++ b/appinventor/blocklyeditor/ploverConfig.js
@@ -143,6 +143,7 @@
     "./src/language_switch.js",
     "./src/warning.js",
     "./src/toolboxController.js",
+    "./src/field.js",
 
     // Dialog Utiltiy
     "./src/util.js",

--- a/appinventor/blocklyeditor/src/field.js
+++ b/appinventor/blocklyeditor/src/field.js
@@ -1,0 +1,35 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright © 2016 Massachusetts Institute of Technology. All rights reserved.
+
+/**
+ * @license
+ * @fileoverview Visual blocks editor for MIT App Inventor
+ * Add additional "class methods" to Blockly.Field
+ */
+
+'use strict';
+
+goog.provide('AI.Blockly.Field');
+
+goog.require('Blockly.Field');
+
+
+/**
+ * Sets the value of the field. Since AI runs an older version of blockly,
+ * the newValue should always be a string.
+ *
+ * This is overridden so that the field correctly updates the display text
+ * even if the newValue is the same as the old value.
+ * @param {string} newValue The new value.
+ */
+Blockly.Field.prototype.setValue = function(newValue) {
+  if (newValue === null) {
+    return null;  // No change if null;
+  }
+  var oldValue = this.getValue();  // Must get value before setting text.
+  this.setText(newValue);  // Always update text. See #1238.
+  if (this.sourceBlock_ && Blockly.Events.isEnabled() && newValue != oldValue) {
+    Blockly.Events.fire(new Blockly.Events.Change(
+        this.sourceBlock_, 'field', this.name, oldValue, newValue));
+  }
+};


### PR DESCRIPTION
### Resolves

Closes #1238 

### Description

The Blockly.Field class was not properly updating the text of the field under certain circumstances. This makes sure that the text always gets a chance to update, and allows setText to determine if it actually needs to.

See https://github.com/mit-cml/appinventor-sources/issues/1238#issuecomment-591137818 for additional context.

Also note: I patched the Blockly.Field class because I wanted to make sure this wasn't a problem with any validators in the future. But alternatively I could just patch the number block's field if you like that solution better.

### Testing

Pressing "Enter" and clicking the workspace:
![NumberBlock](https://user-images.githubusercontent.com/25440652/75588821-491f3980-5a2e-11ea-922a-f99729455c7a.gif)
Yail is correctly generated:
![NumberBlockYail](https://user-images.githubusercontent.com/25440652/75588931-78ce4180-5a2e-11ea-9ec7-cb3467cb384b.png)
