### PR TITLE
Parameter moving under cursor cancels field editing 

### DIFF
--- a/appinventor/blocklyeditor/src/field_flydown.js
+++ b/appinventor/blocklyeditor/src/field_flydown.js
@@ -141,7 +141,8 @@ Blockly.FieldFlydown.prototype.showFlydownMaker_ = function() {
   var field = this; // Name receiver in variable so can close over this variable in returned thunk
   return function() {
     if (Blockly.FieldFlydown.showPid_ !== 0 &&
-        Blockly.dragMode_ === Blockly.DRAG_NONE) {
+        Blockly.dragMode_ === Blockly.DRAG_NONE && 
+        Blockly.FieldTextInput.htmlInput_ === null) {
       try {
         field.showFlydown_();
       } catch (e) {


### PR DESCRIPTION
Fixes: #2402 : The flydown does not open when the text input field is being edited. It opens when the text input field is not focused.