### PR TITLE
Hard reset confirmation button should be "Reset"-Resolved 

### DIFF
--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
@@ -809,6 +809,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Network Error",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Network Error Communicating with Companion.<br />Try restarting the Companion and reconnecting",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Reset",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "Companion Version Check",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Your Companion App is out of date. Click 'OK' to start the update. Watch your ",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE2": "Your Companion App is out of date. Restart the Companion and use it to scan the QRCode below in order to update",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ca.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ca.json
@@ -651,6 +651,7 @@
     "Blockly.Msg.REPL_NETWORK_CONNECTION_ERROR": "Error de connexió de xarxa",
     "Blockly.Msg.REPL_NETWORK_ERROR": "Error de xarxa",
     "Blockly.Msg.REPL_OK": "OK",
+    "Blockly.Msg.REPL_RESET": "Restableix",
     "Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "Comprovació de la versió del Companion",
     "Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "L'app Companion està desactualizada. Fes clic a 'OK' per iniciar l'actualització. Presta atenció a la ",
     "Blockly.Msg.LANG_NO_ASSETS": "No hi ha fitxers disponibles",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_de.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_de.json
@@ -538,6 +538,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Netzwerkfehler",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Netzwerkfehler in der Kommunikation mit dem Companion.<br />Versuche, den Companion neuzustarten und neu zu verbinden",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Zurücksetzen",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "Companion Version Check",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Deine Companion App ist veraltet. Klicke 'OK', um das Update zu starten. Achte auf Deine ",
 	"Blockly.Msg.REPL_EMULATORS": "Emulator",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_es.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_es.json
@@ -504,6 +504,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Error de red",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Error de red al comunicarse con Companion.<br />Intenta reinicar Companion y conectar de nuevo con él",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Reiniciar",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "Comprobación de la versión de Companion",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Tu aplicación Companion está anticuada. Haz clic en 'OK' para actualizarla. Consulta la pantalla de tu ",
 	"Blockly.Msg.REPL_EMULATORS": "emulador",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_fr.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_fr.json
@@ -523,6 +523,7 @@
 	"Blockly.Msg.REPL_NO_ERROR_FIVE_SECONDS": "<br/><i>Note:</i>&nbsp;Vous n'allez pas voir une autre erreur rapportée pour 5 secondes.",
 	"Blockly.Msg.REPL_NO_START_EMULATOR": "On ne peut pas ouvrir le compagnon avec l'émulateur",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Réinitialiser",
 	"Blockly.Msg.REPL_OK_LOWER": "Ok",
 	"Blockly.Msg.REPL_PLUGGED_IN_Q": "Branché?",
 	"Blockly.Msg.REPL_RUNTIME_ERROR": "Erreur d'exécution",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hu.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hu.json
@@ -599,6 +599,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Hálózati Hiba",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Hiba történt az AI Companion segédalkalmazással való kapcsolat során.<br />Indítsd újra az AI Companion appot és kapcsolódj hozzá újra",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Visszaállítás",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "AI Companion Verzió Ellenőrzése",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Az AI Companion segédalkalmazásod régi verziójával rendelkezel. Nyomd meg az 'OK' gombot a legújabb verzió letöltéséhez. Figyeld a(z)",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE2": "Az AI Companion segédalkalmazásod régi verziójával rendelkezel. Indítsd újra az AI Companion alkalmazást és szkenneld be vele a lenti QR kódot az aktualizáláshoz.",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hy.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hy.json
@@ -388,6 +388,7 @@
     "Blockly.Msg.DIALOG_ENTER_VALUES": "Մուտքագրել արժեքները",
     "Blockly.Msg.REPL_OK_LOWER": "Լավ",
     "Blockly.Msg.REPL_OK": "Լավ",
+    "Blockly.Msg.REPL_RESET": "Վերականգնել",
     "Blockly.Msg.REPL_NETWORK_ERROR": "Ցանցային սխալ",
     "Blockly.Msg.HIDE_WARNINGS": "Թաքցնել զգուշացումները",
     "Blockly.Msg.SHOW_WARNINGS": "Ցույց տալ զգուշացումները",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_it.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_it.json
@@ -460,6 +460,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Errore di rete",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Errore di Rete nel Comunicare con l'app Companion.<br />Prova a riavviare l'app Companion e a riconnetterti",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Ripristina",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "Controllo Versione app Companion",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Stai usando una vecchia versione dell'App Companion. Clicca 'OK' per avviare l'aggiornamento. Controlla ",
 	"Blockly.Msg.REPL_EMULATORS": "nel tuo emulatore",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_lt.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_lt.json
