### PR TITLE
Fix errors of map components in the designer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircle.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircle.java
@@ -219,6 +219,8 @@ public class MockCircle extends MockMapFeatureBaseWithFill {
     this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::setNativeTooltip(*)(
       this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getTooltip()()
     );
+    var isVisible = this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getVisibleProperty()();
+    if(!isVisible) map.removeLayer(circle);
   }-*/;
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLineString.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLineString.java
@@ -143,6 +143,8 @@ public class MockLineString extends MockMapFeatureBase {
     this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::setNativeTooltip(*)(
       this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getTooltip()()
     );
+    var isVisible = this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getVisibleProperty()();
+    if(!isVisible) map.removeLayer(polyline);
   }-*/;
 
   private native void preserveLayerData()/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMapFeatureBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMapFeatureBase.java
@@ -74,7 +74,12 @@ public abstract class MockMapFeatureBase extends MockVisibleComponent implements
   protected void onSelectedChange(boolean selected) {
     super.onSelectedChange(selected);
     setSelected(selected);
-    setEditing(selected);
+    boolean isVisible = getVisibleProperty();
+    setEditing(isVisible && selected);
+  }
+  
+  boolean getVisibleProperty() {
+    return Boolean.parseBoolean(getPropertyValue(PROPERTY_NAME_VISIBLE));
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMarker.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMarker.java
@@ -430,6 +430,8 @@ public class MockMarker extends MockMapFeatureBaseWithFill {
       marker.on('click dragstart', marker.clickHandler);
       marker.on('dragend', marker.dragHandler);
     }
+    var isVisible = this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getVisibleProperty()();
+    if(!isVisible) map.removeLayer(marker);
   }-*/;
 
   native double getLatitude()/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockPolygon.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockPolygon.java
@@ -215,6 +215,8 @@ public class MockPolygon extends MockPolygonBase {
     this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::setNativeTooltip(*)(
       this.@com.google.appinventor.client.editor.simple.components.MockPolygon::getTooltip()()
     );
+    var isVisible = this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getVisibleProperty()();
+    if(!isVisible) map.removeLayer(polygon);
   }-*/;
 
   private native void preserveLayerData()/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockRectangle.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockRectangle.java
@@ -184,6 +184,8 @@ public class MockRectangle extends MockPolygonBase {
     this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::setNativeTooltip(*)(
       this.@com.google.appinventor.client.editor.simple.components.MockPolygon::getTooltip()()
     );
+    var isVisible = this.@com.google.appinventor.client.editor.simple.components.MockMapFeatureBase::getVisibleProperty()();
+    if(!isVisible) map.removeLayer(rect);
   }-*/;
 
   private native void setBounds(double south, double west, double north, double east)/*-{


### PR DESCRIPTION
Fixes #2444 and #2441.
#2444 was caused because the feature was always added to the map irrespective of its visibility, on reloading the designer. Checking its visibility and calling `removeLayer()` if required solves the issue.
#2441 is solved by enabling the edit feature only if the feature is visible (in `onSelectedChange()`).
