### PR TITLE
Add a github action to diff important files

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -2,9 +2,17 @@ name: Diff
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - master
+      - ucr
+    paths:
+      - appinventor/components/**
   pull_request:
-    branches: [ "master" ]
+    branches:
+      - master
+      - ucr
+    paths:
+      - appinventor/components/**
 
 jobs:
   diff:

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -45,10 +45,13 @@ jobs:
         working-directory: master/appinventor
 
       - name: Diff simple_components.json
-        run: diff --unified master/appinventor/build/components/simple_components.json current/appinventor/build/components/simple_components.json
+        continue-on-error: true
+        run: diff --unified --color <(jq -C -S . master/appinventor/build/components/simple_components.json) <(jq -C -S . current/appinventor/build/components/simple_components.json)
 
       - name: Diff simple_components.txt
-        run: diff --unified master/appinventor/build/components/simple_components.txt current/appinventor/build/components/simple_components.txt
+        continue-on-error: true
+        run: diff --unified --color master/appinventor/build/components/simple_components.txt current/appinventor/build/components/simple_components.txt
 
       - name: Diff simple_components_build_info.json
-        run: diff --unified master/appinventor/build/components/simple_components_build_info.json current/appinventor/build/components/simple_components_build_info.json
+        continue-on-error: true
+        run: diff --unified --color <(jq -C -S . master/appinventor/build/components/simple_components_build_info.json) <(jq -C -S . current/appinventor/build/components/simple_components_build_info.json)

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,54 @@
+name: Diff
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          
+      - name: Install 32-bit dependencies
+        run: sudo apt-get install -y libc6-i386 lib32z1 lib32stdc++6
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: current
+          submodules: recursive
+
+      - name: Checkout master
+        uses: actions/checkout@v3
+        with:
+            ref: master
+            path: master
+            submodules: recursive
+            
+      - name: Build current
+        run: |
+          ant MakeAuthKey
+          ant noplay
+        working-directory: current/appinventor
+        
+      - name: Build master
+        run: |
+          ant MakeAuthKey
+          ant noplay
+        working-directory: master/appinventor
+
+      - name: Diff simple_components.json
+        run: diff --unified master/appinventor/build/components/simple_components.json current/appinventor/build/components/simple_components.json
+
+      - name: Diff simple_components.txt
+        run: diff --unified master/appinventor/build/components/simple_components.txt current/appinventor/build/components/simple_components.txt
+
+      - name: Diff simple_components_build_info.json
+        run: diff --unified master/appinventor/build/components/simple_components_build_info.json current/appinventor/build/components/simple_components_build_info.json

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff simple_components.json
         continue-on-error: true
-        run: diff --unified --color <(jq -C -S . master/appinventor/build/components/simple_components.json) <(jq -C -S . current/appinventor/build/components/simple_components.json)
+        run: diff --unified --color <(jq 'del(.[] | .dateBuilt)' master/appinventor/build/components/simple_components.json) <(jq 'del(.[] | .dateBuilt)' current/appinventor/build/components/simple_components.json)
 
       - name: Diff simple_components.txt
         continue-on-error: true
@@ -54,4 +54,4 @@ jobs:
 
       - name: Diff simple_components_build_info.json
         continue-on-error: true
-        run: diff --unified --color <(jq -C -S . master/appinventor/build/components/simple_components_build_info.json) <(jq -C -S . current/appinventor/build/components/simple_components_build_info.json)
+        run: diff --unified --color <(jq . master/appinventor/build/components/simple_components_build_info.json) <(jq . current/appinventor/build/components/simple_components_build_info.json)


### PR DESCRIPTION
This is particularly important when someone opens a PR with changes to the `components` module.

Sample output: https://github.com/pavi2410/appinventor-sources/actions/runs/3074968797/jobs/4968070243