### PR TITLE
Fix ListView handling of filters and recyled elements

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -73,10 +73,10 @@ public class ListAdapterWithRecyclerView
         filteredList = new ArrayList<>(items);
       } else {
         for (YailDictionary itemDict : items) {
-          Object o = itemDict.get("Text2");
+          Object o = itemDict.get(Component.LISTVIEW_KEY_DESCRIPTION);
           String filterString = itemDict.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
           if (o != null) {
-            filterString += " " + o;
+            filterString += " " + o.toString().toLowerCase();
           }
           if (filterString.toLowerCase().contains(filterQuery)) {
             filteredList.add(itemDict);
@@ -85,21 +85,26 @@ public class ListAdapterWithRecyclerView
       }
       results.count = filteredList.size();
       results.values = filteredList;
+      Log.e(LOG_TAG, "Perform filter size " + filteredList.size() + " count " + results.count);
       return results;
     }
 
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
       filterItems = (List<YailDictionary>) filterResults.values;
+      Log.e(LOG_TAG, "Publish Results size " + filterItems.size() + " count " + filterResults.count);
       // Usually GUI objects take up no screen space when set to invisible, but setting a CardView object to invisible
       // was displaying an empty object. Therefore, set the height to 0 as well.
       // Setting visibility on individual entries will keep the selected index(ices) the same regardless of filter.
       for (int i = 0; i < items.size(); ++i) {
         if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
+          Log.e(LOG_TAG, "Filter matches item " + i);
           isVisible[i] = true;
           if (itemViews[i] != null) {
             itemViews[i].setVisibility(View.VISIBLE);
-            itemViews[i].getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams)itemViews[i].getLayoutParams();
+            layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            itemViews[i].setLayoutParams(layoutParams);
           }
         } else {
           isVisible[i] = false;
@@ -300,6 +305,7 @@ public class ListAdapterWithRecyclerView
       }
     });
 
+    Log.e(LOG_TAG, "onBindViewHolder for position " + position);
     YailDictionary dictItem = items.get(position);
     String first = dictItem.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
     String second = "";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -78,7 +78,7 @@ public class ListAdapterWithRecyclerView
           if (o != null) {
             filterString += " " + o;
           }
-          if (filterString.toLowerCase().startsWith(filterQuery)) {
+          if (filterString.toLowerCase().contains(filterQuery)) {
             filteredList.add(itemDict);
           }
         }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -99,9 +99,7 @@ public class ListAdapterWithRecyclerView
           isVisible[i] = true;
           if (itemViews[i] != null) {
             itemViews[i].setVisibility(View.VISIBLE);
-            RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams)itemViews[i].getLayoutParams();
-            layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT;
-            itemViews[i].setLayoutParams(layoutParams);
+           itemViews[i].getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;;
           }
         } else {
           isVisible[i] = false;
@@ -310,7 +308,7 @@ public class ListAdapterWithRecyclerView
     String first = dictItem.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
     String second = "";
     if (dictItem.containsKey(Component.LISTVIEW_KEY_DESCRIPTION)) {
-      second = dictItem.get("Text2").toString();
+      second = dictItem.get(Component.LISTVIEW_KEY_DESCRIPTION).toString();
     }
     if (layoutType == Component.LISTVIEW_LAYOUT_SINGLE_TEXT) {
       holder.textViewFirst.setText(first);
@@ -353,6 +351,9 @@ public class ListAdapterWithRecyclerView
     {
       holder.cardView.setVisibility(View.GONE);
       holder.cardView.getLayoutParams().height = 0;
+    } else {
+      holder.cardView.setVisibility(View.VISIBLE);
+      holder.cardView.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
     }
     itemViews[position] = holder.cardView;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -94,21 +94,21 @@ public class ListAdapterWithRecyclerView
       // Usually GUI objects take up no screen space when set to invisible, but setting a CardView object to invisible
       // was displaying an empty object. Therefore, set the height to 0 as well.
       // Setting visibility on individual entries will keep the selected index(ices) the same regardless of filter.
-        for (int i = 0; i < items.size(); ++i) {
-          if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
-            isVisible[i] = true;
-            if (itemViews[i] != null) {
-              itemViews[i].setVisibility(View.VISIBLE);
-              itemViews[i].getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
-            }
-          } else {
-            isVisible[i] = false;
-            if (itemViews[i] != null) {
-              itemViews[i].setVisibility(View.GONE);
-              itemViews[i].getLayoutParams().height = 0;
-            }
+      for (int i = 0; i < items.size(); ++i) {
+        if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
+          isVisible[i] = true;
+          if (itemViews[i] != null) {
+            itemViews[i].setVisibility(View.VISIBLE);
+            itemViews[i].getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+          }
+        } else {
+          isVisible[i] = false;
+          if (itemViews[i] != null) {
+            itemViews[i].setVisibility(View.GONE);
+            itemViews[i].getLayoutParams().height = 0;
           }
         }
+      }
     }
   };
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -94,9 +94,6 @@ public class ListAdapterWithRecyclerView
       // Usually GUI objects take up no screen space when set to invisible, but setting a CardView object to invisible
       // was displaying an empty object. Therefore, set the height to 0 as well.
       // Setting visibility on individual entries will keep the selected index(ices) the same regardless of filter.
