### PR TITLE
Fix shrinking font when FontSize == 24

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
@@ -212,13 +212,10 @@ abstract class MockButtonBase extends MockVisibleComponent implements FormChange
    */
   private void setFontSizeProperty(String text) {
     float convertedText = Float.parseFloat(text);
-    if (convertedText == 14.0 || convertedText == 24.0) {
-      MockForm form = ((YaFormEditor) editor).getForm();
-      if (form != null && form.getPropertyValue("BigDefaultText").equals("True")) {
-        MockComponentsUtil.setWidgetFontSize(buttonWidget, "24");
-      } else {
-        MockComponentsUtil.setWidgetFontSize(buttonWidget, "14");
-      }
+    MockForm form = ((YaFormEditor) editor).getForm();
+    if (convertedText == FONT_DEFAULT_SIZE && form != null
+        && form.getPropertyValue("BigDefaultText").equals("True")) {
+      MockComponentsUtil.setWidgetFontSize(buttonWidget, "24");
     } else {
       MockComponentsUtil.setWidgetFontSize(buttonWidget, text);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -100,13 +100,10 @@ public final class MockLabel extends MockVisibleComponent implements FormChangeL
    */
   private void setFontSizeProperty(String text) {
     float convertedText = Float.parseFloat(text);
-    if (convertedText == 14.0 || convertedText == 24.0) {
-      MockForm form = ((YaFormEditor) editor).getForm();
-      if (form != null && form.getPropertyValue("BigDefaultText").equals("True")) {
-        MockComponentsUtil.setWidgetFontSize(labelWidget, "24");
-      } else {
-        MockComponentsUtil.setWidgetFontSize(labelWidget, "14");
-      }
+    MockForm form = ((YaFormEditor) editor).getForm();
+    if (convertedText == FONT_DEFAULT_SIZE && form != null
+        && form.getPropertyValue("BigDefaultText").equals("True")) {
+      MockComponentsUtil.setWidgetFontSize(labelWidget, "24");
     } else {
       MockComponentsUtil.setWidgetFontSize(labelWidget, text);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
@@ -134,13 +134,10 @@ abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener
    */
   private void setFontSizeProperty(String text) {
     float convertedText = Float.parseFloat(text);
-    if (convertedText == 14.0 || convertedText == 24.0) {
-      MockForm form = ((YaFormEditor) editor).getForm();
-      if (form != null && form.getPropertyValue("BigDefaultText").equals("True")) {
-        MockComponentsUtil.setWidgetFontSize(textBoxWidget, "24");
-      } else {
-        MockComponentsUtil.setWidgetFontSize(textBoxWidget, "14");
-      }
+    MockForm form = ((YaFormEditor) editor).getForm();
+    if (convertedText == 14.0 && form != null
+        && form.getPropertyValue("BigDefaultText").equals("True")) {
+      MockComponentsUtil.setWidgetFontSize(textBoxWidget, "24");
     } else {
       MockComponentsUtil.setWidgetFontSize(textBoxWidget, text);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -68,6 +68,8 @@ public abstract class MockVisibleComponent extends MockComponent {
   // get the length is percent of Screen1
   public static final int LENGTH_PERCENT_TAG = -1000;
 
+  public static final int FONT_DEFAULT_SIZE = 14;
+
   // Useful colors
   protected static final String COLOR_NONE = "00FFFFFF";
   protected static final String COLOR_DEFAULT = "00000000";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -659,15 +659,9 @@ public abstract class ButtonBase extends AndroidViewComponent
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE)
   public void FontSize(float size) {
-    if (Math.abs(size-Component.FONT_DEFAULT_SIZE)<.01 || Math.abs(size-24)<.01) {
-      if (container.$form().BigDefaultText()) {
-        TextViewUtil.setFontSize(view, 24);
-      }
-      else {
-        TextViewUtil.setFontSize(view, Component.FONT_DEFAULT_SIZE);
-      }
-    }
-    else {
+    if (size == FONT_DEFAULT_SIZE && container.$form().BigDefaultText()) {
+      TextViewUtil.setFontSize(view, 24);
+    } else {
       TextViewUtil.setFontSize(view, size);
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
@@ -316,15 +316,9 @@ private void setLabelMargins(boolean hasMargins) {
   @SimpleProperty
   public void FontSize(float size) {
 
-    if (Math.abs(size-Component.FONT_DEFAULT_SIZE)<.01 || Math.abs(size-24)<.01) {
-      if (isBigText || container.$form().BigDefaultText()) {
-        TextViewUtil.setFontSize(view, 24);
-      }
-      else {
-        TextViewUtil.setFontSize(view, Component.FONT_DEFAULT_SIZE);
-      }
-    }
-    else {
+    if (size == FONT_DEFAULT_SIZE && (isBigText || container.$form().BigDefaultText())) {
+      TextViewUtil.setFontSize(view, 24);
+    } else {
       TextViewUtil.setFontSize(view, size);
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
@@ -358,15 +358,9 @@ public abstract class TextBoxBase extends AndroidViewComponent
       defaultValue = Component.FONT_DEFAULT_SIZE + "")
   @SimpleProperty
   public void FontSize(float size) {
-    if (Math.abs(size-Component.FONT_DEFAULT_SIZE)<.01 || Math.abs(size-24)<.01) {
-      if (container.$form().BigDefaultText()) {
-        TextViewUtil.setFontSize(view, 24);
-      }
-      else {
-        TextViewUtil.setFontSize(view, Component.FONT_DEFAULT_SIZE);
-      }
-    }
-    else {
+    if (size == FONT_DEFAULT_SIZE && container.$form().BigDefaultText()) {
+      TextViewUtil.setFontSize(view, 24);
+    } else {
       TextViewUtil.setFontSize(view, size);
     }
   }


### PR DESCRIPTION
Murielle's change captures the situation where FontSize == 24 and causes it to revert to the smaller default font size of 14. This behavior causes issues in existing apps because the font ends up being smaller than expected, visually altering the app.

This change updates the logic so that we only capture the condition where the font size is set to the default and increases the font size when the BigDefaultText property is set on the form.

Change-Id: Idd2f1c32362ab6581ffb6b7139fb7b62d9b21234