### PR TITLE
Fix streaming SpeechRecognizer not working on Android 11

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Compiler.java
@@ -221,6 +221,8 @@ public final class Compiler {
       new ConcurrentHashMap<String, Set<String>>();
   private final ConcurrentMap<String, Set<String>> broadcastReceiversNeeded =
       new ConcurrentHashMap<String, Set<String>>();
+  private final ConcurrentMap<String, Set<String>> queriesNeeded =
+      new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Set<String>> servicesNeeded =
       new ConcurrentHashMap<String, Set<String>>();
   private final ConcurrentMap<String, Set<String>> contentProvidersNeeded =
@@ -480,6 +482,11 @@ public final class Compiler {
     return broadcastReceiversNeeded;
   }
 
+  @VisibleForTesting
+  Map<String, Set<String>> getQueries() {
+    return queriesNeeded;
+  }
+
   // Just used for testing
   @VisibleForTesting
   Map<String, Set<String>> getServices() {
@@ -670,6 +677,24 @@ public final class Compiler {
     }
 
     mergeConditionals(conditionals.get(ComponentDescriptorConstants.BROADCAST_RECEIVERS_TARGET), broadcastReceiversNeeded);
+  }
+
+  /*
+   * Generate a set of conditionally included queries needed by this project.
+   */
+  @VisibleForTesting
+  void generateQueries() {
+    try {
+      loadJsonInfo(queriesNeeded, ComponentDescriptorConstants.QUERIES_TARGET);
+    } catch (IOException e) {
+      // This is fatal.
+      userErrors.print(String.format(ERROR_IN_STAGE, "Services"));
+    } catch (JSONException e) {
+      // This is fatal, but shouldn't actually ever happen.
+      userErrors.print(String.format(ERROR_IN_STAGE, "Services"));
+    }
+
+    mergeConditionals(conditionals.get(ComponentDescriptorConstants.QUERIES_TARGET), queriesNeeded);
   }
 
   /*
@@ -1056,6 +1081,18 @@ public final class Compiler {
         }
       }
 
+      if (queriesNeeded.size() > 0) {
+        out.write("  <queries>\n");
+        for (Map.Entry<String, Set<String>> componentSubElSetPair : queriesNeeded.entrySet()) {
+          Set<String> subelementSet = componentSubElSetPair.getValue();
+          for (String subelement : subelementSet) {
+            // replace %packageName% with the actual packageName
+            out.write(subelement.replace("%packageName%", packageName));
+          }
+        }
+        out.write("  </queries>\n");
+      }
+
       int minSdk = Integer.parseInt((project.getMinSdk() == null) ? DEFAULT_MIN_SDK : project.getMinSdk());
       if (!isForCompanion) {
         for (Set<String> minSdks : minSdksNeeded.values()) {
@@ -1390,28 +1427,30 @@ public final class Compiler {
         reporter.report(0);
       }
 
-      statReporter.nextStage(compiler, "generateAssets");
-      compiler.generateAssets();
       statReporter.nextStage(compiler, "generateActivities");
       compiler.generateActivities();
-      statReporter.nextStage(compiler, "generateMetadata");
-      compiler.generateMetadata();
       statReporter.nextStage(compiler, "generateActivityMetadata");
       compiler.generateActivityMetadata();
+      statReporter.nextStage(compiler, "generateAssets");
+      compiler.generateAssets();
       statReporter.nextStage(compiler, "generateBroadcastReceivers");
       compiler.generateBroadcastReceivers();
-      statReporter.nextStage(compiler, "generateServices");
-      compiler.generateServices();
       statReporter.nextStage(compiler, "generateContentProviders");
       compiler.generateContentProviders();
       statReporter.nextStage(compiler, "generateLibNames");
       compiler.generateLibNames();
+      statReporter.nextStage(compiler, "generateMetadata");
+      compiler.generateMetadata();
+      statReporter.nextStage(compiler, "generateMinSdks");
+      compiler.generateMinSdks();
       statReporter.nextStage(compiler, "generateNativeLibNames");
       compiler.generateNativeLibNames();
       statReporter.nextStage(compiler, "generatePermissions");
       compiler.generatePermissions();
-      statReporter.nextStage(compiler, "generateMinSdks");
-      compiler.generateMinSdks();
+      statReporter.nextStage(compiler, "generateQueries");
+      compiler.generateQueries();
+      statReporter.nextStage(compiler, "generateServices");
+      compiler.generateServices();
 
       // TODO(Will): Remove the following call once the deprecated
       //             @SimpleBroadcastReceiver annotation is removed. It should

--- a/appinventor/components/src/com/google/appinventor/components/annotations/UsesQueries.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/UsesQueries.java
@@ -1,0 +1,35 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2021 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations;
+
+import com.google.appinventor.components.annotations.androidmanifest.IntentFilterElement;
+import com.google.appinventor.components.annotations.androidmanifest.ProviderElement;
+
+/**
+ * Annotation to describe a &lt;queries&gt; entry required by Android SDK 30.
+ */
+public @interface UsesQueries {
+  /**
+   * An array of intents that will be included in the &lt;queries&gt; element.
+   *
+   * @return the array of intents of interest
+   */
+  IntentFilterElement[] intents() default {};
+
+  /**
+   * A package name that will be included in the &lt;queries&gt; element.
+   *
+   * @return the array containing package names of interest
+   */
+  String[] packageNames() default {};
+
+  /**
+   * A provider element that will be included in the &lt;queries&gt;
+   *
+   * @return the array containing provider elements of interest
+   */
+  ProviderElement[] providers() default {};
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
@@ -26,6 +26,7 @@ public final class ComponentDescriptorConstants {
   public static final String NATIVE_TARGET = "native";
   public static final String PERMISSIONS_TARGET = "permissions";
   public static final String BROADCAST_RECEIVERS_TARGET = "broadcastReceivers";
+  public static final String QUERIES_TARGET = "queries";
   public static final String SERVICES_TARGET = "services";
   public static final String CONTENT_PROVIDERS_TARGET = "contentProviders";
   public static final String ANDROIDMINSDK_TARGET = "androidMinSdk";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
@@ -6,6 +6,9 @@
 
 package com.google.appinventor.components.runtime;
 
+import static android.Manifest.permission.INTERNET;
+import static android.Manifest.permission.RECORD_AUDIO;
+
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -14,6 +17,9 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
+import com.google.appinventor.components.annotations.UsesQueries;
+import com.google.appinventor.components.annotations.androidmanifest.ActionElement;
+import com.google.appinventor.components.annotations.androidmanifest.IntentFilterElement;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
@@ -42,8 +48,7 @@ import android.speech.RecognizerIntent;
     iconName = "images/speechRecognizer.png")
 
 @SimpleObject
-@UsesPermissions(permissionNames = "android.permission.RECORD_AUDIO," +
-        "android.permission.INTERNET")
+@UsesPermissions({RECORD_AUDIO, INTERNET})
 public class SpeechRecognizer extends AndroidNonvisibleComponent
     implements Component, OnClearListener, SpeechListener {
 
@@ -92,7 +97,7 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
       form.runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          form.askPermission(Manifest.permission.RECORD_AUDIO,
+          form.askPermission(RECORD_AUDIO,
               new PermissionResultHandler() {
                 @Override
                 public void HandlePermissionResponse(String permission, boolean granted) {
@@ -100,7 +105,7 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
                     me.havePermission = true;
                     me.GetText();
                   } else {
-                    form.dispatchPermissionDeniedEvent(me, "GetText", Manifest.permission.RECORD_AUDIO);
+                    form.dispatchPermissionDeniedEvent(me, "GetText", RECORD_AUDIO);
                   }
                 }
           });
@@ -205,10 +210,15 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
   @SimpleProperty(description = "If true, a separate dialog is used to recognize speech "
       + "(the default). If false, speech is recognized in the background and "
       + "partial results are also provided.")
+  @UsesQueries(intents = {
+      @IntentFilterElement(actionElements = {
+          @ActionElement(name = "android.speech.RecognitionService")
+      })
+  })
   public void UseLegacy(boolean useLegacy) {
     this.useLegacy = useLegacy;
     Stop();
-    if (useLegacy == true || Build.VERSION.SDK_INT<8) {
+    if (useLegacy || Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO) {
       speechRecognizerController = new IntentBasedSpeechRecognizer(container, recognizerIntent);
     } else {
       speechRecognizerController = new ServiceBasedSpeechRecognizer(container, recognizerIntent);

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -250,10 +250,11 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
    * @param sb The StringBuilder to receive the JSON descriptor.
    */
   private void outputConditionalAnnotations(ComponentInfo component, StringBuilder sb) {
-    if (component.conditionalPermissions.size() +
-        component.conditionalBroadcastReceivers.size() +
-        component.conditionalServices.size() +
-        component.conditionalContentProviders.size() == 0) {
+    if (component.conditionalBroadcastReceivers.size()
+        + component.conditionalContentProviders.size()
+        + component.conditionalPermissions.size()
+        + component.conditionalQueries.size()
+        + component.conditionalServices.size() == 0) {
       return;
     }
     sb.append(",\n  \"conditionals\":{\n    ");
@@ -267,6 +268,14 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       if (!first) sb.append(",\n    ");
       sb.append("\"broadcastReceivers\": ");
       outputMultimap(sb, "    ", component.conditionalBroadcastReceivers);
+      first = false;
+    }
+    if (component.conditionalQueries.size() > 0) {
+      if (!first) {
+        sb.append(",\n    ");
+      }
+      sb.append("\"queries\": ");
+      outputMultimap(sb, "    ", component.conditionalQueries);
       first = false;
     }
     if (component.conditionalServices.size() > 0) {

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
@@ -85,6 +85,7 @@ public final class ComponentListGenerator extends ComponentProcessor {
     appendComponentInfo(sb, ComponentDescriptorConstants.ACTIVITY_METADATA_TARGET, component.activityMetadata);
     appendComponentInfo(sb, ComponentDescriptorConstants.ANDROIDMINSDK_TARGET, Collections.singleton(Integer.toString(component.getAndroidMinSdk())));
     appendComponentInfo(sb, ComponentDescriptorConstants.BROADCAST_RECEIVERS_TARGET, component.broadcastReceivers);
+    appendComponentInfo(sb, ComponentDescriptorConstants.QUERIES_TARGET, component.queries);
     appendComponentInfo(sb, ComponentDescriptorConstants.SERVICES_TARGET, component.services);
     appendComponentInfo(sb, ComponentDescriptorConstants.CONTENT_PROVIDERS_TARGET, component.contentProviders);
     appendConditionalComponentInfo(component, sb);
@@ -104,10 +105,11 @@ public final class ComponentListGenerator extends ComponentProcessor {
    * @param sb Target StringBuilder to receive the conditional description
    */
   private static void appendConditionalComponentInfo(ComponentInfo component, StringBuilder sb) {
-    if (component.conditionalPermissions.size() +
-        component.conditionalBroadcastReceivers.size() + 
-        component.conditionalServices.size() + 
-        component.conditionalContentProviders.size() == 0) {
+    if (component.conditionalBroadcastReceivers.size()
+        + component.conditionalContentProviders.size()
+        + component.conditionalPermissions.size()
+        + component.conditionalQueries.size()
+        + component.conditionalServices.size() == 0) {
       return;
     }
     sb.append(", \"" + ComponentDescriptorConstants.CONDITIONALS_TARGET + "\": { ");
@@ -115,6 +117,8 @@ public final class ComponentListGenerator extends ComponentProcessor {
     appendMap(sb, component.conditionalPermissions);
     sb.append(", \"" + ComponentDescriptorConstants.BROADCAST_RECEIVERS_TARGET + "\": ");
     appendMap(sb, component.conditionalBroadcastReceivers);
+    sb.append(", \"" + ComponentDescriptorConstants.QUERIES_TARGET + "\": ");
+    appendMap(sb, component.conditionalQueries);
     sb.append(", \"" + ComponentDescriptorConstants.SERVICES_TARGET + "\": ");
     appendMap(sb, component.conditionalServices);
     sb.append(", \"" + ComponentDescriptorConstants.CONTENT_PROVIDERS_TARGET + "\": ");


### PR DESCRIPTION
Android 30 introduced a new mechanism to limit fingerprinting of users based on querying the installed packages. This seems to also extend to binding services, a feature that is used by the SpeechRecognizer component when it is used in streaming mode (UseLegacy = false). This causes the component to not work on Android 11.

This change addresses the issue in two parts. The first commit implements a new annotation `@UsesQueries` to allow for adding the [`<queries>`](https://developer.android.com/guide/topics/manifest/queries-element) element to the manifest. The second commit updates the SpeechRecognizer component to use this new annotation.

I tested this functionality by building 3 apps. The first was the companion (`ant PlayApp`) and used aapt to verify that the queries element appears in the compiled app. The second was a test app with the speech recognizer's UseLegacy property set to false, to confirm that the element appears. The last app was a completely unrelated app to ensure that the queries element did not appear (conditional inclusion). The apps were tested on Android 11 as earlier Android versions do not have knowledge of the `<queries>` element.

[SpeechRecognizerTest.aia.zip](https://github.com/mit-cml/appinventor-sources/files/7144138/SpeechRecognizerTest.aia.zip)
