### PR TITLE
Typo in the Picture-In-Picture element.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/ActivityElement.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/ActivityElement.java
@@ -609,9 +609,9 @@ public @interface ActivityElement {
    *
    * This attribute was added in API level 24.
    *
-   * @return  the activity supportPictureInPicture attribute
+   * @return  the activity supportsPictureInPicture attribute
    */
-  String supportPictureInPicture() default "";
+  String supportsPictureInPicture() default "";
 
   /**
    * The task that the activity has an affinity for. Activities with the same


### PR DESCRIPTION
It was not possible to implement or support Picture-In-Picture in my activity due to the lack of an "s" in the support**s**PictureInPicture element. Change corrected in this request.