### PR TITLE
Add missing upgrader for PasswordTextBox

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1398,6 +1398,10 @@ public final class YoungAndroidFormUpgrader {
       // Added PasswordVisible Property
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Added NumbersOnly property
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -1766,10 +1770,10 @@ public final class YoungAndroidFormUpgrader {
       // of XML using dictionaries.
       srcCompVersion = 7;
     }
-    if (srcCompVersion < 8)  {
-    	// The methods PatchText, PatchTextWithEncoding, and PatchFile were added.
-        // No properties need to be modified to upgrade to version 8.
-        srcCompVersion = 8;
+    if (srcCompVersion < 8) {
+      // The methods PatchText, PatchTextWithEncoding, and PatchFile were added.
+      // No properties need to be modified to upgrade to version 8.
+      srcCompVersion = 8;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2611,7 +2611,10 @@ Blockly.Versioning.AllUpgradeMaps =
     3: "noUpgrade",
 
     // PasswordVisible was added
-    4: "noUpgrade"
+    4: "noUpgrade",
+
+    // NumbersOnly was added
+    5: "noUpgrade"
 
   }, // End PasswordTextBox upgraders
 


### PR DESCRIPTION
PR #2478 added a new property to the PasswordTextBox and bumped the version numbers, but it did not implement the upgrade paths. Projects in the nb187 release that have password inputs fails to upgrade correctly. This change adds the missing upgraders.

Change-Id: I442f1906f7500a6c44a23de2dd7588375abc2253