@@ -646,6 +646,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "Tinklo klaida",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "Tinklo klaida jungiantis su „AI2 Companion“. Pabandykite iš naujo paleisti ir vėl prisijungti.",
 	"Blockly.Msg.REPL_OK": "Gerai",
+	"Blockly.Msg.REPL_RESET": "Nustatyti iš naujo",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "„AI2 Companion“ versijos tikrinimas",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "Jūsų „AI2 Companion“ programa neatnaujinta. Spustelėkite „Gerai“ norėdami atnaujinti. ",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE2": "Jūsų „AI2 Companion“ programa neatnaujinta. Iš naujo paleiskite „AI2 Companion“ ir naudokite jį nuskaitant QR kodą, kad galėtumėte atnaujinti",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_nl.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_nl.json
@@ -492,6 +492,7 @@
     "Blockly.Msg.LANG_TEXT_APPEND_VARIABLE": "item",
     "Blockly.Msg.LANG_MATH_ARITHMETIC_TOOLTIP_MULTIPLY": "Geeft het product van twee getallen terug.",
     "Blockly.Msg.REPL_OK": "OK",
+    "Blockly.Msg.REPL_RESET": "Resetten",
     "Blockly.Msg.LANG_PROCEDURES_DOTHENRETURN_THEN_RETURN": "resultaat",
     "Blockly.Msg.LANG_CONTROLS_FORRANGE_INPUT_COLLAPSED_PREFIX": "voor ",
     "Blockly.Msg.LANG_MATH_TRIG_ATAN2_Y": "j",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pl.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pl.json
@@ -547,5 +547,8 @@
 	"Blockly.Msg.LANG_COMPONENT_BLOCK_SETTER_TITLE_TO": "do",
 	"Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_SETTER_TITLE_SET": "ustaw",
 	"Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_SETTER_TITLE_TO": "do",
-	"Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_SETTER_TITLE_OF_COMPONENT": "składnika"
+	"Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_SETTER_TITLE_OF_COMPONENT": "składnika",
+	"Blockly.Msg.REPL_RESET": "Resetowanie",
+	"Blockly.Msg.REPL_FACTORY_RESET": "Spowoduje to próbę zresetowania emulatora do stanu fabrycznego. Jeśli wcześniej aktualizowałeś aplikację Companion zainstalowaną w emulatorze, prawdopodobnie będziesz musiał zrobić to ponownie.",
+	"Blockly.Msg.REPL_CANCEL": "Anulować"
 }

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt.json
@@ -493,6 +493,7 @@
 	"Blockly.Msg.LANG_TEXT_APPEND_VARIABLE": "elemento",
 	"Blockly.Msg.LANG_MATH_ARITHMETIC_TOOLTIP_MULTIPLY": "Retornar o produto dos dois números.",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Reiniciar",
 	"Blockly.Msg.LANG_PROCEDURES_DOTHENRETURN_THEN_RETURN": "resultado",
 	"Blockly.Msg.LANG_CONTROLS_FORRANGE_INPUT_COLLAPSED_PREFIX": "para cada ",
 	"Blockly.Msg.LANG_MATH_TRIG_ATAN2_Y": "y",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt_BR.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt_BR.json
@@ -495,6 +495,7 @@
 	"Blockly.Msg.LANG_TEXT_APPEND_VARIABLE": "item",
 	"Blockly.Msg.LANG_MATH_ARITHMETIC_TOOLTIP_MULTIPLY": "Retornar o produto dos dois números.",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Reajustar",
 	"Blockly.Msg.LANG_PROCEDURES_DOTHENRETURN_THEN_RETURN": "resultado",
 	"Blockly.Msg.LANG_CONTROLS_FORRANGE_INPUT_COLLAPSED_PREFIX": "para cada ",
 	"Blockly.Msg.LANG_MATH_TRIG_ATAN2_Y": "y",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ru.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ru.json
@@ -543,6 +543,7 @@
 	"Blockly.Msg.REPL_NO_ERROR_FIVE_SECONDS": "<br/><i>Внимание:</i>&nbsp;Отчет о другой ошибке появится не ранее, чем через 5 секунд.",
 	"Blockly.Msg.REPL_NO_START_EMULATOR": "Невозможно запустить MIT AI Companion с эмулятором",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Перезагрузить",
 	"Blockly.Msg.REPL_OK_LOWER": "Ок",
 	"Blockly.Msg.REPL_PLUGGED_IN_Q": "Вы подключены?",
 	"Blockly.Msg.REPL_RUNTIME_ERROR": "Ошибка времени исполнения",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_sv.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_sv.json
