### PR TITLE
Add hostname to buildserver/vars

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -258,6 +258,7 @@ public class BuildServer {
     RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
     DateFormat dateTimeFormat = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.FULL);
     variables.put("state", getShutdownState() + "");
+    variables.put("hostname", InetAddress.getLocalHost().getHostName());
     if (shuttingTime != 0) {
       variables.put("shutdown-time", dateTimeFormat.format(new Date(shuttingTime)));
     }


### PR DESCRIPTION
We run 9-15 buildservers simultaneously and have a status page that
reports the /buildserver/vars foreach server. However it is hard to know
which status is for which buildserver. So we add the buildserver
hostname here.

Change-Id: I46fc59626cccf668ab57a5f81581273f0358fd1e