### PR TITLE
Use Authkey in sources if there is one

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -360,16 +360,29 @@
     <delete file="${tmp.dir}/authkey/meta"/>
     <delete file="${tmp.dir}/authkey/1"/>
   </target>
-
+  <!-- =====================================================================
+       Check to see if the war/WEB-INF directory already has an
+       authkey, which would mean it was copied over in WarLibs from
+       the source tree. In the master branch this will *not* be the
+       case, but it may be in a branding branch.
+       ===================================================================== -->
+  <target name="CheckBuildAuthKey"
+          depends="init,WarLibs">
+    <available file="${build.war.dir}/WEB-INF/authkey/meta"
+               property="authkey.inbuild" />
+  </target>
   <!-- =====================================================================
        Install the Authkey into the correct location
+       but only if we don't already have one copied over
+       from war/WEB-INF.
        ===================================================================== -->
   <target name="InstallAuthKey"
-          depends="init,CheckAuthKey,WarLibs">
+          depends="init,CheckAuthKey,WarLibs,CheckBuildAuthKey"
+          unless="${authkey.inbuild}">
     <fail message="You Must Create an Auth Key see misc/docs/authkey.md"
           unless="${authkey.exists}" />
     <unzip dest="${build.war.dir}/WEB-INF"
-      src="${user.home}/.appinventor/authkey.zip"/>
+           src="${user.home}/.appinventor/authkey.zip" />
   </target>
 
   <!-- =====================================================================


### PR DESCRIPTION
Normally there is no authkey stored in the source tree. Instead
developers run "ant MakeAuthKey" to generate a personal authkey which
is then copied into the build tree.

However our branding branches include an authkey in the sources (in
war/WEB-INF), often customized for the installation. This change
causes this source resident key to over-ride the developer's personal
authkey.

Change-Id: I47761db8028d2432b3f5f0dcb1ece725ef5af0ac