### PR TITLE
Dx Capacity Exceeds - Error handling 

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
@@ -175,11 +175,11 @@ public class DexExecTask {
         }
     }
 
-    public boolean execute(List<File> paths) {
+    public String[] execute(List<File> paths) {
         // pre dex libraries if needed
         if (mPredex) {
             boolean successPredex = preDexLibraries(paths);
-            if (!successPredex) return false;
+            if (!successPredex) return new String[]{Boolean.toString(false),"",""};
         }
 
         System.out.println(String.format(
@@ -189,10 +189,10 @@ public class DexExecTask {
     }
 
     private boolean runDx(File input, String output, boolean showInputs) {
-        return runDx(Collections.singleton(input), output, showInputs);
+        return Boolean.parseBoolean(runDx(Collections.singleton(input), output, showInputs)[0]);
     }
 
-    private boolean runDx(Collection<File> inputs, String output, boolean showInputs) {
+    private String[] runDx(Collection<File> inputs, String output, boolean showInputs) {
         int mx = mChildProcessRamMb - 200;
 
         List<String> commandLineList = new ArrayList<String>();
@@ -232,7 +232,7 @@ public class DexExecTask {
         String[] dxCommandLine = new String[commandLineList.size()];
         commandLineList.toArray(dxCommandLine);
 
-        boolean dxSuccess = Execution.execute(null, dxCommandLine, System.out, System.err);
+        String[] dxSuccess = Execution.executeandget(null, dxCommandLine, System.out, System.err);
         return dxSuccess;
 
     }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Execution.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Execution.java
@@ -30,6 +30,38 @@ public final class Execution {
   private static final Joiner joiner = Joiner.on(" ");
 
   /*
+   * Input stream handler and string buffer recorder used for stdout/stderr redirection and to return results in StringBuffer
+   */
+  private static class RedirectStreamHandleAndgetBuffer extends Thread {
+    // Streams to redirect from and to
+    private final InputStream input;
+    private final PrintWriter output;
+    private final StringBuffer outputbuffer;
+
+    RedirectStreamHandleAndgetBuffer(PrintWriter output, InputStream input, StringBuffer outputbuffer) {
+      this.input = Preconditions.checkNotNull(input);
+      this.output = Preconditions.checkNotNull(output);
+      this.outputbuffer = Preconditions.checkNotNull(outputbuffer);
+      start();
+    }
+
+    @Override
+    public void run() {
+      try {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        String line;
+        while ((line = reader.readLine()) != null) {
+          output.println(line);
+          outputbuffer.append(line).append("\n");
+        }
+      } catch (IOException ioe) {
+        // OK to ignore...
+        LOG.log(Level.WARNING, "____I/O Redirection failure: ", ioe);
+      }
+    }
+  }
+
+  /*
    * Input stream handler used for stdout and stderr redirection.
    */
   private static class RedirectStreamHandler extends Thread {
@@ -115,6 +147,36 @@ public final class Execution {
     } catch (Exception e) {
       LOG.log(Level.WARNING, "____Execution failure: ", e);
       return false;
+    }
+  }
+
+  /**
+   * Executes a command in a command shell.
+   *
+   * @param workingDir  working directory for the command
+   * @param command  command to execute and its arguments
+   * @param out  standard output stream to redirect to
+   * @param err  standard error stream to redirect to
+   * @return  String Array with three arguments [true/false-String,Out-String,Err-String]
+   */
+  public static String[] executeandget(File workingDir, String[] command, PrintStream out,
+                                       PrintStream err) {
+    LOG.log(Level.INFO, "____Executing " + joiner.join(command));
+    if (System.getProperty("os.name").startsWith("Windows")){
+      for(int i =0; i < command.length; i++){
+        command[i] = command[i].replace("\"", "\\\"");
+      }
+    }
+    try {
+      Process process = Runtime.getRuntime().exec(command, null, workingDir);
+      StringBuffer strBufferOut=new StringBuffer();
+      StringBuffer strBufferErr=new StringBuffer();
+      new RedirectStreamHandleAndgetBuffer(new PrintWriter(out, true), process.getInputStream(),strBufferOut);
+      new RedirectStreamHandleAndgetBuffer(new PrintWriter(err, true), process.getErrorStream(),strBufferErr);
+      return new String[]{Boolean.toString(process.waitFor() == 0),strBufferOut.toString(),strBufferErr.toString()};
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "____Execution failure: ", e);
+      return new String[]{"false","",""}; //Must have size 3
     }
   }
 


### PR DESCRIPTION
Fixes #2344
Checks if the dx produced "too many classes in main-classes.txt" error, If yes then recreates main-classes.txt by excluding the user-created classes. Executes the dx task again with the replaced main-classes.txt. The existing execute methods are used by other processes, so there was a need to create a separate stream handler method that can print to stdin and return the output buffer to check the type of error.
Excluding user source classes in main-classes.txt will add them in secondary dex files. Since the necessary Appcompat, Runtime, etc. classes are in primary dex and loaded initially by Dalvikvm, It's okay to include user-created screens in the secondary dex file if in case the error occurs. The projects with dx error and regular projects are tested and APK files worked fine on devices.
Project .aia that produces similar dex error and handled by the functionality:
[CheckDex2.zip](https://github.com/mit-cml/appinventor-sources/files/5762996/CheckDex2.zip)


