### PR TITLE
Fix image resizing on scalar changes

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageBase.java
@@ -77,6 +77,17 @@ abstract class MockImageBase extends MockVisibleComponent {
     }
   }
 
+  /*
+   * This was overridden as on changing width / height, the image is not altered but only the
+   * enclosing div element is resized. Calling resizeImage() resizes the underlying image wrt
+   * the enclosing div element.
+   */
+  @Override
+  public void setPixelSize(int width, int height) {
+    super.setPixelSize(width, height);
+    resizeImage();
+  }
+
   @Override
   public int getPreferredWidth() {
     // The superclass uses getOffsetWidth, which won't work for us.


### PR DESCRIPTION
Fixes #2502.
`resizeImage()` was not called on scalar changes, hence underlying image was not properly resized according to the enclosing div element. This overrides `setPixelSize()` so as to always call `resizeImage()` on scalar changes.