### PR TITLE
Fix app crash when failing to put/post in Web component

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
@@ -1131,25 +1131,38 @@ public class Web extends AndroidNonvisibleComponent implements Component {
       form.dispatchPermissionDeniedEvent(Web.this, method, e);
     } catch (FileUtil.FileException e) {
       form.dispatchErrorOccurredEvent(Web.this, method,
-        e.getErrorMessageNumber());
+          e.getErrorMessageNumber());
     } catch (RequestTimeoutException e) {
       form.dispatchErrorOccurredEvent(Web.this, method,
-        ErrorMessages.ERROR_WEB_REQUEST_TIMED_OUT, webProps.urlString);
+          ErrorMessages.ERROR_WEB_REQUEST_TIMED_OUT, webProps.urlString);
     } catch (Exception e) {
       int message;
+      String[] args;
+      //noinspection IfCanBeSwitch
       if (method.equals("Get")) {
         message = ErrorMessages.ERROR_WEB_UNABLE_TO_GET;
-      } else if (method.equals("PostFile")) {
-        message = ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT_FILE;
-      } else if (method.equals("PutFile")) {
-        message = ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT_FILE;
+        args = new String[] { webProps.urlString };
       } else if (method.equals("Delete")) {
         message = ErrorMessages.ERROR_WEB_UNABLE_TO_DELETE;
+        args = new String[] { webProps.urlString };
+      } else if (method.equals("PostFile") || method.equals("PutFile")) {
+        message = ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT_FILE;
+        args = new String[] { postFile, webProps.urlString };
       } else {
         message = ErrorMessages.ERROR_WEB_UNABLE_TO_POST_OR_PUT;
+        String content = "";
+        try {
+          if (postData != null) {
+            //noinspection CharsetObjectCanBeUsed
+            content = new String(postData, "UTF-8");
+          }
+        } catch (UnsupportedEncodingException e1) {
+          Log.e(LOG_TAG, "UTF-8 is the default charset for Android but not available???");
+        }
+        args = new String[] { content, webProps.urlString };
       }
       form.dispatchErrorOccurredEvent(Web.this, method,
-        message, webProps.urlString);
+          message, (Object[]) args);
     }
   }
 


### PR DESCRIPTION
[From the forum](https://community.appinventor.mit.edu/t/app-shuts-randomly-on-post-method-without-a-warning/14075/10?u=ewpatton): App crashes when the Web component fails to put/post using the Web component. The issue is that the error message requires two strings but only one is provided, throwing an uncaught error that terminates the process. This change ensures that the error message for put/post receives the two strings required for the error to be formatted correctly.

Change-Id: Ie2c1087e4c7bb4c686abc826d93b885850cd0169