### PR TITLE
Label Click & LongClick Events

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1287,6 +1287,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 5) {
       srcCompVersion = 5;
     }
+    if (srcCompVersion < 6) {
+      // The Click & LongClick events are added.
+      componentProperties.put("Clickable", new ClientJsonString("False"));
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2048,7 +2048,10 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2: Add HTMLFormat property
     4: "noUpgrade",
 
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // AI2: Click & LongClick events are added.
+    6: "noUpgrade"
 
   }, // End Label upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1038,8 +1038,10 @@ public class YaVersion {
   // - The HTML format is defined.
   // For LABEL_COMPONENT_VERSION 5:
   // - The HTMLContent property is defined.
+  // For LABEL_COMPONENT_VERSION 6:
+  // - The Click & LongClick events are added.
 
-  public static final int LABEL_COMPONENT_VERSION = 5;
+  public static final int LABEL_COMPONENT_VERSION = 6;
 
   // For LINESTRING_COMPONENT_VERSION 1:
   // - Initial LineString implementation for Maps

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
@@ -10,6 +10,7 @@ import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.IsColor;
 import com.google.appinventor.components.annotations.PropertyCategory;
+import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
@@ -82,6 +83,9 @@ public final class Label extends AndroidViewComponent implements AccessibleCompo
   //Whether or not the text should be big
   private boolean isBigText = false;
 
+  // Whether the label is clickable and long clickable or not
+  private boolean isClickable = false;
+
   /**
    * Creates a new Label component.
    *
@@ -132,6 +136,42 @@ public final class Label extends AndroidViewComponent implements AccessibleCompo
   @Override
   public View getView() {
     return view;
+  }
+
+  @SimpleEvent(description = "An event that occurs when an label is clicked.")
+  public void Click() {
+    EventDispatcher.dispatchEvent(this, "Click");
+  }
+
+  @SimpleEvent(description = "An event that occurs when an label is long clicked.")
+  public void LongClick() {
+    EventDispatcher.dispatchEvent(this, "LongClick");
+  }
+
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+          defaultValue = "False")
+  @SimpleProperty(description = "Specifies whether the label should be clickable or not.")
+  public void Clickable(boolean clickable) {
+    this.isClickable = clickable;
+    view.setClickable(this.isClickable);
+    if (this.isClickable) {
+      view.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+          Click();
+        }
+      });
+      view.setOnLongClickListener(new View.OnLongClickListener() {
+        @Override
+        public boolean onLongClick(View v) {
+          LongClick();
+          return false;
+        }
+      });
+    } else {
+      view.setOnClickListener(null);
+      view.setOnLongClickListener(null);
+    }
   }
 
   /**


### PR DESCRIPTION
From the [community](https://community.appinventor.mit.edu/t/feature-request-label-clickable-option-add-on-appinventor/14706), the user has requested so many times for **Click** & **LongClick** events in Label Component.

## About Feature
This PR adds two new events and one designer property to handle **Click** & **LongClick** events similar to Image Component.

### Click
<img width="169" alt="component_event" src="https://user-images.githubusercontent.com/80121827/134461731-367db28b-b14c-427c-b507-fee41994ca6f.png"> <br>
**Params** : No Params   
**Description** : The event raised when a Lable is clicked. 

### LongClick
<img width="201" alt="component_event (1)" src="https://user-images.githubusercontent.com/80121827/134461961-8786f887-2b79-4ca8-b573-ef4c07bc4c6c.png"> <br>
**Params** : No Params   
**Description** : The event raised when a Lable is long clicked. 

### Clickable
<img width="240" alt="component_set_get" src="https://user-images.githubusercontent.com/80121827/134462098-7f40807c-d00d-4392-b988-0d4d3a09f26f.png"> <br>
**Param Type** : boolean 
**Description** : Specifies whether the Label is clickable or not.
