### PR TITLE
Changed TestToSpeech to TextToSpeech

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
@@ -54,7 +54,7 @@ import com.google.appinventor.components.runtime.util.YailList;
 // TODO(hal): This language and country code method using strings as abbreviations was
 // deprecated in API level 21.
 @DesignerComponent(version = YaVersion.TEXTTOSPEECH_COMPONENT_VERSION,
-description = "The TestToSpeech component speaks a given text aloud.  You can set " +
+description = "The TextToSpeech component speaks a given text aloud.  You can set " +
     "the pitch and the rate of speech. " +
     "<p>You can also set a language by supplying a language code.  This changes the pronunciation " +
     "of words, not the actual language spoken.  For example, setting the language to French " +


### PR DESCRIPTION
Fixes #2438 
Changed "TestToSpeech" to "TextToSpeech" in description.
Steps to Check:
1) Open Description of TextToSpeech component in the designer view.
2) Verify that it shows "TextToSpeech" instead of "TestToSpeech".

![Screenshot from 2021-03-17 23-30-31](https://user-images.githubusercontent.com/68317116/111515497-dd168d00-8778-11eb-9aa3-cb2231f27b70.png)
