### PR TITLE
Update Chrome-deprecated functions in drag and drop code

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/utils/html5dnd.js
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/html5dnd.js
@@ -26,7 +26,7 @@ top.HTML5DragDrop_confirmOverwriteKey = function(callback) {};
 top.HTML5DragDrop_getNewProjectName = function(filename, callback) {};
 top.HTML5DragDrop_confirmOverwriteAsset = function(proejctId, name, callback) {};
 top.HTML5DragDrop_checkProjectNameForCollision = function(name) {};
-top.HTML5DragDrop_shouldShowDropTarget = function(target) {};s
+top.HTML5DragDrop_shouldShowDropTarget = function(target) {};
 
 var dropdiv = document.createElement('div');
 dropdiv.className = 'dropdiv';
@@ -49,7 +49,7 @@ function readUrl(item, cb) {
     if (xhr.readyState === 4) {
       if (xhr.status === 200) {
         if (xhr.response.name === undefined) {
-          var name = item.substr(item.lastIndexOf('/') + 1);
+          var name = item.substring(item.lastIndexOf('/') + 1);
           // Discourse generates random names that sometimes begin with numbers. The actual file
           // name is given in a Content-Disposition header, but browsers block access to it on
           // security grounds. Instead, we prepend Project_ to make it a valid project name.
@@ -83,8 +83,8 @@ function handleDroppedItem(item, cb) {
 
 function importProject(droppedItem) {
   var filename = droppedItem.name;
-  filename = filename.substr(filename.lastIndexOf('/') + 1);
-  var projectName = filename.substr(0, filename.length - 4);
+  filename = filename.substring(filename.lastIndexOf('/') + 1);
+  var projectName = filename.substring(0, filename.length - 4);
   function doUploadProject(blob) {
     // Upload project
     var xhr = new XMLHttpRequest();
@@ -264,9 +264,10 @@ function targetIsBlocksEditor(el) {
 }
 
 function targetIsGwtDialogBox(e) {
-  if (e.path) {
-    for (var i = e.path.length - 1; i > 0; i--) {
-      if (e.path[i].classList && e.path[i].classList.contains('ode-DialogBox')) {
+  var path = e.composedPath();
+  if (path) {
+    for (var i = path.length - 1; i > 0; i--) {
+      if (path[i].classList && path[i].classList.contains('ode-DialogBox')) {
         return true;
       }
     }
@@ -346,9 +347,10 @@ function onDragOver(e) {
 
 function onDragLeave(e) {
   var node = e.target;
+  var path = e.composedPath();
   if (node === dropdiv
       || (node.nodeType === Node.ELEMENT_NODE && node.querySelector('.ode-DeckPanel'))
-      || (e.path && e.path.length <= 10)) {
+      || (path && path.length <= 10)) {
     hideDropDiv();
   }
 }


### PR DESCRIPTION
There was a warning in the Chrome console about Event.path being removed in a future version of Chrome. This was never a standardized property, but there is a method that effectively serves the same purpose. I have updated the drag and drop code, which relies on Event.path, to use the standardized method. There were also a few other minor issues in that code that were cleaned up as well (a dangling character that prevents super dev mode from working and String.substr is also deprecated).

Change-Id: I0323e81b5065e873759f8832cb94259a37b66a7e