### PR TITLE
Add support for other Vagrant providers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,18 +8,25 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "generic/ubuntu2204"
 
   config.vm.boot_timeout = 400
 
   config.vm.provider "virtualbox" do |v|
-    v.name = "ForAppinventor2-bionic64"
+    v.name = "ForAppinventor2-jammy64"
     v.memory = "4096"
     v.customize ["modifyvm", :id, "--usb", "on"]
     # fix for slow network
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     v.customize ["modifyvm", :id, "--nictype1", "virtio"]
+  end
+  
+  config.vm.provider "libvirt" do |v|
+    # By default, './' is synced onto '/vagrant' with NFS, which does not work for debian family images for some reason;
+    # hence we use rsync. There are a few broken links in the source tree that will fail the default rsync syncing sche-
+    # me, so we give explicit rsync args and omit "--copy-links".
+    config.vm.synced_folder './', '/vagrant', type: 'rsync', rsync__args: ["--verbose", "--archive", "--update"]
   end
 
   config.vm.provision :shell, path: "bootstrap.sh"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,8 +5,8 @@ dpkg --add-architecture i386
 # Install dependencies
 apt-get update
 apt-get upgrade -y
-apt-get install -y libc6:i386 libstdc++6:i386 glibc-doc:i386 gcc-5-base:i386 gcc-6-base:i386 libgcc1:i386 \
-     openjdk-8-jdk zip unzip ant lib32z1 adb phantomjs
+apt-get install -y libc6:i386 zlib1g:i386 libstdc++6:i386 \
+     openjdk-8-jdk zip unzip bzip2 ant adb
 
 # Install App Engine
 mkdir -p /opt/appengine
@@ -14,12 +14,19 @@ cd /opt/appengine
 wget --no-verbose -O /tmp/appengine.zip https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.68.zip
 unzip -o /tmp/appengine.zip
 
+# Install PhantomJS
+cd /home/vagrant
+export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
+wget --no-verbose https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+tar -xvf $PHANTOM_JS.tar.bz2 -C /usr/local/share/
+ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+
 # Configure shell
 echo "export PATH=$PATH:/opt/appengine/appengine-java-sdk-1.9.68/bin" >> /home/vagrant/.bashrc
 echo "cd /vagrant/appinventor" >> /home/vagrant/.bashrc
 
 # Configure java
-update-java-alternatives -s java-1.8.0-openjdk-amd64
+update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 # Make the auth key in advance
 cd /vagrant/appinventor


### PR DESCRIPTION
The current setup only has support for VirtualBox, but not other Vagrant providers. I changed the Vagrantfile to add support for the other providers. And since Ubuntu 18.04 is end of life next year, I thought it would be a good idea to also change the base box to the latest LTS Ubuntu version (22.04).

This pull request also includes the changes proposed in #2554 by @peanutbutterandcrackers.