### PR TITLE
Fix nullptr in text connection check

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/text.js
+++ b/appinventor/blocklyeditor/src/blocks/text.js
@@ -36,8 +36,12 @@ Blockly.Blocks['text'] = {
 };
 
 Blockly.Blocks.text.connectionCheck = function (myConnection, otherConnection, opt_value) {
-  var block = myConnection.sourceBlock_;
   var otherTypeArray = otherConnection.check_;
+  if (!otherTypeArray) {  // Other connection accepts everything.
+    return true;
+  }
+
+  var block = myConnection.sourceBlock_;
   var shouldIgnoreError = Blockly.mainWorkspace.isLoading;
   var value = opt_value || block.getFieldValue('TEXT');
 

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/mocha/text.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/mocha/text.js
@@ -39,6 +39,7 @@ suite('Text Blocks', function() {
     var string = { check_: ['String'] };
     var key = { check_: ['Key'] };
     var many = { check_: ['Number', 'String'] };
+    var untyped = { check_: null };
     var invalidNumbers = [
       'cat', '4cat', 'e', '  zero  ', '0x0', '.', '-', '+', '', '-e-', '+e+'
     ];
@@ -83,6 +84,14 @@ suite('Text Blocks', function() {
 
     test('Should connect with many checks', function() {
       chai.assert.isTrue(check(mockConnection('cat'), many));
-    })
+    });
+
+    test('Should connect to untyped when a number', function() {
+      chai.assert.isTrue(check(mockConnection('1'), untyped));
+    });
+
+    test('Should connect to untyped when not number', function() {
+      chai.assert.isTrue(check(mockConnection('cat'), untyped));
+    });
   });
 })


### PR DESCRIPTION
### Resolves

Closes #2205 

### Description

Untyped connections have a `.check_` value of null. This meant that if you connected a text block to an untyped connection it would throw a null error when it tried to access the `.length` of the `.check_`.

This adds an explicit check for untyped connections so that this error does not occur.

### Testing

Rebuilt and replicated the steps from #2205. Could not replicate the error.

### Additional Info

Thank you for reporting this @xuwenbin ! I think this should fix it :D 