### PR TITLE
Add Support for Changing Hint Text color for Textboxes

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -876,6 +876,10 @@ public final class YoungAndroidFormUpgrader {
       // RequestFocus function was added (via TextBoxBase)
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // The HintColor property was added
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 
@@ -1402,6 +1406,10 @@ public final class YoungAndroidFormUpgrader {
       // Added NumbersOnly property
       srcCompVersion = 5;
     }
+    if (srcCompVersion < 6) {
+      // The HintColor property was added
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 
@@ -1732,6 +1740,10 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 6) {
       // ReadOnly property was added
       srcCompVersion = 6;
+    }
+    if (srcCompVersion < 7) {
+      // The HintColor property was added
+      srcCompVersion = 7;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1824,7 +1824,10 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "ai1CantDoUpgrade", // Just indicates we couldn't do upgrade even if we wanted to
 
     // RequestFocus was added
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // The HintColor property was added
+    4: "noUpgrade"
 
   }, // End EmailPicker upgraders
 
@@ -2618,7 +2621,10 @@ Blockly.Versioning.AllUpgradeMaps =
     4: "noUpgrade",
 
     // NumbersOnly was added
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // The HintColor property was added
+    6: "noUpgrade"
 
   }, // End PasswordTextBox upgraders
 
@@ -2960,7 +2966,10 @@ Blockly.Versioning.AllUpgradeMaps =
     5: "noUpgrade",
 
     // AI3: Added ReadOnly property
-    6: "noUpgrade"
+    6: "noUpgrade",
+
+    // The HintColor property was added
+    7: "noUpgrade"
 
   }, // End TextBox upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -49,6 +49,7 @@ public class ComponentConstants {
    * TextBox, PasswordTextBox, and EmailPicker components.
    */
   public static final int TEXTBOX_PREFERRED_WIDTH = 160;
+  public static final String TEXTBOX_HINT_COLOR = "&H808080";
 
    /**
    * HorizontalArrangement, VerticalArrangement, and Screen

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -861,7 +861,9 @@ public class YaVersion {
   // - The Alignment property was renamed to TextAlignment.
   // For EMAILPICKER_COMPONENT_VERSION 3:
   // - RequestFocus function was added (via TextBoxBase)
-  public static final int EMAILPICKER_COMPONENT_VERSION = 3;
+  // For EMAILPICKER_COMPONENT_VERSION 4:
+  // - The HintColor property was added
+  public static final int EMAILPICKER_COMPONENT_VERSION = 4;
 
   // For FEATURE_COLLECTION_COMPONENT_VERSION 1:
   // - Initial FeatureCollection implementation for Maps
@@ -1189,9 +1191,11 @@ public class YaVersion {
   // - Added RequestFocus Function (via TextBoxBase)
   // For PASSWORDTEXTBOX_COMPONENT_VERSION 4:
   // - Added PasswordVisible property
-  // For For PASSWORDTEXTBOX_COMPONENT_VERSION 5:
+  // For PASSWORDTEXTBOX_COMPONENT_VERSION 5:
   // - Added NumbersOnly property
-  public static final int PASSWORDTEXTBOX_COMPONENT_VERSION = 5;
+  // For PASSWORDTEXTBOX_COMPONENT_VERSION 6:
+  // - The HintColor property was added
+  public static final int PASSWORDTEXTBOX_COMPONENT_VERSION = 6;
 
   // For PEDOMETER_COMPONENT_VERSION 2:
   // - The step sensing algorithm was updated to be more accurate.
@@ -1296,7 +1300,9 @@ public class YaVersion {
   // - RequestFocus method was added
   // For TEXTBOX_COMPONENT_VERSION 6:
   // - ReadOnly property was added
-  public static final int TEXTBOX_COMPONENT_VERSION = 6;
+  // For TEXTBOX_COMPONENT_VERSION 7:
+  // - The HintColor property was added
+  public static final int TEXTBOX_COMPONENT_VERSION = 7;
 
   // For TEXTING_COMPONENT_VERSION 2:
   // Texting over Wifi was implemented using Google Voice

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
@@ -74,6 +74,9 @@ public abstract class TextBoxBase extends AndroidViewComponent
   //The default text color of the textbox hint, according to theme
   private int hintColorDefault;
 
+  // Backing for hint text color
+  private int hintColor;
+
   /**
    * Creates a new TextBoxBase component
    *
@@ -122,10 +125,9 @@ public abstract class TextBoxBase extends AndroidViewComponent
     FontSize(Component.FONT_DEFAULT_SIZE);
     Hint("");
     if (isHighContrast || container.$form().HighContrast()) {
-      view.setHintTextColor(COLOR_YELLOW);
-    }
-    else {
-      view.setHintTextColor(hintColorDefault);
+      HintColor(COLOR_YELLOW);
+    } else {
+      HintColor(hintColorDefault);
     }
 
     Text("");
@@ -570,5 +572,33 @@ public abstract class TextBoxBase extends AndroidViewComponent
   @Override
   public boolean getLargeFont() {
     return isBigText;
+  }
+
+  /**
+   * Specifies the hint text color of the %type% as an alpha-red-green-blue integer.
+   *
+   * @param color hint RGB color with alpha
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
+      defaultValue = ComponentConstants.TEXTBOX_HINT_COLOR)
+  @SimpleProperty(description = "The color for the hint text color. You can choose a color by name the " +
+      "Designer or in the Blocks Editor.")
+  public void HintColor(int color) {
+    hintColor = color;
+    view.setHintTextColor(color);
+    view.invalidate();
+  }
+
+  /**
+   * Returns the hint text color of the %type% as an alpha-red-green-blue
+   * integer.
+   *
+   * @return hint RGB color with alpha
+   */
+  @SimpleProperty(description = "The color for the hint text. You can choose a color by name the " +
+      "Designer or in the Blocks Editor.")
+  @IsColor
+  public int HintColor() {
+    return hintColor;
   }
 }


### PR DESCRIPTION
Adds support for changing the hint text color of the apppinventor textboxes ( the `TextBox`, `PasswordTextbox`, and `EmailPicker`), by adding a new `HintColor` property to the `TextBoxBase` class.
Fixes #2519