### PR TITLE
New PlaybackSpeed property in Player Component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1470,7 +1470,11 @@ public final class YoungAndroidFormUpgrader {
         // The OtherPlayerStarted event was added.
         // Properties related to this component have now been upgraded to version  6.
         srcCompVersion = 6;
-      }
+    }
+    if (srcCompVersion < 7) {
+      // - The PlaybackSpeed property was added.
+      srcCompVersion = 7;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2695,7 +2695,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI2: - The PlayInForeground property was added.
     // - The OtherPlayerStarted event was added.
-    6: "noUpgrade"
+    6: "noUpgrade",
+
+    // - The PlaybackSpeed property was added.
+    7 : "noUpgrade"
 
   }, // End Player upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1233,8 +1233,10 @@ public class YaVersion {
   // For PLAYER_COMPONENT_VERSION 6:
   // - The PlayInForeground property was added.
   // - The OtherPlayerStarted event was added.
+  // For PLAYER_COMPONENT_VERSION 7:
+  // - The PlaybackSpeed property was added.
 
-  public static final int PLAYER_COMPONENT_VERSION = 6;
+  public static final int PLAYER_COMPONENT_VERSION = 7;
 
   // For POLYGON_COMPONENT_VERSION 1:
   // - Initial Polygon implementation for Maps

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
+import android.media.PlaybackParams;
 import android.os.Vibrator;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
@@ -336,6 +337,44 @@ public final class Player extends AndroidNonvisibleComponent
   @SimpleProperty
   public void PlayOnlyInForeground(boolean shouldForeground) {
     playOnlyInForeground = shouldForeground;
+  }
+
+  /**
+   * Sets the playback speed of the `Player` component.
+   * playback speed is only supported for API level >= 23
+   *
+   * @param speed float value of playback speed.
+   */
+  @DesignerProperty(
+      editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT,
+      defaultValue = "1.0")
+  @SimpleProperty
+  public void PlaybackSpeed(float speed) {
+    if(SdkLevel.getLevel() >= SdkLevel.LEVEL_MARSHMALLOW) {
+      PlaybackParams playbackParams = player.getPlaybackParams();
+      playbackParams.setSpeed(speed);
+      player.setPlaybackParams(playbackParams);
+    } else {
+      PlayerError("Playback speed setting not supported");
+    }
+  }
+
+  /**
+   * Returns the playback speed of the `Player` component.
+   * playback speed is only supported for API level >= 23, for lower version of android and
+   * if playback speed is not set in that case it returns 1.0(Normal Speed) and raised PlayerError event
+   * with exception message.
+   *
+   * @return the float value of the playback speed
+   */
+  @SimpleProperty(description = "Sets the speed factor of the Player.")
+  public float PlaybackSpeed()  {
+    try {
+      return player.getPlaybackParams().getSpeed();
+    } catch (IllegalStateException illegalStateException) {
+      PlayerError(illegalStateException.getMessage());
+    }
+    return 1.0f;
   }
 
   /**


### PR DESCRIPTION
From the community [see this](https://community.appinventor.mit.edu/t/change-the-speed-rate-of-music-player/42149) a user asked about **How to change the speed rate of the Music Player?**

## About the PR
This PR will add the new designer property as well as the new block property (getter and setter) for the support of setting **PlaybackSpeed** of the Player component.

### Designer Property 
![Capture](https://user-images.githubusercontent.com/80121827/134768460-213d0d0c-b4d4-4955-ab6a-92006ff9396b.PNG)

<table>
    <tr>
       <td><b>Property Name</b></td>
       <td>PlaybackSpeed</td>
    </tr>
    <tr>
       <td><b>Default Value</b></td>
       <td>1.0</td>
    </tr>
    <tr>
       <td><b>Editor Type</b></td>
       <td>PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT</td>
    </tr>
</table>

### Block Properties
<img width="284" alt="component_set_get (1)" src="https://user-images.githubusercontent.com/80121827/134768461-765300fd-2719-46a4-bb31-8280df0078ba.png">

Sets the playback speed of the Player component, the PlaybackSpeed is only supported for **API level >= 23** for the lower version of android it will raise an event **PlayerError** with the message `Playback speed setting not supported`.

<img width="225" alt="component_set_get (2)" src="https://user-images.githubusercontent.com/80121827/134768462-ac6b9f14-d33d-480f-a0e7-2f7036938cc6.png">

Returns the playback speed of the Player component, the PlaybackSpeed is only supported for **API level >= 23**, for lower version of android and if playback speed is not set in that case it returns 1.0(Normal Speed) and raised **PlayerError** event with the exception message.
