### PR TITLE
Fix blockly comment text color

### DIFF
--- a/appinventor/blocklyeditor/media/blockly.css
+++ b/appinventor/blocklyeditor/media/blockly.css
@@ -127,6 +127,7 @@
   resize: none;
   background-color: #ffc;
   overflow: hidden;
+  color: #000;
 }
 .blocklyHtmlInput {
   font-family: sans-serif;


### PR DESCRIPTION
### Description

Currently blockly comments have the colors background: `#FFC` and font: `#555`. *Technically* these colors pass accessibility tests, but it can still be hard to read.

By default blockly comments are supposed to have a font color of `#000`. AI's comments did not because the designer css was overflowing into the Blockly workspace.

This PR changes the comment text color back to the default `#000`.

### Testing
![BetterCSS](https://user-images.githubusercontent.com/25440652/80527040-99404c80-8948-11ea-910e-f031ed275230.png)
(open the image in a new tab for a better reference).

I also inspected the textarea element to ensure the font color was being applied.

### Additional Information

This was originally discussed in the comments of [this forum post](https://community.appinventor.mit.edu/t/comment-font-size-is-so-small/7847).