### PR TITLE
Fix CSV parsing issues in presence of trailing comma

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/CsvUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/CsvUtil.java
@@ -185,7 +185,16 @@ public final class CsvUtil {
         trailingComma = delimitedCellLength > 0 && buf[pos + delimitedCellLength - 1] == ',';
         pos += delimitedCellLength;
         delimitedCellLength = cellLength = -1;
+        int oldLimit = limit;
         haveMoreData = pos < limit || indexAfterCompactionAndFilling(pos) < limit;
+        // If the CSV data ends with a trailing comma, haveMoreData will be false even though there
+        // is one (empty) cell remaining. The cell "appears" if a trailing carriage return is added
+        // to the input CSV. The following code handles this edge case by checking that we have no
+        // more data and if the last character in the buffer was a comma. If so, it appends the
+        // empty cell that would otherwise be dropped.
+        if (!haveMoreData && buf[oldLimit - 1] == ',') {
+          result.add("");
+        }
       } while (trailingComma && haveMoreData && lookingAtCell());
       return result;
     }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/CsvUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/CsvUtilTest.java
@@ -171,4 +171,23 @@ public class CsvUtilTest extends TestCase {
     String expectedCSVString = "\"field0\",\"field1\",\"field2\"";
     assertEquals(expectedCSVString, CsvUtil.toCsvRow(YailList.makeList(row)));
   }
+
+  public void testTrailingCommaRow() throws Exception {
+    String testString1 = "a,b,c,,,";
+    String testString2 = testString1 + "\n";
+    YailList list1 = CsvUtil.fromCsvRow(testString1);
+    YailList list2 = CsvUtil.fromCsvRow(testString2);
+    assertEquals(6, list1.size());
+    assertEquals(6, list2.size());
+    assertEquals(list2, list1);
+  }
+
+  public void testTrailingCommaTable() throws Exception {
+    String testString1 = "a,b,c,,,\nd,e,f,,,";
+    String testString2 = testString1 + "\n";
+    YailList list1 = CsvUtil.fromCsvTable(testString1);
+    YailList list2 = CsvUtil.fromCsvTable(testString2);
+    assertEquals(list2.getObject(0), list1.getObject(0));
+    assertEquals(list2.getObject(1), list1.getObject(1));
+  }
 }


### PR DESCRIPTION
This is a small fix requested by Taifun. The issue at hand is that the following two CSV parse differently even though they encode the same information: "a,b,c," and "a,b,c,\n". The former parses as (a b c) and the latter parses as (a b c *empty-string*). This is problematic when dealing with results from a database, such as sqlite, because there might be a string of such commas (depending on whether data is present), resulting in lists that may be of two different lengths and a typical out of bounds error when trying to access the missing last element.

This change fixes the issue by testing for this edge case with CsvParser by looking at whether there is no more data and the last character in the buffer is a comma. If these two conditions are met, then the empty cell is appended. There are also unit tests for both the row and table versions of parsing.

Change-Id: I5e715f22b21f1f5c18a80d8ff73a59ed4cedbdc1