### PR TITLE
Add support for user supplied Yandex API keys

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -370,6 +370,8 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradeRectangleProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("FeatureCollection")) {
         srcCompVersion = upgradeFeatureCollection(componentProperties, srcCompVersion);
+      } else if (componentType.equals("YandexTranslate")) {
+        srcCompVersion = upgradeYandexTranslateProperties(componentProperties, srcCompVersion);
       }
 
       if (srcCompVersion < sysCompVersion) {
@@ -1735,6 +1737,16 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 2) {
       // Version 2
       // The GotGeoJSON and GeoJSONError events were renamed in the blocks editor.
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeYandexTranslateProperties(Map<String, JSONValue> componentProperties,
+      int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Version 2
+      // The ApiKey property was added
       srcCompVersion = 2;
     }
     return srcCompVersion;

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2684,7 +2684,7 @@ Blockly.Versioning.AllUpgradeMaps =
 
     //AI2: Added PageLoaded
     8: "noUpgrade",
-      
+
     // AI2: Added BeforePageLoad event and Stop, Reload, and ClearCookies methods
     9: "noUpgrade",
 
@@ -2696,7 +2696,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "YandexTranslate": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+
+    // AI2: ApiKey property added
+    2: "noUpgrade"
 
   } // End YandexTranslate upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -508,8 +508,10 @@ public class YaVersion {
   // - SERIAL_COMPONENT_VERSION was initialized to 1
   // For YOUNG_ANDROID_VERSION 205:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 31
+  // For YOUNG_ANDROID_VERSION 206:
+  // - YANDEX_COMPONENT_VERSION was incremented to 2.
 
-  public static final int YOUNG_ANDROID_VERSION = 205;
+  public static final int YOUNG_ANDROID_VERSION = 206;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -1334,7 +1336,9 @@ public class YaVersion {
 
   // For YANDEX_COMPONENT_VERSION 1:
   // - Initial version.
-  public static final int YANDEX_COMPONENT_VERSION = 1;
+  // For YANDEX_COMPONENT_VERSION 2:
+  // - Added ApiKey property
+  public static final int YANDEX_COMPONENT_VERSION = 2;
 
   //For PROXIMITYSENSOR_COMPONENT_VERSION: Initial Version
   public static final int PROXIMITYSENSOR_COMPONENT_VERSION = 1;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
@@ -7,23 +7,33 @@
 package com.google.appinventor.components.runtime;
 
 import android.app.Activity;
-import com.google.appinventor.components.annotations.UsesPermissions;
-import org.json.JSONException;
-import org.json.JSONObject;
+
+import android.text.TextUtils;
+
 import com.google.appinventor.components.annotations.DesignerComponent;
+import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.UsesPermissions;
+
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+
 import com.google.appinventor.components.runtime.util.AsynchUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Use this component to translate words and sentences between different languages. This component
@@ -66,6 +76,7 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
   public static final String YANDEX_TRANSLATE_SERVICE_URL =
       "https://translate.yandex.net/api/v1.5/tr.json/translate?key=";
   private final String yandexKey;
+  private String userYandexKey = "DEFAULT";
   private final Activity activity;
 
   /**
@@ -105,7 +116,8 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
   public void RequestTranslation(final String languageToTranslateTo,
                                  final String textToTranslate) {
 
-    if (yandexKey.equals("")){
+    if (TextUtils.isEmpty(yandexKey) &&
+      (TextUtils.isEmpty(userYandexKey) || TextUtils.equals(userYandexKey, "DEFAULT"))) {
       form.dispatchErrorOccurredEvent(YandexTranslate.this, "RequestTranslation",
           ErrorMessages.ERROR_TRANSLATE_NO_KEY_FOUND);
       return;
@@ -139,7 +151,8 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
       throws IOException, JSONException {
 
     final String finalURL = YANDEX_TRANSLATE_SERVICE_URL +
-        this.yandexKey +
+      ((TextUtils.equals(this.userYandexKey, "DEFAULT") ||
+        TextUtils.isEmpty(this.userYandexKey))?this.yandexKey:this.userYandexKey) +
         "&lang=" + languageToTranslateTo +
         "&text=" + URLEncoder.encode(textToTranslate, "UTF-8");
 
@@ -212,6 +225,23 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
       "not be available.")
   public void GotTranslation(String responseCode, String translation) {
     EventDispatcher.dispatchEvent(this, "GotTranslation", responseCode, translation);
+  }
+
+  /**
+   * The Yandex API Key to use. If set to DEFAULT the platform default key (if any)
+   * will be used. Otherwise should be set to a valid API key which can be obtained
+   * from https://tech.yandex.com/translate/. If the platform doesn't have a default
+   * key and one isn't provided here, an error will be raised.
+   */
+
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
+      defaultValue = "DEFAULT")
+  @SimpleProperty(description = "Set the API Key to use with Yandex. " +
+      "You do not need to set this if you are using the MIT system because " +
+      "MIT has its own key builtin. If set, the key provided here will be " +
+      "used instead")
+  public void ApiKey(String apiKey) {
+    this.userYandexKey = apiKey;
   }
 
 }

--- a/appinventor/docs/html/reference/components/media.html
+++ b/appinventor/docs/html/reference/components/media.html
@@ -638,7 +638,13 @@
 
 <h3 id="YandexTranslate-Properties">Properties</h3>
 
-<p class="properties">None</p>
+<dl class="properties">
+  <dt id="YandexTranslate.ApiKey" class="text wo"><em>ApiKey</em></dt>
+  <dd>The Yandex API Key to use. If set to DEFAULT the platform default key (if any)
+ will be used. Otherwise should be set to a valid API key which can be obtained
+ from https://tech.yandex.com/translate/. If the platform doesn’t have a default
+ key and one isn’t provided here, an error will be raised.</dd>
+</dl>
 
 <h3 id="YandexTranslate-Events">Events</h3>
 

--- a/appinventor/docs/markdown/reference/components/media.md
+++ b/appinventor/docs/markdown/reference/components/media.md
@@ -598,8 +598,12 @@ Use this component to translate words and sentences between different languages.
 ### Properties  {#YandexTranslate-Properties}
 
 {:.properties}
-None
 
+{:id="YandexTranslate.ApiKey" .text .wo} *ApiKey*
+: The Yandex API Key to use. If set to DEFAULT the platform default key (if any)
+ will be used. Otherwise should be set to a valid API key which can be obtained
+ from https://tech.yandex.com/translate/. If the platform doesn't have a default
+ key and one isn't provided here, an error will be raised.
 
 ### Events  {#YandexTranslate-Events}
 


### PR DESCRIPTION
Permit the MIT App Inventor programmer to provide their own Yandex API
key. If they do not provide one, the builtin key (for the MIT
deployment) will be used.

Having neither a user provided key or builtin key results in an error.

Change-Id: Ieb25514437133162b68fae7741ffdce5a8463d04