### PR TITLE
fixes background color format

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponentsUtil.java
@@ -33,7 +33,10 @@ public final class MockComponentsUtil {
     if (isNoneColor(color)) {
       DOM.setStyleAttribute(widget.getElement(), "backgroundColor", "transparent");
     } else {
-      DOM.setStyleAttribute(widget.getElement(), "backgroundColor", "#" + getHexString(color, 6));
+      if (color.startsWith("&H") && color.length() == 10) {
+        color = color.substring(0,2) + color.substring(4) + color.substring(2,4);
+      }  // changes format of color from ARGB to RGBA
+      DOM.setStyleAttribute(widget.getElement(), "backgroundColor", "#" + getHexString(color, 8));
     }
   }
 
@@ -259,7 +262,7 @@ public final class MockComponentsUtil {
     int len = color.length();
     if (len < digits) {
       do {
-        color = '0' + color;
+        color = color + '0';
       } while (++len < digits);
 
       return color;


### PR DESCRIPTION
Closes #2417

The input provided to `setWidgetBackgroundColor` was in ARGB format while the `setStyleAttribute` uses the RGBA format. So I converted the color string from ARGB format to RGBA  format. 
Similarly the `getHexString` method also used to return in ARGB format, so I changed that as well.
Lastly, the `setWidgetBackgroundColor` used to ignore the alpha value specified in input color string. Changed it to take that into consideration too.

Steps to Check :

1. Create a label in the designer
2. Open the BackgroundColor property editor and select Custom
3. Pick a color and see the background color change
4. Adjust the alpha down, and see that the background gets a transparent color
