### PR TITLE
Add text bumping when number is replaced w/ text

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/text.js
+++ b/appinventor/blocklyeditor/src/blocks/text.js
@@ -19,10 +19,15 @@ Blockly.Blocks['text'] = {
   category: 'Text',
   helpUrl: Blockly.Msg.LANG_TEXT_TEXT_HELPURL,
   init: function () {
+    var textInput = new Blockly.FieldTextInput('');
+    textInput.onFinishEditing_ = Blockly.Blocks.text
+        .bumpBlockOnFinishEdit.bind(this);
+
     this.setColour(Blockly.TEXT_CATEGORY_HUE);
-    this.appendDummyInput().appendField(Blockly.Msg.LANG_TEXT_TEXT_LEFT_QUOTE).appendField(
-        new Blockly.FieldTextBlockInput(''),
-        'TEXT').appendField(Blockly.Msg.LANG_TEXT_TEXT_RIGHT_QUOTE);
+    this.appendDummyInput()
+        .appendField(Blockly.Msg.LANG_TEXT_TEXT_LEFT_QUOTE)
+        .appendField(textInput, 'TEXT')
+        .appendField(Blockly.Msg.LANG_TEXT_TEXT_RIGHT_QUOTE);
     this.setOutput(true, [Blockly.Blocks.text.connectionCheck]);
     this.setTooltip(Blockly.Msg.LANG_TEXT_TEXT_TOOLTIP);
   },
@@ -52,6 +57,36 @@ Blockly.Blocks.text.connectionCheck = function (myConnection, otherConnection) {
   }
   return false;
 };
+
+/**
+ * Bumps the text block out of its connection iff it is connected to a number
+ * input and it no longer contains a number.
+ * @param {string} finalValue The final value typed into the text input.
+ * @this Blockly.Block
+ */
+Blockly.Blocks.text.bumpBlockOnFinishEdit = function(finalValue) {
+  var connection = this.outputConnection.targetConnection;
+  if (!connection) {
+    return;
+  }
+  if (!isNaN(parseFloat(finalValue))) {
+    // Block is a number, so no matter where it lives it is valid.
+    return;
+  }
+
+  var typeArray = connection.check_;
+  var length = typeArray.length;
+  for (var i = 0; i < length; i++) {
+    var type = typeArray[i];
+    if (type == "String" || type == "Key") {
+      // There is another valid type on the connection.
+      return;
+    }
+  } 
+
+  connection.disconnect();
+  connection.sourceBlock_.bumpNeighbours_();
+}
 
 Blockly.Blocks['text_join'] = {
   // Create a string made up of any number of elements of any type.
@@ -473,10 +508,15 @@ Blockly.Blocks['obfuscated_text'] = {
   helpUrl: Blockly.Msg.LANG_TEXT_TEXT_OBFUSCATE_HELPURL,
   init: function () {
     this.setColour(Blockly.TEXT_CATEGORY_HUE);
-    this.appendDummyInput().appendField(Blockly.Msg.LANG_TEXT_TEXT_OBFUSCATE
-      + " " + Blockly.Msg.LANG_TEXT_TEXT_LEFT_QUOTE).appendField(
-        new Blockly.FieldTextBlockInput(''),
-        'TEXT').appendField(Blockly.Msg.LANG_TEXT_TEXT_RIGHT_QUOTE);
+    var label = Blockly.Msg.LANG_TEXT_TEXT_OBFUSCATE + " " +
+        Blockly.Msg.LANG_TEXT_TEXT_LEFT_QUOTE
+    var textInput = new Blockly.FieldTextBlockInput('');
+    textInput.onFinishEditing_ = Blockly.Blocks.text
+        .bumpBlockOnFinishEdit.bind(this);
+    this.appendDummyInput()
+        .appendField(label)
+        .appendField(textInput,'TEXT')
+        .appendField(Blockly.Msg.LANG_TEXT_TEXT_RIGHT_QUOTE);
     this.setOutput(true, [Blockly.Blocks.text.connectionCheck]);
     this.setTooltip(Blockly.Msg.LANG_TEXT_TEXT_OBFUSCATE_TOOLTIP);
     this.confounder = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 8);

--- a/appinventor/blocklyeditor/src/blocks/text.js
+++ b/appinventor/blocklyeditor/src/blocks/text.js
@@ -35,11 +35,12 @@ Blockly.Blocks['text'] = {
   typeblock: [{translatedName: Blockly.Msg.LANG_CATEGORY_TEXT}]
 };
 
-Blockly.Blocks.text.connectionCheck = function (myConnection, otherConnection) {
+Blockly.Blocks.text.connectionCheck = function (myConnection, otherConnection, opt_value) {
   var block = myConnection.sourceBlock_;
   var otherTypeArray = otherConnection.check_;
   var shouldIgnoreError = Blockly.mainWorkspace.isLoading;
-  var value = block.getFieldValue('TEXT');
+  var value = opt_value || block.getFieldValue('TEXT');
+
   for (var i = 0; i < otherTypeArray.length; i++) {
     if (otherTypeArray[i] == "String") {
       return true;
@@ -69,23 +70,12 @@ Blockly.Blocks.text.bumpBlockOnFinishEdit = function(finalValue) {
   if (!connection) {
     return;
   }
-  if (!isNaN(parseFloat(finalValue))) {
-    // Block is a number, so no matter where it lives it is valid.
-    return;
+  // If the connections are no longer compatible.
+  if (!Blockly.Blocks.text.connectionCheck(
+      this.outputConnection, connection, finalValue)) {
+    connection.disconnect();
+    connection.sourceBlock_.bumpNeighbours_();
   }
-
-  var typeArray = connection.check_;
-  var length = typeArray.length;
-  for (var i = 0; i < length; i++) {
-    var type = typeArray[i];
-    if (type == "String" || type == "Key") {
-      // There is another valid type on the connection.
-      return;
-    }
-  } 
-
-  connection.disconnect();
-  connection.sourceBlock_.bumpNeighbours_();
 }
 
 Blockly.Blocks['text_join'] = {

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -40,6 +40,15 @@ Blockly.WarningHandler.WarningState = {
 };
 
 /**
+ * Regular expression for floating point numbers.
+ *
+ * @type {!RegExp}
+ * @const
+ */
+Blockly.WarningHandler.NUMBER_REGEX =
+  new RegExp("^[-+]?[0-9]*(\\.[0-9]+)?([eE][-+][0-9]+)?$")
+
+/**
  * The currently selected index into the array of block IDs with warnings. If nothing has been
  * selected (i.e., if we are not stepping through warnings), this should be -1 so that the next
  * index will be 0.

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -40,15 +40,6 @@ Blockly.WarningHandler.WarningState = {
 };
 
 /**
- * Regular expression for floating point numbers.
- *
- * @type {!RegExp}
- * @const
- */
-Blockly.WarningHandler.NUMBER_REGEX =
-  new RegExp("^[-+]?[0-9]*(\\.[0-9]+)?([eE][-+][0-9]+)?$")
-
-/**
  * The currently selected index into the array of block IDs with warnings. If nothing has been
  * selected (i.e., if we are not stepping through warnings), this should be -1 so that the next
  * index will be 0.


### PR DESCRIPTION
### Description

If a text block is currently connected to a number input, and the text changes to be not-a-number, the block will get bumped out.

This works for both the normal text block and the obfuscate text block:
![NewTextBlocks](https://user-images.githubusercontent.com/25440652/80263371-48c5a800-8645-11ea-9ab3-62c3b20005ae.gif)
