### PR TITLE
Implement copy and paste support in the designer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/FileEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/FileEditor.java
@@ -122,6 +122,17 @@ public abstract class FileEditor extends Composite {
   }
 
   /**
+   * Returns true if the current editor is shown, that is, only if the designer
+   * view is visible and this editor is the current file editor.
+   * @return true if the editor is shown, otherwise false.
+   */
+  @SuppressWarnings("unused")  // called from JSNI
+  public boolean isActiveEditor() {
+    return Ode.getInstance().getCurrentView() == 0 &&
+        Ode.getInstance().getCurrentFileEditor() == this;
+  }
+
+  /**
    * Called when the FileEditor is about to be closed. Subclasses can override this
    * to remove themselves as listeners.
    */

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/SimpleEditor.java
@@ -6,14 +6,20 @@
 
 package com.google.appinventor.client.editor.simple;
 
+import com.google.appinventor.client.ComponentsTranslation;
 import com.google.appinventor.client.editor.FileEditor;
 import com.google.appinventor.client.editor.ProjectEditor;
 import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.editor.simple.palette.SimplePalettePanel;
 import com.google.appinventor.shared.rpc.project.FileNode;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Abstract editor for files containing Simple components.
@@ -72,4 +78,56 @@ public abstract class SimpleEditor extends FileEditor {
    * Returns true if this editor is for Screen1.
    */
   public abstract boolean isScreen1();
+
+  /**
+   * Returns a new, unique component name based on the set of names returned by
+   * {@link #getComponentNames()}. If hint is given it will be used as the base
+   * for the new name. Otherwise, the type will be used.
+   *
+   * Examples:
+   *
+   * <code>gensymName("Button", null)</code>
+   * <em>=> "Button1"</em>
+   *
+   * <code>gensymName("Button", "Information1")</code>
+   * <em>=> "Information2"</em>
+   *
+   * @param type the type of the component
+   * @param hint an optional hint for the component name. pass null if not needed
+   * @return a new unique name that does not occur in the list of component names
+   * returned by {@link #getComponentNames()}
+   */
+  public String gensymName(String type, String hint) {
+    RegExp regexp = RegExp.compile("(.*?)([0-9]+)$");
+    if (hint != null) {
+      Set<String> names = new HashSet<String>(getComponentNames());
+      String base = hint;
+      int number = 1;
+      if (regexp.test(hint)) {
+        MatchResult result = regexp.exec(hint);
+        base = result.getGroup(1);
+        number = Integer.parseInt(result.getGroup(2));
+      }
+      number++;
+      while (names.contains(base + number)) number++;
+      return base + number;
+    }
+    int highIndex = 0;
+    final String typeName = ComponentsTranslation.getComponentName(type)
+        .toLowerCase()
+        .replace(" ", "_")
+        .replace("'", "_");
+    final int nameLength = typeName.length();
+    for (String cName : this.getComponentNames()) {
+      cName = cName.toLowerCase();
+      try {
+        if (cName.startsWith(typeName)) {
+          highIndex = Math.max(highIndex, Integer.parseInt(cName.substring(nameLength)));
+        }
+      } catch (NumberFormatException e) {
+        continue;
+      }
+    }
+    return type + (highIndex + 1);
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCanvas.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCanvas.java
@@ -9,10 +9,13 @@ package com.google.appinventor.client.editor.simple.components;
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.appinventor.client.editor.simple.palette.SimplePaletteItem;
 import com.google.appinventor.client.widgets.dnd.DragSource;
+import com.google.common.collect.Sets;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -26,6 +29,8 @@ public final class MockCanvas extends MockContainer {
    * Component type name.
    */
   public static final String TYPE = "Canvas";
+
+  public static final Set<String> ACCEPTABLE_TYPES = Collections.unmodifiableSet(Sets.newHashSet(MockBall.TYPE, MockImageSprite.TYPE));
 
   // UI components
   private final AbsolutePanel canvasWidget;
@@ -59,6 +64,11 @@ public final class MockCanvas extends MockContainer {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public boolean willAcceptComponentType(String type) {
+    return ACCEPTABLE_TYPES.contains(type);
   }
 
   /*

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -592,6 +592,16 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   }
 
   /**
+   * Renames the component to {@code newName}.
+   * @param newName The new name for the component.
+   */
+  public void rename(String newName) {
+    String oldName = getPropertyValue(PROPERTY_NAME_NAME);
+    properties.changePropertyValue(PROPERTY_NAME_NAME, newName);
+    getForm().fireComponentRenamed(this, oldName);
+  }
+
+  /**
    * Returns the properties set for the component.
    *
    * @return  properties
@@ -762,7 +772,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    *
    * @return  owning component container for this component
    */
-  protected final MockContainer getContainer() {
+  public final MockContainer getContainer() {
     return container;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -263,6 +263,10 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
     return false;
   }
 
+  public boolean willAcceptComponentType(String type) {
+    return !MockCanvas.ACCEPTABLE_TYPES.contains(type) && !MockMap.ACCEPTABLE_TYPES.contains(type);
+  }
+
   // TODO(user): Draw a colored border around the edges of the container
   //                    area while an eligible component is hovering over it.
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -130,7 +130,7 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
     List<MockComponent> visibleChildren = getShowingVisibleChildren();
 
     int beforeActualIndex;
-    if ((beforeVisibleIndex == -1) || (beforeVisibleIndex == visibleChildren.size())) {
+    if ((beforeVisibleIndex == -1) || (beforeVisibleIndex >= visibleChildren.size())) {
       // Insert after last visible component
       if (visibleChildren.size() == 0) {
         beforeActualIndex = 0;

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -238,6 +238,7 @@ public final class MockForm extends MockContainer {
   private TitleBar titleBar;
   private NavigationBar navigationBar;
   private List<MockComponent> selectedComponents = new ArrayList<MockComponent>(Collections.singleton(this));
+  private MockContainer pasteTarget;
 
   int screenWidth;              // TEMP: Make package visible so we can use it MockHVLayoutBase
   private int screenHeight;
@@ -947,6 +948,11 @@ public final class MockForm extends MockContainer {
       newSelectedComponent.onSelectedChange(false);
       return;
     }
+    if (newSelectedComponent instanceof MockContainer) {
+      pasteTarget = (MockContainer) newSelectedComponent;
+    } else {
+      pasteTarget = newSelectedComponent.getContainer();
+    }
 
     if (!shouldSelectMultipleComponents) {
       for (MockComponent component : selectedComponents) {
@@ -966,6 +972,14 @@ public final class MockForm extends MockContainer {
 
   public final MockComponent getLastSelectedComponent() {
     return selectedComponents.get(selectedComponents.size() - 1);
+  }
+
+  public final MockContainer getPasteTarget() {
+    return pasteTarget;
+  }
+
+  public final void setPasteTarget(MockContainer target) {
+    this.pasteTarget = target;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -238,7 +238,7 @@ public final class MockForm extends MockContainer {
   private TitleBar titleBar;
   private NavigationBar navigationBar;
   private List<MockComponent> selectedComponents = new ArrayList<MockComponent>(Collections.singleton(this));
-  private MockContainer pasteTarget;
+  private MockContainer pasteTarget = this;
 
   int screenWidth;              // TEMP: Make package visible so we can use it MockHVLayoutBase
   private int screenHeight;

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMap.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMap.java
@@ -7,24 +7,25 @@ package com.google.appinventor.client.editor.simple.components;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.appinventor.client.ErrorReporter;
-import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.appinventor.client.editor.simple.palette.SimplePaletteItem;
 import com.google.appinventor.client.widgets.dnd.DragSource;
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.common.collect.Sets;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.google.gwt.user.client.ui.Image;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public final class MockMap extends MockContainer {
   public static final String TYPE = "Map";
+  public static final Set<String> ACCEPTABLE_TYPES = Collections.unmodifiableSet(Sets.newHashSet(MockMarker.TYPE, MockLineString.TYPE, MockPolygon.TYPE, MockRectangle.TYPE, MockCircle.TYPE, MockFeatureCollection.TYPE));
   protected static final String PROPERTY_NAME_LATITUDE = "Latitude";
   protected static final String PROPERTY_NAME_LONGITUDE = "Longitude";
   protected static final String PROPERTY_NAME_MAP_TYPE = "MapType";
@@ -144,6 +145,11 @@ public final class MockMap extends MockContainer {
       component = (MockComponent) source.getDragWidget();
     }
     return component instanceof MockMapFeature;
+  }
+
+  @Override
+  public boolean willAcceptComponentType(String type) {
+    return ACCEPTABLE_TYPES.contains(type);
   }
 
   private void setBackgroundColorProperty(String text) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -668,6 +668,9 @@ public class BlocklyPanel extends HTMLPanel {
   native void makeActive()/*-{
     Blockly.mainWorkspace = this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
     Blockly.mainWorkspace.refreshBackpack();
+    if (Blockly.mainWorkspace.pendingRender === true) {
+      Blockly.mainWorkspace.pendingRenderFunc();
+    }
     // Trigger a screen switch to send new YAIL.
     var parts = Blockly.mainWorkspace.formName.split(/_(.+)/);  // Split string on first _
     if (Blockly.ReplMgr.isConnected()) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -25,6 +25,8 @@ import com.google.appinventor.client.explorer.SourceStructureExplorerItem;
 import com.google.appinventor.client.explorer.project.ComponentDatabaseChangeListener;
 import com.google.appinventor.client.output.OdeLog;
 import com.google.appinventor.client.widgets.dnd.DropTarget;
+import com.google.appinventor.shared.properties.json.JSONArray;
+import com.google.appinventor.shared.properties.json.JSONValue;
 import com.google.appinventor.shared.rpc.project.ChecksumedFileException;
 import com.google.appinventor.shared.rpc.project.ChecksumedLoadFile;
 import com.google.appinventor.shared.rpc.project.FileDescriptorWithContent;
@@ -33,6 +35,8 @@ import com.google.appinventor.shared.youngandroid.YoungAndroidSourceAnalyzer;
 import com.google.common.collect.Maps;
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.user.client.Command;
@@ -704,6 +708,129 @@ public final class YaBlocksEditor extends FileEditor
   public void makeActiveWorkspace() {
     blocksArea.makeActive();
   }
+
+  private static native void set(JavaScriptObject jso, String key, String value)/*-{
+    jso[key] = value;
+  }-*/;
+
+  /**
+   * Converts a Java Map from String to String into a JSON object with the same contents.
+   * @param javaMap The source mapping in Java
+   * @return A JSON object with the same key-value mapping as {@code javaMap}
+   */
+  public static JavaScriptObject toJSO(Map<String, String> javaMap) {
+    JavaScriptObject jso = JavaScriptObject.createObject();
+    for (Map.Entry<String, String> entry : javaMap.entrySet()) {
+      set(jso, entry.getKey(), entry.getValue());
+    }
+    return jso;
+  }
+
+  /**
+   *
+   * @param array
+   * @return
+   */
+  public static JsArrayString toJsArrayString(JSONArray array) {
+    JsArrayString result = (JsArrayString) JsArrayString.createArray();
+    for (JSONValue v : array.getElements()) {
+      result.push(v.asString().getString());
+    }
+    return result;
+  }
+
+  public native void pasteFromJSNI(JavaScriptObject componentSubstitutionMap, JsArrayString blocks)/*-{
+    var workspace = this.@com.google.appinventor.client.editor.youngandroid.YaBlocksEditor::blocksArea.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
+    if (Blockly.Events.isEnabled()) {
+      Blockly.Events.setGroup(true);
+    }
+    blocks.forEach(function(blockXml) {
+      var dom = Blockly.Xml.textToDom(blockXml);
+      var mutations = dom.getElementsByTagName('mutation');
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
+        var instanceName = mutation.getAttribute('instance_name');
+        if (instanceName && instanceName in componentSubstitutionMap) {
+          mutation.setAttribute('instance_name', componentSubstitutionMap[instanceName]);
+        }
+      }
+      var fields = dom.getElementsByTagName('field');
+      for (var i = 0; i < fields.length; i++) {
+        var field = fields[i];
+        if (field.getAttribute('name') === 'COMPONENT_SELECTOR') {
+          if (field.textContent in componentSubstitutionMap) {
+            field.firstChild.nodeValue = componentSubstitutionMap[field.textContent];
+          }
+        }
+      }
+      try {
+        var block = Blockly.Xml.domToBlock(dom.firstElementChild, workspace);
+        var blockX = parseInt(dom.firstElementChild.getAttribute('x'), 10);
+        var blockY = parseInt(dom.firstElementChild.getAttribute('y'), 10);
+        if (!isNaN(blockX) && !isNaN(blockY)) {
+          if (workspace.RTL) {
+            blockX = -blockX;
+          }
+          // Offset block until not clobbering another block and not in connection
+          // distance with neighbouring blocks.
+          do {
+            var collide = false;
+            var allBlocks = workspace.getAllBlocks();
+            for (var i = 0, otherBlock; otherBlock = allBlocks[i]; i++) {
+              var otherXY = otherBlock.getRelativeToSurfaceXY();
+              if (Math.abs(blockX - otherXY.x) <= 1 &&
+                Math.abs(blockY - otherXY.y) <= 1) {
+                collide = true;
+                break;
+              }
+            }
+            if (!collide) {
+              // Check for blocks in snap range to any of its connections.
+              var connections = block.getConnections_(false);
+              for (var i = 0, connection; connection = connections[i]; i++) {
+                var neighbour = connection.closest(Blockly.SNAP_RADIUS,
+                  new goog.math.Coordinate(blockX, blockY));
+                if (neighbour.connection) {
+                  collide = true;
+                  break;
+                }
+              }
+            }
+            if (collide) {
+              if (workspace.RTL) {
+                blockX -= Blockly.SNAP_RADIUS;
+              } else {
+                blockX += Blockly.SNAP_RADIUS;
+              }
+              blockY += Blockly.SNAP_RADIUS * 2;
+            }
+          } while (collide);
+          block.moveBy(blockX, blockY);
+        }
+        if (workspace.rendered) {
+          block.initSvg();
+          workspace.requestRender(block);
+        }
+      } catch(e) {
+        console.log(e);
+      }
+    });
+    if (Blockly.Events.isEnabled()) {
+      Blockly.Events.setGroup(false);
+    }
+  }-*/;
+
+  public native JsArrayString getTopBlocksForComponentByName(String name)/*-{
+    var workspace = this.@com.google.appinventor.client.editor.youngandroid.YaBlocksEditor::blocksArea.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace;
+    var topBlocks = workspace.getTopBlocks();
+    var result = [];
+    for (var i = 0, block; block = topBlocks[i]; i++) {
+      if (block.instanceName === name) {
+        result.push('<xml>' + Blockly.Xml.domToText(Blockly.Xml.blockToDomWithXY(block)) + '</xml>');
+      }
+    }
+    return result;
+  }-*/;
 
   public static native void resendAssetsAndExtensions()/*-{
     if (top.ReplState && (top.ReplState.state == Blockly.ReplMgr.rsState.CONNECTED ||

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -1098,13 +1098,23 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     StringBuilder sb = new StringBuilder();
     String sep = "";
     sb.append("[");
-    for (MockComponent component : form.getSelectedComponents()) {
-      if (component instanceof MockForm) {
-        continue;
+    if (form.getSelectedComponents().size() == 1 &&
+        form.getSelectedComponents().get(0) instanceof MockForm) {
+      // We can't copy screens, but we can copy all of the children of a screen...
+      for (MockComponent component : form.getChildren()) {
+        sb.append(sep);
+        encodeComponentProperties(component, sb, false);
+        sep = ",";
       }
-      sb.append(sep);
-      encodeComponentProperties(component, sb, false);
-      sep = ",";
+    } else {
+      for (MockComponent component : form.getSelectedComponents()) {
+        if (component instanceof MockForm) {
+          continue;
+        }
+        sb.append(sep);
+        encodeComponentProperties(component, sb, false);
+        sep = ",";
+      }
     }
     sb.append("]");
     if (sb.length() == 2) {

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -1230,13 +1230,18 @@ Blockly.WorkspaceSvg.prototype.requestRender = function(block) {
   if (!this.pendingRender) {
     this.needsRendering = [];
     this.pendingBlockIds = {};
-    this.pendingRender = setTimeout(function() {
+    this.pendingRenderFunc = function() {
       try {
         this.render(this.needsRendering.length === 0 ? undefined : this.needsRendering);
       } finally {
         this.pendingRender = null;
       }
-    }.bind(this));
+    }.bind(this);
+    if (this.svgGroup_.parentElement.parentElement.parentElement.style.display === 'none') {
+      this.pendingRender = true;
+    } else {
+      this.pendingRender = setTimeout(this.pendingRenderFunc, 0);
+    }
   }
   if (block) {
     // Rendering uses Blockly.BlockSvg.renderDown, so we only need a list of the topmost blocks

--- a/appinventor/docs/html/reference/other/editing-functions.html
+++ b/appinventor/docs/html/reference/other/editing-functions.html
@@ -21,7 +21,7 @@
                                    }
      //--><!]]>
     </script>
-    <title>Other Reference Materials</title></head>
+    <title>Editing Functions in App Inventor</title></head>
 <body class="mit_app_inventor"><nav class="navbar navbar-expand-xl navbar-light">
     <a class="navbar-brand" href="http://appinventor.mit.edu/">
 	<img src="/static/images/logo2.png" alt="Logo">
@@ -121,43 +121,53 @@
 </nav>
 <div class="default-page">
             <div class="header">
-	        <h1 class="font-weight-bold text-center offset-xl-2 col-xl-8">Other Reference Materials</h1>
+	        <h1 class="font-weight-bold text-center offset-xl-2 col-xl-8">Editing Functions in App Inventor</h1>
             </div>
             <div class="container-fluid">
                 <article class="documentation">
-<p>These documents provide additional details on some App Inventor topics.</p>
+<p>Beginning with version nb184, App Inventor has included the capability to cut, copy, and paste parts of your app design. This document explains this functionality.</p>
 
-<ul>
-  <li><a href="editing-functions.html">Editing Your App (Copy and Paste)</a></li>
-  <li><a href="activitystarter.html">Using the Activity Starter</a></li>
-  <li><a href="appstoplay.html">Uploading Your Apps to Google Play</a></li>
-  <li><a href="tinywebdb.html">Creating a Custom TinyWebDB Service</a></li>
-  <li><a href="testing.html">Live Development, Testing, and Debugging Tools</a></li>
-  <li><a href="emulator.html">Building Apps with the Emulator</a></li>
-  <li><a href="displaylist.html">Displaying a List</a></li>
-  <li><a href="locationsensor.html">Using the Location Sensor</a></li>
-  <li><a href="sizes.html">Specifying Sizes of Components</a></li>
-  <li><a href="media.html">Accessing Images and Sounds</a></li>
-  <li><a href="usingImages.html">Using Images with App Inventor</a></li>
-  <li><a href="https://docs.google.com/document/d/1HuWW8C3Ghz-pO-tWRpod2znM5wD7RfK10b2J37ftf2E/pub">Interfacing App Inventor projects to external sensors</a></li>
-  <li><a href="manyscreens.html">Building apps with many screens</a></li>
-  <li><a href="json-web-apis.html">Working with JSON and Web APIs</a></li>
-  <li><a href="xml.html">Working with XML and Web Services</a></li>
-  <li><a href="genymotion.html">Using the Genymotion emulator with App Inventor</a></li>
-  <li><a href="extensions.html">App Inventor Extensions</a></li>
-  <li><a href="responsiveDesign.html">Responsive Design in App Inventor</a></li>
-  <li><a href="compatibilityIssues.html">Compatibility Issues with releases of Android and App Inventor</a></li>
-  <li><a href="extensionsMultitouch.html">Using App Inventor extensions to implement multitouch: Scale Detector</a></li>
-  <li><a href="extensionsRotation.html">Using App Inventor extensions to implement multitouch: Rotation Detector</a></li>
-  <li><a href="extensionsGestures.html">Extending MIT App Inventor with Multi-touch and Gesture Detection</a></li>
-  <li><a href="backpack.html">Using the “Backpack” Cut and Paste system</a></li>
-  <li><a href="firebaseIntro.html">Brief introduction to cloud data and the Firebase component</a></li>
-  <li><a href="IoT.html">Controlling Internet of Things Devices with MIT App Inventor</a></li>
-  <li><a href="merger.html">Project merger tool</a></li>
-  <li><a href="vr.html">Experiments with Virtual Reality and MIT App Inventor</a></li>
-  <li><a href="any-component-blocks.html">Don’t Repeat Yourself (DRY) using Generic Blocks</a></li>
-  <li><a href="download-pngs.html">Import and export code blocks as PNGs</a></li>
-</ul>
+<h2 id="manipulating-components">Manipulating Components</h2>
+
+<p>Your app design is made up of one or more components in a tree structure that starts at the Screen. You can add components by dragging them in from the Palette panel to the left of the designer. You can customize components by changing their properties in the Properties panel to the right of the designer.</p>
+
+<h3 id="selecting-components">Selecting Components</h3>
+
+<p>You select components by clicking on them. Starting with release nb182, you can select multiple components by holding a platform specific key (Ctrl on Windows/Linux, Command on macOS) and clicking on additional components. This feature is sometimes referred to in App Inventor as multiselect. When you select multiple components, the properties panel will update to only show common properties among the selected components. Changing a property in this mode will change it for all of the selected components.</p>
+
+<h3 id="copying-components">Copying Components</h3>
+
+<p>Once you have selected one or more elements, use the standard keyboard shortcut for your platform to copy them (Ctrl+C on Windows/Linux, ⌘C on macOS). This places the contents of the selection onto your system’s clipboard.</p>
+
+<p>You can also use the Cut shortcut (Ctrl+X on Windows/Linux, ⌘X on macOS) to copy elements to the clipboard and immediately delete them, so that they can be pasted elsewhere.</p>
+
+<h3 id="pasting-components">Pasting Components</h3>
+
+<p>Once you have copied components to the clipboard, you can press the paste shortcut key (Ctrl+V on Windows/Linux, ⌘V on macOS) to paste them. When copying and pasting components, the default behavior is to copy both the design as well as the behavior (i.e., the blocks). If you would prefer to only paste the component without copying its behavior, hold the shift key while pressing the paste key combination. App Inventor will skip pasting the blocks if the shift key is held.</p>
+
+<p>When pasting, App Inventor will rename the pasted components if there is a collision with existing components in the project. It does this by computing a fresh name for each colliding name. The renaming algorithm works by either adding a numeric suffix to the name, or by incrementing the numeric suffix of the name until the collision is resolved. For example, if you copy a component named <code class="highlighter-rouge">ResetButton</code>, the first copy will be called <code class="highlighter-rouge">ResetButton1</code>, the second will be called <code class="highlighter-rouge">ResetButton2</code>, and so forth. These new names are also subsituted into the copied blocks code, if any.</p>
+
+<h2 id="manipulating-blocks">Manipulating Blocks</h2>
+
+<p>The blocks editor is where you provide the behavior for your app. Like the designer, it supports copying and pasting blocks. You can also use the <a href="backpack.html">backpack</a> to transfer blocks between projects, or <a href="download-pngs.html">download blocks as images</a> that you can share with others.</p>
+
+<h3 id="copying-blocks">Copying Blocks</h3>
+
+<p>To copy a block, first select the block. You can copy the block by either pressing the copy shortcut for your platform (Ctrl+C for Windows/Linux, ⌘C for macOS). The copy action is also available on the context menu by right clicking (Ctrl+clicking on macOS) the block.</p>
+
+<h3 id="paste-blocks">Paste Blocks</h3>
+
+<p>To paste a block, press the paste shortcut for your platofmr (Ctrl+V for Windows/Linux, ⌘V on macOS). The paste action is also available on the context menu by right clicking (Ctrl+clicking on macOS) the workspace.</p>
+
+<h2 id="copying-screens">Copying Screens</h2>
+
+<p>App Inventor allows you to copy and paste the content of a screen, effectively allowing you to copy screens.</p>
+
+<p>To copy a screen, select the screen either by clicking its background or selecting it in the structure tree. Press the copy shortcut key to copy it. Next, create a new screen. Press the paste shortcut key in this new screen to paste the contents copied from the previous screen.</p>
+
+<h2 id="sharing-designs">Sharing Designs</h2>
+
+<p>Because the copy functionality puts the content of your selection onto the clipboard, it is possible to share the content in a text form although the format is somewhat complex. For example, you can copy a component and paste its textual representation into a text document or email. Someone can select the text, copy it, and then paste it into App Inventor to recreate the component’s representation. This can help you build a collection of design elements for your apps.</p>
 
 </article>
 <script>

--- a/appinventor/docs/markdown/reference/other/editing-functions.md
+++ b/appinventor/docs/markdown/reference/other/editing-functions.md
@@ -1,0 +1,48 @@
+---
+title: Editing Functions in App Inventor
+layout: documentation
+---
+
+Beginning with version nb184, App Inventor has included the capability to cut, copy, and paste parts of your app design. This document explains this functionality.
+
+## Manipulating Components
+
+Your app design is made up of one or more components in a tree structure that starts at the Screen. You can add components by dragging them in from the Palette panel to the left of the designer. You can customize components by changing their properties in the Properties panel to the right of the designer.
+
+### Selecting Components
+
+You select components by clicking on them. Starting with release nb182, you can select multiple components by holding a platform specific key (Ctrl on Windows/Linux, Command on macOS) and clicking on additional components. This feature is sometimes referred to in App Inventor as multiselect. When you select multiple components, the properties panel will update to only show common properties among the selected components. Changing a property in this mode will change it for all of the selected components.
+
+### Copying Components
+
+Once you have selected one or more elements, use the standard keyboard shortcut for your platform to copy them (Ctrl+C on Windows/Linux, ⌘C on macOS). This places the contents of the selection onto your system's clipboard.
+
+You can also use the Cut shortcut (Ctrl+X on Windows/Linux, ⌘X on macOS) to copy elements to the clipboard and immediately delete them, so that they can be pasted elsewhere.
+
+### Pasting Components
+
+Once you have copied components to the clipboard, you can press the paste shortcut key (Ctrl+V on Windows/Linux, ⌘V on macOS) to paste them. When copying and pasting components, the default behavior is to copy both the design as well as the behavior (i.e., the blocks). If you would prefer to only paste the component without copying its behavior, hold the shift key while pressing the paste key combination. App Inventor will skip pasting the blocks if the shift key is held.
+
+When pasting, App Inventor will rename the pasted components if there is a collision with existing components in the project. It does this by computing a fresh name for each colliding name. The renaming algorithm works by either adding a numeric suffix to the name, or by incrementing the numeric suffix of the name until the collision is resolved. For example, if you copy a component named `ResetButton`, the first copy will be called `ResetButton1`, the second will be called `ResetButton2`, and so forth. These new names are also subsituted into the copied blocks code, if any.
+
+## Manipulating Blocks
+
+The blocks editor is where you provide the behavior for your app. Like the designer, it supports copying and pasting blocks. You can also use the [backpack](backpack.html) to transfer blocks between projects, or [download blocks as images](download-pngs.html) that you can share with others.
+
+### Copying Blocks
+
+To copy a block, first select the block. You can copy the block by either pressing the copy shortcut for your platform (Ctrl+C for Windows/Linux, ⌘C for macOS). The copy action is also available on the context menu by right clicking (Ctrl+clicking on macOS) the block.
+
+### Paste Blocks
+
+To paste a block, press the paste shortcut for your platofmr (Ctrl+V for Windows/Linux, ⌘V on macOS). The paste action is also available on the context menu by right clicking (Ctrl+clicking on macOS) the workspace.
+
+## Copying Screens
+
+App Inventor allows you to copy and paste the content of a screen, effectively allowing you to copy screens.
+
+To copy a screen, select the screen either by clicking its background or selecting it in the structure tree. Press the copy shortcut key to copy it. Next, create a new screen. Press the paste shortcut key in this new screen to paste the contents copied from the previous screen.
+
+## Sharing Designs
+
+Because the copy functionality puts the content of your selection onto the clipboard, it is possible to share the content in a text form although the format is somewhat complex. For example, you can copy a component and paste its textual representation into a text document or email. Someone can select the text, copy it, and then paste it into App Inventor to recreate the component's representation. This can help you build a collection of design elements for your apps.

--- a/appinventor/docs/markdown/reference/other/index.md
+++ b/appinventor/docs/markdown/reference/other/index.md
@@ -5,6 +5,7 @@ layout: documentation
 
 These documents provide additional details on some App Inventor topics.
 
+* [Editing Your App (Copy and Paste)](editing-functions.html)
 * [Using the Activity Starter](activitystarter.html)
 * [Uploading Your Apps to Google Play](appstoplay.html)
 * [Creating a Custom TinyWebDB Service](tinywebdb.html)


### PR DESCRIPTION
This change adds support for copying and pasting components in the
designer. It handles the entire tree from a given component (and
supports multiple roots for if we allow multiple selection in the
future). Name substitution will occur if a component exists with the
same name when pasting. Top level blocks referencing the copied
components are also included in the operation. Holding the shift key
while pasting will disable pasting the event handlers.

Resolves #726
Resolves #840

Change-Id: Ica9637f8d07e7287cd698248c60533a5e10af752