### PR TITLE
Fixes documentation for the flung part of canvas and Imagesprite

### DIFF
--- a/appinventor/docs/html/reference/components/animation.html
+++ b/appinventor/docs/html/reference/components/animation.html
@@ -339,7 +339,7 @@
   <dd>When a fling gesture (quick swipe) is made on the canvas: provides
  the (x,y) position of the start of the fling, relative to the upper
  left of the canvas. Also provides the speed (pixels per millisecond) and heading
- (0-360 degrees) of the fling, as well as the x velocity and y velocity
+ (-180 to 180 degrees) of the fling, as well as the x velocity and y velocity
  components of the fling’s vector. The value “flungSprite” is true if a sprite
  was located near the the starting point of the fling gesture.</dd>
   <dt id="Canvas.TouchDown">TouchDown(<em class="number">x</em>,<em class="number">y</em>)</dt>
@@ -482,7 +482,7 @@
   <dd>When a fling gesture (quick swipe) is made on the sprite: provides
  the (x,y) position of the start of the fling, relative to the upper
  left of the canvas. Also provides the speed (pixels per millisecond) and heading
- (0-360 degrees) of the fling, as well as the x velocity and y velocity
+ (-180 to 180 degrees) of the fling, as well as the x velocity and y velocity
  components of the fling’s vector.</dd>
   <dt id="ImageSprite.NoLongerCollidingWith">NoLongerCollidingWith(<em class="component">other</em>)</dt>
   <dd>Event indicating that a pair of sprites are no longer colliding.</dd>

--- a/appinventor/docs/markdown/reference/components/animation.md
+++ b/appinventor/docs/markdown/reference/components/animation.md
@@ -255,7 +255,7 @@ A two-dimensional touch-sensitive rectangular panel on which drawing can
 : When a fling gesture (quick swipe) is made on the canvas: provides
  the (x,y) position of the start of the fling, relative to the upper
  left of the canvas. Also provides the speed (pixels per millisecond) and heading
- (0-360 degrees) of the fling, as well as the x velocity and y velocity
+ (-180 to 180 degrees) of the fling, as well as the x velocity and y velocity
  components of the fling's vector. The value "flungSprite" is true if a sprite
  was located near the the starting point of the fling gesture.
 
@@ -429,7 +429,7 @@ A 'sprite' that can be placed on a [`Canvas`](#Canvas), where it can react to to
 : When a fling gesture (quick swipe) is made on the sprite: provides
  the (x,y) position of the start of the fling, relative to the upper
  left of the canvas. Also provides the speed (pixels per millisecond) and heading
- (0-360 degrees) of the fling, as well as the x velocity and y velocity
+ (-180 to 180 degrees) of the fling, as well as the x velocity and y velocity
  components of the fling's vector.
 
 {:id="ImageSprite.NoLongerCollidingWith"} NoLongerCollidingWith(*other*{:.component})


### PR DESCRIPTION
# Fixes 1340
This PR is fixing the documentation of the Heading in Flung in Canvas and ImageSprite
