### PR TITLE
Implement a universal URL format for assets in WebViewer

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -74,7 +74,9 @@ import com.google.appinventor.components.runtime.util.SdkLevel;
  * to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
  * `file:///android_asset/` in compiled apps and `/sdcard/AppInventor/assets/` in the Companion.
  * Both of these options will continue to work but the `http://localhost/` approach will work in
- * both scenarios.
+ * both scenarios. You may also use "file:///appinventor_asset/" which provides more security by
+ * preventing the use of asynchronous requests from JavaScript in your assets from going out to the
+ * web.
  *
  * @internaldoc
  * Component for displaying web pages

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -29,6 +29,8 @@ import com.google.appinventor.components.common.YaVersion;
 
 import com.google.appinventor.components.runtime.util.EclairUtil;
 import com.google.appinventor.components.runtime.util.FroyoUtil;
+import com.google.appinventor.components.runtime.util.FroyoWebViewClient;
+import com.google.appinventor.components.runtime.util.HoneycombWebViewClient;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 
@@ -67,6 +69,12 @@ import com.google.appinventor.components.runtime.util.SdkLevel;
  * ```
  * Calling `setWebViewString` from JavaScript will also run the {@link #WebViewStringChange(String)}
  * event so that the blocks can handle when the {@link #WebViewString(String)} property changes.
+ *
+ * Beginning with release nb184a, you can specify a HomeUrl beginning with `http://localhost/`
+ * to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
+ * `file:///android_asset/` in compiled apps and `/sdcard/AppInventor/assets/` in the Companion.
+ * Both of these options will continue to work but the `http://localhost/` approach will work in
+ * both scenarios.
  *
  * @internaldoc
  * Component for displaying web pages
