### PR TITLE
Fix disabled blocks not working with backpack

### DIFF
--- a/appinventor/blocklyeditor/src/backpack.js
+++ b/appinventor/blocklyeditor/src/backpack.js
@@ -53,6 +53,8 @@ Blockly.Backpack = function(targetWorkspace, opt_options) {
   } else {
     opt_options = opt_options || {};
     this.options = new Blockly.Options(opt_options);
+    // Parsing loses this option so we have to reassign.
+    this.options.disabledPatternId = opt_options.disabledPatternId;
   }
   this.workspace_ = targetWorkspace;
   this.flyout_ = new Blockly.BackpackFlyout(this.options);

--- a/appinventor/blocklyeditor/src/backpackFlyout.js
+++ b/appinventor/blocklyeditor/src/backpackFlyout.js
@@ -78,19 +78,14 @@ Blockly.BackpackFlyout.prototype.dispose = function() {
 };
 
 /**
- * Filter the blocks on the flyout to disable the ones that are above the
- * capacity limit.
+ * Returns if the flyout allows a new instance of the given block to be created.
+ * Always returns true to allow disabled blocks to be dragged out.
+ * @param {!Blockly.BlockSvg} _block The block to copy from the flyout.
+ * @return {boolean} True if the flyout allows the block to be instantiated.
  */
-Blockly.BackpackFlyout.prototype.filterForCapacity_ = function() {
-  if (!this.targetWorkspace_) return;
-  var remainingCapacity = this.targetWorkspace_.remainingCapacity();
-  var blocks = this.workspace_.getTopBlocks(false);
-  for (var i = 0, block; block = blocks[i]; i++) {
-    var allBlocks = block.getDescendants();
-    var disabled = allBlocks.length > remainingCapacity;
-    block.setDisabled(disabled);
-  }
-};
+Blockly.BackpackFlyout.prototype.isBlockCreatable_ = function(_block) {
+  return true;
+}
 
 /**
  * Stop binding to the global mouseup and mousemove events.

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -230,7 +230,11 @@ Blockly.WorkspaceSvg.prototype.addWarningIndicator = function() {
  */
 Blockly.WorkspaceSvg.prototype.addBackpack = function() {
   if (Blockly.Backpack && !this.options.readOnly) {
-    this.backpack_ = new Blockly.Backpack(this, {scrollbars: true, media: './assets/'});
+    this.backpack_ = new Blockly.Backpack(this, {
+        scrollbars: true,
+        media: './assets/',
+        disabledPatternId: this.options.disabledPatternId,
+      });
     var svgBackpack = this.backpack_.createDom(this);
     this.svgGroup_.appendChild(svgBackpack);
     this.backpack_.init();


### PR DESCRIPTION
### Resolves

Closes #2147 

### Description

1) Bumps blockly lib commit to match https://github.com/mit-cml/blockly/pull/6
2) Removes filterForCapacity override from backpack b/c the functionality is identical to the super.
3) Overrides isBlockCreatable_ so that disabled blocks can be dragged from the flyout.

### Testing
![FixBackpack](https://user-images.githubusercontent.com/25440652/79254925-53f52880-7e3a-11ea-85f6-f7785fe208c0.gif)
