### PR TITLE
URL encode faultData in bug report

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/BugReport.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/BugReport.java
@@ -58,7 +58,7 @@ public final class BugReport {
     } catch (Exception e) {
       // Not sure there is much we can do here!
     }
-    additionalInformation = Urls.escapeQueryParameter(additionalInformation); // encode 
+    additionalInformation = Urls.escapeQueryParameter(additionalInformation); // encode
     return BUG_REPORT_FORM_LINK + "?notes=" + notes + "&foundIn=" + foundIn + "&projectId=" + projectId + "&faultData=" + additionalInformation;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/BugReport.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/BugReport.java
@@ -58,6 +58,7 @@ public final class BugReport {
     } catch (Exception e) {
       // Not sure there is much we can do here!
     }
+    additionalInformation = Urls.escapeQueryParameter(additionalInformation); // encode 
     return BUG_REPORT_FORM_LINK + "?notes=" + notes + "&foundIn=" + foundIn + "&projectId=" + projectId + "&faultData=" + additionalInformation;
   }
 


### PR DESCRIPTION
This PR proposes the change to encode the `faultData` query parameter of bug report link.

The below screenshot shows the issue with not encoding the text for `faultData`.
![](https://lh3.googleusercontent.com/-fT_gjtNLHms/XzKuj8M5TCI/AAAAAAAAC5M/AV8jNDjTqt0QAT6nruIBK1nbGRWec2-WACK8BGAsYHg/s0/2020-08-11.png)