@@ -515,8 +523,12 @@ public final class WebViewer extends AndroidViewComponent {
   }
 
   private void resetWebViewClient() {
-    if (SdkLevel.getLevel() >= SdkLevel.LEVEL_FROYO) {
-      webview.setWebViewClient(FroyoUtil.getWebViewClient(ignoreSslErrors, followLinks, container.$form(), this));
+    if (SdkLevel.getLevel() >= SdkLevel.LEVEL_HONEYCOMB) {
+      webview.setWebViewClient(new HoneycombWebViewClient(followLinks, ignoreSslErrors,
+          container.$form(), this));
+    } else if (SdkLevel.getLevel() >= SdkLevel.LEVEL_FROYO) {
+      webview.setWebViewClient(new FroyoWebViewClient<>(followLinks, ignoreSslErrors,
+          container.$form(), this));
     } else {
       webview.setWebViewClient(new WebViewerClient());
     }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoUtil.java
@@ -8,16 +8,11 @@ package com.google.appinventor.components.runtime.util;
 
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.media.AudioManager;
-import android.net.http.SslError;
 import android.view.Display;
-import android.webkit.SslErrorHandler;
-import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import com.google.appinventor.components.runtime.Component;
-import com.google.appinventor.components.runtime.EventDispatcher;
 import com.google.appinventor.components.runtime.Form;
 import com.google.appinventor.components.runtime.Player;
 
@@ -126,43 +121,8 @@ public class FroyoUtil {
    * @param ignoreErrors set to true to ignore errors
    */
   public static WebViewClient getWebViewClient(final boolean ignoreErrors,
-    final boolean followLinks, final Form form, final Component component) {
-    return new WebViewClient() {
-      @Override
-      public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        return !followLinks;
-      }
-
-      @Override
-      public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-        if (ignoreErrors) {
-          handler.proceed();
-        } else {
-          handler.cancel();
-          form.dispatchErrorOccurredEvent(component, "WebView",
-            ErrorMessages.ERROR_WEBVIEW_SSL_ERROR);
-        }
-      }
-
-      @Override
-      public void onPageStarted(WebView view, String url, Bitmap favicon) {
-        EventDispatcher.dispatchEvent(component, "BeforePageLoad", url);
-      }
-
-      @Override
-      public void onPageFinished(WebView view, String url) {
-        EventDispatcher.dispatchEvent(component, "PageLoaded", url);
-      }
-
-      @Override
-      public void onReceivedError(WebView view, final int errorCode, final String description, final String failingUrl) {
-        form.runOnUiThread(new Runnable() {
-          public void run() {
-            EventDispatcher.dispatchEvent(component, "ErrorOccurred", errorCode, description, failingUrl);
-          }
-        });
-      }
-    };
+      final boolean followLinks, final Form form, final Component component) {
+    return new FroyoWebViewClient(followLinks, ignoreErrors, form, component);
   }
 
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoWebViewClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoWebViewClient.java
@@ -1,0 +1,75 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import android.graphics.Bitmap;
+import android.net.http.SslError;
+import android.webkit.SslErrorHandler;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import com.google.appinventor.components.runtime.Component;
+import com.google.appinventor.components.runtime.EventDispatcher;
+import com.google.appinventor.components.runtime.Form;
+
+/**
+ * A WebViewClient that provides functionality that needs Android 2.2 Froyo or higher.
+ */
+public class FroyoWebViewClient<T extends Component> extends WebViewClient {
+  private final boolean followLinks;
+  private final boolean ignoreErrors;
+  private final Form form;
+  private final T component;
+
+  public FroyoWebViewClient(boolean followLinks, boolean ignoreErrors, Form form, T component) {
+    this.followLinks = followLinks;
+    this.ignoreErrors = ignoreErrors;
+    this.form = form;
+    this.component = component;
+  }
+
+  public T getComponent() {
+    return component;
+  }
+
+  public Form getForm() {
+    return form;
+  }
+
+  @Override
+  public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    return !followLinks;
+  }
+
+  @Override
+  public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+    if (ignoreErrors) {
+      handler.proceed();
+    } else {
+      handler.cancel();
+      form.dispatchErrorOccurredEvent(component, "WebView",
+        ErrorMessages.ERROR_WEBVIEW_SSL_ERROR);
+    }
+  }
+
+  @Override
+  public void onPageStarted(WebView view, String url, Bitmap favicon) {
+    EventDispatcher.dispatchEvent(component, "BeforePageLoad", url);
+  }
+
+  @Override
+  public void onPageFinished(WebView view, String url) {
+    EventDispatcher.dispatchEvent(component, "PageLoaded", url);
+  }
+
+  @Override
+  public void onReceivedError(WebView view, final int errorCode, final String description, final String failingUrl) {
+    form.runOnUiThread(new Runnable() {
+      public void run() {
+        EventDispatcher.dispatchEvent(component, "ErrorOccurred", errorCode, description, failingUrl);
+      }
+    });
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
@@ -1,0 +1,79 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import android.os.Build;
+import android.util.Log;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+import com.google.appinventor.components.runtime.Form;
+import com.google.appinventor.components.runtime.WebViewer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A WebViewClient that provides functionality that needs Android 3.0 Honeycomb or higher.
+ */
+public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
+  private static final String TAG = HoneycombWebViewClient.class.getSimpleName();
+
+  public HoneycombWebViewClient(boolean followLinks, boolean ignoreErrors, Form form,
+      WebViewer component) {
+    super(followLinks, ignoreErrors, form, component);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url.startsWith("http://localhost/")) {
+      return handleAppRequest(url);
+    }
+    return super.shouldInterceptRequest(view, url);
+  }
+
+  @androidx.annotation.RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    if (request.getUrl().getAuthority().equals("localhost")) {
+      return handleAppRequest(request.getUrl().toString());
+    }
+    return super.shouldInterceptRequest(view, request);
+  }
+
+  protected WebResourceResponse handleAppRequest(String url) {
+    String path = url.substring(url.indexOf("//localhost/") + 12);
+    InputStream stream;
+    try {
+      Log.i(TAG, "webviewer requested path = " + path);
+      stream = getForm().openAsset(path);
+      Map<String, String> headers = new HashMap<>();
+      headers.put("Access-Control-Allow-Origin", "localhost");
+      String mimeType = URLConnection.getFileNameMap().getContentTypeFor(path);
+      String encoding = "utf-8";
+      Log.i(TAG, "Mime type = " + mimeType);
+      if (!mimeType.startsWith("text/")) {
+        encoding = null;
+      }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        return new WebResourceResponse(mimeType, encoding, 200, "OK", headers, stream);
+      } else {
+        return new WebResourceResponse(mimeType, encoding, stream);
+      }
+    } catch (IOException e) {
+      ByteArrayInputStream error = new ByteArrayInputStream("404 Not Found".getBytes());
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        return new WebResourceResponse("text/plain", "utf-8", 404, "Not Found", null, error);
+      } else {
+        return new WebResourceResponse("text/plain", "utf-8", error);
+      }
+    }
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
@@ -22,8 +22,10 @@ import java.util.Map;
 /**
  * A WebViewClient that provides functionality that needs Android 3.0 Honeycomb or higher.
  */
+@androidx.annotation.RequiresApi(api = Build.VERSION_CODES.HONEYCOMB)
 public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
   private static final String TAG = HoneycombWebViewClient.class.getSimpleName();
