### PR TITLE
Fix mock button sizing when changing font size

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
@@ -222,6 +222,7 @@ abstract class MockButtonBase extends MockVisibleComponent implements FormChange
     } else {
       MockComponentsUtil.setWidgetFontSize(buttonWidget, text);
     }
+    updatePreferredSizeOfButton();
   }
 
   /*


### PR DESCRIPTION
This change fixes an issue introduced in the big font / high contrast change where changing the font size of a button does not cause the mock button to resize its bounds.

Change-Id: Ic68d72f81eb0f6143c8430a4cb22e7bc878a661b