### PR TITLE
Update CloudDB auth token

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/cloudDBAuth/token.proto
+++ b/appinventor/appengine/src/com/google/appinventor/server/cloudDBAuth/token.proto
@@ -10,6 +10,8 @@ option java_outer_classname = "TokenAuth";
 
 message unsigned {
     optional string huuid = 1;
+    optional bool monall = 2 [default = false]; // Can monitor all keys
+    optional bool privileged = 3 [default = false];
 }
 
 // This is the actual message token. The "unsigned" field


### PR DESCRIPTION
Add two boolean fields. The “monall” field (in production for a while)
permits the monitoring of all key changes. This is used for statistics
gathering and research.

The “privileged” flag permits commands that manage the overall server. At
the moment the only such command is one to manually close specified
client connections.

Note: MIT App Inventor itself does not make use of these flags, but the
MIT App Inventor source tree is the canonical authoritative location for
the token format definition.

Change-Id: If7cd4ae7cf2fd49718607aeac51d8a56f76df877