### PR TITLE
Implement LegacyMode for File component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -830,10 +830,15 @@ public final class YoungAndroidFormUpgrader {
 
   private static int upgradeFileProperties(Map<String, JSONValue> componentProperties,
       int srcCompVersion) {
-    if(srcCompVersion < 2) {
+    if (srcCompVersion < 2) {
       // File.AfterFileSaved event was added.
       // No properties need to be modified to upgrade to version 2.
       srcCompVersion = 2;
+    }
+    if (srcCompVersion < 3) {
+      // File.LegacyMode property was added.
+      // No properties need to be modified to upgrade to version 3.
+      srcCompVersion = 3;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1513,7 +1513,11 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI2: The AfterFileSaved event was added.
     // No blocks need to be modified to upgrade to version 2.
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // AI2: The LegacyMode property was added.
+    // No blocks need to be modified to upgrade to version 3.
+    3: "noUpgrade"
 
   }, // End File upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -512,8 +512,10 @@ public class YaVersion {
   // - YANDEX_COMPONENT_VERSION was incremented to 2.
   // For YOUNG_ANDROID_VERSION 207:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 32
+  // For YOUNG_ANDROID_VERSION 208:
+  // - FILE_COMPONENT_VERSION was incremented to 3
 
-  public static final int YOUNG_ANDROID_VERSION = 207;
+  public static final int YOUNG_ANDROID_VERSION = 208;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -816,7 +818,9 @@ public class YaVersion {
 
   // For FILE_COMPONENT_VERSION 2:
   // - The AfterFileSaved event was added.
-  public static final int FILE_COMPONENT_VERSION = 2;
+  // For FILE_COMPONENT_VERSION 3:
+  // - The LegacyMode property was added.
+  public static final int FILE_COMPONENT_VERSION = 3;
 
   // For FORM_COMPONENT_VERSION 2:
   // - The Screen.Scrollable property was added.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/File.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/File.java
@@ -10,11 +10,16 @@ import android.Manifest;
 import android.util.Log;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
+import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.AsynchUtil;
@@ -53,6 +58,7 @@ import java.io.StringWriter;
 public class File extends AndroidNonvisibleComponent implements Component {
   private static final int BUFFER_LENGTH = 4096;
   private static final String LOG_TAG = "FileComponent";
+  private boolean legacy = false;
 
   /**
    * Creates a new File component.
@@ -60,6 +66,30 @@ public class File extends AndroidNonvisibleComponent implements Component {
    */
   public File(ComponentContainer container) {
     super(container.$form());
+    LegacyMode(false);
+  }
+
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "False")
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
+  public void LegacyMode(boolean legacy) {
+    this.legacy = legacy;
+  }
+
+  /**
+   * Allows app to access files from the root of the external storage directory (legacy mode).
+   * Starting with Android 11, this will no longer be allowed and the behavior is strongly
+   * discouraged on Android 10. Starting with Android 10, App Inventor by default will attempt to
+   * store files relative to the app-specific private directory on external storage in accordance
+   * with this security change.
+   *
+   *   **Note:** Apps that enable this property will likely stop working after upgrading to
+   * Android 11, which strongly enforces that apps only write to app-private directories.
+   */
+  @SimpleProperty(description = "Allows app to access files from the root of the external storage "
+      + "directory (legacy mode).")
+  public boolean LegacyMode() {
+    return legacy;
   }
 
   /**
@@ -134,6 +164,7 @@ public class File extends AndroidNonvisibleComponent implements Component {
       "slash, it will be read from the applications private storage (for packaged " +
       "apps) and from /sdcard/AppInventor/data for the Companion.")
   public void ReadFrom(final String fileName) {
+    final boolean legacy = this.legacy;
     form.askPermission(Manifest.permission.READ_EXTERNAL_STORAGE, new PermissionResultHandler() {
       @Override
       public void HandlePermissionResponse(String permission, boolean granted) {
@@ -143,7 +174,7 @@ public class File extends AndroidNonvisibleComponent implements Component {
             if (fileName.startsWith("//")) {
               inputStream = form.openAsset(fileName.substring(2));
             } else {
-              String filepath = AbsoluteFileName(fileName);
+              String filepath = AbsoluteFileName(fileName, legacy);
               Log.d(LOG_TAG, "filepath = " + filepath);
               inputStream = FileUtil.openFile(form, filepath);
             }
@@ -189,6 +220,7 @@ public class File extends AndroidNonvisibleComponent implements Component {
       "located in the programs private storage will be deleted. Starting the file with // is an error " +
       "because assets files cannot be deleted.")
   public void Delete(final String fileName) {
+    final boolean legacy = this.legacy;
     form.askPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, new PermissionResultHandler() {
       @Override
       public void HandlePermissionResponse(String permission, boolean granted) {
@@ -198,7 +230,7 @@ public class File extends AndroidNonvisibleComponent implements Component {
                 ErrorMessages.ERROR_CANNOT_DELETE_ASSET, fileName);
             return;
           }
-          String filepath = AbsoluteFileName(fileName);
+          String filepath = AbsoluteFileName(fileName, legacy);
           if (MediaUtil.isExternalFile(form, fileName)) {
             if (form.isDeniedPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
               form.dispatchPermissionDeniedEvent(File.this, "Delete",
@@ -232,10 +264,11 @@ public class File extends AndroidNonvisibleComponent implements Component {
       }
       return;
     }
+    final boolean legacy = this.legacy;
     final Runnable operation = new Runnable() {
       @Override
       public void run() {
-        final String filepath = AbsoluteFileName(filename);
+        final String filepath = AbsoluteFileName(filename, legacy);
         if (MediaUtil.isExternalFile(form, filepath)) {
           form.assertPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
@@ -388,9 +421,9 @@ public class File extends AndroidNonvisibleComponent implements Component {
    *
    * @param filename the file used to construct the file path
    */
-  private String AbsoluteFileName(String filename) {
+  private String AbsoluteFileName(String filename, boolean legacy) {
     if (filename.startsWith("/")) {
-      return QUtil.getExternalStoragePath(form) + filename;
+      return QUtil.getExternalStoragePath(form, false, legacy) + filename;
     } else {
       java.io.File dirPath;
       if (form.isRepl()) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
@@ -31,10 +31,32 @@ public class QUtil {
    *
    * @param context a context, such as a Form
    * @param forcePrivate force the use of the context-specific path
+   * @param useLegacy use the legacy external storage path even on Android Q and higher
+   * @return the path to the app's shared storage.
+   */
+  public static String getExternalStoragePath(Context context, boolean forcePrivate,
+      boolean useLegacy) {
+    return getExternalStorageDir(context, forcePrivate, useLegacy).getAbsolutePath();
+  }
+
+  /**
+   * Get the SDK-specific external storage path. On Android Q and later, this is always an
+   * app-private directory on the "external" storage. On earlier versions of Android, this returns
+   * the external storage path for all apps (although possibly user-specific).
+   * If the {@code forcePrivate} flag is true, then the app-private directory will always be
+   * returned on devices running Android 2.2 Froyo or later.
+   *
+   * <p>
+   * For more details on why this is needed, see the deprecation notice at
+   * https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()
+   * </p>
+   *
+   * @param context a context, such as a Form
+   * @param forcePrivate force the use of the context-specific path
    * @return the path to the app's shared storage.
    */
   public static String getExternalStoragePath(Context context, boolean forcePrivate) {
-    return getExternalStorageDir(context, forcePrivate).getAbsolutePath();
+    return getExternalStoragePath(context, forcePrivate, false);
   }
 
   /**
@@ -51,7 +73,7 @@ public class QUtil {
    * @return the path to the app's shared storage.
    */
   public static String getExternalStoragePath(Context context) {
-    return getExternalStoragePath(context, false);
+    return getExternalStoragePath(context, false, false);
   }
 
   /**
@@ -89,13 +111,34 @@ public class QUtil {
    * @param forcePrivate force the use of the context-specific path
    * @return the path to the app's shared storage.
    */
-  @SuppressWarnings("deprecation")
   public static File getExternalStorageDir(Context context, boolean forcePrivate) {
+    return getExternalStorageDir(context, forcePrivate, false);
+  }
+
+  /**
+   * Get the SDK-specific external storage directory. On Android Q and later, this is always an
+   * app-private directory on the "external" storage. On earlier versions of Android, this returns
+   * the external storage path for all apps (although possibly user-specific).
+   * If the {@code forcePrivate} flag is true, then the app-private directory will always be
+   * returned on devices running Android 2.2 Froyo or later.
+   *
+   * <p>
+   * For more details on why this is needed, see the deprecation notice at
+   * https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()
+   * </p>
+   *
+   * @param context a context, such as a Form
+   * @param forcePrivate force the use of the context-specific path
+   * @param legacy use the legacy path on Android Q and later
+   * @return the path to the app's shared storage.
+   */
+  @SuppressWarnings("deprecation")
+  public static File getExternalStorageDir(Context context, boolean forcePrivate, boolean legacy) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO) {
       // Context#getExternalFilesDir didn't exist until Froyo
       return Environment.getExternalStorageDirectory();
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q || forcePrivate) {
+    if ((!legacy && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) || forcePrivate) {
       // Q no longer allows using getExternalStorageDirectory()
       return context.getExternalFilesDir(null);
     } else {

--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -219,7 +219,18 @@
 
 <h3 id="File-Properties">Properties</h3>
 
-<p class="properties">None</p>
+<dl class="properties">
+  <dt id="File.LegacyMode" class="boolean"><em>LegacyMode</em></dt>
+  <dd>Allows app to access files from the root of the external storage directory (legacy mode).
+ Starting with Android 11, this will no longer be allowed and the behavior is strongly
+ discouraged on Android 10. Starting with Android 10, App Inventor by default will attempt to
+ store files relative to the app-specific private directory on external storage in accordance
+ with this security change.
+
+    <p><strong>Note:</strong> Apps that enable this property will likely stop working after upgrading to
+ Android 11, which strongly enforces that apps only write to app-private directories.</p>
+  </dd>
+</dl>
 
 <h3 id="File-Events">Events</h3>
 

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -114,8 +114,16 @@ Non-visible component for storing and retrieving files. Use this component to wr
 ### Properties  {#File-Properties}
 
 {:.properties}
-None
 
+{:id="File.LegacyMode" .boolean} *LegacyMode*
+: Allows app to access files from the root of the external storage directory (legacy mode).
+ Starting with Android 11, this will no longer be allowed and the behavior is strongly
+ discouraged on Android 10. Starting with Android 10, App Inventor by default will attempt to
+ store files relative to the app-specific private directory on external storage in accordance
+ with this security change.
+
+   **Note:** Apps that enable this property will likely stop working after upgrading to
+ Android 11, which strongly enforces that apps only write to app-private directories.
 
 ### Events  {#File-Events}
 


### PR DESCRIPTION
With the nb184 change, apps that previously worked on Android 10 may
no longer work if the app in question stored files based on the
external storage root (e.g., /sdcard). While Google isn't enforcing
read/write access to directories outside of the app-private path just
yet (this will be true in Android 11), we switched over most file
operations to use the app-private path anyway starting with Android
Q. New apps will read/write files without issue, however apps that are
used to using the old path on Android 10 have no way to read files
they may have written.

This change adds a LegacyMode property to File, which is False by
default, that allows a developer to access files relative to the root
of the external storage on Android 10 and higher. I've included a note
that the use of this property may cause apps to fail starting with
Android 11.

Change-Id: I4ab0d26e54d2a74535b4a691cfd63826543d29a4