### PR TITLE
Do not capture copy events where user selection exists

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -1008,6 +1008,10 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
         // don't interfere with copy/pasting input
         return false;
       }
+      if ($wnd.getSelection && $wnd.getSelection() && $wnd.getSelection().toString() != '') {
+        // user is copying some other selection on the page
+        return false;
+      }
       if (!editor.@com.google.appinventor.client.editor.FileEditor::isActiveEditor()()) {
         // don't copy/paste in non-active editor
         return false;


### PR DESCRIPTION
The copy-paste implementation for mock components broke some functionality in tablets. Previously, one could copy the 6 character code and paste it into the companion running in split screen mode. However, the copy event now is captured by the YaFormEditor so you end up copying and pasting the content blob for the currently selected component(s) instead. This change will not perform component copy functionality if there exists a text selection (e.g., the 6 character code) anywhere on the page.

Change-Id: Ieea9dbb42095308f365831ba9c036d9e1f88276a