### PR TITLE
Corrected spelling error of the documentation of BluetoothClient: frue → true 

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -932,7 +932,7 @@ public final class MockForm extends MockContainer {
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET, asJson);
     }
-
+    
     if (editor.isLoadComplete()) {
       ((YaFormEditor)editor).reloadComponentPalette(asJson);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -931,10 +931,9 @@ public final class MockForm extends MockContainer {
       editor.getProjectEditor().changeProjectSettingsProperty(
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET, asJson);
-    }
-    
-    if (editor.isLoadComplete()) {
-      ((YaFormEditor)editor).reloadComponentPalette(asJson);
+      if (editor.isLoadComplete()) {
+        ((YaFormEditor)editor).reloadComponentPalette(asJson);
+      }
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -931,9 +931,10 @@ public final class MockForm extends MockContainer {
       editor.getProjectEditor().changeProjectSettingsProperty(
           SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
           SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET, asJson);
-      if (editor.isLoadComplete()) {
-        ((YaFormEditor)editor).reloadComponentPalette(asJson);
-      }
+    }
+
+    if (editor.isLoadComplete()) {
+      ((YaFormEditor)editor).reloadComponentPalette(asJson);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/BluetoothConnectionBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/BluetoothConnectionBase.java
@@ -194,7 +194,7 @@ public abstract class BluetoothConnectionBase extends AndroidNonvisibleComponent
   }
 
   /**
-   * Returns `frue`{:.logic.block} if a connection to a Bluetooth device has been made.
+   * Returns `true`{:.logic.block} if a connection to a Bluetooth device has been made.
    */
   @SimpleProperty(category = PropertyCategory.BEHAVIOR,
       description = "On devices with API level 14 (LEVEL_ICE_CREAM_SANDWICH) or higher, " +

--- a/appinventor/docs/html/reference/components/connectivity.html
+++ b/appinventor/docs/html/reference/components/connectivity.html
@@ -267,7 +267,7 @@ set the following properties:
   <dd>Specifies whether numbers are sent and received with the most significant
  byte first.</dd>
   <dt id="BluetoothClient.IsConnected" class="boolean ro bo"><em>IsConnected</em></dt>
-  <dd>Returns <code class="logic block highlighter-rouge">frue</code> if a connection to a Bluetooth device has been made.</dd>
+  <dd>Returns <code class="logic block highlighter-rouge">true</code> if a connection to a Bluetooth device has been made.</dd>
   <dt id="BluetoothClient.NoLocationNeeded" class="boolean do"><em>NoLocationNeeded</em></dt>
   <dd>On Android 12 and later, indicates that Bluetooth is not used to determine the user’s location.</dd>
   <dt id="BluetoothClient.PollingRate" class="number"><em>PollingRate</em></dt>
@@ -386,7 +386,7 @@ set the following properties:
   <dd>Returns true if this BluetoothServer component is accepting an
  incoming connection.</dd>
   <dt id="BluetoothServer.IsConnected" class="boolean ro bo"><em>IsConnected</em></dt>
-  <dd>Returns <code class="logic block highlighter-rouge">frue</code> if a connection to a Bluetooth device has been made.</dd>
+  <dd>Returns <code class="logic block highlighter-rouge">true</code> if a connection to a Bluetooth device has been made.</dd>
   <dt id="BluetoothServer.Secure" class="boolean"><em>Secure</em></dt>
   <dd>Specifies whether a secure connection should be used.</dd>
 </dl>

--- a/appinventor/docs/markdown/reference/components/connectivity.md
+++ b/appinventor/docs/markdown/reference/components/connectivity.md
@@ -154,7 +154,7 @@ Use `BluetoothClient` to connect your device to other devices using Bluetooth. T
  byte first.
 
 {:id="BluetoothClient.IsConnected" .boolean .ro .bo} *IsConnected*
-: Returns `frue`{:.logic.block} if a connection to a Bluetooth device has been made.
+: Returns `true`{:.logic.block} if a connection to a Bluetooth device has been made.
 
 {:id="BluetoothClient.NoLocationNeeded" .boolean .do} *NoLocationNeeded*
 : On Android 12 and later, indicates that Bluetooth is not used to determine the user's location.
@@ -297,7 +297,7 @@ Use the `BluetoothServer` component to turn your device into a server that recei
  incoming connection.
 
 {:id="BluetoothServer.IsConnected" .boolean .ro .bo} *IsConnected*
-: Returns `frue`{:.logic.block} if a connection to a Bluetooth device has been made.
+: Returns `true`{:.logic.block} if a connection to a Bluetooth device has been made.
 
 {:id="BluetoothServer.Secure" .boolean} *Secure*
 : Specifies whether a secure connection should be used.


### PR DESCRIPTION
Corrected issue [#2938](https://github.com/mit-cml/appinventor-sources/issues/2938) in this PR. Changes:

- Correct the typo from `frue` to `true` in two files.