### PR TITLE
Add external issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: MIT App Inventor Community
+    url: https://community.appinventor.mit.edu/
+    about: Looking for help while developing your apps? Ask in the Community your doubts and questions!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: MIT App Inventor Community
     url: https://community.appinventor.mit.edu/c/mit-app-inventor-help/5
     about: Looking for help while developing your apps? Ask in the Community your doubts and questions!
+  - name: Extension Development
+    url: https://community.appinventor.mit.edu/c/open-source-development/extension-development/25
+    about: For issues while developing an extension, please refer to the specific category in our Community

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: MIT App Inventor Community
-    url: https://community.appinventor.mit.edu/
+    url: https://community.appinventor.mit.edu/c/mit-app-inventor-help/5
     about: Looking for help while developing your apps? Ask in the Community your doubts and questions!


### PR DESCRIPTION
Github introduced the ability to link external sites in the issue templates. It may be worthy to give it a try, so Community could be linked to this repository.

![image](https://user-images.githubusercontent.com/19251112/75938622-80f00c00-5e88-11ea-8b1f-53391f0e91d3.png)
