### PR TITLE
Trigger AfterTextInput on cancel iff TextInputCancelled is not defined

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
@@ -383,9 +383,10 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
           new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
               HideKeyboard((View) input);
-              TextInputCanceled();
-              //User pressed CANCEL. Raise AfterTextInput with CANCEL
-              AfterTextInput(cancelButtonText);
+              if (!TextInputCanceled()) {
+                //User pressed CANCEL. Raise AfterTextInput with CANCEL
+                AfterTextInput(cancelButtonText);
+              }
             }
           });
     }
@@ -414,14 +415,15 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
 
   /**
    * Event raised when the user cancels
-   * {@link #ShowChooseDialog(String, String, String, String, boolean)},
    * {@link #ShowPasswordDialog(String, String, boolean)}, or
    * {@link #ShowTextDialog(String, String, boolean)}.
+   *
+   * @return true if the event was successfully dispatched, otherwise false.
    */
   @SimpleEvent(
-    description = "Event raised when the user canceled ShowTextDialog.")
-  public void TextInputCanceled() {
-    EventDispatcher.dispatchEvent(this, "TextInputCanceled");
+      description = "Event raised when the user canceled ShowTextDialog.")
+  public boolean TextInputCanceled() {
+    return EventDispatcher.dispatchEvent(this, "TextInputCanceled");
   }
 
 


### PR DESCRIPTION
Fixes #2533 based on my most recent comment there.

Change-Id: Ia4d9ed1b35702b3b95dc21136e7954bb73690dfa