### PR TITLE
Introduce new FUTURE category

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
@@ -302,6 +302,11 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
     if (category == ComponentCategory.UNINITIALIZED) {
       return false;
     }
+    // We should only show FUTURE components if the future feature flag is enabled...
+    if (category == ComponentCategory.FUTURE &&
+        !AppInventorFeatures.enableFutureFeatures()) {
+      return false;
+    }
     if (category == ComponentCategory.INTERNAL &&
         !AppInventorFeatures.showInternalComponentsCategory()) {
       return false;

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentCategory.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentCategory.java
@@ -60,6 +60,7 @@ public enum ComponentCategory {
   LEGOMINDSTORMS("LEGO® MINDSTORMS®"),
   EXPERIMENTAL("Experimental"),
   EXTENSION("Extension"),
+  FUTURE("Future"),
   INTERNAL("For internal use only"),
   // UNINITIALIZED is used as a default value so Swing libraries can still compile
   UNINITIALIZED("Uninitialized");
@@ -82,6 +83,7 @@ public enum ComponentCategory {
     DOC_MAP.put("LEGO® MINDSTORMS®", "legomindstorms");
     DOC_MAP.put("Experimental", "experimental");
     DOC_MAP.put("Extension", "extension");
+    DOC_MAP.put("Future", "future");
   }
 
 


### PR DESCRIPTION
Introduces new FUTURE components category which will only show when the future feature flag is enabled in the App Inventor Features settings (#2829).

It behaves in the same way as any other category (components are natively included in the AndroidRuntime), but they just do not show up in the Designer unless the mentioned flag is enabled. Key differences with existing categories:

- `INTERNAL`: This category is intended for private components which are either deprecated (but must be kept on runtime for legacy purposes) or just internal (like PhoneStatus).
- `EXPERIMENTAL`: This category is visible by default, and is intended for components which may expect some bugs to occur, or some components which are actively under development.