### PR TITLE
Fix several typos in comments in EditorManager.java & ProjectEditor.java

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
@@ -287,7 +287,7 @@ public final class EditorManager {
             afterSaving.execute();
           }
           // Set the project modification date to the returned date
-          // for one of the saved files (it doens't really matter which one).
+          // for one of the saved files (it doesn't really matter which one).
           if ((dateHolder.date != 0) && (dateHolder.projectId != 0)) { // We have a date back from the server
             Ode.getInstance().updateModificationDate(dateHolder.projectId, dateHolder.date);
           }
@@ -366,7 +366,7 @@ public final class EditorManager {
    * in the same RPC transaction. However we are now sending them separately
    * so that we can have more fine grained control over handling errors that
    * happen only on one file. In particular, we need to handle the case where
-   * a trivial blocks workspace is attempting to be written over a non-trival
+   * a trivial blocks workspace is attempting to be written over a non-trivial
    * file.
    *
    * If any unhandled errors occur while saving, the afterSavingFiles

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/ProjectEditor.java
@@ -88,7 +88,7 @@ public abstract class ProjectEditor extends Composite {
 
   /**
    * Called when the ProjectEditor widget is loaded after having been hidden. 
-   * Subclasses must implement this method, taking responsiblity for causing 
+   * Subclasses must implement this method, taking responsibility for causing 
    * the onShow method of the selected file editor to be called and for updating 
    * any other UI elements related to showing the project editor.
    */
@@ -96,7 +96,7 @@ public abstract class ProjectEditor extends Composite {
   
   /**
    * Called when the ProjectEditor widget is about to be unloaded. Subclasses
-   * must implement this method, taking responsiblity for causing the onHide 
+   * must implement this method, taking responsibility for causing the onHide 
    * method of the selected file editor to be called and for updating any 
    * other UI elements related to hiding the project editor.
    */
@@ -194,7 +194,7 @@ public abstract class ProjectEditor extends Composite {
       selectedFileEditor.onHide();
     }
     // Note that we still want to do the following statements even if 
-    // selectedFileEdtior == fileEditor already. This handles the case of switching back
+    // selectedFileEditor == fileEditor already. This handles the case of switching back
     // to a previously opened project from another project.
     selectedFileEditor = fileEditor;
     deckPanel.showWidget(index);
@@ -296,14 +296,14 @@ public abstract class ProjectEditor extends Composite {
    * is only available from the designer. Each WebViewer then
    * registers its value here. Each time this hashtable is updated we
    * recompute whether or not location permission is needed based on a
-   * logical OR of all of the WebViwer components registered. Note:
-   * Even if no WebViewer component requires location permisson, other
+   * logical OR of all of the WebViewer components registered. Note:
+   * Even if no WebViewer component requires location permission, other
    * components, such as the LocationSensor may require it. That is
    * handled via the @UsesPermissions mechanism and is independent of
    * this code.
    *
    * @param componentName The name of the component registering location permission
-   * @param newVlue either "True" or "False" indicating whether permission is need.
+   * @param newValue either "True" or "False" indicating whether permission is need.
    */
 
   public final void recordLocationSetting(String componentName, String newValue) {


### PR DESCRIPTION
### Fix typos in comments in EditorManager.java
- doens't -> doesn't
- trival -> trivial

### Fix typos in comments in ProjectEditor.java
- responsiblity -> responsibility
- Edtior -> Editor
- Viwer -> Viewer
- permisson -> permission
- Vlue -> Value