### PR TITLE
Fix some hard-coded HTTP URLs

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -894,7 +894,8 @@ public class TopToolbar extends Composite {
 
       String downloadinfo = "";
       if (!YaVersion.COMPANION_UPDATE_URL1.equals("")) {
-        String url = "http://" + Window.Location.getHost() + YaVersion.COMPANION_UPDATE_URL1;
+        String url = Window.Location.getProtocol() + "//" + Window.Location.getHost()
+            + YaVersion.COMPANION_UPDATE_URL1;
         downloadinfo = "<br/>\n<a href=" + url + ">Download URL: " + url + "</a><br/>\n";
         downloadinfo += BlocklyPanel.getQRCode(url);
       }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/NoProjectDialogBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/NoProjectDialogBox.java
@@ -15,6 +15,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.Widget;
@@ -83,13 +84,17 @@ public class NoProjectDialogBox extends DialogBox {
   @UiHandler("goToTalk")
   void handleGoToTalk(ClickEvent e) {
     this.hide();
-    TemplateUploadWizard.openProjectFromTemplate("http://appinventor.mit.edu/yrtoolkit/yr/aiaFiles/talk_to_me/TalkToMe.asc", new NewTutorialProject());
+    TemplateUploadWizard.openProjectFromTemplate(Window.Location.getProtocol()
+        + "//appinventor.mit.edu/yrtoolkit/yr/aiaFiles/talk_to_me/TalkToMe.asc",
+        new NewTutorialProject());
   }
 
   @UiHandler("goToYR")
   void handleGoToYR(ClickEvent e) {
     this.hide();
-    TemplateUploadWizard.openProjectFromTemplate("http://appinventor.mit.edu/yrtoolkit/yr/aiaFiles/hello_bonjour/translate_tutorial.asc", new NewTutorialProject());
+    TemplateUploadWizard.openProjectFromTemplate(Window.Location.getProtocol()
+        + "//appinventor.mit.edu/yrtoolkit/yr/aiaFiles/hello_bonjour/translate_tutorial.asc",
+        new NewTutorialProject());
   }
 
   @UiHandler("noDialogNewProject")

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
@@ -685,7 +685,7 @@ public class TemplateUploadWizard extends Wizard implements NewUrlDialogCallback
       return;
     }
     if(!url.startsWith("http")) {
-      url = "http://" + url;
+      url = Window.Location.getProtocol() + "//" + url;
     }
     if (url.endsWith(".asc")) {
       openTemplateProject(url, onSuccessCommand);


### PR DESCRIPTION
While testing on ai2-test using HTTPS I noticed that there are some places where we are assuming HTTP. This PR changes those locations to use the window.location.protocol so that the URLs match the current scheme.