### PR TITLE
Add json decode/encode blocks to dictionaries drawer

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/dictionaries.js
+++ b/appinventor/blocklyeditor/src/blocks/dictionaries.js
@@ -517,3 +517,35 @@ Blockly.Blocks['dictionaries_is_dict'] = {
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_DICTIONARIES_IS_DICT_TITLE }]
 };
+
+Blockly.Blocks['dictionaries_from_json'] = {
+  // Convert JSON String to dictionary.
+  category : 'Dictionaries',
+  helpUrl : Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_HELPURL,
+  init : function() {
+    this.setColour(Blockly.DICTIONARY_CATEGORY_HUE);
+    this.setOutput(true, Blockly.Blocks.Utilities.YailTypeToBlocklyType("dictionary",Blockly.Blocks.Utilities.OUTPUT));
+    this.appendValueInput('TEXT')
+      .setCheck(Blockly.Blocks.Utilities.YailTypeToBlocklyType("text",Blockly.Blocks.Utilities.INPUT))
+      .appendField(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_TITLE)
+      .appendField(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSONINPUT_TEXT);
+    this.setTooltip(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_TOOLTIP);
+  },
+  typeblock: [{ translatedName: Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_TITLE }]
+};
+
+Blockly.Blocks['dictionaries_to_json'] = {
+  // Convert dictionary to JSON String.
+  category : 'Dictionaries',
+  helpUrl : Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_HELPURL,
+  init : function() {
+    this.setColour(Blockly.DICTIONARY_CATEGORY_HUE);
+    this.setOutput(true, Blockly.Blocks.Utilities.YailTypeToBlocklyType("text",Blockly.Blocks.Utilities.OUTPUT));
+    this.appendValueInput('DICT')
+      .setCheck(Blockly.Blocks.Utilities.YailTypeToBlocklyType("dictionary",Blockly.Blocks.Utilities.INPUT))
+      .appendField(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_TITLE)
+      .appendField(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSONINPUT_TEXT);
+    this.setTooltip(Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_TOOLTIP);
+  },
+  typeblock: [{ translatedName: Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_TITLE }]
+};

--- a/appinventor/blocklyeditor/src/generators/yail/dictionaries.js
+++ b/appinventor/blocklyeditor/src/generators/yail/dictionaries.js
@@ -227,6 +227,33 @@ Blockly.Yail['dictionaries_walk_all'] = function() {
   return [Blockly.Yail.YAIL_CONSTANT_ALL, Blockly.Yail.ORDER_ATOMIC];
 };
 
