### PR TITLE
#Fixes Issue #2311 Spelling mistake in README.md corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ App Inventor uses Blockly, the web-based visual programming editor from Google, 
 
     $ git submodule update --init
 
-For developers who will be working on Blocky within the context of App Inventor, the preferred checkout procedure is to perform a `git submodule init`, edit the `.git/config` file to use the read/write SSH URL for [MIT CML's Blockly fork](https://github.com/mit-cml/blockly) instead of the public read-only HTTPS URL assumed by default (to support pushing changes). After changing `.git/config`, a `git submodule update` will pull the repository.
+For developers who will be working on Blockly within the context of App Inventor, the preferred checkout procedure is to perform a `git submodule init`, edit the `.git/config` file to use the read/write SSH URL for [MIT CML's Blockly fork](https://github.com/mit-cml/blockly) instead of the public read-only HTTPS URL assumed by default (to support pushing changes). After changing `.git/config`, a `git submodule update` will pull the repository.
 
 If you need to switch back to a branch that does contains the Blockly and Closure Library sources in the tree, you will need to run the command:
 


### PR DESCRIPTION
  #Fixes Issue  #2311 Spelling mistake in READ.md file

There was a spelling mistake for the word "Blockly".   

It was written as "Blocky"

Where as it should be written as "Blockly"