### PR TITLE
Improve "Do It" comments

### DIFF
--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1622,6 +1622,7 @@ Blockly.Msg.en.switch_language_to_english = {
 // Blocklyeditor.js
     Blockly.Msg.GENERATE_YAIL = "Generate Yail";
     Blockly.Msg.DO_IT = "Do It";
+    Blockly.Msg.DO_IT_RESULT = "Do It Result:";
     Blockly.Msg.DO_IT_DISCONNECTED = 'Do It (Companion not connected)';
     Blockly.Msg.CLEAR_DO_IT_ERROR = "Clear Error";
     Blockly.Msg.CAN_NOT_DO_IT = "Cannot Do it";

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1116,8 +1116,8 @@ Blockly.ReplMgr.processRetvals = function(responses) {
 
 Blockly.ReplMgr.setDoitResult = function(block, value) {
     var oldPatt = /Do It Result:.*?\n---\n/m;
-    var patt = new RegExp(Blockly.Msg.DO_IT + ':.*?\n---\n');
-    var result = Blockly.Msg.DO_IT + ': ' + value + '\n---\n';
+    var patt = new RegExp(Blockly.Msg.DO_IT_RESULT + '.*?\n---\n');
+    var result = Blockly.Msg.DO_IT_RESULT + ' ' + value + '\n---\n';
     var text = "";
 
     if (block.comment) {

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1115,11 +1115,13 @@ Blockly.ReplMgr.processRetvals = function(responses) {
 };
 
 Blockly.ReplMgr.setDoitResult = function(block, value) {
-    var patt = /Do It Result:.*?\n---\n/m;
-    var result = 'Do It Result: ' + value + '\n---\n';
+    var oldPatt = /Do It Result:.*?\n---\n/m;
+    var patt = new RegExp(Blockly.Msg.DO_IT + ':.*?\n---\n');
+    var result = Blockly.Msg.DO_IT + ': ' + value + '\n---\n';
     var text = "";
+
     if (block.comment) {
-        text = block.comment.getText();
+        text = block.comment.getText().replace(oldPatt, '');
     }
     if (!text) {
         text = result;

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1116,26 +1116,19 @@ Blockly.ReplMgr.processRetvals = function(responses) {
 
 Blockly.ReplMgr.setDoitResult = function(block, value) {
     var patt = /Do It Result:.*?\n---\n/m;
-    var comment = "";
     var result = 'Do It Result: ' + value + '\n---\n';
+    var text = "";
     if (block.comment) {
-        comment = block.comment.getText();
+        text = block.comment.getText();
     }
-    if (!comment) {
-        comment = result;
+    if (!text) {
+        text = result;
+    } else if (patt.test(text)) { // Already a result there.
+        text = text.replace(patt, result);
     } else {
-        if (patt.test(comment)) { // Already a doit there!
-            comment = comment.replace(patt, result);
-        } else {
-            comment = result + comment;
-        }
+        text = result + text;
     }
-    // If we don't set visible to false, the comment
-    // doesn't always change when it should...
-    if (block.comment) {
-        block.comment.setVisible(false);
-    }
-    block.setCommentText(comment);
+    block.setCommentText(text);
     block.comment.setVisible(true);
 };
 


### PR DESCRIPTION
### Description

Previously triggering a "do it" on a block would move the comment and scroll to the bottom of the text. This wasn't a great UX, especially when moving the text meant your "do it" result wasn't visible.

Now the comment stays in the same place:
![DoItAgain](https://user-images.githubusercontent.com/25440652/80931706-6cd56780-8d70-11ea-9c52-86984f1c657c.gif)

I also added i18n so that the label is in the user's chosen language:
![MacheEs](https://user-images.githubusercontent.com/25440652/80931708-71018500-8d70-11ea-852b-92ce05650aa1.gif)
![DoIt](https://user-images.githubusercontent.com/25440652/80931710-7363df00-8d70-11ea-925b-8dba47939f19.gif)

But as always I'm happy to revert.