### PR TITLE
Improve Rendezvous Use of WebRTCManager

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneStatus.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneStatus.java
@@ -214,6 +214,9 @@ public class PhoneStatus extends AndroidNonvisibleComponent implements Component
     if (!useWebRTC) {
       return;
     }
+    if (firstSeed == null || firstSeed.equals("") || firstSeed.length() != 6) {
+      new Notifier(form).ShowAlert("Code must be 6 characters");
+    }
     WebRTCNativeMgr webRTCNativeMgr = new WebRTCNativeMgr(rendezvousServer, iceServers);
     webRTCNativeMgr.initiate((ReplForm) form, (Context)activity, firstSeed);
     ((ReplForm)form).setWebRTCMgr(webRTCNativeMgr);


### PR DESCRIPTION
WebRTCManager connects to the Rendezvous server to learn “iceCandidates”
as part of WebRTC setup. The was it was doing it resulted in multiple
independent TCP connections (https) to the Rendezvous server as
candidates were queried.

Not only was this inefficient, but when we updated the Rendezvous server
to use http1.1 (and http2 if available), these independent connections
would not close but would instead linger for the life of the Companion,
resulting in wasted resources on the Rendezvous server.

The Rendezvous server compensated by marking Companion connections as
“Connection: Close” so they do not linger.

This change causes the Companion to use one tcp (https) connection (if
the Rendezvous server supported http1.1) for all Rendezvous server
connections.

We add a flag to the data sent to the Rendezvous server (http11) which
lets the Rendezvous server know that it can leave connections open from
newer Companions while still closing connections from Companions built
before this change. On the POST side, we add it to the json that is
sent. On the GET side we add it in a query string.

Note: We only do this in the Companion, not on the browser. Most
browsers will use http2 to connect to the Rendezvous server, so it
doesn’t matter if the Rendezvous server attempts to send the “Connection
close” header because it isn’t used in http2.

We also added a check in PhoneStatus to ensure that the entered code is
exactly 6 characters. This catches the case where people just click the
“Connect with Code” button on the Companion which results in useless
traffic to the Rendezvous server.

Change-Id: I1ec8e4b34716d7f7f67a136ab9345d6b79e2a116