### PR TITLE
Backport property panel improvements from Punya/Alexa

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -382,10 +382,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
   private void findComponentProperties(ComponentDefinition component,
       JSONArray propertiesArray, JSONArray blockPropertiesArray) {
     Map<String, String> descriptions = new HashMap<String, String>();
+    Map<String, String> categoryMap = new HashMap<String, String>();
     for (JSONValue block : blockPropertiesArray.getElements()) {
       Map<String, JSONValue> properties = block.asObject().getProperties();
-      descriptions.put(properties.get("name").asString().getString(),
-          properties.get("description").asString().getString());
+      String name = properties.get("name").asString().getString();
+      categoryMap.put(name, properties.get("category").asString().getString());
+      descriptions.put(name, properties.get("description").asString().getString());
     }
     for (JSONValue propertyValue : propertiesArray.getElements()) {
       Map<String, JSONValue> properties = propertyValue.asObject().getProperties();
@@ -400,11 +402,15 @@ class ComponentDatabase implements ComponentDatabaseInterface {
       }
 
       String name = properties.get("name").asString().getString();
+      String category = categoryMap.get(name);
+      if ( category == null ) {
+        category = "Unspecified";
+      }
       component.add(new PropertyDefinition(name,
           properties.get("defaultValue").asString().getString(),
           name, properties.get("editorType").asString().getString(),
           editorArgsList.toArray(new String[0]),
-          descriptions.get(name)));
+          category, descriptions.get(name)));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/ComponentDatabase.java
@@ -353,7 +353,8 @@ class ComponentDatabase implements ComponentDatabaseInterface {
         properties.get("iconName").asString().getString(),
         properties.containsKey("licenseName") ? properties.get("licenseName").asString().getString() : "",
         componentNode.toJson());
-    findComponentProperties(component, properties.get("properties").asArray());
+    findComponentProperties(component, properties.get("properties").asArray(),
+        properties.get("blockProperties").asArray());
     findComponentBlockProperties(component, properties.get("blockProperties").asArray());
     findComponentEvents(component, properties.get("events").asArray());
     findComponentMethods(component, properties.get("methods").asArray());
