### PR TITLE
Load built-in templates via the repo parameter

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -766,10 +766,6 @@ public class Ode implements EntryPoint {
               @Override
               public void onProjectsLoaded() {
                 projectManager.removeProjectManagerEventListener(this);
-                if (!handleQueryString() && shouldAutoloadLastProject()) {
-                  openPreviousProject();
-                }
-
                 // This handles any built-in templates stored in /war
                 // Retrieve template data stored in war/templates folder and
                 // and save it for later use in TemplateUploadWizard
@@ -781,6 +777,10 @@ public class Ode implements EntryPoint {
                       public void onSuccess(String json) {
                         // Save the templateData
                         TemplateUploadWizard.initializeBuiltInTemplates(json);
+
+                        if (!handleQueryString() && shouldAutoloadLastProject()) {
+                          openPreviousProject();
+                        }
                       }
                     };
                 Ode.getInstance().getProjectService().retrieveTemplateData(TemplateUploadWizard.TEMPLATES_ROOT_DIRECTORY, templateCallback);

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
@@ -631,6 +631,10 @@ public class TemplateUploadWizard extends Wizard implements NewUrlDialogCallback
     }
   }
 
+  private static native boolean isTemplateName(String name)/*-{
+    return new RegExp('^[A-Za-z][A-Za-z0-9]+$').test(name);
+  }-*/;
+
   /**
    * Called from Ode when a template Url is passed as GET parameter.
    *  The Url could take two forms:
@@ -643,6 +647,17 @@ public class TemplateUploadWizard extends Wizard implements NewUrlDialogCallback
    * @param onSuccessCommand command to open the project
    */
   public static void openProjectFromTemplate(String url, final NewProjectCommand onSuccessCommand) {
+    if (isTemplateName(url)) {
+      if (TextValidators.checkNewProjectName(url)) {
+        new TemplateUploadWizard().createProjectFromExistingZip(url, new NewProjectCommand() {
+          @Override
+          public void execute(Project project) {
+            Ode.getInstance().openYoungAndroidProjectInDesigner(project);
+          }
+        });
+      }
+      return;
+    }
     if(!url.startsWith("http")) {
       url = "http://" + url;
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/TemplateUploadWizard.java
@@ -631,9 +631,14 @@ public class TemplateUploadWizard extends Wizard implements NewUrlDialogCallback
     }
   }
 
-  private static native boolean isTemplateName(String name)/*-{
-    return new RegExp('^[A-Za-z][A-Za-z0-9]+$').test(name);
-  }-*/;
+  private static boolean isTemplateName(String name) {
+    for (TemplateInfo template : builtInTemplates) {
+      if (template.name.equals(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   /**
    * Called from Ode when a template Url is passed as GET parameter.


### PR DESCRIPTION
I implemented this for Punya but figured it was helpful for App Inventor as well. The change allows for using built-in template names in the `repo` parameter. For example, `http://localhost:8888/?repo=HelloPurr` will open the HelloPurr project.

Change-Id: I62265b3a60ecf7b651d9a22a32775e5d7434d5e5