+  private static final String ASSET_PREFIX = "file:///appinventor_asset/";
 
   public HoneycombWebViewClient(boolean followLinks, boolean ignoreErrors, Form form,
       WebViewer component) {
@@ -33,7 +35,7 @@ public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
   @SuppressWarnings("deprecation")
   @Override
   public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-    if (url.startsWith("http://localhost/")) {
+    if (url.startsWith("http://localhost/") || url.startsWith(ASSET_PREFIX)) {
       return handleAppRequest(url);
     }
     return super.shouldInterceptRequest(view, url);
@@ -42,14 +44,21 @@ public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
   @androidx.annotation.RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   @Override
   public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-    if (request.getUrl().getAuthority().equals("localhost")) {
+    Log.d(TAG, "scheme = " + request.getUrl().getScheme());
+    if (request.getUrl().getAuthority().equals("localhost")
+        || request.getUrl().toString().startsWith(ASSET_PREFIX)) {
       return handleAppRequest(request.getUrl().toString());
     }
     return super.shouldInterceptRequest(view, request);
   }
 
   protected WebResourceResponse handleAppRequest(String url) {
-    String path = url.substring(url.indexOf("//localhost/") + 12);
+    String path;
+    if (url.startsWith(ASSET_PREFIX)) {
+      path = url.substring(ASSET_PREFIX.length());
+    } else {
+      path = url.substring(url.indexOf("//localhost/") + 12);
+    }
     InputStream stream;
     try {
       Log.i(TAG, "webviewer requested path = " + path);

--- a/appinventor/docs/html/reference/components/userinterface.html
+++ b/appinventor/docs/html/reference/components/userinterface.html
@@ -1459,7 +1459,9 @@ having dark grey components.</li>
  to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
  <code class="highlighter-rouge">file:///android_asset/</code> in compiled apps and <code class="highlighter-rouge">/sdcard/AppInventor/assets/</code> in the Companion.
  Both of these options will continue to work but the <code class="highlighter-rouge">http://localhost/</code> approach will work in
- both scenarios.</p>
+ both scenarios. You may also use “file:///appinventor_asset/” which provides more security by
+ preventing the use of asynchronous requests from JavaScript in your assets from going out to the
+ web.</p>
 
 <h3 id="WebViewer-Properties">Properties</h3>
 

--- a/appinventor/docs/html/reference/components/userinterface.html
+++ b/appinventor/docs/html/reference/components/userinterface.html
@@ -1455,6 +1455,12 @@ having dark grey components.</li>
 <p>Calling <code class="highlighter-rouge">setWebViewString</code> from JavaScript will also run the <a href="#WebViewer.WebViewStringChange"><code class="highlighter-rouge">WebViewStringChange</code></a>
  event so that the blocks can handle when the <a href="#WebViewer.WebViewString"><code class="highlighter-rouge">WebViewString</code></a> property changes.</p>
 
+<p>Beginning with release nb184a, you can specify a HomeUrl beginning with <code class="highlighter-rouge">http://localhost/</code>
+ to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
+ <code class="highlighter-rouge">file:///android_asset/</code> in compiled apps and <code class="highlighter-rouge">/sdcard/AppInventor/assets/</code> in the Companion.
+ Both of these options will continue to work but the <code class="highlighter-rouge">http://localhost/</code> approach will work in
+ both scenarios.</p>
+
 <h3 id="WebViewer-Properties">Properties</h3>
 
 <dl class="properties">

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -1648,6 +1648,12 @@ Component for viewing Web pages.
  Calling `setWebViewString` from JavaScript will also run the [`WebViewStringChange`](#WebViewer.WebViewStringChange)
  event so that the blocks can handle when the [`WebViewString`](#WebViewer.WebViewString) property changes.
 
+ Beginning with release nb184a, you can specify a HomeUrl beginning with `http://localhost/`
+ to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
+ `file:///android_asset/` in compiled apps and `/sdcard/AppInventor/assets/` in the Companion.
+ Both of these options will continue to work but the `http://localhost/` approach will work in
+ both scenarios.
+
 
 
 ### Properties  {#WebViewer-Properties}

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -1652,7 +1652,9 @@ Component for viewing Web pages.
  to reference assets both in the Companion and in compiled apps. Previously, apps needed to use
  `file:///android_asset/` in compiled apps and `/sdcard/AppInventor/assets/` in the Companion.
  Both of these options will continue to work but the `http://localhost/` approach will work in
- both scenarios.
+ both scenarios. You may also use "file:///appinventor_asset/" which provides more security by
+ preventing the use of asynchronous requests from JavaScript in your assets from going out to the
+ web.
 
 
 


### PR DESCRIPTION
Currently, app developers need to specify different URLs based on whether the WebViewer runs in the companion or in a compiled app if they intend to reference app assets. This is further complicated by the fact that in newer versions of Android we will need to use app-specific directories, and while this seems to be consistent there isn't a guarantee that it will be, so now app developers may have to juggle 3 paths.

With this change, the asset test.html can be referenced as `http://localhost/test.html` and it will resolve correctly both in the companion and the compiled app--no futzing with special paths required [*].

[*] Well, technically this only works on Honeycomb and higher, but that's a fairly safe assumption at this point and the old approach still works if people really need that level of backward compatibility (e.g., the old emulator).

Change-Id: I3c429aeae6f4ced89dfd07f75ddaa92e277ed019