### PR TITLE
Fix recursive procedures breaking on mutation

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -190,10 +190,10 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     // [lyn, 10/28/13] I thought this rerendering was unnecessary. But I was wrong!
     // Without it, get bug noticed by Andrew in which toggling horizontal -> vertical params
     // in procedure decl doesn't handle body tag appropriately!
+    for (var i = 0; i < this.inputList.length; i++) {
+      this.inputList[i].init();
+    }
     if (this.rendered) {
-      for (var i = 0; i < this.inputList.length; i++) {
-        this.inputList[i].init();
-      }
       this.render();
     }
     if (this.workspace.loadCompleted) {  // set in BlocklyPanel.java on successful load


### PR DESCRIPTION
### Resolves

Closes #1026

### Description

We want to make sure that inputs get initialized even if the block is not currently rendering. This doesn't hurt performance, because unlike rendering, initialization only affects the single block. This also matches callers.

### Testing

* Replicated steps from the issue and could not reproduce.
* Closing and reloading the project. Serializes and deserializes correctly.
* Arranging parameters vertically and horizontally works.