### PR TITLE
Fix deprecation being inconsistent

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -205,8 +205,8 @@ Blockly.ComponentBlock.addGenericOption = function(block, options) {
  *     associated with the block which is possibly deprecated.
  */
 Blockly.ComponentBlock.checkDeprecated = function(block, data) {
-  if ((!data || data.deprecated) && block.workspace == Blockly.mainWorkspace) {
-    block.badBlock();
+  if (data && data.deprecated && block.workspace == Blockly.mainWorkspace) {
+    block.setDisabled(true);
   }
 }
 
@@ -314,9 +314,10 @@ Blockly.Blocks.component_event = {
       input.init();
     }
 
+    // Set as badBlock if it doesn't exist.
+    this.verify(); 
+    // Disable it if it does exist and is deprecated.
     Blockly.ComponentBlock.checkDeprecated(this, eventType);
-
-    this.verify(); // verify the block and mark it accordingly
 
     this.rendered = oldRendered;
   },
@@ -779,9 +780,10 @@ Blockly.Blocks.component_method = {
     this.errors = [{name:"checkIfUndefinedBlock"}, {name:"checkIsInDefinition"},
       {name:"checkComponentNotExistsError"}, {name: "checkGenericComponentSocket"}];
 
+    // Set as badBlock if it doesn't exist.
+    this.verify(); 
+    // Disable it if it does exist and is deprecated.
     Blockly.ComponentBlock.checkDeprecated(this, this.getMethodTypeObject());
-
-    this.verify(); // verify the block and mark it accordingly
 
     this.rendered = oldRendered;
   },
@@ -1032,9 +1034,9 @@ Blockly.Blocks.component_set_get = {
       this.setColour(Blockly.ComponentBlock.COLOUR_GET);
     }
     var tooltipDescription;
-    if (this.propertyName) {
-      tooltipDescription = componentDb.getInternationalizedPropertyDescription(this.getTypeName(), this.propertyName,
-          this.propertyObject.description);
+    if (this.propertyName && this.propertyObject) {
+      tooltipDescription = componentDb.getInternationalizedPropertyDescription(
+        this.getTypeName(), this.propertyName, this.propertyObject.description);
     } else {
       tooltipDescription = Blockly.Msg.UNDEFINED_BLOCK_TOOLTIP;
     }
@@ -1129,9 +1131,10 @@ Blockly.Blocks.component_set_get = {
       {name:"checkComponentNotExistsError"}, {name: 'checkGenericComponentSocket'},
       {name: 'checkEmptySetterSocket'}];
 
+    // Set as badBlock if it doesn't exist.
+    this.verify(); 
+    // Disable it if it does exist and is deprecated.
     Blockly.ComponentBlock.checkDeprecated(this, this.propertyObject);
-
-    this.verify();
 
     for (var i = 0, input; input = this.inputList[i]; i++) {
       input.init();

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -207,7 +207,6 @@ Blockly.ComponentBlock.addGenericOption = function(block, options) {
 Blockly.ComponentBlock.checkDeprecated = function(block, data) {
   if ((!data || data.deprecated) && block.workspace == Blockly.mainWorkspace) {
     block.badBlock();
-    block.setDisabled(true);
   }
 }
 

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -198,6 +198,20 @@ Blockly.ComponentBlock.addGenericOption = function(block, options) {
 };
 
 /**
+ * Marks the passed block as a badBlock() and disables it if the data associated
+ * with the block is not defined, or the data is marked as deprecated.
+ * @param {Blockly.BlockSvg} block The block to check for deprecation.
+ * @param {EventDescriptor|MethodDescriptor|PropertyDescriptor} data The data
+ *     associated with the block which is possibly deprecated.
+ */
+Blockly.ComponentBlock.checkDeprecated = function(block, data) {
+  if ((!data || data.deprecated) && block.workspace == Blockly.mainWorkspace) {
+    block.badBlock();
+    block.setDisabled(true);
+  }
+}
+
+/**
  * Create an event block of the given type for a component with the given
  * instance name. eventType is one of the "events" objects in a typeJsonString
  * passed to Blockly.Component.add.
@@ -301,10 +315,7 @@ Blockly.Blocks.component_event = {
       input.init();
     }
 
-    if (eventType && eventType.deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
-      this.badBlock();
-      this.setDisabled(true);
-    }
+    Blockly.ComponentBlock.checkDeprecated(this, eventType);
 
     this.verify(); // verify the block and mark it accordingly
 
@@ -769,13 +780,7 @@ Blockly.Blocks.component_method = {
     this.errors = [{name:"checkIfUndefinedBlock"}, {name:"checkIsInDefinition"},
       {name:"checkComponentNotExistsError"}, {name: "checkGenericComponentSocket"}];
 
-    // mark the block bad if the method isn't defined or is marked deprecated
-    var method = this.getMethodTypeObject();
-    if ((!method || method.deprecated === true || method.deprecated === 'true') &&
-        this.workspace === Blockly.mainWorkspace) {
-      this.badBlock();
-      this.setDisabled(true);
-    }
+    Blockly.ComponentBlock.checkDeprecated(this, this.getMethodTypeObject());
 
     this.verify(); // verify the block and mark it accordingly
 
@@ -1125,11 +1130,7 @@ Blockly.Blocks.component_set_get = {
       {name:"checkComponentNotExistsError"}, {name: 'checkGenericComponentSocket'},
       {name: 'checkEmptySetterSocket'}];
 
-    if (thisBlock.propertyObject && this.propertyObject.deprecated === "true" && this.workspace === Blockly.mainWorkspace) {
-      // [lyn, 2015/12/27] mark deprecated properties as bad
-      this.badBlock();
-      this.setDisabled(true);
-    }
+    Blockly.ComponentBlock.checkDeprecated(this, this.propertyObject);
 
     this.verify();
 

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -334,7 +334,6 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
       info.properties[property.name] = property;
       if (typeof property['deprecated'] === 'string') {
         property['deprecated'] = JSON.parse(property['deprecated']);
-        if (property['deprecated']) continue;
       }
       if (property['rw'] == 'read-write') {
         property.mutability = Blockly.PROPERTY_READWRITEABLE;


### PR DESCRIPTION
### Description

Resolves #2216 

Now all feature types correctly react like this:
![Deprecation](https://user-images.githubusercontent.com/25440652/86038715-3590d900-b9f6-11ea-949e-7505cb4feec5.png)

### Testing
Could not replicate the behavior from #2216 

### Additional Info

Question: Why do we disable the blocks? The code gen should still work. There's also a problem that if you re-enable them there is no red "bad block" highlight:
![Re-Enabled](https://user-images.githubusercontent.com/25440652/86039032-b64fd500-b9f6-11ea-80e4-fa676a55aade.png)