### PR TITLE
Change Accerleromter to Accelerometer

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
@@ -69,7 +69,7 @@ public class Camera extends AndroidNonvisibleComponent
   // whether to open into the front-facing camera
   private boolean useFront;
 
-  // wether or not we have permission to use the camera
+  // whether or not we have permission to use the camera
 
   private boolean havePermission = false;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Pedometer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Pedometer.java
@@ -31,7 +31,7 @@ import android.util.Log;
  */
 @DesignerComponent(version = YaVersion.PEDOMETER_COMPONENT_VERSION,
   description = "A Component that acts like a Pedometer. It senses motion via the " +
-  "Accerleromter and attempts to determine if a step has been " +
+  "Accelerometer and attempts to determine if a step has been " +
   "taken. Using a configurable stride length, it can estimate the " +
   "distance traveled as well. ",
   category = ComponentCategory.SENSORS,


### PR DESCRIPTION
Fix typo "Accerleromter"  in Pedometer Component Description to "Accelerometer"


![Screenshot from 2021-04-07 16-23-23](https://user-images.githubusercontent.com/69227287/113856340-ba4b2780-97be-11eb-8208-37e58837ca83.png)
