### PR TITLE
Fix for the BlocksToolKit Bug Issue #2918

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -931,9 +931,10 @@ public final class MockForm extends MockContainer {
       editor.getProjectEditor().changeProjectSettingsProperty(
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET, asJson);
-      if (editor.isLoadComplete()) {
-        ((YaFormEditor)editor).reloadComponentPalette(asJson);
-      }
+    }
+    
+    if (editor.isLoadComplete()) {
+      ((YaFormEditor)editor).reloadComponentPalette(asJson);
     }
   }
 


### PR DESCRIPTION
Issue #2918 

<b>Reason:</b>
According to me after switching screen, reloadComponentPalette() function wasn't calling because it was inside the editor.isScreen1() check.