### PR TITLE
Fix ListView filter with no matches displaying all rows.

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -85,20 +85,17 @@ public class ListAdapterWithRecyclerView
       }
       results.count = filteredList.size();
       results.values = filteredList;
-      Log.e(LOG_TAG, "Perform filter size " + filteredList.size() + " count " + results.count);
       return results;
     }
 
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
       filterItems = (List<YailDictionary>) filterResults.values;
-      Log.e(LOG_TAG, "Publish Results size " + filterItems.size() + " count " + filterResults.count);
       // Usually GUI objects take up no screen space when set to invisible, but setting a CardView object to invisible
       // was displaying an empty object. Therefore, set the height to 0 as well.
       // Setting visibility on individual entries will keep the selected index(ices) the same regardless of filter.
       for (int i = 0; i < items.size(); ++i) {
         if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
-          Log.e(LOG_TAG, "Filter matches item " + i);
           isVisible[i] = true;
           if (itemViews[i] != null) {
             itemViews[i].setVisibility(View.VISIBLE);
@@ -209,6 +206,10 @@ public class ListAdapterWithRecyclerView
     }
   }
 
+  public boolean hasVisibleItems() {
+    return Arrays.asList(isVisible).contains(true);
+  }
+
   @Override
   public RvViewHolder onCreateViewHolder(final ViewGroup parent, int viewType) {
     CardView cardView = new CardView(container.$context());
@@ -305,7 +306,6 @@ public class ListAdapterWithRecyclerView
       }
     });
 
-    Log.e(LOG_TAG, "onBindViewHolder for position " + position);
     YailDictionary dictItem = items.get(position);
     String first = dictItem.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
     String second = "";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -153,8 +153,10 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       @Override
       public void onTextChanged(CharSequence cs, int arg1, int arg2, int arg3) {
         // When user changed the Text
-        Log.e(LOG_TAG, "Filter Changed size " + cs.length());
         if (cs.length() > 0) {
+          if (!listAdapterWithRecyclerView.hasVisibleItems()) {
+            setAdapterData();
+          }
           listAdapterWithRecyclerView.getFilter().filter(cs);
           recyclerView.setAdapter(listAdapterWithRecyclerView);
         } else {
@@ -636,7 +638,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   /**
    * Specifies the `ListView` item's text font size
    *
-   * @param integer value for font size
+   * @param textSize int value for font size
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = DEFAULT_TEXT_SIZE + "")


### PR DESCRIPTION
As reported by @stezelMIT , the new ListView displays all rows when you filter on a string that matches zero rows. This fix changes ListView to display zero rows in this case, which is what the user would expect.