### PR TITLE
Issue #2257: Fixed Empty property descriptions overriding previous no…

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1569,10 +1569,10 @@ public abstract class ComponentProcessor extends AbstractProcessor {
               && !newProperty.description.isEmpty() && !newProperty.isDefaultDescription()) {
             priorProperty.setDescription(newProperty.description);
           }
-          if (!newProperty.longDescription.isEmpty()) {  /* Latter descriptions of the same property
-                                                            override earlier descriptions. */
+          if (!newProperty.longDescription.isEmpty() && !newProperty.isDefaultDescription()) {  /* Latter descriptions of the same property override earlier descriptions. */
             priorProperty.longDescription = newProperty.longDescription;
           }
+
           if (priorProperty.propertyCategory == PropertyCategory.UNSET) {
             priorProperty.propertyCategory = newProperty.propertyCategory;
           } else if (newProperty.propertyCategory != priorProperty.propertyCategory &&


### PR DESCRIPTION
Fixes #2257 : Empty property descriptions override previous non-empty descriptions.