### PR TITLE
Correct translation keys in Blockly tests

### DIFF
--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/component_database_tests.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/component_database_tests.js
@@ -66,9 +66,9 @@ page.open('src/demos/yail/yail_testing_index.html', function(status) {
       'EVENT-TranslatedEvent': 'SuccessfulEvent',
       'METHOD-TranslatedMethod': 'SuccessfulMethod',
       'PROPERTY-TranslatedProperty': 'SuccessfulProperty',
-      'EVENTDESC-TranslatedEvent': 'Successfully translated event test.',
-      'METHODDESC-TranslatedMethod': 'Successfully translated method test.',
-      'PROPDESC-TranslatedProperty': 'Successfully translated property test.'
+      'EVENTDESC-TranslatedEventEventDescriptions': 'Successfully translated event test.',
+      'METHODDESC-TranslatedMethodMethodDescriptions': 'Successfully translated method test.',
+      'PROPDESC-TranslatedPropertyPropertyDescriptions': 'Successfully translated property test.'
     });
 
     var block;


### PR DESCRIPTION
PR #2629 fixed issues with tooltip translations by correcting the lookup code to use the appropriately-formatted keys per [ComponentTranslationGenerator#computeTooltipMap](https://github.com/mit-cml/appinventor-sources/blob/596a092c55749a769726eaee917b53fdb83128fe/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java#L265). However, the PR did not account for the unit tests, which also weren't following the right key structure. This change fixes the unit test so that they match what should be generated by ComponentTranslationGenerator.

Change-Id: If261733ee6a9551819bdd749f9b19eaf130a749c