### PR TITLE
Restore TextSize() to the ListView Component

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -100,6 +100,9 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   private int fontTypeface;
   private int fontTypeDetail;
 
+  /* for backward compatibility */
+  private static final int DEFAULT_TEXT_SIZE = 22;
+
   private int imageWidth;
   private int imageHeight;
   private static final int DEFAULT_IMAGE_WIDTH = 200;
@@ -627,11 +630,43 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   /**
    * Returns the listview's text font Size
    *
+   * This property is provided for backwards compatibility
+   * it takes and returns an integer, but in reality it just
+   * updates the FontSize property, which works with floats
+   *
+   * @return text size as an integer
+   */
+  @SimpleProperty(
+      description = "The text size of the listview items.",
+      category = PropertyCategory.APPEARANCE)
+  public int TextSize() {
+    return Math.round(fontSizeMain);
+  }
+
+  /**
+   * Specifies the `ListView` item's text font size
+   *
+   * @param integer value for font size
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
+      defaultValue = DEFAULT_TEXT_SIZE + "")
+  @SimpleProperty
+  public void TextSize(int textSize) {
+    if (textSize >1000) {
+        textSize = 999;
+    }
+    FontSize(Float.valueOf(textSize));
+  }
+
+  /**
+   * Returns the listview's text font Size
+   *
    * @return text size as an float
    */
   @SimpleProperty(
           description = "The text size of the listview stringItems.",
-          category = PropertyCategory.APPEARANCE)
+          category = PropertyCategory.APPEARANCE,
+          userVisible = false)
   public float FontSize() {
     return fontSizeMain;
   }
@@ -642,8 +677,9 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
    * @param integer value for font size
    */
   @SuppressWarnings("JavadocReference")
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT,
-          defaultValue = "22.0")
+  // Temporarily removed until Companion with support is more prevalent
+  // @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT,
+  //         defaultValue = "22.0")
   @SimpleProperty
   public void FontSize(float fontSize) {
     if (fontSize > 1000 || fontSize < 1)

--- a/appinventor/docs/html/reference/components/userinterface.html
+++ b/appinventor/docs/html/reference/components/userinterface.html
@@ -653,8 +653,6 @@ Valid values for the month field are 1-12 and 1-31 for the day field.</dd>
   <dd>Specifies the list of choices to display.</dd>
   <dt id="ListView.ElementsFromString" class="text wo"><em>ElementsFromString</em></dt>
   <dd>Set the list of choices from a string of comma-separated values.</dd>
-  <dt id="ListView.FontSize" class="number"><em>FontSize</em></dt>
-  <dd>Specifies the <code class="highlighter-rouge">ListView</code> item’s text font size</dd>
   <dt id="ListView.FontSizeDetail" class="number"><em>FontSizeDetail</em></dt>
   <dd>Specifies the <code class="highlighter-rouge">ListView</code> item’s text font size</dd>
   <dt id="ListView.FontTypeface" class="number do"><em>FontTypeface</em></dt>
@@ -696,6 +694,8 @@ Valid values for the month field are 1-12 and 1-31 for the day field.</dd>
   <dd>The text color of the <code class="highlighter-rouge">ListView</code> items.</dd>
   <dt id="ListView.TextColorDetail" class="color"><em>TextColorDetail</em></dt>
   <dd>Specifies the color of the secondary text in a ListView layout</dd>
+  <dt id="ListView.TextSize" class="number"><em>TextSize</em></dt>
+  <dd>Specifies the <code class="highlighter-rouge">ListView</code> item’s text font size</dd>
   <dt id="ListView.Visible" class="boolean"><em>Visible</em></dt>
   <dd>Specifies whether the <code class="highlighter-rouge">ListView</code> should be visible on the screen.  Value is <code class="logic block highlighter-rouge">true</code>
  if the <code class="highlighter-rouge">ListView</code> is showing and <code class="logic block highlighter-rouge">false</code> if hidden.</dd>

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -675,9 +675,6 @@ This is a visible component that allows to place a list of text elements in your
 {:id="ListView.ElementsFromString" .text .wo} *ElementsFromString*
 : Set the list of choices from a string of comma-separated values.
 
-{:id="ListView.FontSize" .number} *FontSize*
-: Specifies the `ListView` item's text font size
-
 {:id="ListView.FontSizeDetail" .number} *FontSizeDetail*
 : Specifies the `ListView` item's text font size
 
@@ -735,6 +732,9 @@ This is a visible component that allows to place a list of text elements in your
 
 {:id="ListView.TextColorDetail" .color} *TextColorDetail*
 : Specifies the color of the secondary text in a ListView layout
+
+{:id="ListView.TextSize" .number} *TextSize*
+: Specifies the `ListView` item's text font size
 
 {:id="ListView.Visible" .boolean} *Visible*
 : Specifies whether the `ListView` should be visible on the screen.  Value is `true`{:.logic.block}


### PR DESCRIPTION
The recent rework of the ListView component removed the TextSize()
property and replaced it with the FontSize() property, which takes a
float instead of an integer.

However this breaks backwards compatibility. So this change restores
the TextSize property, making it an interface to the FontSize
property. I.e., it converts its input to a float and calls FontSize()

Note: This introduces the limitation that you cannot set a fractional
font size in the designer. Doing so will result in the TextSize being
set to the font sized rounded. When properties are sent to the
Companion they are sent in alphabetic sort order, so the rounded
TextSize is sent after the fontSize, so it dominates.

You can, however, set a fractional fontSize from the block.

Change-Id: I6f177645a74d914d15da73bffb31c5f68a3f1086