### PR TITLE
Remove dead link from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,9 @@
     <div class="page6" id="footer">
       <div class="page_container">
         <div id="headers">
-          <h2 class="copyright">App-inventor maintained by <a href="http://mitmobilelearning.org" target="_blank">MIT Center for Mobile Learning</a></h2>
+          <h2 class="copyright">MIT App Inventor maintained by&nbsp;
+          <a href="https://appinventor.mit.edu/explore/our-team"
+          target="_blank">MIT App Inventor Team at CSAIL</a></h2>
           <h2>Published with <a href="http://pages.github.com" target="_blank">GitHub Pages</a> and available under <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a></h2>
         </div>
       </div>


### PR DESCRIPTION
Instead have it point to the “Our Team” page on the main App Inventor website