### PR TITLE
Fix instance typing and cleanup typing

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -25,7 +25,6 @@ goog.provide('Blockly.Blocks.Utilities');
 Blockly.Blocks.Utilities.InstantInTime = function (myConn, otherConn) {
   if (!myConn.sourceBlock_.rendered ||
       !otherConn.sourceBlock_.rendered) {
-    console.log(otherConn.check_);
     if (otherConn.check_ && !otherConn.check_.includes('InstantInTime')) {
       otherConn.sourceBlock_.badBlock();
     }
@@ -43,44 +42,44 @@ Blockly.Blocks.Utilities.InstantInTime = function (myConn, otherConn) {
 // Blockly's convention
 Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap = {
   'number': {
-    input: ['Number'],
-    output: ['Number', 'String', 'Key']
+    'input': ['Number'],
+    'output': ['Number', 'String', 'Key']
   },
   'text': {
-    input: ['String'],
-    output: ['Number', 'String', 'Key']
+    'input': ['String'],
+    'output': ['Number', 'String', 'Key']
   },
   'boolean': {
-    input: ['Boolean'],
-    output: ['Boolean', 'String']
+    'input': ['Boolean'],
+    'output': ['Boolean', 'String']
   },
   'list': {
-    input: ['Array'],
-    output: ['Array', 'String']
+    'input': ['Array'],
+    'output': ['Array', 'String']
   },
   'component': {
-    input: ['COMPONENT'],
-    output: ['COMPONENT', 'Key']
+    'input': ['COMPONENT'],
+    'output': ['COMPONENT', 'Key']
   },
   'InstantInTime': {
-    input: ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
-    output: ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
+    'input': ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
+    'output': ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
   },
   'any': {
-    input: null,
-    output: null
+    'input': null,
+    'output': null
   },
   'dictionary': {
-    input: ['Dictionary'],
-    output: ['Dictionary', 'String', 'Array']
+    'input': ['Dictionary'],
+    'output': ['Dictionary', 'String', 'Array']
   },
   'pair': {
-    input: ['Pair'],
-    output: ['Pair', 'String', 'Array']
+    'input': ['Pair'],
+    'output': ['Pair', 'String', 'Array']
   },
   'key': {
-    input: ['Key'],
-    output: ['String', 'Key']
+    'input': ['Key'],
+    'output': ['String', 'Key']
   }
 };
 
@@ -93,19 +92,14 @@ Blockly.Blocks.Utilities.INPUT = 'input';
  * @param {!string} inputOrOutput Either Utilities.OUTPUT or Utilities.INPUT.
  * @param {Array<string>=} opt_currentType A type array to append, or null.
  */
-Blockly.Blocks.Utilities.YailTypeToBlocklyType =
-  function(yail, inputOrOutput, opt_currentType) {
-    var type = Blockly.Blocks.Utilities
-        .YailTypeToBlocklyTypeMap[yail][inputOrOutput];
-    if (type === undefined) {
-      throw new Error("Unknown Yail type: " + yail + " -- YailTypeToBlocklyType");
-    }
-    if (!opt_currentType || !type) {
-      return type;
-    }
-    Array.prototype.push.apply(type, opt_currentType);
-    return type;
-  };
+Blockly.Blocks.Utilities.YailTypeToBlocklyType = function(yail, inputOrOutput) {
+  var type = Blockly.Blocks.Utilities
+      .YailTypeToBlocklyTypeMap[yail][inputOrOutput];
+  if (type === undefined) {
+    throw new Error("Unknown Yail type: " + yail + " -- YailTypeToBlocklyType");
+  }
+  return type;
+};
 
 
 // Blockly doesn't wrap tooltips, so these can get too wide.  We'll create our own tooltip setter

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -27,33 +27,70 @@ Blockly.Blocks.Utilities.InstantInTime = function () { return 'InstantInTime'; }
 // The Yail type 'any' is repsented by Javascript null, to match
 // Blockly's convention
 Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap = {
-  'number':{input:"Number",output:["Number","String", "Key"]},
-  'text':{input:"String",output:["Number","String", "Key"]},
-  'boolean':{input:"Boolean",output:["Boolean","String"]},
-  'list':{input:"Array",output:["Array","String"]},
-  'component':{input:"COMPONENT",output:["COMPONENT", "Key"]},
-  'InstantInTime':{input:Blockly.Blocks.Utilities.InstantInTime,output:Blockly.Blocks.Utilities.InstantInTime},
-  'any':{input:null,output:null},
-  'dictionary':{input:"Dictionary",output:["Dictionary", "String", "Array"]},
-  'pair':{input:"Pair",output:["Pair", "String", "Array"]},
-  'key':{input:"Key",output:["String", "Key"]}
-  //add  more types here
+  'number': {
+    input: ['Number'],
+    output: ['Number', 'String', 'Key']
+  },
+  'text': {
+    input: ['String'],
+    output: ['Number', 'String', 'Key']
+  },
+  'boolean': {
+    input: ['Boolean'],
+    output: ['Boolean', 'String']
+  },
+  'list': {
+    input: ['Array'],
+    output: ['Array', 'String']
+  },
+  'component': {
+    input: ['COMPONENT'],
+    output: ['COMPONENT', 'Key']
+  },
+  'InstantInTime': {
+    input: ['InstantInTime'],
+    output: ['InstantInTime'],
+  },
+  'any': {
+    input: null,
+    output: null
+  },
+  'dictionary': {
+    input: ['Dictionary'],
+    output: ['Dictionary', 'String', 'Array']
+  },
+  'pair': {
+    input: ['Pair'],
+    output: ['Pair', 'String', 'Array']
+  },
+  'key': {
+    input: ['Key'],
+    output: ['String', 'Key']
+  }
 };
 
-Blockly.Blocks.Utilities.OUTPUT = 1;
-Blockly.Blocks.Utilities.INPUT = 0;
+Blockly.Blocks.Utilities.OUTPUT = 'output';
+Blockly.Blocks.Utilities.INPUT = 'input';
 
-Blockly.Blocks.Utilities.YailTypeToBlocklyType = function(yail,inputOrOutput) {
-
-    var inputOrOutputName = (inputOrOutput == Blockly.Blocks.Utilities.OUTPUT ? "output" : "input");
-    var bType = Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap[yail][inputOrOutputName];
-
-    if (bType !== null || yail == 'any') {
-        return bType;
-    } else {
-        throw new Error("Unknown Yail type: " + yail + " -- YailTypeToBlocklyType");
+/**
+ * Gets the equivalent Blockly type for a given Yail type.
+ * @param {string} yail The Yail type.
+ * @param {!string} inputOrOutput Either Utilities.OUTPUT or Utilities.INPUT.
+ * @param {Array<string>=} opt_currentType A type array to append, or null.
+ */
+Blockly.Blocks.Utilities.YailTypeToBlocklyType =
+  function(yail, inputOrOutput, opt_currentType) {
+    var type = Blockly.Blocks.Utilities
+        .YailTypeToBlocklyTypeMap[yail][inputOrOutput];
+    if (type === undefined) {
+      throw new Error("Unknown Yail type: " + yail + " -- YailTypeToBlocklyType");
     }
-};
+    if (!opt_currentType || !type) {
+      return type;
+    }
+    Array.prototype.push.apply(type, opt_currentType);
+    return type;
+  };
 
 
 // Blockly doesn't wrap tooltips, so these can get too wide.  We'll create our own tooltip setter

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -15,9 +15,24 @@
 
 goog.provide('Blockly.Blocks.Utilities');
 
-// Create a unique object to represent the type InstantInTime,
-// used in the Clock component
-Blockly.Blocks.Utilities.InstantInTime = function () { return 'InstantInTime'; };
+/**
+ * Checks that the given otherConnection is compatible with an InstantInTime
+ * connection. If the workspace is currently loading (eg the blocks are not
+ * yet rendered) this always returns true for backwards compatibility.
+ * @param {!Blockly.Connection} myConn The parent connection.
+ * @param {!Blockly.Connection} otherConn The child connection.
+ */
+Blockly.Blocks.Utilities.InstantInTime = function (myConn, otherConn) {
+  if (!myConn.sourceBlock_.rendered ||
+      !otherConn.sourceBlock_.rendered) {
+    console.log(otherConn.check_);
+    if (otherConn.check_ && !otherConn.check_.includes('InstantInTime')) {
+      otherConn.sourceBlock_.badBlock();
+    }
+    return true;
+  }
+  return !otherConn.check_ || otherConn.check_.includes('InstantInTime');
+};
 
 
 // Convert Yail types to Blockly types
@@ -48,8 +63,8 @@ Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap = {
     output: ['COMPONENT', 'Key']
   },
   'InstantInTime': {
-    input: ['InstantInTime'],
-    output: ['InstantInTime'],
+    input: ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
+    output: ['InstantInTime', Blockly.Blocks.Utilities.InstantInTime],
   },
   'any': {
     input: null,


### PR DESCRIPTION
### Description

1) Fixes 'InstantInTime' typing. Functions do not work as input checks.
2) Reformats the YailTypeToBlocklyTypeMap so that it is more readable.
3) Adds support for an opt_currentType that can be passed to YailTypeToBlocklyType. This is helpful for my current dropdowns project because we must get the Blockly types of the abstract (enum) type and the concrete type separately, then combine them.

