### PR TITLE
Load Assets directly from the App Inventor Server in legacy mode

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/AssetManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/AssetManager.java
@@ -44,7 +44,6 @@ public final class AssetManager implements ProjectChangeListener {
 
   private static class AssetInfo { // Describes one asset
     String fileId;
-    byte [] fileContent;
     boolean loaded;         // true if already loaded to the repl (phone)
     boolean transferred;           // true if asset received on phone
   }
@@ -148,7 +147,6 @@ public final class AssetManager implements ProjectChangeListener {
     String fileId = node.getFileId();
     AssetInfo assetInfo = new AssetInfo();
     assetInfo.fileId = fileId;
-    assetInfo.fileContent = null;
     assetInfo.loaded = false; // Set to true when it is loaded to the repl
     assetInfo.transferred = false; // Set to true when asset is received on phone
     assets.put(fileId, assetInfo);
@@ -192,29 +190,6 @@ public final class AssetManager implements ProjectChangeListener {
     return allow | allowAll;
   }
 
-  private void readIn(final AssetInfo assetInfo) {
-    Ode.getInstance().getProjectService().loadraw2(projectId, assetInfo.fileId,
-      new AsyncCallback<String>() {
-        @Override
-          public void onSuccess(String data) {
-            assetTransferProgress++;
-            assetInfo.fileContent = Base64Util.decodeLines(data);
-            assetInfo.loaded = false; // Set to true when it is loaded to the repl
-            assetInfo.transferred = false; // Set to true when file is received on phone
-            refreshAssets1();
-          }
-        @Override
-          public void onFailure(Throwable ex) {
-          if (retryCount > 0) {
-            retryCount--;
-            readIn(assetInfo);
-          } else {
-            OdeLog.elog("Failed to load asset.");
-          }
-        }
-      });
-  }
-
   private void refreshAssets1(JavaScriptObject callback) {
     assetsTransferredCallback = callback;
     assetTransferProgress = 0;
@@ -226,21 +201,12 @@ public final class AssetManager implements ProjectChangeListener {
     for (AssetInfo a : assets.values()) {
       if (!a.loaded) {
         loadInProgress = true;
-        if (a.fileContent == null && !useWebRTC()) { // Need to fetch it from the server
-          retryCount = 3;
-          ConnectProgressBar.setProgress(100 * assetTransferProgress / (2 * assets.size()),
-            MESSAGES.loadingAsset(a.fileId));
-          readIn(a);          // Read it in asynchronously
-          break;                     // we'll resume when we have it
-        } else {
-          ConnectProgressBar.setProgress(100 * assetTransferProgress / (2 * assets.size()),
-            MESSAGES.sendingAssetToCompanion(a.fileId));
-          boolean didit = doPutAsset(Long.toString(projectId), a.fileId, a.fileContent);
-          if (didit) {
-            assetTransferProgress++;
-            a.loaded = true;
-            a.fileContent = null; // Save memory
-          }
+        ConnectProgressBar.setProgress(100 * assetTransferProgress / (2 * assets.size()),
+          MESSAGES.sendingAssetToCompanion(a.fileId));
+        boolean didit = doPutAsset(Long.toString(projectId), a.fileId);
+        if (didit) {
+          assetTransferProgress++;
+          a.loaded = true;
         }
       }
     }
@@ -349,8 +315,8 @@ public final class AssetManager implements ProjectChangeListener {
       $entry(@com.google.appinventor.client.AssetManager::getExtensionsToLoad());
   }-*/;
 
-  private static native boolean doPutAsset(String projectId, String filename, byte[] content) /*-{
-    return Blockly.ReplMgr.putAsset(projectId, filename, content, function() { window.parent.AssetManager_markAssetTransferred(filename) });
+  private static native boolean doPutAsset(String projectId, String filename) /*-{
+    return Blockly.ReplMgr.putAsset(projectId, filename, null, function() { window.parent.AssetManager_markAssetTransferred(filename) });
   }-*/;
 
   private static native void doCallBack(JavaScriptObject callback) /*-{


### PR DESCRIPTION
This code changes how assets are loaded in legacy mode to use the same strategy as WebRTC. Namely, tell the Companion to fetch the asset directly from the App Inventor server instead of first loading it (inefficiently!) into the browser and then stuffing it into the Companion. This does mean that the Companion needs to be able to reach the App Inventor server.

Note: There is some refactoring of how forms are pushed to the Companion, these are in effect fixes for race conditions in the legacy code that were not apparent until we used it for loading assets. The code to use an HTTP request to learn the Companion version has also been removed. This is now done via the Rendezvous server, so this code is obsolete and has not been used for quite some time.

Note: This code is a prerequisite for #2617
