### PR TITLE
Move network/wifi permissions to PhoneStatus component

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -6,12 +6,9 @@
 
 package com.google.appinventor.components.runtime;
 
-import static android.Manifest.permission.ACCESS_NETWORK_STATE;
-import static android.Manifest.permission.ACCESS_WIFI_STATE;
 import static android.Manifest.permission.INTERNET;
 import static com.google.appinventor.components.runtime.util.PaintUtil.hexStringToInt;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
@@ -45,8 +42,6 @@ import android.widget.ScrollView;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-
-import com.google.appinventor.common.version.AppInventorFeatures;
 
 import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -130,7 +125,7 @@ import org.json.JSONException;
     description = "Top-level component containing all other components in the program",
     showOnPalette = false)
 @SimpleObject
-@UsesPermissions({INTERNET, ACCESS_WIFI_STATE, ACCESS_NETWORK_STATE})
+@UsesPermissions({INTERNET})
 public class Form extends AppInventorCompatActivity
     implements Component, ComponentContainer, HandlesEventDispatching,
     OnGlobalLayoutListener {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneStatus.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneStatus.java
@@ -5,6 +5,9 @@
 
 package com.google.appinventor.components.runtime;
 
+import static android.Manifest.permission.ACCESS_NETWORK_STATE;
+import static android.Manifest.permission.ACCESS_WIFI_STATE;
+
 import android.app.Activity;
 
 import android.content.Context;
@@ -18,8 +21,6 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
 
-import android.os.Build;
-
 import android.util.Log;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -32,18 +33,16 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.annotations.UsesNativeLibraries;
 
+import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 
-import com.google.appinventor.components.runtime.Form;
-import com.google.appinventor.components.runtime.ReplForm;
 import com.google.appinventor.components.runtime.util.AppInvHTTPD;
 import com.google.appinventor.components.runtime.util.EclairUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.WebRTCNativeMgr;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.MessageDigest;
 
@@ -71,6 +70,7 @@ import java.util.Formatter;
 @UsesNativeLibraries(v7aLibraries = "libjingle_peerconnection_so.so",
   v8aLibraries = "libjingle_peerconnection_so.so",
   x86_64Libraries = "libjingle_peerconnection_so.so")
+@UsesPermissions({ACCESS_NETWORK_STATE, ACCESS_WIFI_STATE})
 public class PhoneStatus extends AndroidNonvisibleComponent implements Component {
 
   private static Activity activity;


### PR DESCRIPTION
On occasion, we receive reports of App Inventor apps being flagged by anti-virus programs as malware. Some of the power users investigated further and found that removing the `ACCESS_WIFI_STATE` permissions seemed to alleviate the issue ([ref](https://community.appinventor.mit.edu/t/trojan-security-problem-in-apk/40531/16?u=ewpatton)). This permission and its broader counterpart `ACCESS_NETWORK_STATE` are included in all apps via the Form component, even if the app itself never uses the network (`INTERNET` is also included, but a bit more complicated because people can use HTTP URLs for images). Since the two ACCESS permissions are needed only for the companion (in order to read the IP address of the device), I have migrated them into the PhoneStatus component from the Form component.

Things to consider before making this a PR for review:

- [ ] Do we want to remove `INTERNET` permission as well and advise that if people need this permission they should add a Web component? Alternatively, we could make it a Screen1-specific property but we already have many.
- [ ] Test with components that need internet access as a core feature, such as the WebViewer and Web components, to ensure they still work in compiled apps without the `ACCESS_*_STATE` permissions.

Change-Id: I6813342a07dd861381168a86c7472bd120395521