### PR TITLE
Uses Camera Property

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
@@ -50,6 +50,7 @@ public abstract class ProjectEditor extends Composite {
   private final Map<String, FileEditor> openFileEditors;
   protected final List<String> fileIds; 
   private final HashMap<String,String> locationHashMap = new HashMap<String,String>();
+  private final HashMap<String, String> cameraHashMap = new HashMap<String,String>();
   private final DeckPanel deckPanel;
   private FileEditor selectedFileEditor;
   private final TreeMap<String, Boolean> screenHashMap = new TreeMap<String, Boolean>();
@@ -309,26 +310,50 @@ public abstract class ProjectEditor extends Composite {
   public final void recordLocationSetting(String componentName, String newValue) {
     OdeLog.log("ProjectEditor: recordLocationSetting(" + componentName + "," + newValue + ")");
     locationHashMap.put(componentName, newValue);
-    recomputeLocationPermission();
+    recomputePermission(locationHashMap, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION);
   }
 
-  private final void recomputeLocationPermission() {
-    String usesLocation = "False";
-    for (String c : locationHashMap.values()) {
-      OdeLog.log("ProjectEditor:recomputeLocationPermission: " + c);
+  public final void recordCameraSetting(String componentName, String newValue) {
+    OdeLog.log("ProjectEditor: recordCameraSetting(" + componentName + "," + newValue + ")");
+    cameraHashMap.put(componentName, newValue);
+    recomputePermission(cameraHashMap, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA);
+  }
+
+  private final void recomputePermission(Map<String,String> componentMap, String permissionName) {
+    String usesPermission = "False";
+    for (String c : componentMap.values()) {
+      OdeLog.log(permissionName + ": " + c);
       if (c.equals("True")) {
-        usesLocation = "True";
+        usesPermission = "True";
         break;
       }
     }
-    changeProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION,
-      usesLocation);
+    changeProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS, permissionName, usesPermission);
   }
+
+  // private final void recomputeLocationPermission() {
+  //   String usesLocation = "False";
+  //   for (String c : locationHashMap.values()) {
+  //     OdeLog.log("ProjectEditor:recomputeLocationPermission: " + c);
+  //     if (c.equals("True")) {
+  //       usesLocation = "True";
+  //       break;
+  //     }
+  //   }
+  //   changeProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION,
+  //     usesLocation);
+  // }
 
   public void clearLocation(String componentName) {
     OdeLog.log("ProjectEditor:clearLocation: clearing " + componentName);
     locationHashMap.remove(componentName);
-    recomputeLocationPermission();
+    recomputePermission(locationHashMap, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION);
+  }
+
+  public void clearCamera(String componentName) {
+    OdeLog.log("ProjectEditor:clearCamera: clearing " + componentName);
+    cameraHashMap.remove(componentName);
+    recomputePermission(cameraHashMap, SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1095,6 +1095,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
 
   public void delete() {
     this.editor.getProjectEditor().clearLocation(getName());
+    this.editor.getProjectEditor().clearCamera(getName());
     getForm().select();
     // Pass true to indicate that the component is being permanently deleted.
     getContainer().removeComponent(this, true);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockWebViewer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockWebViewer.java
@@ -30,6 +30,7 @@ public final class MockWebViewer extends MockVisibleComponent {
 
   // Property names that we need to treat specially
   private static final String PROPERTY_NAME_USESLOCATION = "UsesLocation";
+  private static final String PROPERTY_NAME_USESCAMERA = "UsesCamera";
 
   // Large icon image for use in designer.  Smaller version is in the palette.
   private final Image largeImage = new Image(images.webviewerbig());
@@ -88,6 +89,8 @@ public final class MockWebViewer extends MockVisibleComponent {
 
     if (propertyName.equals(PROPERTY_NAME_USESLOCATION)) {
       editor.getProjectEditor().recordLocationSetting(this.getName(), newValue);
+    } else if (propertyName.equals(PROPERTY_NAME_USESCAMERA)) {
+      editor.getProjectEditor().recordCameraSetting(this.getName(), newValue);
     }
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
@@ -46,6 +46,9 @@ public final class YoungAndroidSettings extends Settings {
         SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION, "false",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA, "false",
+        EditableProperty.TYPE_INVISIBLE));
+    addProperty(new EditableProperty(this,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_APP_NAME, "",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,

--- a/appinventor/appengine/src/com/google/appinventor/server/FileImporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileImporterImpl.java
@@ -103,7 +103,7 @@ public final class FileImporterImpl implements FileImporter {
             // the projectName and qualifiedFormName.
             String content = YoungAndroidProjectService.getProjectPropertiesFileContents(
               projectName, qualifiedFormName, null, null, null, null, null, null, null, null,
-              null, null, null, null, null, null);
+              null, null, null, null, null, null, null);
             project.addTextFile(new TextFile(fileName, content));
             isProjectArchive = true;
 
@@ -151,7 +151,7 @@ public final class FileImporterImpl implements FileImporter {
       project.setProjectHistory(projectHistory);
     }
     String settings = YoungAndroidProjectService.getProjectSettings(null, null, null, null, null,
-        null, null, null, null, null, null, null, null, null);
+        null, null, null, null, null, null, null, null, null, null);
     long projectId = storageIo.createProject(userId, project, settings);
     return storageIo.getUserProject(userId, projectId);
   }

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -132,12 +132,13 @@ public final class YoungAndroidProjectService extends CommonProjectService {
    * Returns project settings that can be used when creating a new project.
    */
   public static String getProjectSettings(String icon, String vCode, String vName,
-    String useslocation, String aName, String sizing, String showListsAsJson, String tutorialURL, String subsetJSON,
-    String actionBar, String theme, String primaryColor, String primaryColorDark, String accentColor) {
+    String useslocation, String usescamera, String aName, String sizing, String showListsAsJson, String tutorialURL,
+    String subsetJSON, String actionBar, String theme, String primaryColor, String primaryColorDark, String accentColor) {
     icon = Strings.nullToEmpty(icon);
     vCode = Strings.nullToEmpty(vCode);
     vName = Strings.nullToEmpty(vName);
     useslocation = Strings.nullToEmpty(useslocation);
+    usescamera = Strings.nullToEmpty(usescamera);
     sizing = Strings.nullToEmpty(sizing);
     aName = Strings.nullToEmpty(aName);
     showListsAsJson = Strings.nullToEmpty(showListsAsJson);
@@ -153,6 +154,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE + "\":\"" + vCode +
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME + "\":\"" + vName +
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION + "\":\"" + useslocation +
+        "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA + "\":\"" + usescamera +
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_APP_NAME + "\":\"" + aName +
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_SIZING + "\":\"" + sizing +
         "\",\"" + SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_LISTS_AS_JSON + "\":\"" + showListsAsJson +
@@ -177,7 +179,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
    * @param vname the version name
    */
   public static String getProjectPropertiesFileContents(String projectName, String qualifiedName,
-    String icon, String vcode, String vname, String useslocation, String aname,
+    String icon, String vcode, String vname, String useslocation, String usescamera, String aname,
     String sizing, String showListsAsJson, String tutorialURL, String subsetJSON, String actionBar, String theme,
     String primaryColor, String primaryColorDark, String accentColor) {
     String contents = "main=" + qualifiedName + "\n" +
@@ -196,6 +198,9 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     }
     if (useslocation != null && !useslocation.isEmpty()) {
       contents += "useslocation=" + useslocation + "\n";
+    }
+    if (usescamera != null && !usescamera.isEmpty()) {
+      contents += "usescamera=" + usescamera + "\n";
     }
     if (aname != null) {
       contents += "aname=" + aname + "\n";
@@ -290,6 +295,9 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     String newUsesLocation = Strings.nullToEmpty(settings.getSetting(
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION));
+    String newUsesCamera = Strings.nullToEmpty(settings.getSetting(
+          SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+          SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA));
     String newSizing = Strings.nullToEmpty(settings.getSetting(
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_SIZING));
@@ -336,6 +344,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     String oldVCode = Strings.nullToEmpty(properties.getProperty("versioncode"));
     String oldVName = Strings.nullToEmpty(properties.getProperty("versionname"));
     String oldUsesLocation = Strings.nullToEmpty(properties.getProperty("useslocation"));
+    String oldUsesCamera = Strings.nullToEmpty(properties.getProperty("usescamera"));
     String oldSizing = Strings.nullToEmpty(properties.getProperty("sizing"));
     String oldAName = Strings.nullToEmpty(properties.getProperty("aname"));
     String oldShowListsAsJson = Strings.nullToEmpty(properties.getProperty("showlistsasjson"));
@@ -348,7 +357,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     String oldAccentColor = Strings.nullToEmpty(properties.getProperty("color.accent"));
 
     if (!newIcon.equals(oldIcon) || !newVCode.equals(oldVCode) || !newVName.equals(oldVName)
-      || !newUsesLocation.equals(oldUsesLocation) ||
+      || !newUsesLocation.equals(oldUsesLocation) || !newUsesCamera.equals(oldUsesCamera) ||
          !newAName.equals(oldAName) || !newSizing.equals(oldSizing) ||
       !newShowListsAsJson.equals(oldShowListsAsJson) ||
         !newTutorialURL.equals(oldTutorialURL) || !newSubsetJSON.equals(oldSubsetJSON) || !newActionBar.equals(oldActionBar) ||
@@ -358,7 +367,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
       String projectName = properties.getProperty("name");
       String qualifiedName = properties.getProperty("main");
       String newContent = getProjectPropertiesFileContents(projectName, qualifiedName, newIcon,
-        newVCode, newVName, newUsesLocation, newAName, newSizing, newShowListsAsJson, newTutorialURL, newSubsetJSON,
+        newVCode, newVName, newUsesLocation, newUsesCamera, newAName, newSizing, newShowListsAsJson, newTutorialURL, newSubsetJSON,
         newActionBar, newTheme, newPrimaryColor, newPrimaryColorDark, newAccentColor);
       storageIo.uploadFileForce(projectId, PROJECT_PROPERTIES_FILE_NAME, userId,
           newContent, StorageUtil.DEFAULT_CHARSET);
@@ -421,6 +430,9 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     String useslocation = oldSettings.getSetting(
         SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION);
+    String usescamera = oldSettings.getSetting(
+        SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA);
     String aname = oldSettings.getSetting(
         SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_APP_NAME);
@@ -470,7 +482,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
         String qualifiedFormName = StringUtils.getQualifiedFormName(
             storageIo.getUser(userId).getUserEmail(), newName);
         newContents = getProjectPropertiesFileContents(newName, qualifiedFormName, icon, vcode,
-          vname, useslocation, aname, sizing, showListsAsJson, tutorialURL, subsetJSON, actionBar,
+          vname, useslocation, usescamera, aname, sizing, showListsAsJson, tutorialURL, subsetJSON, actionBar,
           theme, primaryColor, primaryColorDark, accentColor);
       } else {
         // This is some file other than the project properties file.
@@ -495,7 +507,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
 
     // Create the new project and return the new project's id.
     return storageIo.createProject(userId, newProject, getProjectSettings(icon, vcode, vname,
-        useslocation, aname, sizing, showListsAsJson, tutorialURL, subsetJSON, actionBar, theme, primaryColor,
+        useslocation, usescamera, aname, sizing, showListsAsJson, tutorialURL, subsetJSON, actionBar, theme, primaryColor,
         primaryColorDark, accentColor));
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -388,7 +388,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     String propertiesFileName = PROJECT_PROPERTIES_FILE_NAME;
     String propertiesFileContents = getProjectPropertiesFileContents(projectName,
       qualifiedFormName, null, null, null, null, null, null, null, null, null, null, null, null,
-        null, null);
+        null, null, null);
 
     String formFileName = YoungAndroidFormNode.getFormFileId(qualifiedFormName);
     String formFileContents = getInitialFormPropertiesFileContents(qualifiedFormName);
@@ -408,7 +408,7 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     project.addTextFile(new TextFile(yailFileName, yailFileContents));
 
     // Create new project
-    return storageIo.createProject(userId, project, getProjectSettings("", "1", "1.0", "false",
+    return storageIo.createProject(userId, project, getProjectSettings("", "1", "1.0", "false", "false",
         projectName, "Fixed", "false", "", "", "false", "AppTheme.Light.DarkActionBar","0", "0", "0"));
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
@@ -51,6 +51,7 @@ public class SettingsConstants {
   public static final String YOUNG_ANDROID_SETTINGS_VERSION_CODE = "VersionCode";
   public static final String YOUNG_ANDROID_SETTINGS_VERSION_NAME = "VersionName";
   public static final String YOUNG_ANDROID_SETTINGS_USES_LOCATION = "UsesLocation";
+  public static final String YOUNG_ANDROID_SETTINGS_USES_CAMERA = "UsesCamera";
   public static final String YOUNG_ANDROID_SETTINGS_SIZING = "Sizing";
   public static final String YOUNG_ANDROID_SETTINGS_APP_NAME = "AppName";
   public static final String YOUNG_ANDROID_SETTINGS_SHOW_LISTS_AS_JSON = "ShowListsAsJson";

--- a/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceTest.java
@@ -342,6 +342,7 @@ public class ProjectServiceTest {
         "versioncode=1\n" +
         "versionname=1.0\n" +
         "useslocation=false\n" +
+        "usescamera=false\n" +
         "aname=Project1\n" +
         "sizing=Fixed\n" +
         "showlistsasjson=false\n" +
@@ -495,6 +496,7 @@ public class ProjectServiceTest {
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE + "\":\"1\",\"" +
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME + "\":\"1.0\",\"" +
         SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION + "\":\"false\",\"" +
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_CAMERA + "\":\"false\",\"" +
         SettingsConstants.YOUNG_ANDROID_SETTINGS_APP_NAME + "\":\"Project1\",\"" +
         SettingsConstants.YOUNG_ANDROID_SETTINGS_SIZING + "\":\"Fixed\",\"" +
         SettingsConstants.YOUNG_ANDROID_SETTINGS_SHOW_LISTS_AS_JSON + "\":\"false\",\"" +

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -308,7 +308,7 @@ public final class Compiler {
           webViewerPermissions.add("android.permission.ACCESS_MOCK_LOCATION");
         }
 
-        Log.log(Level.INFO, "usesCamera = " + propect.getUsesCamera());
+        LOG.log(Level.INFO, "usesCamera = " + project.getUsesCamera());
         if (project.getUsesCamera().equals("True")) { // Add camera permissions if any WebViewer requests it
         webViewerPermissions.add("android.permission.CAMERA");
         }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -298,14 +298,23 @@ public final class Compiler {
     try {
       loadJsonInfo(permissionsNeeded, ComponentDescriptorConstants.PERMISSIONS_TARGET);
       if (project != null) {    // Only do this if we have a project (testing doesn't provide one :-( ).
+        Set<String> webViewerPermissions = Sets.newHashSet(); // via a Property.
+
         LOG.log(Level.INFO, "usesLocation = " + project.getUsesLocation());
         if (project.getUsesLocation().equals("True")) { // Add location permissions if any WebViewer requests it
-          Set<String> locationPermissions = Sets.newHashSet(); // via a Property.
           // See ProjectEditor.recordLocationSettings()
-          locationPermissions.add("android.permission.ACCESS_FINE_LOCATION");
-          locationPermissions.add("android.permission.ACCESS_COARSE_LOCATION");
-          locationPermissions.add("android.permission.ACCESS_MOCK_LOCATION");
-          permissionsNeeded.put("com.google.appinventor.components.runtime.WebViewer", locationPermissions);
+          webViewerPermissions.add("android.permission.ACCESS_FINE_LOCATION");
+          webViewerPermissions.add("android.permission.ACCESS_COARSE_LOCATION");
+          webViewerPermissions.add("android.permission.ACCESS_MOCK_LOCATION");
+        }
+
+        Log.log(Level.INFO, "usesCamera = " + propect.getUsesCamera());
+        if (project.getUsesCamera().equals("True")) { // Add camera permissions if any WebViewer requests it
+        webViewerPermissions.add("android.permission.CAMERA");
+        }
+
+        if (!webViewerPermissions.isEmpty()) {
+          permissionsNeeded.put("com.google.appinventor.components.runtime.WebViewer", webViewerPermissions);
         }
       }
     } catch (IOException e) {

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
@@ -252,7 +252,7 @@ public final class Project {
    * @return useslocation property
    */
   public String getUsesLocation() {
-    return getOptionalBooleanProperty(propertyName);
+    return getOptionalBooleanProperty(USESLOCATIONTAG);
   }
 
   /**
@@ -261,7 +261,7 @@ public final class Project {
    * @return usescamera property
    */
   public String getUsesCamera() {
-    return getOptionalBooleanProperty(propertyName);
+    return getOptionalBooleanProperty(USESCAMERATAG);
   }
 
   /**

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
@@ -72,6 +72,7 @@ public final class Project {
    *    assets - assets directory (for image and data files bundled with the application)
    *    build - output directory for the compiler
    *    useslocation - flag indicating whether or not the project uses locations
+   *    usescamera - flag indicating whether or not the project uses the camera
    *    aname - the human-readable application name
    *    androidminsdk - the minimum Android sdk required for the app
    *    theme - the base theme for the app
@@ -88,6 +89,7 @@ public final class Project {
   private static final String ASSETSTAG = "assets";
   private static final String BUILDTAG = "build";
   private static final String USESLOCATIONTAG = "useslocation";
+  private static final String USESCAMERATAG = "usescamera";
   private static final String ANAMETAG = "aname";
   private static final String ANDROID_MIN_SDK_TAG = "androidminsdk";
   private static final String ACTIONBAR_TAG = "actionbar";
@@ -250,8 +252,28 @@ public final class Project {
    * @return useslocation property
    */
   public String getUsesLocation() {
-    String retval = properties.getProperty(USESLOCATIONTAG);
-    if (retval == null)         // Older Projects won't have this
+    return getOptionalBooleanProperty(propertyName);
+  }
+
+  /**
+   * gets the usescamera property
+   *
+   * @return usescamera property
+   */
+  public String getUsesCamera() {
+    return getOptionalBooleanProperty(propertyName);
+  }
+
+  /**
+   * Auxiliary function for retrieving a boolean property that might
+   * potentially be null.
+   *
+   * @param propertyName  Name of the property
+   * @return property value, or False if it does not exist
+   */
+  private String getOptionalBooleanProperty(String propertyName) {
+    String retval = properties.getProperty(propertyName);
+    if (retval == null) // Older Projects won't have this
       retval = "False";
     return retval;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -145,7 +145,7 @@ public final class WebViewer extends AndroidViewComponent {
     webview.getSettings().setBuiltInZoomControls(true);
 
     if (SdkLevel.getLevel() >= SdkLevel.LEVEL_ECLAIR)
-      EclairUtil.setupWebViewGeoLoc(this, webview, container.$context());
+      EclairUtil.setupWebViewPermissions(this, webview, container.$context());
 
     container.$add(this);
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -437,6 +437,20 @@ public final class WebViewer extends AndroidViewComponent {
   }
 
   /**
+   * Specifies whether or not this 'WebViewer' can access the Camera of the phone.
+   * 
+   * @param uses  True if the Camera may be accessed
+   */
+   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "False")
+   @SimpleProperty(userVisible = false,
+        description = "Whether or not to give the application permission to use the phone's Camera. " +
+          "This property is available only in the designer.")
+  public void UsesCamera(boolean uses) {
+    // We don't actually do anything here (the work is in the MockWebViewer)
+  }
+
+  /**
    * Determine if the user should be prompted for permission to use the geolocation API while in
    * the webviewer.
    *

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/EclairUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/EclairUtil.java
@@ -66,14 +66,15 @@ public class EclairUtil {
   }
 
   /**
-   * Setup Dialog Box to request location permission from end-user for the Javascript
-   * location (navigator.geolocation.getCurrentLocation()) API.
+   * Setup Dialog Box to request geo-location permission from end-user for the Javascript
+   * location (navigator.geolocation.getCurrentLocation()) API or other permissions (e.g. camera
+   * or microphone).
    *
    * @param webview - The WebView component running the Javascript engine that needs permission
    * @param activity - Its containing activity used for placing the dialog box
    */
 
-  public static void setupWebViewGeoLoc(final WebViewer caller, WebView webview, final Activity activity) {
+  public static void setupWebViewPermissions(final WebViewer caller, WebView webview, final Activity activity) {
     webview.getSettings().setGeolocationDatabasePath(activity.getFilesDir().getAbsolutePath());
     webview.getSettings().setDatabaseEnabled(true);
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/EclairUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/EclairUtil.java
@@ -12,11 +12,13 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 
+import android.net.Uri;
 import android.text.InputType;
 import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.GeolocationPermissions;
 import android.webkit.GeolocationPermissions.Callback;
+import android.webkit.PermissionRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.WebChromeClient;
@@ -57,6 +59,35 @@ public class EclairUtil {
     webview.getSettings().setGeolocationDatabasePath(activity.getFilesDir().getAbsolutePath());
     webview.getSettings().setDatabaseEnabled(true);
     webview.setWebChromeClient(new WebChromeClient() {
+        @Override
+        public void onPermissionRequest(final PermissionRequest request) {
+          if (!caller.PromptforPermission()) {
+            request.grant(request.getResources());
+            return;
+          }
+
+          String origin = request.getOrigin().toString();
+
+          AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
+          alertDialog.setTitle("Permission Request");
+          if (origin.equals("file://"))
+            origin = "This Application";
+          alertDialog.setMessage(origin + " would like to access your camera.");
+          alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Allow",
+            new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int which) {
+                request.grant(request.getResources());
+              }
+            });
+          alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Refuse",
+            new DialogInterface.OnClickListener() {
+              public void onClick(DialogInterface dialog, int which) {
+                request.deny();
+              }
+            });
+          alertDialog.show();
+        }
+
         @Override
         public void onGeolocationPermissionsShowPrompt(String origin,
           Callback callback) {

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -1679,6 +1679,9 @@ Component for viewing Web pages.
  permission to access the geolocation API. If `false`{:.logic.block}, assume permission is
  granted.
 
+{:id="WebViewer.UsesCamera" .boolean .wo .do} *UsesCamera*
+: Specifies whether or not this 'WebViewer' can access the Camera of the phone.
+
 {:id="WebViewer.UsesLocation" .boolean .wo .do} *UsesLocation*
 : Specifies whether or not this `WebViewer` can access the JavaScript
  geolocation API.


### PR DESCRIPTION
# Uses Camera Property
Resolves the new feature request/issue at #2090 by prompting for permissions for the camera, and saving camera permission settings on a project level (as with the location permission right now).

# Tests
Previously, I could not get the camera to work (prior to this PR) using the WebView. After the changes, setting the property to checked will work correctly, prompting for the camera permission and then enabling it properly.

# TODOs
- [ ] GeoLocation permissions might have broken. I could not get map websites to work. I am investigating into this now, but could not see a valid reason for this occuring
- [ ] Change past tests to accommodate for new change
- [ ] Add clearCamera for camera permissions?