@@ -378,7 +379,14 @@ class ComponentDatabase implements ComponentDatabaseInterface {
   /*
    * Enters property information into the component descriptor.
    */
-  private void findComponentProperties(ComponentDefinition component, JSONArray propertiesArray) {
+  private void findComponentProperties(ComponentDefinition component,
+      JSONArray propertiesArray, JSONArray blockPropertiesArray) {
+    Map<String, String> descriptions = new HashMap<String, String>();
+    for (JSONValue block : blockPropertiesArray.getElements()) {
+      Map<String, JSONValue> properties = block.asObject().getProperties();
+      descriptions.put(properties.get("name").asString().getString(),
+          properties.get("description").asString().getString());
+    }
     for (JSONValue propertyValue : propertiesArray.getElements()) {
       Map<String, JSONValue> properties = propertyValue.asObject().getProperties();
 
@@ -391,10 +399,12 @@ class ComponentDatabase implements ComponentDatabaseInterface {
           editorArgsList.add(val.asString().getString());
       }
 
-      component.add(new PropertyDefinition(properties.get("name").asString().getString(),
+      String name = properties.get("name").asString().getString();
+      component.add(new PropertyDefinition(name,
           properties.get("defaultValue").asString().getString(),
-          properties.get("editorType").asString().getString(),
-          editorArgsList.toArray(new String[0])));
+          name, properties.get("editorType").asString().getString(),
+          editorArgsList.toArray(new String[0]),
+          descriptions.get(name)));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -28,6 +28,7 @@ import com.google.appinventor.client.widgets.properties.EditableProperties;
 import com.google.appinventor.client.widgets.properties.EditableProperty;
 import com.google.appinventor.client.widgets.properties.PropertyChangeListener;
 import com.google.appinventor.client.widgets.properties.PropertyEditor;
+import com.google.appinventor.client.widgets.properties.StringPropertyEditor;
 import com.google.appinventor.client.widgets.properties.TextPropertyEditor;
 import com.google.appinventor.client.youngandroid.TextValidators;
 import com.google.appinventor.shared.rpc.project.HasAssetsFolder;
@@ -409,7 +410,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // Add the special name property and set the tooltip
     String name = componentName();
     setTitle(name);
-    addProperty(PROPERTY_NAME_NAME, name, null, null, new TextPropertyEditor());
+    addProperty(PROPERTY_NAME_NAME, name, null, null, null, new TextPropertyEditor());
 
     // TODO(user): Ensure this value is unique within the project using a list of
     // already used UUIDs
@@ -417,7 +418,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // The default value here can be anything except 0, because YoungAndroidProjectService
     // creates forms with an initial Uuid of 0, and Properties.java doesn't encode
     // default values when it generates JSON for a component.
-    addProperty(PROPERTY_NAME_UUID, "-1", null, null, new TextPropertyEditor());
+    addProperty(PROPERTY_NAME_UUID, "-1", null, null, null, new TextPropertyEditor());
     changeProperty(PROPERTY_NAME_UUID, "" + Random.nextInt());
 
     editor.getComponentPalettePanel().configureComponent(this);
@@ -510,7 +511,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    * @param editor  property editor
    */
   public final void addProperty(String name, String defaultValue, String caption,
-      String description, PropertyEditor editor) {
+      String category, String description, PropertyEditor editor) {
 
     int type = EditableProperty.TYPE_NORMAL;
     if (!isPropertyPersisted(name)) {
@@ -522,7 +523,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     if (isPropertyforYail(name)) {
       type |= EditableProperty.TYPE_DOYAIL;
     }
-    properties.addProperty(name, defaultValue, caption, description, editor, type, "", null);
+    properties.addProperty(name, defaultValue, caption, category, description, editor, type, "", null);
   }
 
   /**
@@ -535,7 +536,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    * @param editorArgs  additional editor arguments
    * @param editor  property editor
    */
-  public final void addProperty(String name, String defaultValue, String caption,
+  public final void addProperty(String name, String defaultValue, String caption, String category,
       String description, String editorType, String[] editorArgs, PropertyEditor editor) {
 
     int type = EditableProperty.TYPE_NORMAL;
@@ -548,7 +549,11 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     if (isPropertyforYail(name)) {
       type |= EditableProperty.TYPE_DOYAIL;
     }
-    properties.addProperty(name, defaultValue, caption, description, editor, type, editorType, editorArgs);
+    properties.addProperty(name, defaultValue, caption, category, description, editor, type, editorType, editorArgs);
+  }
+
+  protected final void addProperty(String name) {
+    addProperty(name, "", null, null, null, new StringPropertyEditor());
   }
 
   /**
@@ -1223,8 +1228,12 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     }
     for (PropertyDefinition property : newProperties) {
       if (toBeAdded.contains(property.getName())) {
-        PropertyEditor propertyEditor = PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), (YaFormEditor) editor, property.getEditorArgs());
-        addProperty(property.getName(), property.getDefaultValue(), property.getCaption(), property.getDescription(), property.getEditorType(), property.getEditorArgs(), propertyEditor);
+        PropertyEditor propertyEditor = PropertiesUtil.createPropertyEditor(
+            property.getEditorType(), property.getDefaultValue(),
+            (YaFormEditor) editor, property.getEditorArgs());
+        addProperty(property.getName(), property.getDefaultValue(), property.getCaption(),
+            property.getCategory(), property.getDescription(), property.getEditorType(),
+            property.getEditorArgs(), propertyEditor);
       }
     }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -409,7 +409,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // Add the special name property and set the tooltip
     String name = componentName();
     setTitle(name);
-    addProperty(PROPERTY_NAME_NAME, name, null, new TextPropertyEditor());
+    addProperty(PROPERTY_NAME_NAME, name, null, null, new TextPropertyEditor());
 
     // TODO(user): Ensure this value is unique within the project using a list of
     // already used UUIDs
@@ -417,7 +417,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // The default value here can be anything except 0, because YoungAndroidProjectService
     // creates forms with an initial Uuid of 0, and Properties.java doesn't encode
     // default values when it generates JSON for a component.
-    addProperty(PROPERTY_NAME_UUID, "-1", null, new TextPropertyEditor());
+    addProperty(PROPERTY_NAME_UUID, "-1", null, null, new TextPropertyEditor());
     changeProperty(PROPERTY_NAME_UUID, "" + Random.nextInt());
 
     editor.getComponentPalettePanel().configureComponent(this);
@@ -510,7 +510,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    * @param editor  property editor
    */
   public final void addProperty(String name, String defaultValue, String caption,
-      PropertyEditor editor) {
+      String description, PropertyEditor editor) {
 
     int type = EditableProperty.TYPE_NORMAL;
     if (!isPropertyPersisted(name)) {
@@ -522,7 +522,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     if (isPropertyforYail(name)) {
       type |= EditableProperty.TYPE_DOYAIL;
     }
-    properties.addProperty(name, defaultValue, caption, editor, type, "", null);
+    properties.addProperty(name, defaultValue, caption, description, editor, type, "", null);
   }
 
   /**
@@ -536,7 +536,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    * @param editor  property editor
    */
   public final void addProperty(String name, String defaultValue, String caption,
-      String editorType, String[] editorArgs, PropertyEditor editor) {
+      String description, String editorType, String[] editorArgs, PropertyEditor editor) {
 
     int type = EditableProperty.TYPE_NORMAL;
     if (!isPropertyPersisted(name)) {
@@ -548,7 +548,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     if (isPropertyforYail(name)) {
       type |= EditableProperty.TYPE_DOYAIL;
     }
-    properties.addProperty(name, defaultValue, caption, editor, type, editorType, editorArgs);
+    properties.addProperty(name, defaultValue, caption, description, editor, type, editorType, editorArgs);
   }
 
   /**
@@ -1224,7 +1224,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     for (PropertyDefinition property : newProperties) {
       if (toBeAdded.contains(property.getName())) {
         PropertyEditor propertyEditor = PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), (YaFormEditor) editor, property.getEditorArgs());
-        addProperty(property.getName(), property.getDefaultValue(), property.getCaption(), property.getEditorType(), property.getEditorArgs(), propertyEditor);
+        addProperty(property.getName(), property.getDefaultValue(), property.getCaption(), property.getDescription(), property.getEditorType(), property.getEditorArgs(), propertyEditor);
       }
     }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -713,11 +713,11 @@ public final class MockForm extends MockContainer {
   @Override
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + PORTRAIT_WIDTH, null,
-        "Specifies the width of the component on the screen.",
+        "Appearance", "Specifies the width of the component on the screen.",
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, null,
-        "Specifies the height of the component on the screen.",
+        "Appearance", "Specifies the height of the component on the screen.",
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -713,9 +713,11 @@ public final class MockForm extends MockContainer {
   @Override
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + PORTRAIT_WIDTH, null,
+        "Specifies the width of the component on the screen.",
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, null,
+        "Specifies the height of the component on the screen.",
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageSprite.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageSprite.java
@@ -36,10 +36,10 @@ public final class MockImageSprite extends MockImageBase implements MockSprite {
   protected void addWidthHeightProperties() {
     // Percent based size will scale images strangely, so remove percent based sizes
     addProperty(PROPERTY_NAME_WIDTH, "" + LENGTH_PREFERRED, MESSAGES.widthPropertyCaption(),
-        MESSAGES.ImageSprite__WidthPropertyDescriptions(),
+        "Appearance", MESSAGES.ImageSprite__WidthPropertyDescriptions(),
         new YoungAndroidLengthPropertyEditor(false));
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, MESSAGES.heightPropertyCaption(),
-        MESSAGES.ImageSprite__HeightPropertyDescriptions(),
+        "Appearance", MESSAGES.ImageSprite__HeightPropertyDescriptions(),
         new YoungAndroidLengthPropertyEditor(false));
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageSprite.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockImageSprite.java
@@ -36,8 +36,10 @@ public final class MockImageSprite extends MockImageBase implements MockSprite {
   protected void addWidthHeightProperties() {
     // Percent based size will scale images strangely, so remove percent based sizes
     addProperty(PROPERTY_NAME_WIDTH, "" + LENGTH_PREFERRED, MESSAGES.widthPropertyCaption(),
+        MESSAGES.ImageSprite__WidthPropertyDescriptions(),
         new YoungAndroidLengthPropertyEditor(false));
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, MESSAGES.heightPropertyCaption(),
+        MESSAGES.ImageSprite__HeightPropertyDescriptions(),
         new YoungAndroidLengthPropertyEditor(false));
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -8,6 +8,7 @@ package com.google.appinventor.client.editor.simple.components;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
 
+import com.google.appinventor.client.ComponentsTranslation;
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidLengthPropertyEditor;
 import com.google.appinventor.client.widgets.properties.TextPropertyEditor;
@@ -98,17 +99,19 @@ public abstract class MockVisibleComponent extends MockComponent {
     // Add standard per-child layout properties
     // NOTE: Not all layouts use these properties
     addProperty(PROPERTY_NAME_COLUMN, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        new TextPropertyEditor());
+        null, new TextPropertyEditor());
     addProperty(PROPERTY_NAME_ROW, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        new TextPropertyEditor());
+        null, new TextPropertyEditor());
     addWidthHeightProperties();
   }
 
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + LENGTH_PREFERRED, MESSAGES.widthPropertyCaption(),
+        ComponentsTranslation.getPropertyDescription(getType() + ".WidthPropertyDescriptions"),
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, MESSAGES.heightPropertyCaption(),
+        ComponentsTranslation.getPropertyDescription(getType() + ".HeightPropertyDescriptions"),
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -99,19 +99,19 @@ public abstract class MockVisibleComponent extends MockComponent {
     // Add standard per-child layout properties
     // NOTE: Not all layouts use these properties
     addProperty(PROPERTY_NAME_COLUMN, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        null, new TextPropertyEditor());
+        null, "Appearance", new TextPropertyEditor());
     addProperty(PROPERTY_NAME_ROW, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        null, new TextPropertyEditor());
+        null, "Appearance", new TextPropertyEditor());
     addWidthHeightProperties();
   }
 
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + LENGTH_PREFERRED, MESSAGES.widthPropertyCaption(),
-        ComponentsTranslation.getPropertyDescription(getType() + ".WidthPropertyDescriptions"),
+        "Appearance", ComponentsTranslation.getPropertyDescription(getType() + ".WidthPropertyDescriptions"),
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, MESSAGES.heightPropertyCaption(),
-        ComponentsTranslation.getPropertyDescription(getType() + ".HeightPropertyDescriptions"),
+        "Appearance", ComponentsTranslation.getPropertyDescription(getType() + ".HeightPropertyDescriptions"),
         PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
         new YoungAndroidLengthPropertyEditor());
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -132,7 +132,8 @@ public class PropertiesUtil {
     // Configure properties
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefinitions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
-          ComponentsTranslation.getPropertyName(property.getCaption()), property.getDescription(),
+          ComponentsTranslation.getPropertyName(property.getCaption()),
+          property.getCategory(), property.getDescription(),
           property.getEditorType(), property.getEditorArgs(),
           PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), editor, property.getEditorArgs()));
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -132,7 +132,7 @@ public class PropertiesUtil {
     // Configure properties
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefinitions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
-          ComponentsTranslation.getPropertyName(property.getCaption()),
+          ComponentsTranslation.getPropertyName(property.getCaption()), property.getDescription(),
           property.getEditorType(), property.getEditorArgs(),
           PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), editor, property.getEditorArgs()));
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
@@ -50,7 +50,12 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
 
       // Create content from help string.
       String helpTextKey = scd.getExternal() ? scd.getHelpString() : scd.getName();
-      HTML helpText = new HTML(ComponentsTranslation.getComponentHelpString(helpTextKey));
+      String translatedHelpText = ComponentsTranslation.getComponentHelpString(helpTextKey);
+      if (!scd.getExternal() && translatedHelpText.equals(scd.getName())
+          && !scd.getHelpString().isEmpty()) {
+        translatedHelpText = scd.getHelpString();
+      }
+      HTML helpText = new HTML(translatedHelpText);
       helpText.setStyleName("ode-ComponentHelpPopup-Body");
 
       // Create panel to hold the above three widgets and act as the

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -799,6 +799,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
             name,
             property.getDefaultValue(),
             property.getCaption(),
+            property.getCategory(),
             property.getDescription(),
             PropertiesUtil.createPropertyEditor(property.getEditorType(),
                 property.getDefaultValue(), this, property.getEditorArgs()),

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -799,6 +799,7 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
             name,
             property.getDefaultValue(),
             property.getCaption(),
+            property.getDescription(),
             PropertiesUtil.createPropertyEditor(property.getEditorType(),
                 property.getDefaultValue(), this, property.getEditorArgs()),
             property.getType(),

--- a/appinventor/appengine/src/com/google/appinventor/client/properties/Property.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/properties/Property.java
@@ -25,6 +25,9 @@ public class Property {
   // Current value of the property (initially the same as its default value)
   private String value;
 
+  // Category of the property
+  private final String category;
+
   /**
    * Creates a new property.
    *
@@ -32,10 +35,11 @@ public class Property {
    * @param defaultValue  property's default value (will also be its initial
    *                      current value)
    */
-  public Property(String name, String defaultValue) {
+  public Property(String name, String defaultValue, String category) {
     this.name = name;
     value = defaultValue;
     this.defaultValue = defaultValue;
+    this.category = category;
   }
 
   /**
@@ -72,6 +76,15 @@ public class Property {
    */
   public final String getDefaultValue() {
     return defaultValue;
+  }
+
+  /**
+   * Returns the property's category.
+   *
+   * @return
+   */
+  public final String getCategory() {
+    return category;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
@@ -45,13 +45,14 @@ public class EditableProperties extends Properties<EditableProperty> {
    * @param name  property name
    * @param defaultValue  default value of property
    * @param caption property caption for use in the ui
+   * @param description property description for use in the ui
    * @param editor  property editor
    * @param type  type of property; see {@code TYPE_*} constants in {@link EditableProperty}
    */
 
   public void addProperty(String name, String defaultValue, String caption,
-      PropertyEditor editor, int type, String editorType, String[] editorArgs) {
-    addProperty(new EditableProperty(this, name, defaultValue, caption, editor, type, editorType, editorArgs));
+      String description, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
+    addProperty(new EditableProperty(this, name, defaultValue, caption, description, editor, type, editorType, editorArgs));
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperties.java
@@ -51,8 +51,8 @@ public class EditableProperties extends Properties<EditableProperty> {
    */
 
   public void addProperty(String name, String defaultValue, String caption,
-      String description, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
-    addProperty(new EditableProperty(this, name, defaultValue, caption, description, editor, type, editorType, editorArgs));
+      String category, String description, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
+    addProperty(new EditableProperty(this, name, defaultValue, caption, category, description, editor, type, editorType, editorArgs));
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
@@ -63,6 +63,9 @@ public final class EditableProperty extends Property {
   // Additional arguments for the editor
   private final String[] editorArgs;
 
+  // Property description for use in properties panel help dialogs
+  private final String description;
+
   /**
    * Creates a new property.
    *
@@ -76,7 +79,7 @@ public final class EditableProperty extends Property {
    * @param type  type of property; see {@code TYPE_*} constants
    */
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
-      String caption, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
+      String caption, String description, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
     super(name, defaultValue);
 
     this.properties = properties;
@@ -85,13 +88,14 @@ public final class EditableProperty extends Property {
     this.caption = caption;
     this.editorType = editorType;
     this.editorArgs = editorArgs;
+    this.description = description;
 
     editor.setProperty(this);
   }
 
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
       int type) {
-    this(properties, name, defaultValue, name, new TextPropertyEditor(), type, "", null);
+    this(properties, name, defaultValue, name, null, new TextPropertyEditor(), type, "", null);
   }
 
   /**
@@ -106,7 +110,7 @@ public final class EditableProperty extends Property {
    */
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
       int type, String editorType, String[] editorArgs) {
-    this(properties, name, defaultValue, name, new TextPropertyEditor(), type, editorType, editorArgs);
+    this(properties, name, defaultValue, name, null, new TextPropertyEditor(), type, editorType, editorArgs);
   }
 
   /**
@@ -198,4 +202,7 @@ public final class EditableProperty extends Property {
     this.type = aType;
   }
 
+  public String getDescription() {
+    return description;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/EditableProperty.java
@@ -79,8 +79,9 @@ public final class EditableProperty extends Property {
    * @param type  type of property; see {@code TYPE_*} constants
    */
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
-      String caption, String description, PropertyEditor editor, int type, String editorType, String[] editorArgs) {
-    super(name, defaultValue);
+      String caption, String category, String description, PropertyEditor editor, int type,
+      String editorType, String[] editorArgs) {
+    super(name, defaultValue, category);
 
     this.properties = properties;
     this.type = type;
@@ -95,7 +96,8 @@ public final class EditableProperty extends Property {
 
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
       int type) {
-    this(properties, name, defaultValue, name, null, new TextPropertyEditor(), type, "", null);
+    this(properties, name, defaultValue, name, null, null,
+        new TextPropertyEditor(), type, "", null);
   }
 
   /**
@@ -109,8 +111,8 @@ public final class EditableProperty extends Property {
    * @param type  type of property; see {@code TYPE_*} constants
    */
   public EditableProperty(EditableProperties properties, String name, String defaultValue,
-      int type, String editorType, String[] editorArgs) {
-    this(properties, name, defaultValue, name, null, new TextPropertyEditor(), type, editorType, editorArgs);
+      String category, int type, String editorType, String[] editorArgs) {
+    this(properties, name, defaultValue, name, category, null, new TextPropertyEditor(), type, editorType, editorArgs);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
@@ -9,6 +9,7 @@ package com.google.appinventor.client.widgets.properties;
 import com.google.appinventor.client.editor.simple.components.MockComponent;
 import com.google.appinventor.client.explorer.project.ComponentDatabaseChangeListener;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 
@@ -45,15 +46,29 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
     initWidget(outerPanel);
   }
 
+  boolean hasValidDescription(EditableProperty p) {
+    return p.getDescription() != null &&
+        !p.getDescription().isEmpty() &&
+        !p.getDescription().equals(p.getName());
+  }
+
   /**
    * Adds a new property to be displayed in the UI.
    *
    * @param property  new property to be shown
    */
   void addProperty(EditableProperty property) {
+    HorizontalPanel header = new HorizontalPanel();
     Label label = new Label(property.getCaption());
     label.setStyleName("ode-PropertyLabel");
-    panel.add(label);
+    header.add(label);
+    header.setStyleName("ode-PropertyHeader");
+    if ( hasValidDescription(property) ) {
+      PropertyHelpWidget helpImage = new PropertyHelpWidget(property);
+      header.add(helpImage);
+      helpImage.setStylePrimaryName("ode-PropertyHelpWidget");
+    }
+    panel.add(header);
     PropertyEditor editor = property.getEditor();
     // Since UIObject#setStyleName(String) clears existing styles, only
     // style the editor if it hasn't already been styled during instantiation.
@@ -61,6 +76,7 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
       editor.setStyleName("ode-PropertyEditor");
     }
     panel.add(editor);
+    panel.setWidth("100%");
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
@@ -15,6 +15,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.StackPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +73,7 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
       propertyPanels.put( category, child );
       DisclosurePanel disclosure = new DisclosurePanel( category );
       disclosure.add( child );
-      disclosure.setOpen( true );
+      disclosure.setOpen( !"Advanced".equals(category) );
       disclosure.setWidth( "100%" );
       headers.put( category, disclosure );
     }
@@ -80,7 +81,24 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
   }
 
   private final void updateStackPanel() {
-    Set<String> categories = new TreeSet<String>( headers.keySet() );
+    // Sort the categories Alphabetically, except Advanced should always come last
+    Set<String> categories = new TreeSet<String>(new Comparator<String>() {
+      @Override
+      public int compare(String o1, String o2) {
+        if (o1.equals("Advanced")) {
+          if (o2.equals("Advanced")) {
+            return 0;
+          } else {
+            return 1;
+          }
+        } else if (o2.equals("Advanced")) {
+          return -1;
+        } else {
+          return o1.compareTo(o2);
+        }
+      }
+    });
+    categories.addAll(headers.keySet());
     for ( String category : categories ) {
       panel.add( headers.get( category ) );
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
@@ -1,0 +1,113 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2009-2011 Google, All Rights reserved
+// Copyright 2011-2012 MIT, All rights reserved
+// Released under the MIT License https://raw.github.com/mit-cml/app-inventor/master/mitlicense.txt
+
+package com.google.appinventor.client.widgets.properties;
+
+import com.google.appinventor.client.Images;
+import com.google.appinventor.client.Ode;
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.AbstractImagePrototype;
+import com.google.gwt.user.client.ui.ClickListener;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.PopupListener;
+import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Defines a widget that has the appearance of a question mark and
+ * creates a popup with information about a component when it is clicked on.
+ *
+ */
+public final class PropertyHelpWidget extends Image {
+  private static ImageResource imageResource = null;
+
+  // Keep track of the last time (in milliseconds) of the last closure
+  // so we don't reopen a popup too soon after closing it.  Specifically,
+  // if a user clicks on the question-mark icon to close a popup, we
+  // don't want the question-mark click to reopen it.
+  private long lastClosureTime = 0;
+
+  private class PropertyHelpPopup extends PopupPanel {
+
+    private PropertyHelpPopup(final EditableProperty prop,
+                               final Widget sender) {
+      // Create popup panel.
+      super(true);
+      setStyleName("ode-ComponentHelpPopup");
+      setTitle(prop.getName());
+
+      // Create title from component name.
+      Label titleBar = new Label(prop.getName());
+      setTitle(prop.getName());
+      titleBar.setStyleName("ode-ComponentHelpPopup-TitleBar");
+
+      // Create content from help string.
+      HTML helpText = new HTML(prop.getDescription());
+      helpText.setStyleName("ode-ComponentHelpPopup-Body");
+
+      // Create panel to hold the above three widgets and act as the
+      // popup's widget.
+      final VerticalPanel inner = new VerticalPanel();
+      inner.add(titleBar);
+      inner.add(helpText);
+      inner.setWidth("100%");
+      setWidget(inner);
+
+      // When the panel is closed, save the time in milliseconds.
+      // This will help us avoid immediately reopening it if the user
+      // closed it by clicking on the question-mark icon.
+      addPopupListener(new PopupListener() {
+          @Override
+          public void onPopupClosed(PopupPanel sender, boolean autoClosed) {
+            lastClosureTime = System.currentTimeMillis();
+          }
+        });
+
+//      setPopupPositionAndShow(new PopupPanel.PositionCallback() {
+//          @Override
+//          public void setPosition(int offsetWidth, int offsetHeight) {
+//            // Position the upper-left of the panel just to the right of the
+//            // question-mark icon, unless that would make it too low.
+//            final int X_OFFSET = 20;
+//            final int Y_OFFSET = -5;
+//            setPopupPosition(sender.getAbsoluteLeft() - X_OFFSET - inner.getOffsetWidth(),
+//                             Math.min(
+//                                 sender.getAbsoluteTop() + Y_OFFSET,
+//                                 Math.max(
+//                                     0,
+//                                     Window.getClientHeight() - offsetHeight
+//                                     + Y_OFFSET)));
+//          }
+//        });
+      showRelativeTo(PropertyHelpWidget.this);
+    }
+  }
+
+  public PropertyHelpWidget(final EditableProperty prop) {
+    if (imageResource == null) {
+      Images images = Ode.getImageBundle();
+      imageResource = images.help();
+    }
+    AbstractImagePrototype.create(imageResource).applyTo(this);
+    addClickListener(new ClickListener() {
+        @Override
+        public void onClick(Widget sender) {
+          final long MINIMUM_MS_BETWEEN_SHOWS = 250;  // .25 seconds
+
+          if (System.currentTimeMillis() - lastClosureTime >=
+              MINIMUM_MS_BETWEEN_SHOWS) {
+            new PropertyHelpPopup(prop, sender);
+          }
+        }
+      }
+      );
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
@@ -180,18 +180,20 @@ public interface ComponentDatabaseInterface {
     private final String editorType;
     private final String[] editorArgs;
     private final String description;
+    private final String category;
 
-    public PropertyDefinition(String name, String defaultValue, String editorType, String[] editorArgs, String description) {
-      this(name, defaultValue, name, editorType, editorArgs, null);
+    public PropertyDefinition(String name, String defaultValue, String editorType, String[] editorArgs, String category, String description) {
+      this(name, defaultValue, name, editorType, editorArgs, category, description);
     }
 
-    public PropertyDefinition(String name, String defaultValue, String caption, String editorType, String[] editorArgs, String description) {
+    public PropertyDefinition(String name, String defaultValue, String caption, String editorType, String[] editorArgs, String category, String description) {
       this.name = name;
       this.defaultValue = defaultValue;
       this.caption = caption;
       this.editorType = editorType;
       this.editorArgs = editorArgs;
       this.description = description;
+      this.category = category;
     }
 
     public String getName() {
@@ -216,6 +218,10 @@ public interface ComponentDatabaseInterface {
 
     public String getDescription() {
       return description;
+    }
+
+    public String getCategory() {
+      return category;
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/simple/ComponentDatabaseInterface.java
@@ -179,17 +179,19 @@ public interface ComponentDatabaseInterface {
     private final String caption;
     private final String editorType;
     private final String[] editorArgs;
+    private final String description;
 
-    public PropertyDefinition(String name, String defaultValue, String editorType, String[] editorArgs) {
-      this(name, defaultValue, name, editorType, editorArgs);
+    public PropertyDefinition(String name, String defaultValue, String editorType, String[] editorArgs, String description) {
+      this(name, defaultValue, name, editorType, editorArgs, null);
     }
 
-    public PropertyDefinition(String name, String defaultValue, String caption, String editorType, String[] editorArgs) {
+    public PropertyDefinition(String name, String defaultValue, String caption, String editorType, String[] editorArgs, String description) {
       this.name = name;
       this.defaultValue = defaultValue;
       this.caption = caption;
       this.editorType = editorType;
       this.editorArgs = editorArgs;
+      this.description = description;
     }
 
     public String getName() {
@@ -210,6 +212,10 @@ public interface ComponentDatabaseInterface {
 
     public String[] getEditorArgs() {
       return editorArgs;
+    }
+
+    public String getDescription() {
+      return description;
     }
   }
 

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -1808,6 +1808,14 @@ textarea::-webkit-input-placeholder {
   margin-left: 10px;
 }
 
+.ode-PropertiesPanel td img {
+  margin-top: 8px;
+}
+
+.ode-PropertyHeader img {
+  margin-top: 8px;
+}
+
 /* Gallery Toolbar*/
 .ya-GalleryToolbar {
   background-color: #8fc202;

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -836,9 +836,6 @@ body {
 
 .ode-PropertiesPanel {
   background-color: #f7f9f2;
-  padding-left: 9px;
-  padding-right: 9px;
-  padding-bottom: 9px;
 }
 
 .ode-PropertiesPanel td {
@@ -1814,6 +1811,48 @@ textarea::-webkit-input-placeholder {
 
 .ode-PropertyHeader img {
   margin-top: 8px;
+}
+
+.ode-PropertiesPanel .gwt-StackPanelContent {
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 10px;
+}
+
+.ode-PropertiesPanel .gwt-StackPanelItem div {
+  font-size: 12px;
+  padding: 2px 8px;
+  background-color: #D2E08B;
+  color: #555;
+  height: 16px;
+}
+
+.ode-PropertiesPanel .gwt-DisclosurePanel .content {
+  border: 0;
+  margin: 0;
+}
+
+.ode-PropertiesPanel .gwt-DisclosurePanel > tbody > tr > td {
+  height: 16px;
+  font-size: 12px;
+}
+
+.ode-PropertiesPanel .gwt-DisclosurePanel > tbody > tr > td > a {
+  background-color: #ceda91;
+}
+
+.ode-PropertiesPanel .gwt-DisclosurePanel-closed > tbody > tr+tr > td {
+  margin: 0;
+  padding: 0;
+  height: 0;
+}
+
+.gwt-DisclosurePanel > tbody > tr > td > a > table {
+  border-spacing: 0;
+}
+
+.gwt-DisclosurePanel > tbody > tr > td img {
+  margin-top: 3px;
 }
 
 /* Gallery Toolbar*/

--- a/appinventor/components/src/com/google/appinventor/components/annotations/PropertyCategory.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/PropertyCategory.java
@@ -1,23 +1,60 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2012 MIT, All rights reserved
+// Copyright 2011-2023 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.components.annotations;
 
 /**
- * Categories for Simple properties.  This is used only for documentation.
- *
+ * Categories for Simple properties. For properties marked with {@link DesignerProperty}, the
+ * category will also be used to group related properties together.
  */
 public enum PropertyCategory {
   // TODO(user): i18n category names
+  /**
+   * Category for properties that change component behavior, either in terms of the app developer
+   * or the app end user. For example, Button's Enabled property, even though it changes the
+   * appearance of the button, changes how the user interacts with the button, and therefore is a
+   * Behavior property.
+   */
   BEHAVIOR("Behavior"),
-  APPEARANCE("Appearance"),
-  DEPRECATED("Deprecated"),
-  UNSET("Unspecified");
 
-  private String name;
+  /**
+   * Category for properties that change component appearance. For example, the Notifier component's
+   * BackgroundColor property is an Appearance property since it changes how the view will appear
+   * to the user. While Appearance properties are more applicable to visible components, in some
+   * cases non-visible components (like the Notifier) may take Appearance categories
+   */
+  APPEARANCE("Appearance"),
+
+  /**
+   * Category for properties that are deprecated and may be removed in a future release.
+   */
+  DEPRECATED("Deprecated"),
+
+  /**
+   * The unspecified category. The ComponentProcessor will now throw an error if a property does
+   * not have another category specified.
+   */
+  UNSET("Unspecified"),
+
+  /**
+   * Category for properties that affect the application. Typically, application properties are
+   * Screen1 properties. An example would be the AppName property, which controls the name of the
+   * app displayed in the launcher and Settings app.
+   */
+  APPLICATION("Application"),
+
+  /**
+   * Category for advanced properties that won't need to be adjusted by most users. The Advanced
+   * category is collapsed by default in the properties panel. An example property would be the
+   * Token property of CloudDB, where App Inventor autopopulates the token and that should be
+   * sufficient for most users.
+   */
+  ADVANCED("Advanced");
+
+  private final String name;
 
   PropertyCategory(String categoryName) {
     name = categoryName;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/AccelerometerSensor.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AccelerometerSensor.java
@@ -473,7 +473,8 @@ public int getDeviceDefaultOrientation() {
     "you to update your project, you can also just set this property to “true” " +
     "and our compensation code will be deactivated. Note: We recommend that " +
     "you update your project as we may remove this property in a future " +
-    "release.")
+    "release.",
+    category = PropertyCategory.BEHAVIOR)
   public void LegacyMode(boolean legacyMode) {
     this.legacyMode = legacyMode;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Ball.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Ball.java
@@ -126,7 +126,8 @@ public final class Ball extends Sprite {
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = "5")
-  @SimpleProperty(description = "The distance from the edge of the Ball to its center.")
+  @SimpleProperty(description = "The distance from the edge of the Ball to its center.",
+      category = PropertyCategory.APPEARANCE)
   public void Radius(int radius) {
     int dr = radius - this.radius;
     // If the origin is at the center, the upper left corner moves to keep the center constant.
@@ -167,7 +168,7 @@ public final class Ball extends Sprite {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
       defaultValue = Component.DEFAULT_VALUE_COLOR_BLACK)
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void PaintColor(int argb) {
     paintColor = argb;
     if (argb != Component.COLOR_DEFAULT) {
@@ -189,7 +190,8 @@ public final class Ball extends Sprite {
       defaultValue = DEFAULT_ORIGIN_AT_CENTER ? "True" : "False")
   @SimpleProperty(userVisible = false,
       description = "Whether the x- and y-coordinates should represent the center of the Ball " +
-          "(true) or its left and top edges (false).")
+          "(true) or its left and top edges (false).",
+      category = PropertyCategory.BEHAVIOR)
   public void OriginAtCenter(boolean b) {
     super.OriginAtCenter(b);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
@@ -308,7 +308,9 @@ public class Chart extends AndroidViewComponent
       defaultValue = "100")
   @SimpleProperty(description = "Sets the Pie Radius of a Pie Chart from 0% to 100%, where the "
       + "percentage indicates the percentage of the hole fill. 100% means that a full Pie Chart "
-      + "is drawn, while values closer to 0% correspond to hollow Pie Charts.", userVisible = false)
+      + "is drawn, while values closer to 0% correspond to hollow Pie Charts.",
+      userVisible = false,
+      category = PropertyCategory.APPEARANCE)
   public void PieRadius(int percent) {
     this.pieRadius = percent;
 
@@ -325,7 +327,7 @@ public class Chart extends AndroidViewComponent
    *
    * @return True if legend is enabled, false otherwise
    */
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public boolean LegendEnabled() {
     return this.legendEnabled;
   }
@@ -349,7 +351,7 @@ public class Chart extends AndroidViewComponent
    *
    * @return True if grid is enabled, false otherwise
    */
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public boolean GridEnabled() {
     return this.gridEnabled;
   }
@@ -431,7 +433,7 @@ public class Chart extends AndroidViewComponent
    * @see #Labels(YailList)
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING)
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void LabelsFromString(String labels) {
     // Retrieve the elements from the CSV-formatted String
     YailList labelsList = ElementsUtil.elementsFromString(labels);
@@ -446,7 +448,7 @@ public class Chart extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void XFromZero(boolean zero) {
     this.zeroX = zero;
 
@@ -468,7 +470,7 @@ public class Chart extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void YFromZero(boolean zero) {
     this.zeroY = zero;
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ChartDataBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ChartDataBase.java
@@ -272,7 +272,7 @@ public abstract class ChartDataBase implements Component, DataSourceChangeListen
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_CHART_POINT_SHAPE,
       defaultValue = "0")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void PointShape(PointStyle shape) {
 
     // Only change the Point Shape if the Chart Data Model is a
@@ -293,7 +293,7 @@ public abstract class ChartDataBase implements Component, DataSourceChangeListen
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_CHART_LINE_TYPE,
       defaultValue = "0")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void LineType(LineType type) {
 
     // Only change the Line Type if the Chart Data Model is a

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ChatBot.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ChatBot.java
@@ -364,7 +364,7 @@ public final class ChatBot extends AndroidNonvisibleComponent {
       defaultValue = "")
   @SimpleProperty(description = "The MIT Access token to use. MIT App Inventor will automatically fill this " +
     "value in. You should not need to change it.",
-    userVisible = true)
+    userVisible = true, category = PropertyCategory.ADVANCED)
   public void Token(String token) {
     this.token = token;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
@@ -55,7 +55,8 @@ public class FeatureCollection extends MapFeatureContainerBase implements MapFea
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTAREA)
   @SimpleProperty(description = "Loads a collection of features from the given string. If the " +
       "string is not valid GeoJSON, the ErrorLoadingFeatureCollection error will be run with " +
-      "url = <string>.")
+      "url = <string>.",
+      category = PropertyCategory.APPEARANCE)
   public void FeaturesFromGeoJSON(String geojson) {
     try {
       processGeoJSON("<string>", geojson);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/File.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/File.java
@@ -16,6 +16,7 @@ import android.util.Log;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -122,7 +123,7 @@ public class File extends FileBase implements Component {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
   @UsesPermissions(READ_EXTERNAL_STORAGE)
   public void ReadPermission(boolean required) {
     // not used programmatically
@@ -151,7 +152,7 @@ public class File extends FileBase implements Component {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
   @UsesPermissions(WRITE_EXTERNAL_STORAGE)
   public void WritePermission(boolean required) {
     // not used programmatically

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FileBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FileBase.java
@@ -58,7 +58,7 @@ public abstract class FileBase extends AndroidNonvisibleComponent implements Com
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FILESCOPE,
       defaultValue = "App")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
   public void DefaultScope(FileScope scope) {
     this.scope = scope;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FirebaseDB.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FirebaseDB.java
@@ -381,7 +381,8 @@ public class FirebaseDB extends AndroidNonvisibleComponent implements Component 
     "screen, it makes all Firebase components on all screens persistent. " +
     "This is a limitation of the low level Firebase library. Also be " +
     "aware that if you want to set persist to true, you should do so " +
-    "before connecting the Companion for incremental development.")
+    "before connecting the Companion for incremental development.",
+    category = PropertyCategory.BEHAVIOR)
   public void Persist(boolean value) {
     Log.i(LOG_TAG, "Persist Called: Value = " + value);
     if (persist != value) {     // We are making a change

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1597,7 +1597,7 @@ public class Form extends AppInventorCompatActivity
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void ActionBar(boolean enabled) {
     if (SdkLevel.getLevel() < SdkLevel.LEVEL_HONEYCOMB) {
       // ActionBar is available on SDK 11 or higher
@@ -1851,7 +1851,7 @@ public class Form extends AppInventorCompatActivity
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPLICATION)
   public void Icon(String name) {
     // We don't actually need to do anything.
   }
@@ -1866,7 +1866,8 @@ public class Form extends AppInventorCompatActivity
     defaultValue = "1")
   @SimpleProperty(userVisible = false,
     description = "An integer value which must be incremented each time a new Android "
-    +  "Application Package File (APK) is created for the Google Play Store.")
+    +  "Application Package File (APK) is created for the Google Play Store.",
+    category = PropertyCategory.APPLICATION)
   public void VersionCode(int vCode) {
     // We don't actually need to do anything.
   }
@@ -1881,7 +1882,8 @@ public class Form extends AppInventorCompatActivity
     defaultValue = "1.0")
   @SimpleProperty(userVisible = false,
     description = "A string which can be changed to allow Google Play "
-    + "Store users to distinguish between different versions of the App.")
+    + "Store users to distinguish between different versions of the App.",
+    category = PropertyCategory.APPLICATION)
   public void VersionName(String vName) {
     // We don't actually need to do anything.
   }
@@ -1898,11 +1900,12 @@ public class Form extends AppInventorCompatActivity
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_SIZING,
       defaultValue = "Responsive", alwaysSend = true)
   @SimpleProperty(userVisible = false,
-  // This desc won't apprear as a tooltip, since there's no block, but we'll keep it with the source.
-  description = "If set to fixed,  screen layouts will be created for a single fixed-size screen and autoscaled. " +
-      "If set to responsive, screen layouts will use the actual resolution of the device.  " +
-      "See the documentation on responsive design in App Inventor for more information. " +
-      "This property appears on Screen1 only and controls the sizing for all screens in the app.")
+      // This desc won't apprear as a tooltip, since there's no block, but we'll keep it with the source.
+      description = "If set to fixed,  screen layouts will be created for a single fixed-size screen and autoscaled. " +
+          "If set to responsive, screen layouts will use the actual resolution of the device.  " +
+          "See the documentation on responsive design in App Inventor for more information. " +
+          "This property appears on Screen1 only and controls the sizing for all screens in the app.",
+      category = PropertyCategory.APPLICATION)
   public void Sizing(String value) {
     // This is used by the project and build server.
     // We also use it to adjust sizes
@@ -1978,8 +1981,9 @@ public class Form extends AppInventorCompatActivity
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
       defaultValue = "")
   @SimpleProperty(userVisible = false,
-  description = "This is the display name of the installed application in the phone." +
-      "If the AppName is blank, it will be set to the name of the project when the project is built.")
+      description = "This is the display name of the installed application in the phone." +
+          "If the AppName is blank, it will be set to the name of the project when the project is built.",
+      category = PropertyCategory.APPLICATION)
   public void AppName(String aName) {
     // We don't actually need to do anything.
   }
@@ -2052,7 +2056,8 @@ public class Form extends AppInventorCompatActivity
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_THEME,
       defaultValue = ComponentConstants.DEFAULT_THEME)
-  @SimpleProperty(userVisible = false, description = "Sets the theme used by the application.")
+  @SimpleProperty(userVisible = false, description = "Sets the theme used by the application.",
+      category = PropertyCategory.APPLICATION)
   public void Theme(String theme) {
     if (SdkLevel.getLevel() < SdkLevel.LEVEL_HONEYCOMB) {
       backgroundColor = Component.COLOR_WHITE;
@@ -2114,7 +2119,8 @@ public class Form extends AppInventorCompatActivity
     defaultValue = "")
   @SimpleProperty(userVisible = false,
     description = "A URL to use to populate the Tutorial Sidebar while "
-    + "editing a project. Used as a teaching aid.")
+    + "editing a project. Used as a teaching aid.",
+    category = PropertyCategory.APPLICATION)
   public void TutorialURL(String url) {
     // We don't actually do anything This property is stored in the
     // project properties file
@@ -2125,7 +2131,8 @@ public class Form extends AppInventorCompatActivity
   @SimpleProperty(userVisible = false,
     description = "A JSON string representing the subset for the screen. Authors of template apps "
       + "can use this to control what components, designer properties, and blocks are available "
-      + "in the project.")
+      + "in the project.",
+    category = PropertyCategory.APPLICATION)
   public void BlocksToolkit(String json) {
     // We don't actually do anything. This property is stored in the
     // project properties file

--- a/appinventor/components/src/com/google/appinventor/components/runtime/GameClient.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/GameClient.java
@@ -316,7 +316,7 @@ public class GameClient extends AndroidNonvisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
       defaultValue = "http://appinvgameserver.appspot.com")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
   public void ServiceURL(String url){
     if (url.endsWith("/")) {
       this.serviceUrl = url.substring(0, url.length() - 1);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
@@ -90,7 +90,8 @@ public final class Image extends AndroidViewComponent {
   }
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING, defaultValue = "")
-  @SimpleProperty(description = "A written description of what the image looks like.")
+  @SimpleProperty(description = "A written description of what the image looks like.",
+      category = PropertyCategory.APPEARANCE)
   public void AlternateText(String description){
     view.setContentDescription(description);
   }
@@ -208,7 +209,8 @@ public final class Image extends AndroidViewComponent {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
     defaultValue = "False")
   // @Deprecated -- We will deprecate this in a future release (jis: 2/12/2016)
-  @SimpleProperty(description = "Specifies whether the image should be resized to match the size of the ImageView.")
+  @SimpleProperty(description = "Specifies whether the image should be resized to match the size of the ImageView.",
+      category = PropertyCategory.APPEARANCE)
   public void ScalePictureToFit(boolean scale) {
     if (scale)
       view.setScaleType(ImageView.ScaleType.FIT_XY);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImageBot.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImageBot.java
@@ -90,7 +90,7 @@ public class ImageBot extends AndroidNonvisibleComponent {
       defaultValue = "")
   @SimpleProperty(description = "The MIT Access token to use. MIT App Inventor will automatically fill this " +
     "value in. You should not need to change it.",
-    userVisible = true)
+    userVisible = true, category = PropertyCategory.ADVANCED)
   public void Token(String token) {
     this.token = token;
   }
@@ -130,7 +130,7 @@ public class ImageBot extends AndroidNonvisibleComponent {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = "256")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Size(int size) {
     this.size = size;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
@@ -160,7 +160,7 @@ public class LineString extends MapFeatureBase implements MapLineString {
    * @param points String containing a sequence of points for the LineString.
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTAREA)
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void PointsFromString(String points) {
     final String functionName = "PointsFromString";
     try {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -557,7 +557,7 @@ public final class ListView extends AndroidViewComponent implements AdapterView.
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
           defaultValue = Component.DEFAULT_VALUE_COLOR_LTGRAY)
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void SelectionColor(int argb) {
     selectionColor = argb;
     setAdapterData();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -537,7 +537,7 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_MAP_UNIT_SYSTEM,
       defaultValue = "1")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void ScaleUnits(@Options(ScaleUnits.class) int units) {
     // Make sure units is a valid ScaleUnits.
     ScaleUnits scaleUnits = ScaleUnits.fromUnderlyingValue(units);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
@@ -207,7 +207,7 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
   @Override
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "False")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Draggable(boolean draggable) {
     this.draggable = draggable;
     map.getController().updateFeatureDraggable(this);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
@@ -231,7 +231,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_LATITUDE,
       defaultValue = "0")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Latitude(double latitude) {
     Log.d(TAG, "Latitude");
     if (latitude < -90 || latitude > 90) {
@@ -262,7 +262,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_LONGITUDE,
       defaultValue = "0")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Longitude(double longitude) {
     Log.d(TAG, "Longitude");
     if (longitude < -180 || longitude > 180) {
@@ -290,7 +290,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    * @param path a relative or absolute path, or a url, to an image asset to use for the marker.
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET)
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void ImageAsset(@Asset String path) {
     Log.d(TAG, "ImageAsset");
     this.imagePath = path;
@@ -320,7 +320,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   @Override
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT,
       defaultValue = "3")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void AnchorHorizontal(@Options(HorizontalAlignment.class) int horizontal) {
     // Make sure the horizontal alignment is a valid HorizontalAlignment.
     HorizontalAlignment alignment = HorizontalAlignment.fromUnderlyingValue(horizontal);
@@ -368,7 +368,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   @Override
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT,
       defaultValue = "3")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void AnchorVertical(@Options(VerticalAlignment.class) int vertical) {
     // Make sure the vertical alignment is a valid VerticalAlignment.
     VerticalAlignment alignment = VerticalAlignment.fromUnderlyingValue(vertical);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Navigation.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Navigation.java
@@ -130,7 +130,8 @@ public class Navigation extends AndroidNonvisibleComponent implements Component 
    * @param key the API key to use for authentication requests
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING)
-  @SimpleProperty(description = "API Key for Open Route Service.")
+  @SimpleProperty(description = "API Key for Open Route Service.",
+      category = PropertyCategory.BEHAVIOR)
   public void ApiKey(String key) {
     apiKey = key;
   }
@@ -285,7 +286,8 @@ public class Navigation extends AndroidNonvisibleComponent implements Component 
    *
    * @param language the language to use for generating directions
    */
-  @SimpleProperty(description = "The language to use for textual directions.")
+  @SimpleProperty(description = "The language to use for textual directions.",
+      category = PropertyCategory.BEHAVIOR)
   @DesignerProperty(defaultValue = "en")
   public void Language(String language) {
     this.language = language;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Notifier.java
@@ -473,7 +473,8 @@ public final class Notifier extends AndroidNonvisibleComponent implements Compon
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
       defaultValue = Component.DEFAULT_VALUE_COLOR_DKGRAY)
-  @SimpleProperty(description="Specifies the background color for alerts (not dialogs).")
+  @SimpleProperty(description="Specifies the background color for alerts (not dialogs).",
+      category = PropertyCategory.APPEARANCE)
   public void BackgroundColor(@IsColor int argb) {
     backgroundColor = argb;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Player.java
@@ -299,7 +299,8 @@ public final class Player extends AndroidNonvisibleComponent
       editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_FLOAT,
       defaultValue = "50")
   @SimpleProperty(
-      description = "Sets the volume to a number between 0 and 100")
+      description = "Sets the volume to a number between 0 and 100",
+      category = PropertyCategory.BEHAVIOR)
   public void Volume(int vol) {
     if (playerState == State.PREPARED || playerState == State.PLAYING || playerState == State.PAUSED_BY_USER) {
       if (vol > 100 || vol < 0) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
@@ -197,7 +197,8 @@ public class Polygon extends PolygonBase implements MapPolygon {
    */
   @SuppressWarnings("squid:S00100")
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTAREA)
-  @SimpleProperty(description = "Constructs a polygon from the given list of coordinates.")
+  @SimpleProperty(description = "Constructs a polygon from the given list of coordinates.",
+      category = PropertyCategory.APPEARANCE)
   public void PointsFromString(String pointString) {
     if (TextUtils.isEmpty(pointString)) {
       points = new ArrayList<List<GeoPoint>>();  // create a new list in case the user has saved a reference
@@ -285,7 +286,8 @@ public class Polygon extends PolygonBase implements MapPolygon {
    */
   @SuppressWarnings("squid:S00100")
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTAREA)
-  @SimpleProperty(description = "Constructs holes in a polygon from a given list of coordinates per hole.")
+  @SimpleProperty(description = "Constructs holes in a polygon from a given list of coordinates per hole.",
+      category = PropertyCategory.APPEARANCE)
   public void HolePointsFromString(String pointString) {
     if (TextUtils.isEmpty(pointString)) {
       holePoints = new ArrayList<List<List<GeoPoint>>>();  // create a new list in case the user has saved a reference

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SingleValueSensor.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SingleValueSensor.java
@@ -7,6 +7,7 @@
 package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.PropertyTypeConstants;
@@ -100,7 +101,7 @@ public abstract class SingleValueSensor extends AndroidNonvisibleComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "True")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Enabled(boolean enabled) {
     setEnabled(enabled);
   }
@@ -128,7 +129,7 @@ public abstract class SingleValueSensor extends AndroidNonvisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = DEFAULT_REFRESH_TIME + "")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void RefreshTime(int time) {
     refreshTime = time;
     if (enabled) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
@@ -29,6 +29,7 @@ import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -209,7 +210,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
 
   /* Getter and Setters for Properties */
 
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public String CredentialsJson() {
     return credentialsPath;
   }
@@ -221,7 +222,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
     this.credentialsPath = credentialsPath;
   }
 
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public String SpreadsheetID() {
     return spreadsheetID;
   }
@@ -247,8 +248,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
    * in {@link com.google.appinventor.client.editor.simple.components.MockSpreadsheet}
    * and consists of the current App Inventor project name.
    */
-  @SimpleProperty(
-    userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.BEHAVIOR)
   public String ApplicationName() {
     return applicationName;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sprite.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sprite.java
@@ -179,7 +179,7 @@ public abstract class Sprite extends VisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = DEFAULT_ENABLED ? "True" : "False")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Enabled(boolean enabled) {
     timerInternal.Enabled(enabled);
   }
@@ -206,7 +206,7 @@ public abstract class Sprite extends VisibleComponent
    * @suppressdoc
    * @param userHeading degrees above the positive x-axis
    */
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
       defaultValue = DEFAULT_HEADING + "")
@@ -245,7 +245,7 @@ public abstract class Sprite extends VisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = DEFAULT_INTERVAL + "")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.BEHAVIOR)
   public void Interval(int interval) {
     timerInternal.Interval(interval);
   }
@@ -258,7 +258,8 @@ public abstract class Sprite extends VisibleComponent
    * milliseconds
    */
   @SimpleProperty(
-      description = "The number of pixels that the %type% should move every interval, if enabled.")
+      description = "The number of pixels that the %type% should move every interval, if enabled.",
+      category = PropertyCategory.BEHAVIOR)
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
       defaultValue = DEFAULT_SPEED + "")
@@ -300,7 +301,7 @@ public abstract class Sprite extends VisibleComponent
   @DesignerProperty(
       editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = DEFAULT_VISIBLE ? "True" : "False")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void Visible(boolean visible) {
     this.visible = visible;
     registerChange();
@@ -361,7 +362,7 @@ public abstract class Sprite extends VisibleComponent
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
       defaultValue = "0.0")
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   public void Y(double y) {
     updateY(y);
     registerChange();
@@ -379,7 +380,7 @@ public abstract class Sprite extends VisibleComponent
    *        in front of ones with lower numbers; if values are equal for
    *        sprites, either can go in front of the other
    */
-  @SimpleProperty
+  @SimpleProperty(category = PropertyCategory.APPEARANCE)
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_FLOAT,
                     defaultValue = DEFAULT_Z + "")
   public void Z(double layer) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TableArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TableArrangement.java
@@ -8,6 +8,7 @@ package com.google.appinventor.components.runtime;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
@@ -19,6 +20,7 @@ import android.app.Activity;
 import android.view.View;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -90,7 +92,7 @@ public class TableArrangement extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = "2")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void Columns(int numColumns) {
     viewLayout.setNumColumns(numColumns);
   }
@@ -112,7 +114,7 @@ public class TableArrangement extends AndroidViewComponent
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_NON_NEGATIVE_INTEGER,
       defaultValue = "2")
-  @SimpleProperty(userVisible = false)
+  @SimpleProperty(userVisible = false, category = PropertyCategory.APPEARANCE)
   public void Rows(int numRows) {
     viewLayout.setNumRows(numRows);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Translator.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Translator.java
@@ -11,6 +11,7 @@ import android.util.Log;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -375,7 +376,7 @@ public final class Translator extends AndroidNonvisibleComponent {
       defaultValue = "")
   @SimpleProperty(description = "The API Key to use. MIT App Inventor will automatically fill this " +
     "value in. You should not need to change it.",
-    userVisible = true)
+      userVisible = true, category = PropertyCategory.ADVANCED)
   public void ApiKey(String apiKey) {
     this.apiKey = apiKey;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -288,7 +288,8 @@ public final class VideoPlayer extends AndroidViewComponent implements
   @SimpleProperty(
       description = "Sets the volume to a number between 0 and 100. " +
       "Values less than 0 will be treated as 0, and values greater than 100 " +
-      "will be treated as 100.")
+      "will be treated as 100.",
+      category = PropertyCategory.BEHAVIOR)
   public void Volume(int vol) {
     // clip volume to range [0, 100]
     vol = Math.max(vol, 0);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -480,7 +480,8 @@ public final class WebViewer extends AndroidViewComponent {
       defaultValue = "False")
   @SimpleProperty(userVisible = false,
       description = "Whether or not to give the application permission to use the Javascript geolocation API. " +
-          "This property is available only in the designer.")
+          "This property is available only in the designer.",
+      category = PropertyCategory.BEHAVIOR)
   public void UsesLocation(boolean uses) {
     // We don't actually do anything here (the work is in the MockWebViewer)
   }
@@ -509,7 +510,7 @@ public final class WebViewer extends AndroidViewComponent {
 
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
       defaultValue = "True")
-  @SimpleProperty(userVisible = true)
+  @SimpleProperty(userVisible = true, category = PropertyCategory.BEHAVIOR)
   public void PromptforPermission(boolean prompt) {
     this.prompt = prompt;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -130,7 +131,8 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
   @SimpleProperty(description = "Set the API Key to use with Yandex. " +
       "You do not need to set this if you are using the MIT system because " +
       "MIT has its own key builtin. If set, the key provided here will be " +
-      "used instead")
+      "used instead",
+      category = PropertyCategory.BEHAVIOR)
   public void ApiKey(String apiKey) {
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -7,6 +7,7 @@
 package com.google.appinventor.components.scripts;
 
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.PropertyCategory;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -172,7 +173,9 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       // Note: carrying this over from the old Java blocks editor. I'm not sure
       // that we'll actually do anything with invisible properties in the blocks
       // editor. (sharon@google.com)
-      json.put(outputBlockProperty(prop, alwaysSendProperties.contains(prop.name),
+      json.put(outputBlockProperty(prop, component.name,
+          component.designerProperties.get(prop.name),
+          alwaysSendProperties.contains(prop.name),
           defaultValues.get(prop.name)));
     }
     parent.put("blockProperties", json);
@@ -268,7 +271,12 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
    *                   needing to be sent
    * @param defaultValue The default value of the property (only required if alwaysSend is true).
    */
-  private JSONObject outputBlockProperty(Property prop, boolean alwaysSend, String defaultValue) {
+  private JSONObject outputBlockProperty(Property prop, String componentName,
+      DesignerProperty designProp, boolean alwaysSend, String defaultValue) {
+    if (prop.getCategory() == PropertyCategory.UNSET && designProp != null) {
+      messager.printMessage(Diagnostic.Kind.ERROR,
+          "Property " + componentName + "." + prop.name + " has no category.");
+    }
     JSONObject json = new JSONObject();
     json.put("name", prop.name);
     json.put("description", prop.getDescription());

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -276,6 +276,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     outputHelper(prop.getHelperKey(), json);
     json.put("rw", prop.isUserVisible() ? prop.getRwString() : "invisible");
     json.put("deprecated", Boolean.toString(prop.isDeprecated()));
+    json.put("category", prop.getCategory().getName());
     if (alwaysSend) {
       json.put("alwaysSend", true);
       json.put("defaultValue", defaultValue);

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -833,6 +833,10 @@ public abstract class ComponentProcessor extends AbstractProcessor {
         return WRITE_ONLY;
       }
     }
+
+    protected PropertyCategory getCategory() {
+      return propertyCategory;
+    }
   }
 
   /**


### PR DESCRIPTION
This PR brings property panel improvements that have been deployed both in Punya and the Alexa versions of App Inventor back to the open source version. It contains the following improvements:

1. A help icon next to property names that describe what the property does
2. Properties are grouped together based on the category specified in the `@SimpleProperty` annotation, with an `Advanced` category that sorts to the end and is collapsed by default
3. Support for handling untranslated strings in the help widget

Resolves #2399 
Resolves #2400 