-      if (filterItems == null || filterItems.size() == 0) {
-        Arrays.fill(isVisible, Boolean.TRUE);
-      } else {
         for (int i = 0; i < items.size(); ++i) {
           if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
             isVisible[i] = true;
@@ -112,7 +109,6 @@ public class ListAdapterWithRecyclerView
             }
           }
         }
-      }
     }
   };
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -85,20 +85,17 @@ public class ListAdapterWithRecyclerView
       }
       results.count = filteredList.size();
       results.values = filteredList;
-      Log.e(LOG_TAG, "Perform filter size " + filteredList.size() + " count " + results.count);
       return results;
     }
 
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
       filterItems = (List<YailDictionary>) filterResults.values;
-      Log.e(LOG_TAG, "Publish Results size " + filterItems.size() + " count " + filterResults.count);
       // Usually GUI objects take up no screen space when set to invisible, but setting a CardView object to invisible
       // was displaying an empty object. Therefore, set the height to 0 as well.
       // Setting visibility on individual entries will keep the selected index(ices) the same regardless of filter.
       for (int i = 0; i < items.size(); ++i) {
         if (filterItems.size() > 0 && filterItems.contains(items.get(i))) {
-          Log.e(LOG_TAG, "Filter matches item " + i);
           isVisible[i] = true;
           if (itemViews[i] != null) {
             itemViews[i].setVisibility(View.VISIBLE);
@@ -209,6 +206,10 @@ public class ListAdapterWithRecyclerView
     }
   }
 
+  public boolean hasVisibleItems() {
+    return Arrays.asList(isVisible).contains(true);
+  }
+
   @Override
   public RvViewHolder onCreateViewHolder(final ViewGroup parent, int viewType) {
     CardView cardView = new CardView(container.$context());
@@ -305,7 +306,6 @@ public class ListAdapterWithRecyclerView
       }
     });
 
-    Log.e(LOG_TAG, "onBindViewHolder for position " + position);
     YailDictionary dictItem = items.get(position);
     String first = dictItem.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
     String second = "";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -78,7 +78,7 @@ public class ListAdapterWithRecyclerView
           if (o != null) {
             filterString += " " + o;
           }
-          if (filterString.toLowerCase().contains(filterQuery)) {
+          if (filterString.toLowerCase().startsWith(filterQuery)) {
             filteredList.add(itemDict);
           }
         }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -153,8 +153,10 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       @Override
       public void onTextChanged(CharSequence cs, int arg1, int arg2, int arg3) {
         // When user changed the Text
-        Log.e(LOG_TAG, "Filter Changed size " + cs.length());
         if (cs.length() > 0) {
+          if (!listAdapterWithRecyclerView.hasVisibleItems()) {
+            setAdapterData();
+          }
           listAdapterWithRecyclerView.getFilter().filter(cs);
           recyclerView.setAdapter(listAdapterWithRecyclerView);
         } else {
@@ -636,7 +638,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
   /**
    * Specifies the `ListView` item's text font size
    *
-   * @param integer value for font size
+   * @param textSize int value for font size
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = DEFAULT_TEXT_SIZE + "")

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -153,9 +153,8 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       @Override
       public void onTextChanged(CharSequence cs, int arg1, int arg2, int arg3) {
         // When user changed the Text
-        if (cs.length() == 0) {
-          setAdapterData();
-        } else {
+        setAdapterData();
+        if (cs.length() > 0) {
           listAdapterWithRecyclerView.getFilter().filter(cs.toString());
         }
       }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -153,9 +153,12 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
       @Override
       public void onTextChanged(CharSequence cs, int arg1, int arg2, int arg3) {
         // When user changed the Text
-        setAdapterData();
+        Log.e(LOG_TAG, "Filter Changed size " + cs.length());
         if (cs.length() > 0) {
-          listAdapterWithRecyclerView.getFilter().filter(cs.toString());
+          listAdapterWithRecyclerView.getFilter().filter(cs);
+          recyclerView.setAdapter(listAdapterWithRecyclerView);
+        } else {
+          setAdapterData();
         }
       }
 


### PR DESCRIPTION
Add handling of elements filtered out and then restored when the filter is changed before they are cycled back into memory. Previously, elements were not restored to visible, resulting in items that disappeared permanently as the filter changed.