### PR TITLE
Add Gallery Readonly Flag

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -192,7 +192,7 @@ public class DesignToolbar extends Toolbar {
       addButton(new ToolbarItem(WIDGET_NAME_REMOVEFORM, MESSAGES.removeFormButton(),
           new RemoveFormAction()));
     }
-    if (galleryEnabled) {
+    if (galleryEnabled && !Ode.getInstance().getGalleryReadOnly()) {
       addButton(new ToolbarItem(WIDGET_NAME_SENDTOGALLERY,
           MESSAGES.publishToGalleryButton(), new SendToGalleryAction()));
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -2469,6 +2469,10 @@ public class Ode implements EntryPoint {
     }
   }
 
+  public boolean getGalleryReadOnly() {
+    return config.getGalleryReadOnly();
+  }
+
   /**
    * setRendezvousServer
    *

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
@@ -65,8 +65,10 @@ public class ProjectToolbar extends Toolbar {
     if (galleryEnabled) {
       addButton(new ToolbarItem(WIDGET_NAME_LOGINTOGALLERY, MESSAGES.loginToGallery(),
           new LoginToGalleryAction()));
-      addButton(new ToolbarItem(WIDGET_NAME_SENDTONG, MESSAGES.publishToGalleryButton(),
-          new SendToGalleryAction()));
+      if (!Ode.getInstance().getGalleryReadOnly()) {
+        addButton(new ToolbarItem(WIDGET_NAME_SENDTONG, MESSAGES.publishToGalleryButton(),
+            new SendToGalleryAction()));
+      }
     }
 
     setTrashTabButtonsVisible(false);

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -64,6 +64,7 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
     config.setDefaultCloudDBserver(Flag.createFlag("clouddb.server", "").get());
     config.setNoop(Flag.createFlag("session.noop", 0).get());
     config.setGalleryEnabled(Flag.createFlag("gallery.enabled", false).get());
+    config.setGalleryReadOnly(Flag.createFlag("gallery.readonly", false).get());
     config.setGalleryLocation(Flag.createFlag("gallery.location", "").get());
 
     if (!Flag.createFlag("build2.server.host", "").get().isEmpty()) {

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
@@ -40,6 +40,7 @@ public class Config implements IsSerializable, Serializable {
                                      // target SDK).
   private boolean galleryEnabled;
   private String galleryLocation;
+  private boolean galleryReadOnly;
 
   public Config() {
   }
@@ -210,6 +211,14 @@ public class Config implements IsSerializable, Serializable {
 
   public void setGalleryLocation(String value) {
     galleryLocation = value;
+  }
+
+  public boolean getGalleryReadOnly() {
+    return galleryReadOnly;
+  }
+
+  public void setGalleryReadOnly(boolean value) {
+    galleryReadOnly = value;
   }
 
 }


### PR DESCRIPTION
When set we do not display the “Send to Gallery” Button, only the “Login
to Gallery” button. The Gallery itself enforces read only status, so if
the button is enabled but the gallery is in read only (for this
instance) then the user will receive an error when they attempt to send
a project to the gallery. But it is better if we can just avoid the
issue by not providing the button in the first place.

Another implementation here could be to have the server side actually
check in with the gallery itself to determine read-only status, but for
now we provide it as a config flag so we do not have to work out the
details of how and when the server would communicate with the Gallery as
well as how to handle errors and time-outs etc.

Change-Id: Ib6ca63ab2ca63636d7451762f782050dbffd9b3c