### PR TITLE
Fix AAB asset compression breaking media files

### DIFF
--- a/appinventor/components/build.xml
+++ b/appinventor/components/build.xml
@@ -168,7 +168,7 @@
     <copy toFile="${public.deps.dir}/android.jar" file="${android.lib}" />
     <copy toFile="${public.deps.dir}/dx.jar" file="${lib.dir}/android/tools/dx.jar" />
     <copy toFile="${public.deps.dir}/apksigner.jar" file="${lib.dir}/android/tools/apksigner.jar" />
-    <copy toFile="${public.deps.dir}/bundletool.jar" file="${lib.dir}/android/tools/bundletool-all-0.15.0.jar" />
+    <copy toFile="${public.deps.dir}/bundletool.jar" file="${lib.dir}/android/tools/bundletool-all-1.7.1.jar" />
     <copy toFile="${public.deps.dir}/CommonVersion.jar" file="${build.dir}/common/CommonVersion.jar" />
 
     <!-- Add extension libraries here -->


### PR DESCRIPTION
This change addresses an issue raised by the power users testing the AAB functionality on ai2-test. In particular, most non-PNG assets are compressed by Google when recombining the AAB into various APKs. This works fine in most cases because most code paths use Form's `openAsset` method, which returns an uncompressed InputStream. However, in the case of components such as Sound and Player, they use AssetFileDescriptors, which access the raw byte stream (which is now DEFLATE compressed).

This change does the following:

1. Substitute a newer version of the bundletool utility that supports additional configuration
2. Generate BundleConfig.pb.json that contains regexs to indicate asset types that should not be compressed when creating APKs

Change-Id: Ia066d7cb12fd72d95ffc4605aabbc3feef2b067e