### PR TITLE
Fix building apps with non-ASCII app names

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Properties;
@@ -145,11 +146,8 @@ public final class Project {
 
       // Load project file
       properties = new Properties();
-      FileInputStream in = new FileInputStream(file);
-      try {
+      try (InputStreamReader in = new InputStreamReader(new FileInputStream(file))) {
         properties.load(in);
-      } finally {
-        in.close();
       }
     } catch (IOException e) {
       e.printStackTrace();
@@ -264,14 +262,7 @@ public final class Project {
    * @return  app name
    */
   public String getAName() {
-    //The non-English character set can't be shown properly and need special encoding.
-    String appName = properties.getProperty(ANAMETAG);
-    try {
-      appName = new String(appName.getBytes("ISO-8859-1"), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-    } catch (NullPointerException e) {
-    }
-    return appName;
+    return properties.getProperty(ANAMETAG, properties.getProperty(NAMETAG));
   }
 
   /**


### PR DESCRIPTION
Fixes #2542 

It turns out that the Java Properties class will read/write using a different default charset depending on whether the method is called with an InputStream or a Reader. In the change I made that produces the project.properties file on the appengine server, I used a different version that produces UTF-8 compliant properties rather than the original ISO-8859-1 formatted. However, the build server was set up to read the ISO-8859-1 encoding. This updates the buildserver to also use UTF-8.

Change-Id: Idf2d133b1c3007a545af6a99c8e0b085bb9adb35