### PR TITLE
Make sure AppInventorBinaries exists

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/JsonUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/JsonUtil.java
@@ -460,6 +460,11 @@ public class JsonUtil {
     ///////////////////////////////////////////////////////////////////////////////
 
     File destDirectory = new File(Uri.parse(fullDirName).getPath());
+    if (!destDirectory.isDirectory()) {
+      if (!destDirectory.mkdirs()) {
+        throw new YailRuntimeError("Unable to create " + destDirectory, "Write");
+      }
+    }
     final Synchronizer<Boolean> result = new Synchronizer<>();
     File dest;
     try {


### PR DESCRIPTION
This directory is used to store images fetched from CloudDB. We need
to make sure it exists before we use it!

Change-Id: I776930f67256c5e93fd3c75564341c8d2a27c1fe