@@ -493,6 +493,7 @@
 	"Blockly.Msg.LANG_TEXT_APPEND_VARIABLE": "element",
 	"Blockly.Msg.LANG_MATH_ARITHMETIC_TOOLTIP_MULTIPLY": "Ger produkten av de två talen.",
 	"Blockly.Msg.REPL_OK": "OK",
+	"Blockly.Msg.REPL_RESET": "Återställa",
 	"Blockly.Msg.LANG_PROCEDURES_DOTHENRETURN_THEN_RETURN": "resultat",
 	"Blockly.Msg.LANG_CONTROLS_FORRANGE_INPUT_COLLAPSED_PREFIX": "för ",
 	"Blockly.Msg.LANG_MATH_TRIG_ATAN2_Y": "y",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_tr.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_tr.json
@@ -281,6 +281,7 @@
     "Blockly.Msg.LANG_MATH_COMPARE_TOOLTIP_GT": "İlk sayı ikinci numaradan büyükse \n'doğru' döndürür.",
     "Blockly.Msg.LANG_MATH_TRIG_TOOLTIP_COS": "Verilen açının kosinüsünü derece cinsinden verir.",
     "Blockly.Msg.REPL_OK": "OK",
+    "Blockly.Msg.REPL_RESET": "Sıfırla",
     "Blockly.Msg.ENABLE_BLOCK": "Bloğu Etkinleştir",
     "Blockly.Msg.LANG_PROCEDURES_MUTATORARG_TITLE": "Giriş:",
     "Blockly.Msg.LANG_CONTROLS_FORRANGE_INPUT_START": "itibaren",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_CN.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_CN.json
@@ -520,6 +520,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "网络故障",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "与AI伴侣通信故障，<br />请尝试重新启动AI伴侣并重新连接",
 	"Blockly.Msg.REPL_OK": "确定",
+	"Blockly.Msg.REPL_RESET": "重置",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "检查AI伴侣版本",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "AI伴侣已版本过期，点击“确定”升级。",
 	"Blockly.Msg.REPL_EMULATORS": "查看模拟器",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_TW.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_TW.json
@@ -514,6 +514,7 @@
 	"Blockly.Msg.REPL_NETWORK_ERROR": "網路故障",
 	"Blockly.Msg.REPL_NETWORK_ERROR_RESTART": "與 AI Companion 連線故障, <a href=\"http://explore.appinventor.mit.edu/ai2/connection-help\" target=\"_blank\">更多連線說明請點我</a>",
 	"Blockly.Msg.REPL_OK": "確定",
+	"Blockly.Msg.REPL_RESET": "重置",
 	"Blockly.Msg.REPL_COMPANION_VERSION_CHECK": "檢查 AI Companion 的程式版本",
 	"Blockly.Msg.REPL_COMPANION_OUT_OF_DATE": "AI Companion 程式版本太舊，點選「OK」來升級。 ",
 	"Blockly.Msg.REPL_EMULATORS": "查看模擬器",

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1890,9 +1890,9 @@ Blockly.ReplMgr.hardreset = function(formName, callback) {
 
 Blockly.ReplMgr.ehardreset = function(formName) {
     var context = this;
-    var dialog = new Blockly.Util.Dialog(Blockly.Msg.REPL_DO_YOU_REALLY_Q, Blockly.Msg.REPL_FACTORY_RESET, Blockly.Msg.REPL_OK, true, Blockly.Msg.REPL_CANCEL, 0, function(response) {
+    var dialog = new Blockly.Util.Dialog(Blockly.Msg.REPL_DO_YOU_REALLY_Q, Blockly.Msg.REPL_FACTORY_RESET, Blockly.Msg.REPL_RESET, true, Blockly.Msg.REPL_CANCEL, 0, function(response) {
         dialog.hide();
-        if (response == Blockly.Msg.REPL_OK) {
+        if (response == Blockly.Msg.REPL_RESET) {
             context.hardreset(formName, function() {
                 var xhr = goog.net.XmlHttp();
                 xhr.open("GET", "http://localhost:8004/emulatorreset/", true);


### PR DESCRIPTION
Fixes https://github.com/mit-cml/appinventor-sources/pull/1228 , this PR has added translation in proper manner , also including the translation for polisky.
Thus changes the ok - reset in all cases except the korean one.

In this the cancel,ok,factory_reset text is also changed for polisky.

This is referencing the older PR #2830 