### PR TITLE
Update YoungAndroidProjectService.java

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -842,8 +842,8 @@ public final class YoungAndroidProjectService extends CommonProjectService {
         return appengineHost.get();
       }
     } else {
-      // TODO(user): Figure out how to make this more generic
-      return "localhost:8888";
+      // No more hard-coded port number for DevServer; read it from appengine-web.xml instead.
+      return appengineHost.get();
     }
   }
 


### PR DESCRIPTION
No more hard-coded port number for DevServer; read it from appengine-web.xml instead.