+
+Blockly.Yail['dictionaries_from_json'] = function() {
+  // Convert JSON String to dictionary.
+  var argument0 = Blockly.Yail.valueToCode(this, 'TEXT', Blockly.Yail.ORDER_NONE) || "\"\"";
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "yali-dictionary-dict-from-json" + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;
+  code = code + argument0;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + Blockly.Yail.YAIL_OPEN_COMBINATION;
+  code = code + "text" + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "dict from json" + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  return [ code, Blockly.Yail.ORDER_ATOMIC ];
+};
+
+Blockly.Yail['dictionaries_to_json'] = function() {
+  // Convert dictionary to JSON String.
+  var argument0 = Blockly.Yail.valueToCode(this, 'DICT', Blockly.Yail.ORDER_NONE) || Blockly.Yail.YAIL_EMPTY_DICT;
+  var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "yali-dictionary-dict-to-json" + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_OPEN_COMBINATION + Blockly.Yail.YAIL_LIST_CONSTRUCTOR + Blockly.Yail.YAIL_SPACER;
+  code = code + argument0;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  code = code + Blockly.Yail.YAIL_SPACER + Blockly.Yail.YAIL_QUOTE + Blockly.Yail.YAIL_OPEN_COMBINATION;
+  code = code + "dictionary" + Blockly.Yail.YAIL_CLOSE_COMBINATION + Blockly.Yail.YAIL_SPACER;
+  code = code + Blockly.Yail.YAIL_DOUBLE_QUOTE + "dict to json" + Blockly.Yail.YAIL_DOUBLE_QUOTE + Blockly.Yail.YAIL_CLOSE_COMBINATION;
+  return [ code, Blockly.Yail.ORDER_ATOMIC ];
+};
+
 Blockly.Yail['dictionaries_is_dict'] = function() {
   var argument = Blockly.Yail.valueToCode(this, 'THING', Blockly.Yail.ORDER_NONE) || Blockly.Yail.YAIL_EMPTY_DICT;
   var code = Blockly.Yail.YAIL_CALL_YAIL_PRIMITIVE + "yail-dictionary?" + Blockly.Yail.YAIL_SPACER;

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1092,6 +1092,16 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_DICTIONARIES_IS_DICT_TOOLTIP = 'Tests if something is a dictionary.';
     Blockly.Msg.LANG_DICTIONARIES_IS_DICT_HELPURL = '/reference/blocks/dictionaries.html#is-a-dictionary';
 
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_TITLE = 'JSON to dictionary';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_TOOLTIP = 'Converts a JSON string into a dictionary';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSONINPUT_TEXT = 'text';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_FROM_JSON_HELPURL = '/reference/blocks/dictionaries.html#dictionary-from-json';
+
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_TITLE = 'dictionary to JSON';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_TOOLTIP = 'Converts a dictionary into a JSON string';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSONINPUT_TEXT = 'dictionary';
+    Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_TO_JSON_HELPURL = '/reference/blocks/dictionaries.html#dictionary-to-json';
+    
 // Variables Blocks.
     Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_HELPURL = '/reference/blocks/variables.html#global';
     Blockly.Msg.LANG_VARIABLES_GLOBAL_DECLARATION_TITLE_INIT = 'initialize global';

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -966,6 +966,7 @@
 (module-static #t)
 
 (define-alias CsvUtil <com.google.appinventor.components.runtime.util.CsvUtil>)
+(define-alias JsonUtil <com.google.appinventor.components.runtime.util.JsonUtil>)
 (define-alias Double <java.lang.Double>)
 (define-alias Float <java.lang.Float>)
 (define-alias Integer <java.lang.Integer>)
@@ -2513,7 +2514,8 @@ Dictionary implementation.
 - combine two dicts         (yail-dictionary-combine-dicts first-dictionary second-dictionary)
 - turn alist to dict        (yail-dictionary-alist-to-dict alist)
 - turn dict to alist        (yail-dictionary-dict-to-alist dict)
-
+- dict from json            (yali-dictionary-dict-from-json text)
+- json to dict              (yali-dictionary-dict-to-json yali-dictionary)
 - is YailDictionary?        (yail-dictionary? x)
 
 |#
@@ -2587,6 +2589,20 @@ Dictionary implementation.
 
 (define (yail-dictionary? x)
   (instance? x YailDictionary))
+
+(define (yali-dictionary-dict-from-json str)
+  (try-catch
+    (JsonUtil:getObjectFromJson str #t)
+    (exception org.json.JSONException
+      (signal-runtime-error
+        (string-append 
+          "Unable to decode the JSON text: " str)
+        (exception:getMessage)))))
+
+(define (yali-dictionary-dict-to-json yali-dictionary)
+  (if (not (yail-dictionary? yali-dictionary))
+    (signal-runtime-error "Argument value to \"dictionary to JSON\" must be a dictionary" "Expecting dictionary")
+    (JsonUtil:encodeJsonObject yali-dictionary)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
### Description
Closes #2123
Add blocks in dictionaries drawer to encode/decode JSON. These blocks will reuse the functionality implemented in JSONUtils and already used by the Web component.

- **dictionary to JSON**
![image](https://user-images.githubusercontent.com/19463218/105572155-74fc8980-5d7b-11eb-86c7-60e195ca1914.png)

- **dictionary from JSON**
![image](https://user-images.githubusercontent.com/19463218/105572163-82b20f00-5d7b-11eb-88f7-80da1980f821.png)