### PR TITLE
Set initial currentView to projects in Ode.java

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -201,7 +201,7 @@ public class Ode implements EntryPoint {
   public static final int PROJECTS = 1;
   public static final int USERADMIN = 2;
   public static final int TRASHCAN = 3;
-  public static int currentView = DESIGNER;
+  public static int currentView = PROJECTS;
 
   /*
    * The following fields define the general layout of the UI as seen in the following diagram:


### PR DESCRIPTION
Fixes #2433 and #2419.
Both of these bugs were caused because the initial `currentView` (in Ode.java) was incorrectly set to `DESIGNER`. If autoload was on this assumption turned out to be true and the behaviour was as expected. Only when autoload was off did we experience sime issues. 
Setting the initial `currentView` to `PROJECTS` fixes these bugs as the projects screen is always loaded first. 