### PR TITLE
Make WebRTC Connections more robust

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -445,7 +445,7 @@ Blockly.ReplMgr.putYail = (function() {
             webrtcpeer = new RTCPeerConnection(top.ReplState.iceservers);
             webrtcpeer.oniceconnectionstatechange = function(evt) {
                 console.log("oniceconnectionstatechange: evt.type = " + evt.type + " connection state = " + this.iceConnectionState);
-                connectionstate = this.iceConnectionState;
+                connectionstate = webrtcpeer.iceConnectionState;
                 if (connectionstate == "disconnected" ||
                     connectionstate == "failed") {
                     webrtcerror(true, Blockly.Msg.REPL_WEBRTC_CONNECTION_ERROR + "\n" + "state = " + connectionstate);


### PR DESCRIPTION
It turns out that the iceConnectionState on the connectionStateChange
event is about a particular ICE Candidate pair, which may not be the
selected and in use candidate pair. However checking the
iceConnectionState on the WebRTCPeer object itself yields the state of
the “selected” and in use candidate pair.

Change-Id: I7d14041300ce82a02fd1bd04b9a940f26216d802