### PR TITLE
Fix WebViewer crash on old Android due to NPE

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
@@ -68,7 +68,8 @@ public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
       String mimeType = URLConnection.getFileNameMap().getContentTypeFor(path);
       String encoding = "utf-8";
       Log.i(TAG, "Mime type = " + mimeType);
-      if (!mimeType.startsWith("text/")) {
+      if (mimeType == null
+          || (!mimeType.startsWith("text/") && !mimeType.equals("application/javascript"))) {
         encoding = null;
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
The ability to reference assets using http://localhost/ as an
authority fail on older versions of Android due to a
NullPointerException caused by the MIME type lookup returning null
rather than a valid MIME type. This can happen even for common file
types like JavaScript files. Newer versions of Android have a more
complete MIME type table and don't exhibit this issue.

Change-Id: I3f1b3846262f0c1613ad7807c1758a7d24fb246d