### PR TITLE
Fix galleryId, repo, and template URLs when autoload is false

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -583,58 +583,72 @@ public class Ode implements EntryPoint {
     resizeWorkArea((WorkAreaPanel) deckPanel.getWidget(debuggingTabIndex));
   }
 
-  public void openPreviousProject() {
+  /**
+   * Processes the template and galleryId flags.
+   *
+   * @return true if a template or gallery id is present and being handled, otherwise false.
+   */
+  private boolean handleQueryString() {
     if (userSettings == null) {
-      OdeLog.wlog("Ignoring openPreviousProject() since userSettings is null");
-      return;
+      return false;
     }
-    OdeLog.log("Ode.openPreviousProject called");
-    final String value = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS).
-      getPropertyValue(SettingsConstants.GENERAL_SETTINGS_CURRENT_PROJECT_ID);
-
     // Retrieve the userTemplates
-    String userTemplates = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS).
-      getPropertyValue(SettingsConstants.USER_TEMPLATE_URLS);
+    String userTemplates = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS)
+        .getPropertyValue(SettingsConstants.USER_TEMPLATE_URLS);
     TemplateUploadWizard.setStoredTemplateUrls(userTemplates);
 
     if (templateLoadingFlag) {  // We are loading a template, open it instead
                                 // of the last project
       NewProjectCommand callbackCommand = new NewProjectCommand() {
-          @Override
-          public void execute(Project project) {
-            templateLoadingFlag = false;
-            Ode.getInstance().openYoungAndroidProjectInDesigner(project);
-          }
-        };
+        @Override
+        public void execute(Project project) {
+          templateLoadingFlag = false;
+          Ode.getInstance().openYoungAndroidProjectInDesigner(project);
+        }
+      };
       TemplateUploadWizard.openProjectFromTemplate(templatePath, callbackCommand);
-    } else if(galleryIdLoadingFlag){
+      return true;
+    } else if (galleryIdLoadingFlag) {
       try {
-        long galleryId_Long = Long.valueOf(galleryId);
+        long galleryId = Long.parseLong(this.galleryId);
         final OdeAsyncCallback<GalleryApp> callback = new OdeAsyncCallback<GalleryApp>(
             // failure message
             MESSAGES.galleryError()) {
-              @Override
-              public void onSuccess(GalleryApp app) {
-                if(app == null){
-                  openProject(value);
-                  Window.alert(MESSAGES.galleryIdNotExist());
-                }else{
-                  Ode.getInstance().switchToGalleryAppView(app, GalleryPage.VIEWAPP);
-                }
-              }
-            };
-        Ode.getInstance().getGalleryService().getApp(galleryId_Long, callback);
+          @Override
+          public void onSuccess(GalleryApp app) {
+            if (app == null) {
+              Window.alert(MESSAGES.galleryIdNotExist());
+              // Reset the galleryId flag and then load the previous project
+              galleryIdLoadingFlag = false;
+              openPreviousProject();
+            } else {
+              Ode.getInstance().switchToGalleryAppView(app, GalleryPage.VIEWAPP);
+            }
+          }
+        };
+        Ode.getInstance().getGalleryService().getApp(galleryId, callback);
+        return true;
       } catch (NumberFormatException e) {
-        openProject(value);
         Window.alert(MESSAGES.galleryIdNotExist());
       }
-    } else {
-      openProject(value);
     }
+    return false;
+  }
+
+  /**
+   * Opens the user's last project, if the information is known.
+   */
+  private void openPreviousProject() {
+    if (userSettings == null) {
+      OdeLog.wlog("Ignoring openPreviousProject() since userSettings is null");
+      return;
+    }
+    final String value = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS)
+        .getPropertyValue(SettingsConstants.GENERAL_SETTINGS_CURRENT_PROJECT_ID);
+    openProject(value);
   }
 
   private void openProject(String projectIdString) {
-    OdeLog.log("Ode.openProject called for " + projectIdString);
     if (projectIdString.equals("")) {
       openPreviousProject();
     } else if (!projectIdString.equals("0")) {
@@ -853,7 +867,7 @@ public class Ode implements EntryPoint {
               @Override
               public void onProjectsLoaded() {
                 projectManager.removeProjectManagerEventListener(this);
-                if (shouldAutoloadLastProject()) {
+                if (!handleQueryString() && shouldAutoloadLastProject()) {
                   openPreviousProject();
                 }
 


### PR DESCRIPTION
As reported by the [power users](https://community.appinventor.mit.edu/t/gallery-links-not-working/8987?u=ewpatton), the galleryId parameter does not work if the user has disabled the autoload functionality. This change fixes that by processing the template and galleryId parameters prior to the autoload check.

Change-Id: If329454dfdb33f99df07be008369d220a4a11de9