### PR TITLE
Fix LineString.PointsFromString docs

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
@@ -146,8 +146,7 @@ public class LineString extends MapFeatureBase implements MapLineString {
 
   /**
    * Set the points of the LineString from a specially-coded character string of the form:
-   * [[longitude1, latitude1], [longitude2, latitude2], ...]
-   * Note the reversal of latitude and longitude versus how they are typically represented.
+   * [[latitude1, longitude1], [latitude2, longitude2], ...]
    *
    * @param points String containing a sequence of points for the LineString.
    */

--- a/appinventor/docs/html/reference/components/maps.html
+++ b/appinventor/docs/html/reference/components/maps.html
@@ -369,8 +369,7 @@
   <dd>The list of points, as pairs of latitudes and longitudes, in the <code class="highlighter-rouge">LineString</code>.</dd>
   <dt id="LineString.PointsFromString" class="text wo"><em>PointsFromString</em></dt>
   <dd>Set the points of the LineString from a specially-coded character string of the form:
- [[longitude1, latitude1], [longitude2, latitude2], …]
- Note the reversal of latitude and longitude versus how they are typically represented.</dd>
+ [[latitude1, longitude1], [latitude2, longitude2], …]</dd>
   <dt id="LineString.StrokeColor" class="color"><em>StrokeColor</em></dt>
   <dd>Sets or gets the color used to outline the <code class="highlighter-rouge">LineString</code>.</dd>
   <dt id="LineString.StrokeOpacity" class="number"><em>StrokeOpacity</em></dt>

--- a/appinventor/docs/markdown/reference/components/maps.md
+++ b/appinventor/docs/markdown/reference/components/maps.md
@@ -288,8 +288,7 @@ A `FeatureCollection` groups one or more map features together. Any events that 
 
 {:id="LineString.PointsFromString" .text .wo} *PointsFromString*
 : Set the points of the LineString from a specially-coded character string of the form:
- [[longitude1, latitude1], [longitude2, latitude2], ...]
- Note the reversal of latitude and longitude versus how they are typically represented.
+ [[latitude1, longitude1], [latitude2, longitude2], ...]
 
 {:id="LineString.StrokeColor" .color} *StrokeColor*
 : Sets or gets the color used to outline the `LineString`.


### PR DESCRIPTION
### Resolves

Closes #2176 

### Description

Corrects the LineString.PointsFromString javadoc and associated markdown and html files. Files were rebuilt using `ant docs`.