### PR TITLE
Mitigate Chrome 89 change

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -313,6 +313,12 @@ Blockly.ReplMgr.putYail = (function() {
     var webrtcforcestop = false;
     var webrtcdata;
     var seennonce = {};
+    var fixchrome89 = function(desc) {
+        var sdp = desc.sdp;
+        sdp = sdp.replace("a=extmap-allow-mixed\r\n", "")
+        desc.sdp = sdp;
+        return desc;
+    };
     var engine = {
         // Enqueue form for the phone
         'putYail' : function(code, block, success, failure) {
@@ -507,7 +513,7 @@ Blockly.ReplMgr.putYail = (function() {
                 webrtcrunning = false;
             };
             webrtcpeer.createOffer().then(function(desc) {
-                offer = desc;
+                offer = fixchrome89(desc);
                 var xhr = new XMLHttpRequest();
                 xhr.open('POST', top.ReplState.rendezvous2, true);
                 xhr.send(JSON.stringify({'key' : key + '-s',


### PR DESCRIPTION
Chrome 89 implements RFC8285 by default. It implements a general
mechanism for RTP header extensions. We do not use these....

Unfortunately the WebRTC library we are using in the Companion does not
understand the extension request in the WebRTC offer message and refuses
the offer completely, resulting in WebRTC not working from Chrome
89 (and presumably onward).

This change removes the extension from the offer prior to sending it to
the Companion, so WebRTC works again.

We believe this is harmless, because we do not use audio or video over
WebRTC and this extension has no impact on the data channel (which we do
use).

Change-Id: I68f4ebaa2099ca0b4bbc7b1abd0a565dbde1f4e6