### PR TITLE
Fix issues with Gallery

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -616,7 +616,7 @@ public class Ode implements EntryPoint {
             MESSAGES.galleryError()) {
           @Override
           public void onSuccess(GalleryApp app) {
-            if (app == null) {
+            if (app == null || !app.getActive()) {
               Window.alert(MESSAGES.galleryIdNotExist());
               // Reset the galleryId flag and then load the previous project
               galleryIdLoadingFlag = false;


### PR DESCRIPTION
This PR contains two fixes and should probably be merged via rebase rather than squashing.

The first fix addresses the use of galleryId to reference deactivated apps, either due to moderation or because the user deletes the underlying App Inventor project. Gallery apps that are inactive will now cause an error message saying the app is not found.

The second fix addresses deleting apps from the trash that are published to the gallery. If you publish a project, the logic to delete the app from the trash is broken. It only deactivates the app and doesn't delete the project. This change calls the deleteProject function after the gallery app has been deactivated to ensure the project is removed from the server and project list.