### PR TITLE
Adjust Web file access permission checks

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
@@ -1174,7 +1174,7 @@ public class Web extends AndroidNonvisibleComponent implements Component,
     final List<String> neededPermissions = new ArrayList<>();
 
     // Check if we need permission to read the postFile, if any
-    if (postFile != null && FileUtil.needsPermission(form, postFile) && !haveReadPermission) {
+    if (postFile != null && FileUtil.needsReadPermission(form, postFile) && !haveReadPermission) {
       neededPermissions.add(READ_EXTERNAL_STORAGE);
     }
 
@@ -1182,7 +1182,7 @@ public class Web extends AndroidNonvisibleComponent implements Component,
     if (saveResponse) {
       String target = FileUtil.resolveFileName(form, webProps.responseFileName,
           form.DefaultFileScope());
-      if (FileUtil.needsPermission(form, target) && !haveWritePermission) {
+      if (FileUtil.needsWritePermission(form, target) && !haveWritePermission) {
         neededPermissions.add(WRITE_EXTERNAL_STORAGE);
       }
     }


### PR DESCRIPTION
Fixes #2744 

Starting with Android 11, read and write access diverge (specifically, write goes away). We therefore need to call more appropriate functions to check whether each permission is really needed. 

Change-Id: I03937e412b1ce3e59bb7ef00a9066d608dc265e6