### PR TITLE
Fix show status bar

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -645,6 +645,9 @@ public final class MockForm extends MockContainer {
     boolean visible = Boolean.parseBoolean(text);
     phoneBar.setVisible(visible);
     phoneBar.getVisibility(visible);
+    if (screenWidth == 0 || screenHeight == 0) { // This happens when a project is loaded
+      return;                                    // so don't attempt to resize to 0,0
+    }
     resizePanel(screenWidth,screenHeight); // update the MockForm size
   }
 


### PR DESCRIPTION
Do not attempt to resize the MockForm when Width and Height are
zero. This happens during initialization when a project is loading, so
just don’t do it.

The bug here is harmless, but results in errors in the browser console
during project load. This fix eliminates those error.

Change-Id: I5953b9e184548c3d004c89dd8573817f77bbd912