### PR TITLE
Fix HELPURL for radix number block

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/math.js
+++ b/appinventor/blocklyeditor/src/blocks/math.js
@@ -50,7 +50,7 @@ Blockly.Blocks.math_number.validator = function (text) {
 Blockly.Blocks['math_number_radix'] = {
   category:'Math',
 
-  helpUrl: Blockly.Msg.LANG_MATH_NUMBER_RADIX_TOOLTIP,
+  helpUrl: Blockly.Msg.LANG_MATH_NUMBER_RADIX_HELPURL,
 
   init: function() {
     this.dropdown = new Blockly.FieldDropdown([


### PR DESCRIPTION
The URL was pointing to the block tooltip instead.