### PR TITLE
Update Companion Build Dependencies

### DIFF
--- a/appinventor/buildserver/build.xml
+++ b/appinventor/buildserver/build.xml
@@ -217,7 +217,7 @@
        PlayAppExtras: builds ../build/buildserver/MITAI2Companion-full.apk
        ===================================================================== -->
   <target name="PlayAppExtras"
-          depends="CheckPlayAppExtras"
+          depends="CheckPlayAppExtras,PlayApp"
           unless="PlayAppExtras.uptodate">
     <java classname="com.google.appinventor.buildserver.Main" fork="true" failonerror="true">
       <classpath>
@@ -255,7 +255,7 @@
        Emulator: builds ../build/buildserver/Emulator.apk
        ===================================================================== -->
   <target name="Emulator"
-          depends="CheckEmulator"
+          depends="CheckEmulator,PlayAppExtras"
           unless="Emulator.uptodate">
     <java classname="com.google.appinventor.buildserver.Main" fork="true" failonerror="true">
       <classpath>


### PR DESCRIPTION
Update dependencies so using “ant Emulator” will build all of the
prerequisites (like “ant PlayApp” and “ant PlayAppExtras”). Note: You
must still have the commit that adds back the package loader code in
order for the built Emulator to be able to update itself.

Change-Id: Ieeac79f7b8c31c67144a3b5639484967bc1391f1