### PR TITLE
Only send Strict Transport Security Header using https

### DIFF
--- a/appinventor/appengine/war/index.jsp
+++ b/appinventor/appengine/war/index.jsp
@@ -13,7 +13,9 @@
         }
      return;
    }
-   response.setHeader("Strict-Transport-Security", "max-age=3600");
+   if (AppInventorFeatures.enableHttpRedirect()) {
+       response.setHeader("Strict-Transport-Security", "max-age=3600");
+   }
 %>
 <!-- Copyright 2007-2009 Google Inc. All Rights Reserved. -->
 <!-- Copyright 2011-2020 Massachusetts Institute of Technology. All Rights Reserved. -->


### PR DESCRIPTION
If AppInventorFeatures.enableHttpRedirect() is false, don't send the Strict-Transport-Security header. Chrome appears to ignore it when it is sent over http instead of https, but I wouldn't want to depend on that behavior!

Change-Id: I585fc6164a57d7502b737c4596cbd42b84489dd2