### PR TITLE
Add a flag "auth.deleteaccountallowed"

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -2508,6 +2508,10 @@ public class Ode implements EntryPoint {
     return config.getGalleryReadOnly();
   }
 
+  public boolean getDeleteAccountAllowed() {
+    return config.getDeleteAccountAllowed();
+  }
+
   /**
    * setRendezvousServer
    *

--- a/appinventor/appengine/src/com/google/appinventor/client/TopPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopPanel.java
@@ -175,7 +175,10 @@ public class TopPanel extends Composite {
 
     // Sign Out
     userItems.add(new DropDownItem(WIDGET_NAME_SIGN_OUT, MESSAGES.signOutLink(), new SignOutAction()));
-    userItems.add(new DropDownItem(WIDGET_NAME_DELETE_ACCOUNT, MESSAGES.deleteAccountLink(), new DeleteAccountAction(), "ode-ContextMenuItem-Red"));
+    // if we are allowed to delete accounts
+    if (ode.getDeleteAccountAllowed()) {
+      userItems.add(new DropDownItem(WIDGET_NAME_DELETE_ACCOUNT, MESSAGES.deleteAccountLink(), new DeleteAccountAction(), "ode-ContextMenuItem-Red"));
+    }
 
     accountButton = new DropDownButton(WIDGET_NAME_USER, " " , userItems, true);
     accountButton.setStyleName("ode-TopPanelButton");

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -41,6 +41,8 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
   @SuppressWarnings("SimpleDateFormat")
   private static final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
 
+  private static boolean deleteAccountAllowed = Flag.createFlag("auth.deleteaccountallowed", true).get();
+
   /**
    * Returns System Config, including user information record
    *
@@ -79,6 +81,7 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
     config.setGalleryEnabled(Flag.createFlag("gallery.enabled", false).get());
     config.setGalleryReadOnly(Flag.createFlag("gallery.readonly", false).get());
     config.setGalleryLocation(Flag.createFlag("gallery.location", "").get());
+    config.setDeleteAccountAllowed(deleteAccountAllowed);
 
     if (!Flag.createFlag("build2.server.host", "").get().isEmpty()) {
       config.setSecondBuildserver(true);
@@ -224,6 +227,9 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
 
   @Override
   public String deleteAccount() {
+    if (!deleteAccountAllowed) {
+      return ("");
+    }
     if (storageIo.deleteAccount(userInfoProvider.getUserId())) {
       String delAccountUrl = Flag.createFlag("deleteaccount.url", "NONE").get();
       if (delAccountUrl.equals("NONE")) {

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
@@ -44,6 +44,7 @@ public class Config implements IsSerializable, Serializable {
   private boolean galleryReadOnly;
   private List<String> tutorialUrlAllowed;
   private boolean serverExpired;
+  private boolean deleteAccountAllowed;
 
   public Config() {
   }
@@ -238,6 +239,14 @@ public class Config implements IsSerializable, Serializable {
 
   public void setServerExpired(boolean value) {
     serverExpired = value;
+  }
+
+  public boolean getDeleteAccountAllowed() {
+    return deleteAccountAllowed;
+  }
+
+  public void setDeleteAccountAllowed(boolean value) {
+    deleteAccountAllowed = value;
   }
 
 }


### PR DESCRIPTION
This flag controls whether or not the "Delete Account" menu item is
displayed. If account deletion is not allowed, the back-end also will
not function.

The default is to permit account deletion.

Change-Id: Ia205532c00f7b32b94e63adedd0a7cfacb17a4c7