### PR TITLE
0-indexed row numbers returned in Spreadsheets component resolved

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
@@ -1786,7 +1786,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
                     || (!exact && sheet_row.get(colID - 1).contains(value)))
                     {
                       Log.d(LOG_TAG, "Read with Filter check col: " + rowNum);
-                      return_rows.add(rowNum);
+                      return_rows.add(rowNum + 1);
                       return_data.add(sheet_row);
                     }
                   }


### PR DESCRIPTION
fixes #2813

This PR is making the filter of spreadsheets return the 1-indeex row number while reading from the spreadsheets.