### PR TITLE
Support %packageName% token

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -1230,7 +1230,10 @@ public final class Compiler {
                 subelement.contains("android.provider.Telephony.SMS_RECEIVED")) {
               continue;
             }
-            out.write(subelement);
+            out.write(
+              subelement
+                .replace("%packageName%", packageName) // replace %packageName% with the actual packageName
+            );
           }
         }
       }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -1196,7 +1196,10 @@ public final class Compiler {
           for (Map.Entry<String, Set<String>> metadataElementSetPair : metadataElements) {
             Set<String> metadataElementSet = metadataElementSetPair.getValue();
             for (String metadataElement : metadataElementSet) {
-              out.write(metadataElement);
+              out.write(
+                metadataElement
+                  .replace("%packageName%", packageName) // replace %packageName% with the actual packageName
+              );
             }
           }
         }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -1075,7 +1075,10 @@ public final class Compiler {
       }
 
       for (String permission : permissions) {
-        out.write("  <uses-permission android:name=\"" + permission + "\" />\n");
+        out.write("  <uses-permission android:name=\"" +
+                  permission
+                    .replace("%packageName%", packageName) // replace %packageName% with the actual packageName
+                  + "\" />\n");
       }
 
       if (isForCompanion) {      // This is so ACRA can do a logcat on phones older then Jelly Bean


### PR DESCRIPTION
This token (`%packageName%` allows extension devs to work with an app's application ID without knowing in advance. This is similar to how AGP + Gradle does it with `${applicationId}`.

From Community: https://community.appinventor.mit.edu/t/annotation-usescontentproviders/15424?u=pavi2410

Supports substitution in:
- [x] @UsesActivities
- [x] @UsesActivityMetadata
- [x] @UsesApplicationMetadata
- [x] @UsesBroadcastReceivers
- [x] @UsesServices
- [x] @UsesContentProviders
- [x] @UsesPermissions