### PR TITLE
Update NearField component to Kodular sources

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -416,6 +416,8 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradeEv3UltrasonicSensorProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("NxtDirectCommands")) {
         srcCompVersion = upgradeNxtDirectCommandsProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("NearField")) {
+        srcCompVersion = upgradeNearFieldProperties(componentProperties, srcCompVersion);
       }
 
       if (srcCompVersion < sysCompVersion) {
@@ -2036,6 +2038,16 @@ public final class YoungAndroidFormUpgrader {
       int srcCompVersion) {
     if (srcCompVersion < 2) {
       // Adds dropdown blocks.
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeNearFieldProperties(
+      Map<String, JSONValue> componentProperties,
+      int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Adds tagId parameter to TagRead event.
       srcCompVersion = 2;
     }
     return srcCompVersion;

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2454,7 +2454,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "NearField": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+
+    // Added tagId parameter to TagRead event
+    2: "noUpgrade"
 
   }, // End NearField upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -571,8 +571,10 @@ public class YaVersion {
   // - SPREADSHEET_COMPONENT_VERSION was incremented to 2
   // For YOUNG_ANDROID_VERSION 221;
   // - BLUETOOTHCLIENT_COMPONENT_VERSION was incremented to 8
+  // For YOUNG_ANDROID_VERSION 222:
+  // - NEARFIELD_COMPONENT_VERSION was incremented to 2
 
-  public static final int YOUNG_ANDROID_VERSION = 221;
+  public static final int YOUNG_ANDROID_VERSION = 222;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -1163,7 +1165,10 @@ public class YaVersion {
   public static final int NAVIGATION_COMPONENT_VERSION = 2;
 
   // For NEARFIELD_COMPONENT_VERSION 1:
-  public static final int NEARFIELD_COMPONENT_VERSION = 1;
+  // - Initial NearField implementation
+  // For NEARFIELD_COMPONENT_VERSION 2:
+  // Added tagId parameter to TagRead event
+  public static final int NEARFIELD_COMPONENT_VERSION = 2;
 
   // For NOTIFIER_COMPONENT_VERSION 2:
   // - To ShowChooseDialog and ShowTextDialog, new arg was added to indicate if dialog is cancelable

--- a/appinventor/components/src/com/google/appinventor/components/runtime/NearField.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/NearField.java
@@ -90,10 +90,10 @@ implements OnStopListener, OnResumeListener, OnPauseListener, OnNewIntentListene
    * See Compiler.java.
    */
   @SimpleEvent
-  public void TagRead(String message) {
+  public void TagRead(String tagId, String message) {
     Log.d(TAG, "Tag read: got message " + message);
     tagContent = message;
-    EventDispatcher.dispatchEvent(this, "TagRead", message);
+    EventDispatcher.dispatchEvent(this, "TagRead", tagId, message);
   }
 
   /**
@@ -221,5 +221,15 @@ implements OnStopListener, OnResumeListener, OnPauseListener, OnNewIntentListene
   @Override
   public void onStop() {
     // TODO Auto-generated method stub
+  }
+
+  public static String toHexString(byte[] buffer) {
+    StringBuilder sb = new StringBuilder();
+
+    for (byte b: buffer) {
+      sb.append(String.format("%02x", b&0xff));
+    }
+
+    return sb.toString().toUpperCase();
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/GingerbreadUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/GingerbreadUtil.java
@@ -127,7 +127,8 @@ public class GingerbreadUtil {
         byte[] payload = msgs[0].getRecords()[0].getPayload();
         //the substring chops off the two language encoding bits at the beginning
         String message = new String(payload).substring(3);
-        nfc.TagRead(message);
+        Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+        nfc.TagRead(NearField.toHexString(tag.getId()), message);
       } else {
         Tag detectedTag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
         NdefMessage msg = null;


### PR DESCRIPTION
This PR adds the Tag ID parameter to the TagRead event, as Kodular-Creator sources right now. This was the only discrepancy between both components.