### PR TITLE
Cache Assets in the Companion

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HashDatabase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HashDatabase.java
@@ -1,0 +1,137 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2022 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.ContextWrapper;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import android.util.Log;
+
+import com.google.appinventor.components.runtime.util.HashDbInitialize.HashTable;
+
+import java.io.File;
+
+public final class HashDatabase extends SQLiteOpenHelper {
+
+  private static class ExternalContext extends ContextWrapper {
+    Context base;
+
+    public ExternalContext(Context base) {
+      super(base);
+      this.base = base;
+    }
+
+    @Override
+    public File getDatabasePath(String name) {
+      String dir = QUtil.getReplDatabasePath(base, true);
+      String dbfile = dir + File.separator + name;
+      if (!dbfile.endsWith(".db")) {
+        dbfile += ".db";
+      }
+      File result = new File(dbfile);
+      if (!result.getParentFile().exists()) {
+        result.getParentFile().mkdirs();
+      }
+      return result;
+
+    }
+  }
+
+  private static final String TABLE_NAME = HashTable.TABLE_NAME ;
+  private static final String KEY_NAME = HashTable.COLUMN_1_NAME;
+  private static final String KEY_HASH = HashTable.COLUMN_2_NAME;
+  private static final String KEY_TIMESTAMP = HashTable.COLUMN_3_NAME;
+  private static final String[] COLUMNS = { KEY_NAME, KEY_HASH, KEY_TIMESTAMP };
+
+  private static final String SQL_CREATE_ENTRIES =
+    "CREATE TABLE " + TABLE_NAME + " (" +
+    KEY_NAME + " TEXT," +
+    KEY_HASH + " TEXT," +
+    KEY_TIMESTAMP + " TEXT)";
+
+  private static final String SQL_DELETE_ENTRIES =
+    "DROP TABLE IF EXISTS " + TABLE_NAME;
+
+  public static final int DATABASE_VERSION = 1;
+  public static final String DATABASE_NAME = "hashTable.db";
+
+  public HashDatabase(Context context) {
+    super(new ExternalContext(context), DATABASE_NAME, null, DATABASE_VERSION);
+  }
+  public void onCreate(SQLiteDatabase db) {
+    db.execSQL(SQL_CREATE_ENTRIES);
+  }
+
+  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    // migrate the data to the new table and then delete the old data
+    db.execSQL(SQL_DELETE_ENTRIES);
+    onCreate(db);
+  }
+
+  public void deleteOne(HashFile hashFile) {
+    SQLiteDatabase db = this.getWritableDatabase();
+    db.delete(TABLE_NAME, "fileName = ?", new String[] { hashFile.getFileName() });
+    db.close();
+  }
+
+  public HashFile getHashFile(String fileName) {
+    SQLiteDatabase db = this.getReadableDatabase();
+    Cursor cursor = db.query(TABLE_NAME, // a. table
+      COLUMNS, // b. column names
+      " fileName = ?", // c. selections
+      new String[] { fileName }, // d. selections args
+      null, // e. group by
+      null, // f. having
+      null, // g. order by
+      null); // h. limit
+    Log.d("Database",cursor.toString());
+    if (cursor == null  || cursor.getCount()<1) {
+      cursor.close();
+      db.close();
+      return null;
+    }
+    if (cursor != null)
+      cursor.moveToFirst();
+
+    HashFile hashFile = new HashFile();
+    hashFile.setFileName(cursor.getString(0));
+    hashFile.setHash(cursor.getString(1));
+    hashFile.setTimestamp(cursor.getString(2));
+    cursor.close();
+    db.close();
+    return hashFile;
+  }
+
+  public void insertHashFile(HashFile hashFile) {
+    SQLiteDatabase db = this.getWritableDatabase();
+    ContentValues values = new ContentValues();
+    values.put(KEY_NAME, hashFile.getFileName());
+    values.put(KEY_HASH, hashFile.getHash());
+    values.put(KEY_TIMESTAMP, hashFile.getTimestamp());
+    db.insert(TABLE_NAME, null, values);
+    db.close();
+  }
+
+  public int updateHashFile(HashFile hashFile) {
+    SQLiteDatabase db = this.getWritableDatabase();
+    ContentValues values = new ContentValues();
+    values.put(KEY_NAME, hashFile.getFileName());
+    values.put(KEY_HASH, hashFile.getHash());
+    values.put(KEY_TIMESTAMP, hashFile.getTimestamp());
+
+    int i = db.update(TABLE_NAME, // table
+      values, // column/value
+      "fileName = ?", // selections
+      new String[] { hashFile.getFileName() });
+    db.close();
+    return i;
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HashDbInitialize.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HashDbInitialize.java
@@ -1,0 +1,22 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2022 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import android.provider.BaseColumns;
+
+public class HashDbInitialize {
+  private HashDbInitialize() {}
+
+  /**
+   * Inner class that defines the table contents
+   */
+  public static class HashTable implements BaseColumns {
+    public static final String TABLE_NAME = "HashDatabase";
+    public static final String COLUMN_1_NAME = "fileName";
+    public static final String COLUMN_2_NAME = "hashFile";
+    public static final String COLUMN_3_NAME = "timeStamp";
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/HashFile.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/HashFile.java
@@ -1,0 +1,98 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2022 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Locale;
+
+
+public class HashFile {
+
+  private String fileName;
+  private String hash;
+  private String timestamp;
+
+  public HashFile() {
+  }
+
+  /**
+   * Constructors for initialize HashFile object to be stored in the database
+   */
+  public HashFile(String fileName, String hash, Date time) {
+    this.fileName = fileName;
+    this.hash = hash;
+    this.timestamp = formatTimestamp(time);
+  }
+
+  /**
+   * Constructors for initialize HashFile object which we get from the database
+   */
+  public HashFile(String fileName, String hash, String timestamp) {
+    this.fileName = fileName;
+    this.hash = hash;
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Getter for file name
+   */
+  public String getFileName() {
+    return fileName;
+  }
+
+  /**
+   * Setter for file name
+   */
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  /**
+   * Getter for hash
+   */
+  public String getHash() {
+    return hash;
+  }
+
+  /**
+   * Setter for has
+   */
+  public void setHash(String hash) {
+    this.hash = hash;
+  }
+
+  /**
+   * Getter for time stamp
+   */
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Setter for time stamp (to be stored in database)
+   */
+  public void setTimestampInDb(Date time) {
+    this.timestamp = formatTimestamp(time);
+  }
+
+  /**
+   * Setter for time stamp (get from database)
+   */
+  public void setTimestamp(String timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Convert Date to String
+   */
+  public String formatTimestamp(Date timestamp) {
+    SimpleDateFormat dateFormat = new SimpleDateFormat(
+      "yyyy-MM-dd HH:mm:ss", Locale.getDefault());
+    return dateFormat.format(timestamp);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
@@ -171,6 +171,30 @@ public class QUtil {
   }
 
   /**
+   * Get the SDK-specific path where the REPL databases live. On Android Q and later, this is always
+   * an app-private directory on the "external" storage. On earlier versions of Android, this
+   * returns the external storage path for all apps (although possibly user-specific).
+   * If the {@code forcePrivate} flag is true, then the app-private directory will always be
+   * returned on devices running Android 2.2 Froyo or later.
+   *
+   * <p>
+   * For more details on why this is needed, see the deprecation notice at
+   * https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()
+   * </p>
+   *
+   * @param context a context, such as a Form
+   * @param forcePrivate force the use of the context-specific path
+   * @return the path to the REPL's database storage
+   */
+  public static String getReplDatabasePath(Context context, boolean forcePrivate) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      return getExternalStoragePath(context, forcePrivate) + "/databases/";
+    } else {
+      return getExternalStoragePath(context, forcePrivate) + "/AppInventor/databases/";
+    }
+  }
+
+  /**
    * Get the SDK-specific path to where the REPL assets live. On Android Q and later, this is always
    * an app-private directory on the "external" storage. On earlier versions of Android, this
    * returns the external storage path for all apps (although possibly user-specific).


### PR DESCRIPTION
Use an SQLite3 database on the Companion to keep track of assets that
are already available in Companion storage to avoid downloading
assets, which can be large at times. This saves time and bandwidth.

Co-authored-by: jingmiao-z <jz1@wellesley.edu>
Co-authored-by: Annie <lannie9400@gmail.com>
Change-Id: I645a27360a401bc56c734e971e7723da61746020