### PR TITLE
Fix new blocks getting added to backpack on click

### DIFF
--- a/appinventor/blocklyeditor/src/block_svg.js
+++ b/appinventor/blocklyeditor/src/block_svg.js
@@ -148,6 +148,7 @@ Blockly.BlockSvg.prototype.onMouseUp_ = (function(func) {
         if (Blockly.getMainWorkspace().hasBackpack() &&
             Blockly.getMainWorkspace().getBackpack().isOpen) {
           var backpack = Blockly.getMainWorkspace().getBackpack();
+          goog.Timer.callOnce(backpack.close, 100, backpack);
           backpack.addToBackpack(Blockly.selected, true);
           backpack.onMouseUp(e, Blockly.selected.dragStartXY_);
         }


### PR DESCRIPTION
### Resolves

Closes #2153 

### Description

Blocks were getting added to the backpack on click because the backpack was not getting closed. This re-adds the close call found [here](https://github.com/mit-cml/appinventor-sources/commit/5a38a3553f09951ab3b68f5ef08f239c381d0e46#diff-6f2565ae506c4db8b5a6535beb9bce0eR686).

I think this was just removed accidentally during a blockly core upgrade, but if there's a reason it was removed I can look for a different solution.

### Testing

Could not reproduce the error using the steps from #2153 