### PR TITLE
Vagrantfile: Add support for libvirt images.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,14 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--nictype1", "virtio"]
   end
 
+  config.vm.provider :libvirt do |libvirt|
+    config.vm.box = "generic/ubuntu1804"
+    # By default, './' is synced onto '/vagrant' with NFS, which does not work for debian family images for some reason;
+    # hence we use rsync. There are a few broken links in the source tree that will fail the default rsync syncing sche-
+    # me, so we give explicit rsync args and omit "--copy-links".
+    config.vm.synced_folder './', '/vagrant', type: 'rsync', rsync__args: ["--verbose", "--archive", "--update"]
+  end
+
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.network :forwarded_port, guest: 8888, host: 8888


### PR DESCRIPTION
Add support for libvirt images in the Vagrantfile. Tested and found to be working.