### PR TITLE
Add osmdroid.jar as dependency of Navigation component

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Navigation.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Navigation.java
@@ -18,6 +18,7 @@ import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
@@ -50,6 +51,7 @@ import org.osmdroid.util.GeoPoint;
     nonVisible = true,
     iconName = "images/navigation.png")
 @UsesPermissions(permissionNames = "android.permission.INTERNET")
+@UsesLibraries({"osmdroid.jar"})
 @SimpleObject
 public class Navigation extends AndroidNonvisibleComponent implements Component {
 


### PR DESCRIPTION
The Navigation component makes use of org.osmdroid.util.GeoPoint, but
if it is included in a project without also including a Map component,
compiled apps fail due to the fact that GeoPoint is not in the final
binary. This change asserts that the Navigation component is dependent
on osmdroid.jar when building apps.

Change-Id: I1111c710e3b53a6dc85d65668ef140d6286ec585