### PR TITLE
Fix Camera filename ending in PNG, not JPG

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Camera.java
@@ -145,7 +145,7 @@ public class Camera extends AndroidNonvisibleComponent
    */
   @SimpleFunction
   public void TakePicture() {
-    final ScopedFile target = FileUtil.getScopedPictureFile(form, "png");
+    final ScopedFile target = FileUtil.getScopedPictureFile(form, "jpg");
     if (!havePermission) {
       String[] permissions;
       if (FileUtil.needsWritePermission(target)) {


### PR DESCRIPTION
Change-Id: Ibe479cf038d00229c84f0ee394730e42aef469e6