### PR TITLE
Bugfix. Make sure extension temp file is in the APK bucket

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -2445,7 +2445,7 @@ public class ObjectifyStorageIo implements  StorageIo {
   @VisibleForTesting
   void setGcsFileContent(String gcsPath, byte[] content) throws IOException {
     GcsOutputChannel outputChannel = gcsService.createOrReplace(
-      new GcsFilename(getGcsBucketToUse(FileData.RoleEnum.SOURCE), gcsPath),
+      new GcsFilename(getGcsBucketToUse(FileData.RoleEnum.TARGET), gcsPath),
         GcsFileOptions.getDefaultInstance());
     outputChannel.write(ByteBuffer.wrap(content));
     outputChannel.close();


### PR DESCRIPTION
We were looking for it in the APK bucket, but we put it in the Source bucket. This change fixes that!

Change-Id: I89d68b5a5f6b369c9a57e433806d7fc563d6e9d0