### PR TITLE
Use AssetFetcher to update the Companion

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -74,7 +74,8 @@ public class BlocklyPanel extends HTMLPanel {
         MESSAGES.useCompanion(YaVersion.PREFERRED_COMPANION, YaVersion.PREFERRED_COMPANION + "u"),
         YaVersion.COMPANION_UPDATE_URL,
         YaVersion.COMPANION_UPDATE_URL1,
-        YaVersion.COMPANION_UPDATE_EMULATOR_URL);
+        YaVersion.COMPANION_UPDATE_EMULATOR_URL,
+        YaVersion.EMULATOR_UPDATE_URL);
     for (int i = 0; i < YaVersion.ACCEPTABLE_COMPANIONS.length; i++) {
       addAcceptableCompanion(YaVersion.ACCEPTABLE_COMPANIONS[i]);
     }
@@ -880,11 +881,12 @@ public class BlocklyPanel extends HTMLPanel {
     return $wnd.PREFERRED_COMPANION;
   }-*/;
 
-  static native void setPreferredCompanion(String comp, String url, String url1, String url2) /*-{
+  static native void setPreferredCompanion(String comp, String url, String url1, String url2, String url3) /*-{
     $wnd.PREFERRED_COMPANION = comp;
     $wnd.COMPANION_UPDATE_URL = url;
     $wnd.COMPANION_UPDATE_URL1 = url1;
     $wnd.COMPANION_UPDATE_EMULATOR_URL = url2;
+    $wnd.EMULATOR_UPDATE_URL = url3;
   }-*/;
 
   static native void addAcceptableCompanionPackage(String comp) /*-{

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1563,6 +1563,7 @@ public class YaVersion {
   public static final String ACCEPTABLE_COMPANION_PACKAGE = "edu.mit.appinventor.aicompanion3";
 
   public static final String PREFERRED_COMPANION = "2.64";
+  public static final String EMULATOR_UPDATE_URL = ""; // Should be an APK
   public static final String COMPANION_UPDATE_URL = "";
   public static final String COMPANION_UPDATE_URL1 = "";
   public static final String COMPANION_UPDATE_EMULATOR_URL = "";

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AssetFetcher.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AssetFetcher.java
@@ -6,6 +6,9 @@
 package com.google.appinventor.components.runtime.util;
 
 import android.content.Context;
+import android.content.Intent;
+
+import android.net.Uri;
 
 import android.util.Log;
 
@@ -82,28 +85,28 @@ public class AssetFetcher {
 
   public static void upgradeCompanion(final String cookieValue, final String inputUri) {
     // The code below is commented out because of issues with the Google Play Store
-    //
-    // background.submit(new Runnable() {
-    //     @Override
-    //     public void run() {
-    //       String [] parts = inputUri.split("/", 0);
-    //       String asset = parts[parts.length-1];
-    //       File assetFile = getFile(inputUri, cookieValue, asset, 0);
-    //       if (assetFile != null) {
-    //         try {
-    //           Form form = Form.getActiveForm();
-    //           Intent intent = new Intent(Intent.ACTION_VIEW);
-    //           Uri packageuri = NougatUtil.getPackageUri(form, assetFile);
-    //           intent.setDataAndType(packageuri, "application/vnd.android.package-archive");
-    //           intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-    //           form.startActivity(intent);
-    //         } catch (Exception e) {
-    //           Log.e(LOG_TAG, "ERROR_UNABLE_TO_GET", e);
-    //           RetValManager.sendError("Unable to Install new Companion Package.");
-    //         }
-    //       }
-    //     }
-    //   });
+
+    background.submit(new Runnable() {
+        @Override
+        public void run() {
+          String [] parts = inputUri.split("/", 0);
+          String asset = parts[parts.length-1];
+          File assetFile = getFile(inputUri, cookieValue, asset, 0);
+          if (assetFile != null) {
+            try {
+              Form form = Form.getActiveForm();
+              Intent intent = new Intent(Intent.ACTION_VIEW);
+              Uri packageuri = NougatUtil.getPackageUri(form, assetFile);
+              intent.setDataAndType(packageuri, "application/vnd.android.package-archive");
+              intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+              form.startActivity(intent);
+            } catch (Exception e) {
+              Log.e(LOG_TAG, "ERROR_UNABLE_TO_GET", e);
+              RetValManager.sendError("Unable to Install new Companion Package.");
+            }
+          }
+        }
+      });
     return;
   }
 


### PR DESCRIPTION
Instead of the client browser fetching the updated Companion and sending it down to the running Companion, we request the running Companion to perform the download and then call on the package manager to install it.

Note: Prior to building a Companion version for the Google Play Store, this change should be reverted because the store's static analysis will see the call to the package manager and Google will reject the update.

Change-Id: I8fb8518db66099d19936a46b1d779fcceba83e5b