### PR TITLE
Fix PNG export when browser extensions inject CSS

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -38,7 +38,13 @@ goog.require('goog.Timer');
         console.warn("Cannot include styles from other hosts: "+sheets[i].href);
         continue;
       }
-      var rules = sheets[i].cssRules;
+      var rules = null;
+      try {
+        rules = sheets[i].cssRules;
+      } catch (e) {
+        console.warn('Skipping a potentially injected stylesheet', e);
+        continue;
+      }
       if (rules != null) {
         for (var j = 0; j < rules.length; j++) {
           var rule = rules[j];


### PR DESCRIPTION
Relevant thread: https://community.appinventor.mit.edu/t/i-cant-download-my-blocks-as-image-at-all/24833?u=ewpatton

I was not able to replicate the issue, however. The logic of the change is that when the CSS rules are read, if an exception is thrown, to skip that CSS and continue. This is okay because our CSS won't throw an error due to cross-origin security checks.

Change-Id: I305dca87f36e6d6659a3586cb9b3b014bbcafa89