### PR TITLE
Fix gyro sensor - reset previousValue to -1 on mode switch

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
@@ -176,6 +176,8 @@ public class Ev3GyroSensor extends LegoMindstormsEv3Sensor implements Deleteable
   }
 
   private void setMode(String newModeString) {
+    previousValue = -1;
+
     if (SENSOR_MODE_ANGLE_STRING.equals(newModeString))
       mode = SENSOR_MODE_ANGLE;
     else if (SENSOR_MODE_RATE_STRING.equals(newModeString))

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
@@ -185,8 +185,9 @@ public class Ev3GyroSensor extends LegoMindstormsEv3Sensor implements Deleteable
     else
       throw new IllegalArgumentException();
 
-    if (oldMode != mode)
+    if (oldMode != mode) {
       previousValue = -1;
+    }
 
     this.modeString = newModeString;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Ev3GyroSensor.java
@@ -176,7 +176,7 @@ public class Ev3GyroSensor extends LegoMindstormsEv3Sensor implements Deleteable
   }
 
   private void setMode(String newModeString) {
-    previousValue = -1;
+    final int oldMode = mode;
 
     if (SENSOR_MODE_ANGLE_STRING.equals(newModeString))
       mode = SENSOR_MODE_ANGLE;
@@ -184,6 +184,9 @@ public class Ev3GyroSensor extends LegoMindstormsEv3Sensor implements Deleteable
       mode = SENSOR_MODE_RATE;
     else
       throw new IllegalArgumentException();
+
+    if (oldMode != mode)
+      previousValue = -1;
 
     this.modeString = newModeString;
   }


### PR DESCRIPTION
### Description

Closes #2291 

### Testing

No hardware available for testing as yet, b/c covid. Requires a Lego Ev3 Gyro sensor to test.

### Additional Info

@ewpatton  I assume I don't need to bump the component version for this? But if I do  I'm happy to =)