### PR TITLE
Fix Marker sizing

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
@@ -52,9 +52,9 @@ import org.osmdroid.util.GeoPoint;
  */
 @DesignerComponent(version = YaVersion.MARKER_COMPONENT_VERSION,
     category = ComponentCategory.MAPS,
-    description = "<p>An icon positioned at a point to indicate information on a map. Markers " +
-        "can be used to provide an info window, custom fill and stroke colors, and custom " +
-        "images to convey information to the user.</p>")
+    description = "<p>An icon positioned at a point to indicate information on a map. Markers "
+        + "can be used to provide an info window, custom fill and stroke colors, and custom "
+        + "images to convey information to the user.</p>")
 @SimpleObject
 @UsesLibraries(libraries = "osmdroid.aar, androidsvg.jar")
 public class Marker extends MapFeatureBaseWithFill implements MapMarker {
@@ -235,7 +235,8 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   public void Latitude(double latitude) {
     Log.d(TAG, "Latitude");
     if (latitude < -90 || latitude > 90) {
-      container.$form().dispatchErrorOccurredEvent(this, "Latitude", ErrorMessages.ERROR_INVALID_LATITUDE, latitude);
+      container.$form().dispatchErrorOccurredEvent(this, "Latitude",
+          ErrorMessages.ERROR_INVALID_LATITUDE, latitude);
     } else {
       location.setLatitude(latitude);
       clearGeometry();
@@ -265,7 +266,8 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   public void Longitude(double longitude) {
     Log.d(TAG, "Longitude");
     if (longitude < -180 || longitude > 180) {
-      container.$form().dispatchErrorOccurredEvent(this, "Longitude", ErrorMessages.ERROR_INVALID_LONGITUDE, longitude);
+      container.$form().dispatchErrorOccurredEvent(this, "Longitude",
+          ErrorMessages.ERROR_INVALID_LONGITUDE, longitude);
     } else {
       location.setLongitude(longitude);
       clearGeometry();
@@ -292,15 +294,15 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   public void ImageAsset(@Asset String path) {
     Log.d(TAG, "ImageAsset");
     this.imagePath = path;
-    map.getController().updateFeatureImage(this);
+    setNeedsUpdate();
   }
 
   /**
    * Specifies the image shown for the `Marker`. If set to the empty string "", then the default
    * marker icon will be used.
    */
-  @SimpleProperty(description = "The ImageAsset property is used to provide an alternative image " +
-      "for the Marker.")
+  @SimpleProperty(description = "The ImageAsset property is used to provide an alternative image "
+      + "for the Marker.")
   public String ImageAsset() {
     return imagePath;
   }
@@ -443,7 +445,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
     if (this.width == LENGTH_FILL_PARENT) {
       return map.getView().getWidth();
     } else if (this.width < LENGTH_PERCENT_TAG) {
-      return (int)(((double) -this.width + LENGTH_PERCENT_TAG)/100.0 * map.getView().getWidth());
+      return (int)(((double) -this.width + LENGTH_PERCENT_TAG) / 100.0 * map.getView().getWidth());
     }
     return this.width;
   }
@@ -482,7 +484,8 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
     if (this.height == LENGTH_FILL_PARENT) {
       return map.getView().getHeight();
     } else if (this.height < LENGTH_PERCENT_TAG) {
-      return (int)(((double) -this.height + LENGTH_PERCENT_TAG)/100.0 * map.getView().getHeight());
+      return (int)(((double) -this.height + LENGTH_PERCENT_TAG) / 100.0
+          * map.getView().getHeight());
     }
     return this.height;
   }
@@ -537,8 +540,8 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    * @return
    */
   @SuppressWarnings("squid:S00100")
-  @SimpleFunction(description = "Compute the distance, in meters, between a Marker and a " +
-      "latitude, longitude point.")
+  @SimpleFunction(description = "Compute the distance, in meters, between a Marker and a "
+      + "latitude, longitude point.")
   public double DistanceToPoint(double latitude, double longitude) {
     return GeometryUtil.distanceBetween(this, new GeoPoint(latitude, longitude));
   }
@@ -552,9 +555,8 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    * @return
    */
   @SuppressWarnings("squid:S00100")
-  @SimpleFunction(description = "Returns the bearing from the Marker to the given latitude and " +
-      "longitude, in degrees " +
-      "from due north.")
+  @SimpleFunction(description = "Returns the bearing from the Marker to the given latitude and "
+      + "longitude, in degrees from due north.")
   public double BearingToPoint(double latitude, double longitude) {
     return location.bearingTo(new GeoPoint(latitude, longitude));
   }
@@ -571,10 +573,10 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    * @return The bearing in degrees east of due north
    */
   @SuppressWarnings("squid:S00100")
-  @SimpleFunction(description = "Returns the bearing from the Marker to the given map feature, " +
-      "in degrees from due north. If the centroids parameter is true, the bearing will be to the " +
-      "center of the map feature. Otherwise, the bearing will be computed to the point in the " +
-      "feature nearest the Marker.")
+  @SimpleFunction(description = "Returns the bearing from the Marker to the given map feature, "
+      + "in degrees from due north. If the centroids parameter is true, the bearing will be to the "
+      + "center of the map feature. Otherwise, the bearing will be computed to the point in the "
+      + "feature nearest the Marker.")
   public double BearingToFeature(MapFactory.MapFeature mapFeature, final boolean centroids) {
     return mapFeature == null ? -1 : mapFeature.accept(bearingComputation, this, centroids);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -15,6 +15,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.media.MediaPlayer;
 import android.media.SoundPool;
 import android.net.Uri;
@@ -448,17 +449,35 @@ public class MediaUtil {
   }
 
   /**
+   * Loads the image specified by mediaPath and returns a {@link Drawable}.
+   *
+   * <p/>If mediaPath is null or empty, null is returned.
+   *
+   * @param form the Form
+   * @param mediaPath the path to the media
+   * @param continuation An AsyncCallbackPair that will receive a BitmapDrawable on success.
+   *                     On exception or failure the appropriate handler will be triggered.
+   */
+  public static void getBitmapDrawableAsync(final Form form, final String mediaPath,
+       final AsyncCallbackPair<BitmapDrawable> continuation) {
+    getBitmapDrawableAsync(form, mediaPath, -1, -1, continuation);
+  }
+
+  /**
    * Loads the image specified by mediaPath and returns a Drawable.
    *
    * <p/>If mediaPath is null or empty, null is returned.
    *
    * @param form the Form
    * @param mediaPath the path to the media
-   * @param continuation An AsyncCallbackPair that will receive a
-   * BitmapDrawable on success. On exception or failure the appropriate
-   * handler will be triggered.
+   * @param desiredWidth the desired width of the image
+   * @param desiredHeight the desired height of the image
+   * @param continuation An AsyncCallbackPair that will receive a BitmapDrawable on success.
+   *                     On exception or failure the appropriate handler will be triggered.
    */
-  public static void getBitmapDrawableAsync(final Form form, final String mediaPath, final AsyncCallbackPair<BitmapDrawable> continuation) {
+  public static void getBitmapDrawableAsync(final Form form, final String mediaPath,
+      final int desiredWidth, final int desiredHeight,
+      final AsyncCallbackPair<BitmapDrawable> continuation) {
     if (mediaPath == null || mediaPath.length() == 0) {
       continuation.onSuccess(null);
       return;
@@ -540,12 +559,15 @@ public class MediaUtil {
           //   5. set the density in the scaled bitmap.
 
           originalBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
-          if ((options.inSampleSize != 1) || (form.deviceDensity() == 1.0f)) {
+          boolean needsResize = desiredWidth > 0 && desiredHeight >= 0;
+          if (!needsResize && (options.inSampleSize != 1 || form.deviceDensity() == 1.0f)) {
             continuation.onSuccess(originalBitmapDrawable);
             return;
           }
-          int scaledWidth = (int) (form.deviceDensity() * originalBitmapDrawable.getIntrinsicWidth());
-          int scaledHeight = (int) (form.deviceDensity() * originalBitmapDrawable.getIntrinsicHeight());
+          int scaledWidth = (int) (form.deviceDensity()
+              * (desiredWidth > 0 ? desiredWidth : originalBitmapDrawable.getIntrinsicWidth()));
+          int scaledHeight = (int) (form.deviceDensity()
+              * (desiredHeight > 0 ? desiredHeight : originalBitmapDrawable.getIntrinsicHeight()));
           Log.d(LOG_TAG, "form.deviceDensity() = " + form.deviceDensity());
           Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicWidth() = " + originalBitmapDrawable.getIntrinsicWidth());
           Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicHeight() = " + originalBitmapDrawable.getIntrinsicHeight());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MediaUtil.java
@@ -508,7 +508,7 @@ public class MediaUtil {
         } catch (PermissionException e) {
           continuation.onFailure("PERMISSION_DENIED:" + e.getPermissionNeeded());
           return;
-        } catch(IOException e) {
+        } catch (IOException e) {
           if (mediaSource == MediaSource.CONTACT_URI) {
             // There's no photo for this contact, return a placeholder image.
             BitmapDrawable drawable = new BitmapDrawable(form.getResources(),
@@ -524,7 +524,7 @@ public class MediaUtil {
           if (is != null) {
             try {
               is.close();
-            } catch(IOException e) {
+            } catch (IOException e) {
               // suppress error on close
               Log.w(LOG_TAG, "Unexpected error on close", e);
             }
@@ -532,7 +532,7 @@ public class MediaUtil {
           is = null;
           try {
             bos.close();
-          } catch(IOException e) {
+          } catch (IOException e) {
             // Should never fail to close a ByteArrayOutputStream
           }
           bos = null;
@@ -544,7 +544,8 @@ public class MediaUtil {
           bis.mark(read);
           BitmapFactory.Options options = getBitmapOptions(form, bis, mediaPath);
           bis.reset();
-          BitmapDrawable originalBitmapDrawable = new BitmapDrawable(form.getResources(), decodeStream(bis, null, options));
+          BitmapDrawable originalBitmapDrawable = new BitmapDrawable(form.getResources(),
+              decodeStream(bis, null, options));
           // If options.inSampleSize == 1, then the image was not unreasonably large and may represent
           // the actual size the user intended for the image. However we still have to scale it by
           // the device density.
@@ -569,23 +570,26 @@ public class MediaUtil {
           int scaledHeight = (int) (form.deviceDensity()
               * (desiredHeight > 0 ? desiredHeight : originalBitmapDrawable.getIntrinsicHeight()));
           Log.d(LOG_TAG, "form.deviceDensity() = " + form.deviceDensity());
-          Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicWidth() = " + originalBitmapDrawable.getIntrinsicWidth());
-          Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicHeight() = " + originalBitmapDrawable.getIntrinsicHeight());
+          Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicWidth() = "
+              + originalBitmapDrawable.getIntrinsicWidth());
+          Log.d(LOG_TAG, "originalBitmapDrawable.getIntrinsicHeight() = "
+              + originalBitmapDrawable.getIntrinsicHeight());
           Bitmap scaledBitmap = Bitmap.createScaledBitmap(originalBitmapDrawable.getBitmap(),
               scaledWidth, scaledHeight, false);
-          BitmapDrawable scaledBitmapDrawable = new BitmapDrawable(form.getResources(), scaledBitmap);
+          BitmapDrawable scaledBitmapDrawable =
+              new BitmapDrawable(form.getResources(), scaledBitmap);
           scaledBitmapDrawable.setTargetDensity(form.getResources().getDisplayMetrics());
           originalBitmapDrawable = null; // So it will get GC'd on the next line
           System.gc();                   // We likely used a lot of memory, so gc now.
           continuation.onSuccess(scaledBitmapDrawable);
-        } catch(Exception e) {
+        } catch (Exception e) {
           Log.w(LOG_TAG, "Exception while loading media.", e);
           continuation.onFailure(e.getMessage());
         } finally {
           if (bis != null) {
             try {
               bis.close();
-            } catch(IOException e) {
+            } catch (IOException e) {
               // suppress error on close
               Log.w(LOG_TAG, "Unexpected error on close", e);
             }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -999,19 +999,19 @@ class NativeOpenStreetMapController implements MapController, MapListener {
 
   private void getMarkerDrawableRaster(final MapMarker aiMarker,
       final AsyncCallbackPair<Drawable> callback) {
-    MediaUtil.getBitmapDrawableAsync(form, aiMarker.ImageAsset(),
-        new AsyncCallbackPair<BitmapDrawable>() {
-      @Override
-      public void onFailure(String message) {
-        callback.onSuccess(getDefaultMarkerDrawable(aiMarker));
-      }
+    MediaUtil.getBitmapDrawableAsync(form, aiMarker.ImageAsset(), aiMarker.Width(),
+        aiMarker.Height(), new AsyncCallbackPair<BitmapDrawable>() {
+          @Override
+          public void onFailure(String message) {
+            callback.onSuccess(getDefaultMarkerDrawable(aiMarker));
+          }
 
-      @Override
-      public void onSuccess(BitmapDrawable result) {
-        result.setAlpha((int) Math.round(aiMarker.FillOpacity() * 255.0f));
-        callback.onSuccess(result);
-      }
-    });
+          @Override
+          public void onSuccess(BitmapDrawable result) {
+            result.setAlpha((int) Math.round(aiMarker.FillOpacity() * 255.0f));
+            callback.onSuccess(result);
+          }
+        });
   }
 
   private Drawable getDefaultMarkerDrawable(MapMarker aiMarker) {


### PR DESCRIPTION
Reported via the [forum](https://community.appinventor.mit.edu/t/marker-imageasset-width-and-height-issue/38089?u=ewpatton) by @kdclang: Marker image does not respect the width/height properties. This PR addresses this issue.

For testing, I loaded kitty.png into a project and set it to be the image of a marker. I adjusted the width and height to be 64px each. The companion properly reflected changing these properties.