### PR TITLE
Remove buggy build caching code

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -500,22 +500,6 @@ public final class YoungAndroidProjectService extends CommonProjectService {
 
     storageIo.storeNonce(nonce, userId, projectId);
     List<String> buildOutputFiles = storageIo.getProjectOutputFiles(userId, projectId);
-    if (storageIo.getProjectDateBuilt(userId, projectId) > storageIo.getProjectDateModified(userId, projectId)) {
-      boolean isAabOutput = false;
-      for (String buildOutputFile : buildOutputFiles) {
-        if (buildOutputFile.endsWith(".aab")) {
-          isAabOutput = true;
-          break;
-        }
-      }
-
-      if (isAabOutput && isAab || !isAabOutput && !isAab) {
-        LOG.info("Cache hit for project " + projectId);
-        return new RpcResult(-2, "Cache hit for project " + projectId, "");
-      }
-    }
-    LOG.info("Cache expired for project " + projectId);
-    storageIo.updateProjectBuiltDate(userId, projectId, 0);
 
     // Delete the existing build output files, if any, so that future attempts to get it won't get
     // old versions.
@@ -857,9 +841,6 @@ public final class YoungAndroidProjectService extends CommonProjectService {
                                       buildResultJsonObj.getString("output"),
                                       buildResultJsonObj.getString("error"),
                                       outputStr);
-          if (buildResultJsonObj.getInt("result") == 0) {
-            storageIo.updateProjectBuiltDate(userId, projectId, System.currentTimeMillis());
-          }
         } catch (JSONException e) {
           buildResult = new RpcResult(1, "", "");
         }

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/ObjectifyStorageIo.java
@@ -917,50 +917,6 @@ public class ObjectifyStorageIo implements  StorageIo {
   }
 
   @Override
-  public long getProjectDateBuilt(final String userId, final long projectId) {
-    final Result<Long> builtDate = new Result<Long>();
-    try {
-      runJobWithRetries(new JobRetryHelper() {
-        @Override
-        public void run(Objectify datastore) {
-          ProjectData pd = datastore.find(projectKey(projectId));
-          if (pd != null) {
-            builtDate.t = pd.dateBuilt;
-          } else {
-            builtDate.t = (long) 0;
-          }
-        }
-      }, false); // Transaction not needed, and we want the caching we get if we don't
-                 // use them.
-    } catch (ObjectifyException e) {
-      throw CrashReport.createAndLogError(LOG, null,
-          collectUserProjectErrorInfo(userId, projectId), e);
-    }
-    return builtDate.t;
-  }
-
-  @Override
-  public long updateProjectBuiltDate(final String userId, final long projectId, final long builtDate) {
-    try {
-      runJobWithRetries(new JobRetryHelper() {
-        @Override
-        public void run(Objectify datastore) {
-          ProjectData pd = datastore.find(projectKey(projectId));
-          if (pd != null) {
-            pd.dateBuilt = builtDate;
-            datastore.put(pd);
-          }
-        }
-      }, false); // Transaction not needed, and we want the caching we get if we don't
-                 // use them.
-    } catch (ObjectifyException e) {
-      throw CrashReport.createAndLogError(LOG, null,
-          collectUserProjectErrorInfo(userId, projectId), e);
-    }
-    return builtDate;
-  }
-
-  @Override
   public String getProjectHistory(final String userId, final long projectId) {
     final Result<String> projectHistory = new Result<String>();
     try {

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/StorageIo.java
@@ -230,25 +230,6 @@ public interface StorageIo {
   long getProjectDateModified(String userId, long projectId);
 
   /**
-   * Returns the date the project was last exported.
-   * @param userId a user Id (the request is made on behalf of this user)
-   * @param projectId  project id
-   *
-   * @return long milliseconds
-   */
-  long getProjectDateBuilt(String userId, long projectId);
-
-  /**
-   * Sets the date the project was last exported.
-   * @param userId a user Id (the request is made on behalf of this user)
-   * @param projectId  project id
-   * @long  builtDate the date to set
-   *
-   * @return long milliseconds
-   */
-  long updateProjectBuiltDate(String userId, long projectId, long builtDate);
-
-  /**
    * Returns the specially formatted list of project history.
    * @param userId a user Id (the request is made on behalf of this user)
    * @param projectId  project id


### PR DESCRIPTION
As part of the UI Binder update, code was added to cache builds. In particular this code would avoid calling the buildserver if the project had not been modified since the last build.

However, it turns out that we *always* update the project modification date when we do a build. So we do not really know whether or not the project was really modified. However the caching code would get triggered if you did two builds very close in time (within a few seconds) only because the updateProjectModDate() call in ObjectifyStorageIo.java would only do an update if the last modification was a while ago. This change was made years ago to cut down on the number of API calls we made every time a file was saved.

And... When the cache code was triggered, it didn't actually result in the dialog box with the download link and barcode.

This commit removes the caching code and the updateProjectBuildDate interface in StorageIo, as it is no longer needed.

Change-Id: I6acc567c8bc52076a5d43a47f3a481c2b402112b