### PR TITLE
Fix Race Condition in Dyslexic font setting

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1574,7 +1574,17 @@ public class Ode implements EntryPoint {
     userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS).
             changePropertyValue(SettingsConstants.USER_DYSLEXIC_FONT,
                     "" + dyslexicFont);
-    userSettings.saveSettings(null);
+    userSettings.saveSettings(new Command() {
+        @Override
+        public void execute() {
+          // Reload for the new font to take effect. We
+          // do this here because we need to make sure that
+          // the user settings were saved before we terminate
+          // this browsing session. This is particularly important
+          // for Firefox
+          Window.Location.reload();
+        }
+      });
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -844,7 +844,11 @@ public class TopToolbar extends Composite {
     @Override
     public void execute() {
       Ode.getInstance().setUserDyslexicFont(true);
-      Window.Location.reload();
+      // Window.Location.reload();
+      // Note: We used to reload here, but this causes
+      // a race condition with the saving of the user
+      // settings. So we now reload in the callback to
+      // saveSettings (in Ode.java)
     }
   }
 
@@ -852,7 +856,8 @@ public class TopToolbar extends Composite {
     @Override
     public void execute() {
       Ode.getInstance().setUserDyslexicFont(false);
-      Window.Location.reload();
+      // Window.Location.reload();
+      // Not: See above comment
     }
   }
 


### PR DESCRIPTION
Need to move the browser reload to a callback to make sure the RPC call
to change the user settings actually had time to run. This didn’t seem
to be an issue with Chrome, but is with Firefox.

Change-Id: If8233cd60c730f75f4a62c2a96365c9d63272b3e