### PR TITLE
Fix: do not read in whole file in UploadServlet

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/FileImporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileImporterImpl.java
@@ -175,13 +175,16 @@ public final class FileImporterImpl implements FileImporter {
     while ((bytes = bis.read(buffer, 0, buffer.length)) != -1) {
       bos.write(buffer, 0, bytes);
       fileLength += bytes;
+      if (fileLength > maxSizeBytes) {
+        // Read the rest of the stream, but throw it away
+        // and throw an error, so we do not consume memory storing
+        // a large object
+        while((bytes = bis.read(buffer, 0, buffer.length)) != -1) {
+        }
+        throw new FileImporterException(UploadResponse.Status.FILE_TOO_LARGE);
+      }
     }
     bos.flush();
-
-    // First check the file length, to avoid loading the file into memory if it is too large anyhow.
-    if (fileLength > maxSizeBytes) {
-      throw new FileImporterException(UploadResponse.Status.FILE_TOO_LARGE);
-    }
 
     byte[] content = os.toByteArray();
 


### PR DESCRIPTION
The change is actually in FileImporterImpl.java. Previous code read
the whole object into memory and then threw an error if it was too
large. This can result in a Java Heap overflow, which is bad. So we
incrementally check the incoming data size as we read it. If it is
larger then the configured maximum, we keep reading, but throw the
byte away instead of consuming memory.

Change-Id: Ife3180eacb4ec5037be077142849667d7010b102