### PR TITLE
Set ListView SelectionIndex before loading of elements is complete

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -183,6 +183,7 @@ public class ListAdapterWithRecyclerView
 
   public void toggleSelection(int pos) {
     // With single select, clicked item becomes the only selected item
+    // Using 0-indexed array.
     Arrays.fill(selection, Boolean.FALSE);
     for (int i = 0; i < itemViews.length; i++) {
       // Views are created when they are displayed, so this list may not be fully populated.
@@ -192,7 +193,9 @@ public class ListAdapterWithRecyclerView
     }
     if (pos >= 0) {
       selection[pos] = true;
-      itemViews[pos].setBackgroundColor(selectionColor);
+      if (itemViews[pos] != null) {
+        itemViews[pos].setBackgroundColor(selectionColor);
+      }
     }
   }
 


### PR DESCRIPTION
Reference: https://community.appinventor.mit.edu/t/listview-selection-error/45502

When the Screen.Initialize event executes, the Cardview objects for each ListView element have not loaded. If the SelectionIndex is set using blocks in this event, the object will be null when the component tries to change the background color of the selected element.

This probably would also happen if the element was not loaded in the Recyclerview.