### PR TITLE
Fix Stackoverflow error in the ListPicker component

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AnimationUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AnimationUtil.java
@@ -144,7 +144,7 @@ public final class AnimationUtil {
    */
   public static void ApplyCloseScreenAnimation(Activity activity, String animType) {
     ScreenAnimation anim = ScreenAnimation.fromUnderlyingValue(animType);
-    AnimationUtil.ApplyCloseScreenAnimation(activity, animType);
+    AnimationUtil.ApplyCloseScreenAnimation(activity, anim);
   }
 
   /**


### PR DESCRIPTION
Addresses the StackOverFlowError when selecting a list item or doing a backpress while in the `ListPickerActivity`, since the `ApplyCloseScreenAnimation(Activity, String)` was infinity calling it self back again.
This appears to affect the `ListPickerActivity` only, and not the `Form` as well, because of the fact the `Form` directly invokes the `ApplyCloseScreenAnimation(Activity, ScreenAnimation)` method.