### PR TITLE
Make AssetBox always visible

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -852,10 +852,6 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     sourceStructureExplorer.clearTree();
     SourceStructureBox.getSourceStructureBox().setVisible(false);
 
-    // Hide the assets box.
-    AssetListBox assetListBox = AssetListBox.getAssetListBox();
-    assetListBox.setVisible(false);
-
     Ode.getInstance().hideComponentDesigner();
   }
 


### PR DESCRIPTION
AssetBox appears on both Blocks and Designer views, but code in unloadDesigner.

This is now fixed.