### PR TITLE
Fix NPE in WebView using data URIs on Android 5+

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HoneycombWebViewClient.java
@@ -45,7 +45,7 @@ public class HoneycombWebViewClient extends FroyoWebViewClient<WebViewer> {
   @Override
   public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
     Log.d(TAG, "scheme = " + request.getUrl().getScheme());
-    if (request.getUrl().getAuthority().equals("localhost")
+    if ("localhost".equals(request.getUrl().getAuthority())
         || request.getUrl().toString().startsWith(ASSET_PREFIX)) {
       return handleAppRequest(request.getUrl().toString());
     }


### PR DESCRIPTION
As reported [here](https://community.appinventor.mit.edu/t/data-uri-now-crashing-companion-and-compiled/18150/4), data URIs cannot be used in WebViewer. The previous attempt at a fixed worked in the older emulator but does not work on newer devices because a different code path is taken (triggering a different NPE). To address this, I swapped the order of the equality call so that it is always called on the constant "localhost".

Change-Id: I766797612f831cb6de388b6a2e590a84f98f5117