### PR TITLE
Fix typo 'any' to 'ant' and Invalid Companion Path

### DIFF
--- a/buildtools
+++ b/buildtools
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ROOTDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 title() {
   echo -ne "\e]0;$*\a"
 }
@@ -86,7 +88,7 @@ companion() {
   if [ $? -eq 0 ]; then
     echo ""
     echo The companion is generated at:
-    echo "$PWD"/build/buildserver/MIT AI2 Companion.apk
+    echo "$ROOTDIR"/appinventor/build/buildserver/MIT AI2 Companion.apk
   fi
 }
 
@@ -96,7 +98,7 @@ extension() {
   if [ $? -eq 0 ]; then
     echo ""
     echo The extension is generated at:
-    echo $PWD/appinventor/components/build/extensions
+    echo "$ROOTDIR/appinventor/components/build/extensions"
   fi
 }
 

--- a/buildtools
+++ b/buildtools
@@ -86,7 +86,7 @@ companion() {
   if [ $? -eq 0 ]; then
     echo ""
     echo The companion is generated at:
-    echo $PWD/appinventor/build/buildserver/MIT AI2 Companion.apk
+    echo "$PWD"/build/buildserver/MIT AI2 Companion.apk
   fi
 }
 

--- a/buildtools
+++ b/buildtools
@@ -82,7 +82,7 @@ buildnoplay() {
 
 companion() {
   title Building Companion...
-  any PlayApp
+  ant PlayApp
   if [ $? -eq 0 ]; then
     echo ""
     echo The companion is generated at:

--- a/buildtools
+++ b/buildtools
@@ -98,7 +98,7 @@ extension() {
   if [ $? -eq 0 ]; then
     echo ""
     echo The extension is generated at:
-    echo "$ROOTDIR/appinventor/components/build/extensions"
+    echo "$ROOTDIR"/appinventor/components/build/extensions
   fi
 }
 


### PR DESCRIPTION
It should be "ant PlayApp" to build the companion, not "any PlayApp"