### PR TITLE
Fix dictionary to list coercion

### DIFF
--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
@@ -1328,4 +1328,20 @@ public class YailEvalTest extends TestCase {
         asdict.get("list"));
     assertEquals(YailDictionary.makeDictionary("a", "b"), asdict.get("dictionary"));
   }
+
+  public void testDictToListCoercion() throws Throwable {
+    /* Tests that coercion to a list only coerces the top-level dictionary */
+    String schemeInputString = "(call-yail-primitive yail-list-get-item " +
+    "  (*list-for-runtime* (call-yail-primitive make-yail-dictionary " +
+    "    (*list-for-runtime* (call-yail-primitive make-dictionary-pair " +
+    "      (*list-for-runtime* " +
+    "        \"key\" " +
+    "        (call-yail-primitive make-yail-dictionary " +
+    "          (*list-for-runtime* ) '() \"make a dictionary\") ) " +
+    "      '(key any)  \"make a pair\") ) " +
+    "    '(pair ) \"make a dictionary\") " +
+    "  1) '(list number) \"select list item\")";
+    String schemeResultString = "(key {})";
+    assertEquals(schemeResultString, scheme.eval(schemeInputString).toString());
+  }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/YailDictionary.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/YailDictionary.java
@@ -226,25 +226,9 @@ public class YailDictionary extends LinkedHashMap<Object, Object>
   @SuppressWarnings({"unused", "WeakerAccess"})  // Called from runtime.scm
   public static YailList dictToAlist(YailDictionary dict) {
     List<Object> list = new ArrayList<>();
-
     for (Map.Entry<Object, Object> entry : dict.entrySet()) {
-      Object currentKey = entry.getKey();
-      Object currentValue = entry.getValue();
-
-      List<Object> currentPair = new ArrayList<>();
-      currentPair.add(currentKey);
-
-      if (currentValue instanceof YailDictionary) {
-        currentPair.add(dictToAlist((YailDictionary) currentValue));
-      } else if (currentValue instanceof YailList) {
-        currentPair.add(checkListForDicts((YailList) currentValue));
-      } else {
-        currentPair.add(currentValue);
-      }
-
-      list.add(YailList.makeList(currentPair));
+      list.add(YailList.makeList(new Object[] {entry.getKey(), entry.getValue()}));
     }
-
     return YailList.makeList(list);
   }
 

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/YailDictionaryTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/YailDictionaryTest.java
@@ -245,7 +245,7 @@ public class YailDictionaryTest {
 
   @Test
   public void testDictToAlist() {
-    YailList target = getTestList();
+    YailList target = getDictToListTestList();
     YailDictionary dict = getTestDict();
     assertEquals(target, YailDictionary.dictToAlist(dict));
   }
@@ -396,5 +396,21 @@ public class YailDictionaryTest {
     target.put("dict", abdict);
     target.put("list-with-dict", YailList.makeList(singletonList(abdict)));
     return target;
+  }
+
+  private static YailList getDictToListTestList() {
+    // Only the top level is converted to a list.
+    YailList ablist = YailList.makeList(Arrays.asList("a", "b"));
+    YailDictionary abdict = YailDictionary.makeDictionary("a", "b");
+    return YailList.makeList(new Object[] {
+         YailList.makeList(new Object[] { "number", 1 }),
+         YailList.makeList(new Object[] { "string", "foo" }),
+         YailList.makeList(new Object[] { "empty-list", YailList.makeEmptyList() }),
+         YailList.makeList(new Object[] { "list",
+             YailList.makeList(asList(ablist, 2, 3)) }),
+         YailList.makeList(new Object[] { "dict", abdict }),
+         YailList.makeList(new Object[] { "list-with-dict",
+             YailList.makeList(singletonList(abdict)) })
+    });
   }
 }


### PR DESCRIPTION
### Resolves

Closes #2087 

### Description

Removes the recursion from the YailDictionary dictToAlist function so that child dictionaries are not converted to lists.

### Testing

Tested that all of the following cases performed correctly:
![blocks (15)](https://user-images.githubusercontent.com/25440652/76263564-6fa65700-621c-11ea-8306-58b6b0602838.png)


Also added a unit test to make sure that the coercion is happening correctly. The test models the output of the following blocks.
![blocks (14)](https://user-images.githubusercontent.com/25440652/76263504-500f2e80-621c-11ea-8e40-e031112e8ef8.png)

[EDIT: Didn't realize there was also a pure-java test case haha. Fixing.]