### PR TITLE
Remove Column and Row properties from Form

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -47,8 +47,8 @@ public abstract class MockVisibleComponent extends MockComponent {
   protected static final String PROPERTY_NAME_VISIBLE = "Visible";
   protected static final String PROPERTY_NAME_WIDTH = "Width";
   protected static final String PROPERTY_NAME_HEIGHT = "Height";
-  protected static final String PROPERTY_NAME_COLUMN = "Column";
-  protected static final String PROPERTY_NAME_ROW = "Row";
+  public static final String PROPERTY_NAME_COLUMN = "Column";
+  public static final String PROPERTY_NAME_ROW = "Row";
 
   // Note: the values below are duplicated in Component.java
   // If you change them here, change them there!

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -25,6 +25,7 @@ import com.google.appinventor.client.editor.simple.components.FormChangeListener
 import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.editor.simple.components.MockContainer;
 import com.google.appinventor.client.editor.simple.components.MockForm;
+import com.google.appinventor.client.editor.simple.components.MockVisibleComponent;
 import com.google.appinventor.client.editor.simple.components.utils.PropertiesUtil;
 import com.google.appinventor.client.editor.simple.palette.DropTargetProvider;
 import com.google.appinventor.client.editor.simple.palette.SimpleComponentDescriptor;
@@ -636,6 +637,16 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     // Set the name of the component (on instantiation components are assigned a generated name)
     String componentName = properties.get("$Name").asString().getString();
     mockComponent.changeProperty("Name", componentName);
+
+    if (mockComponent instanceof MockForm) {
+      // A bug in an early version of multiselect resulted in Form gaining Row and Column
+      // properties, which are reserved for visible components that can appear in TableArrangements.
+      // Form doesn't have these properties, so we need to clean up the properties. The remove
+      // call here is idempotent--if the property is present, it is removed. If not present, the
+      // map remains unchanged.
+      properties.remove(MockVisibleComponent.PROPERTY_NAME_ROW);
+      properties.remove(MockVisibleComponent.PROPERTY_NAME_COLUMN);
+    }
 
     // Set component properties
     for (String name : properties.keySet()) {


### PR DESCRIPTION
In nb183 it was possible to select the the Screen and multiple other components, and when dragging one of the selected components into a TableArrangement have all of the selected components gain the dragged component's Column and Row properties. This is problematic for Screen because even though it is a visible component, it doesn't inherit from VisibleComponent (which defines the row/column properties), therefore YAIL generated from this Screen would fail to compile due to the use of undefined properties. This commit removes these properties from the MockForm when it loads in order to correct for this behavior. I have not been able to replicate the issue on nb183a and later, and I believe that it was fixed by #2132.

Change-Id: I986ce001d40ff7ea4423e7a21d29e3fad3e2eabc