### PR TITLE
Ensure TOS form is less than height of page

### DIFF
--- a/appinventor/appengine/war/Ya_tos_form.html
+++ b/appinventor/appengine/war/Ya_tos_form.html
@@ -6,7 +6,7 @@
     <script src="static/js/tos.js"></script>
   </head>
 
-<body>
+<body class="tosPage">
 
 <div class="floatingBox">
     To use App Inventor for Android, you must accept the following terms of service.

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -50,9 +50,13 @@ body {
 }
 
 /* For the TOS Form*/
+.tosPage {
+  margin: 0;
+}
+
 .floatingBox {
-  width: 300px;
-  height: 250px;
+  width: 332px;
+  height: 282px;
   background-color: white;
   position: absolute;
   top:0;
@@ -64,6 +68,24 @@ body {
   box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.065);
   text-align: center;
   border: 1px #262626;
+  max-width: 100%;
+  max-height: 100%;
+  box-sizing: border-box;
+  overflow: scroll;
+}
+
+.tosBox {
+  overflow: scroll;
+  text-align: left;
+  max-height: calc(100% - 200px);
+}
+
+.tosBox h1 {
+  text-align: center;
+}
+
+.tosBox h3 {
+  text-align: center;
 }
 
 /*


### PR DESCRIPTION
A student with a small screen and larger font had trouble accepting the TOS because it wasn't obvious that both the text are and the page needed scrolling. This change adjusts the CSS for the TOS page so that the float box where the TOS appears is never larger than the browser viewport and adjusts the textarea where the terms appear to be small enough so that the accept button should always be at the bottom of the page.

Note: The CSS will also need to be adjusted in the branding branch. @jisqyv 

Change-Id: I9d60e51e14af7982b9aa8ac3c7dea333d5d5a9c1