### PR TITLE
Refactor build server to use factory pattern

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -10,6 +10,7 @@ import com.google.appinventor.buildserver.stats.SimpleStatReporter;
 import com.google.appinventor.buildserver.stats.StatCalculator;
 import com.google.appinventor.buildserver.stats.StatCalculator.Stats;
 import com.google.appinventor.buildserver.stats.StatReporter;
+import com.google.appinventor.buildserver.tasks.android.AndroidBuildFactory;
 import com.google.appinventor.common.version.GitBuildId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
@@ -822,6 +823,8 @@ public class BuildServer {
       });
 
     // Now that the command line options have been processed, we can create the buildExecutor.
+    AndroidBuildFactory.install();
+    // TODO(ewpatton): Enable iOS build factory here when published
     buildExecutor = new NonQueuingExecutor(commandLineOptions.maxSimultaneousBuilds);
 
     int port = commandLineOptions.port;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
@@ -16,14 +16,13 @@
 
 package com.google.appinventor.buildserver;
 
+import com.google.appinventor.buildserver.util.Execution;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,8 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Dex task, modified from the Android SDK to run in BuildServer.

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
@@ -7,6 +7,7 @@
 package com.google.appinventor.buildserver;
 
 import com.google.appinventor.buildserver.stats.NullStatReporter;
+import com.google.appinventor.buildserver.tasks.android.AndroidBuildFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,6 +95,9 @@ public final class Main {
       cmdLineParser.printUsage(System.err);
       System.exit(1);
     }
+
+    AndroidBuildFactory.install();
+    // TODO(ewpatton): Install iOS build factory once published
 
     ProjectBuilder projectBuilder = new ProjectBuilder(new NullStatReporter());
     ZipFile zip = null;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/context/AndroidCompilerContext.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/context/AndroidCompilerContext.java
@@ -1,0 +1,15 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.context;
+
+/**
+ * The AndroidCompilerContext provides a context for builds targeting Android.
+ */
+public class AndroidCompilerContext extends CompilerContext<AndroidPaths> {
+  public AndroidCompilerContext() {
+    super(new AndroidPaths());
+  }
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/context/AndroidPaths.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/context/AndroidPaths.java
@@ -1,0 +1,98 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2021-2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.context;
+
+import com.google.appinventor.buildserver.util.ExecutorUtils;
+import java.io.File;
+
+/**
+ * The AndroidPaths class extends the Paths class to include Android-specific
+ * file locations, such as where to place merged resources and the R class
+ * files needed by Android apps.
+ */
+public class AndroidPaths extends Paths {
+  private File drawableDir;
+  private File libsDir;
+  private File classesDir;
+  private File manifest;
+  private File mergedResDir;
+  private File tmpPackageName;
+
+  @Override
+  public void mkdirs(File buildDir) {
+    super.mkdirs(buildDir);
+    setDeployDir(ExecutorUtils.createDir(buildDir, "deploy"));
+    setResDir(ExecutorUtils.createDir(buildDir, "res"));
+    setDrawableDir(ExecutorUtils.createDir(buildDir, "drawable"));
+    setLibsDir(ExecutorUtils.createDir(buildDir, "libs"));
+    setClassesDir(ExecutorUtils.createDir(buildDir, "classes"));
+  }
+
+  public File getDrawableDir() {
+    return drawableDir;
+  }
+
+  public void setDrawableDir(File drawableDir) {
+    this.drawableDir = drawableDir;
+  }
+
+  public File getLibsDir() {
+    return libsDir;
+  }
+
+  public void setLibsDir(File libsDir) {
+    this.libsDir = libsDir;
+  }
+
+  public File getClassesDir() {
+    return classesDir;
+  }
+
+  public void setClassesDir(File classesDir) {
+    this.classesDir = classesDir;
+  }
+
+  public File getManifest() {
+    return manifest;
+  }
+
+  public void setManifest(File manifest) {
+    this.manifest = manifest;
+  }
+
+  public File getMergedResDir() {
+    return mergedResDir;
+  }
+
+  public void setMergedResDir(File mergedResDir) {
+    this.mergedResDir = mergedResDir;
+  }
+
+  public File getTmpPackageName() {
+    return tmpPackageName;
+  }
+
+  public void setTmpPackageName(File tmpPackageName) {
+    this.tmpPackageName = tmpPackageName;
+  }
+
+  @Override
+  public String toString() {
+    return "Paths{"
+        + "outputFileName='" + outputFileName + '\''
+        + ", buildDir=" + buildDir
+        + ", deployDir=" + deployDir
+        + ", resDir=" + resDir
+        + ", drawableDir=" + drawableDir
+        + ", tmpDir=" + tmpDir
+        + ", libsDir=" + libsDir
+        + ", assetsDir=" + assetsDir
+        + ", manifest=" + manifest
+        + ", mergedResDir=" + mergedResDir
+        + ", tmpPackageName=" + tmpPackageName
+        + '}';
+  }
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/context/Paths.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/context/Paths.java
@@ -5,27 +5,32 @@
 
 package com.google.appinventor.buildserver.context;
 
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import java.io.File;
 
 public class Paths {
-  private final String outputFileName;
+  protected String outputFileName;
 
-  private File buildDir;
-  private File deployDir;
+  protected File projectRootDir;
+  protected File buildDir;
+  protected File deployDir;
 
-  private File resDir;
-  private File drawableDir;
-  private File tmpDir;
-  private File libsDir;
-  private File assetsDir;
-  private File classesDir;
+  protected File resDir;
+  protected File tmpDir;
+  protected File assetsDir;
 
-  private File manifest;
+  protected Paths() {
+  }
 
-  private File mergedResDir;
-  private File tmpPackageName;
+  public void setProjectRootDir(File projectRootDir) {
+    this.projectRootDir = projectRootDir;
+  }
 
-  public Paths(String outputFileName) {
+  public File getProjectRootDir() {
+    return projectRootDir;
+  }
+
+  public void setOutputFileName(String outputFileName) {
     this.outputFileName = outputFileName;
   }
 
@@ -57,28 +62,12 @@ public class Paths {
     this.resDir = resDir;
   }
 
-  public File getDrawableDir() {
-    return drawableDir;
-  }
-
-  public void setDrawableDir(File drawableDir) {
-    this.drawableDir = drawableDir;
-  }
-
   public File getTmpDir() {
     return tmpDir;
   }
 
   public void setTmpDir(File tmpDir) {
     this.tmpDir = tmpDir;
-  }
-
-  public File getLibsDir() {
-    return libsDir;
-  }
-
-  public void setLibsDir(File libsDir) {
-    this.libsDir = libsDir;
   }
 
   public File getAssetsDir() {
@@ -89,36 +78,9 @@ public class Paths {
     this.assetsDir = assetsDir;
   }
 
-  public File getClassesDir() {
-    return classesDir;
-  }
-
-  public void setClassesDir(File classesDir) {
-    this.classesDir = classesDir;
-  }
-
-  public File getManifest() {
-    return manifest;
-  }
-
-  public void setManifest(File manifest) {
-    this.manifest = manifest;
-  }
-
-  public File getMergedResDir() {
-    return mergedResDir;
-  }
-
-  public void setMergedResDir(File mergedResDir) {
-    this.mergedResDir = mergedResDir;
-  }
-
-  public File getTmpPackageName() {
-    return tmpPackageName;
-  }
-
-  public void setTmpPackageName(File tmpPackageName) {
-    this.tmpPackageName = tmpPackageName;
+  public void mkdirs(File buildDir) {
+    setBuildDir(ExecutorUtils.createDir(buildDir));
+    setTmpDir(ExecutorUtils.createDir(buildDir, "tmp"));
   }
 
   @Override
@@ -128,13 +90,8 @@ public class Paths {
         + ", buildDir=" + buildDir
         + ", deployDir=" + deployDir
         + ", resDir=" + resDir
-        + ", drawableDir=" + drawableDir
         + ", tmpDir=" + tmpDir
-        + ", libsDir=" + libsDir
         + ", assetsDir=" + assetsDir
-        + ", manifest=" + manifest
-        + ", mergedResDir=" + mergedResDir
-        + ", tmpPackageName=" + tmpPackageName
         + '}';
   }
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/interfaces/AndroidTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/interfaces/AndroidTask.java
@@ -1,0 +1,15 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.interfaces;
+
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+
+/**
+ * The AndroidTask interface is a marker interface for Android-specific tasks
+ * that constrains the task context to AndroidCompilerContext.
+ */
+public interface AndroidTask extends Task<AndroidCompilerContext> {
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/interfaces/CommonTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/interfaces/CommonTask.java
@@ -1,18 +1,15 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2023 MIT, All rights reserved
+// Copyright 2023 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.buildserver.interfaces;
 
-import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.context.CompilerContext;
 
-public interface Task<C extends CompilerContext<?>> {
-  /**
-   * Main method to run the task.
-   *
-   * @return TaskResult
-   */
-  TaskResult execute(C context);
+/**
+ * The CommonTask interface is a marker interface for tasks common to all
+ * target platforms.
+ */
+public interface CommonTask extends Task<CompilerContext<?>> {
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AndroidBuildFactory.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AndroidBuildFactory.java
@@ -1,0 +1,93 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.tasks.android;
+
+import com.google.appinventor.buildserver.BuildType;
+import com.google.appinventor.buildserver.Compiler;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.context.AndroidPaths;
+import com.google.appinventor.buildserver.tasks.common.BuildFactory;
+
+/**
+ * The AndroidBuildFactory is responsible for setting up the sequence of tasks
+ * needed to compile an Android app from an App Inventor project. The factory
+ * supports creating both Android Packages (APKs) and Android App Bundles (AABs).
+ */
+public class AndroidBuildFactory extends BuildFactory<AndroidPaths, AndroidCompilerContext> {
+
+  private final boolean isAab;
+
+  public static void install() {
+    register(BuildType.APK_EXTENSION, new AndroidBuildFactory(false));
+    register(BuildType.AAB_EXTENSION, new AndroidBuildFactory(true));
+  }
+
+  protected AndroidBuildFactory(boolean isAab) {
+    super(isAab ? "aab" : "apk");
+    this.isAab = isAab;
+  }
+
+  @Override
+  protected void prepareAppIcon(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.prepareAppIcon(compiler);
+    compiler.add(PrepareAppIcon.class);
+  }
+
+  @Override
+  protected void prepareMetadata(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.prepareMetadata(compiler);
+    compiler.add(XmlConfig.class);
+    compiler.add(CreateManifest.class);
+  }
+
+  @Override
+  protected void attachLibraries(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.attachLibraries(compiler);
+    compiler.add(AttachNativeLibs.class);
+    compiler.add(AttachAarLibs.class);
+    compiler.add(AttachCompAssets.class);
+  }
+
+  @Override
+  protected void processAssets(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.processAssets(compiler);
+    compiler.add(MergeResources.class);
+    compiler.add(SetupLibs.class);
+    compiler.add(isAab ? RunAapt2.class : RunAapt.class);
+  }
+
+  @Override
+  protected void compileSources(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.compileSources(compiler);
+    compiler.add(GenerateClasses.class);
+    compiler.add(RunMultidex.class);
+  }
+
+  @Override
+  protected void createAppPackage(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.createAppPackage(compiler);
+    compiler.add(isAab ? RunBundletool.class : RunApkBuilder.class);
+  }
+
+  @Override
+  protected void signApp(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.signApp(compiler);
+    if (!isAab) {
+      compiler.add(RunZipAlign.class);
+      compiler.add(RunApkSigner.class);
+    }
+  }
+
+  @Override
+  protected void createOutputBundle(Compiler<AndroidPaths, AndroidCompilerContext> compiler) {
+    super.createOutputBundle(compiler);
+  }
+
+  @Override
+  public Class<AndroidCompilerContext> getContextClass() {
+    return AndroidCompilerContext.class;
+  }
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachAarLibs.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachAarLibs.java
@@ -3,18 +3,19 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
 import com.google.appinventor.buildserver.util.AARLibraries;
 import com.google.appinventor.buildserver.util.AARLibrary;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 
 import java.io.File;
 import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -26,9 +27,9 @@ import java.util.Set;
  */
 
 @BuildType(apk = true, aab = true)
-public class AttachAarLibs implements Task {
+public class AttachAarLibs implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     final File explodedBaseDir = ExecutorUtils.createDir(context.getPaths().getBuildDir(),
         "exploded-aars");
     final File generatedDir = ExecutorUtils.createDir(context.getPaths().getBuildDir(),

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachCompAssets.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachCompAssets.java
@@ -3,14 +3,15 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.YoungAndroidConstants;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
+
 import com.google.common.io.Files;
 
 import java.io.File;
@@ -22,9 +23,9 @@ import java.io.IOException;
  */
 
 @BuildType(apk = true, aab = true)
-public class AttachCompAssets implements Task {
+public class AttachCompAssets implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     try {
       // Gather non-library assets to be added to apk's Asset directory.
       // The assets directory have been created before this.

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachNativeLibs.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/AttachNativeLibs.java
@@ -3,7 +3,7 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import static com.google.appinventor.buildserver.YoungAndroidConstants.EXT_COMPS_DIR_NAME;
 import static com.google.appinventor.components.common.ComponentDescriptorConstants.ARM64_V8A_SUFFIX;
@@ -11,12 +11,13 @@ import static com.google.appinventor.components.common.ComponentDescriptorConsta
 import static com.google.appinventor.components.common.ComponentDescriptorConstants.X86_64_SUFFIX;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.YoungAndroidConstants;
-import com.google.appinventor.buildserver.context.Paths;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.context.AndroidPaths;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
+
 import com.google.common.io.Files;
 
 import java.io.File;
@@ -28,10 +29,10 @@ import java.io.IOException;
  */
 
 @BuildType(apk = true, aab = true)
-public class AttachNativeLibs implements Task {
+public class AttachNativeLibs implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
-    Paths paths = context.getPaths();
+  public TaskResult execute(AndroidCompilerContext context) {
+    AndroidPaths paths = context.getPaths();
     paths.setLibsDir(ExecutorUtils.createDir(paths.getBuildDir(),
         YoungAndroidConstants.LIBS_DIR_NAME));
     File armeabiDir = ExecutorUtils.createDir(paths.getLibsDir(),

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -3,16 +3,18 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
 import com.google.appinventor.buildserver.Project;
 import com.google.appinventor.buildserver.Signatures;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
 import com.google.appinventor.buildserver.util.PermissionConstraint;
+
 import com.google.appinventor.components.common.YaVersion;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -33,12 +35,12 @@ import java.util.Set;
  */
 // CreateManifest
 @BuildType(apk = true, aab = true)
-public class CreateManifest implements Task {
+public class CreateManifest implements AndroidTask {
   private static final String NEARFIELD_COMPONENT =
       "com.google.appinventor.components.runtime.NearField";
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     context.getPaths().setManifest(new File(context.getPaths().getBuildDir(),
         "AndroidManifest.xml"));
 
@@ -107,7 +109,7 @@ public class CreateManifest implements Task {
       }
 
       final Map<String, Set<String>> queriesNeeded = context.getComponentInfo().getQueriesNeeded();
-      if (queriesNeeded.size() > 0) {
+      if (!queriesNeeded.isEmpty()) {
         out.write("  <queries>\n");
         for (Map.Entry<String, Set<String>> componentSubElSetPair : queriesNeeded.entrySet()) {
           Set<String> subelementSet = componentSubElSetPair.getValue();
@@ -216,7 +218,7 @@ public class CreateManifest implements Task {
       // risk for App Inventor App end-users.
       out.write("android:debuggable=\"false\" ");
       // out.write("android:debuggable=\"true\" "); // DEBUGGING
-      if (appName.equals("")) {
+      if (appName.isEmpty()) {
         out.write("android:label=\"" + projectName + "\" ");
       } else {
         out.write("android:label=\"" + appName + "\" ");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/GenerateClasses.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/GenerateClasses.java
@@ -3,17 +3,19 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.Execution;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.Project;
 import com.google.appinventor.buildserver.Signatures;
 import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.YoungAndroidConstants;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.context.AndroidPaths;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.Execution;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
@@ -32,11 +34,11 @@ import java.util.Set;
  * Compiles screen source files written in YAIL to Java class files.
  */
 @BuildType(apk = true, aab = true)
-public class GenerateClasses implements Task {
-  CompilerContext context;
+public class GenerateClasses implements AndroidTask {
+  CompilerContext<AndroidPaths> context;
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     this.context = context;
 
     if (!this.compileRClasses()) {
@@ -205,7 +207,7 @@ public class GenerateClasses implements Task {
 
   @VisibleForTesting
   boolean compileRClasses() {
-    if (context.getComponentInfo().getExplodedAarLibs().size() == 0) {
+    if (context.getComponentInfo().getExplodedAarLibs().isEmpty()) {
       return true;  // nothing to see here
     }
     int error;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/MergeResources.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/MergeResources.java
@@ -3,16 +3,16 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.android.ide.common.internal.AaptCruncher;
 import com.android.ide.common.internal.PngCruncher;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 
 import java.io.File;
 
@@ -21,9 +21,9 @@ import java.io.File;
  * compiler.mergeResources()
  */
 @BuildType(apk = true, aab = true)
-public class MergeResources implements Task {
+public class MergeResources implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     // these should exist from earlier build steps
     File intermediates = ExecutorUtils.createDir(context.getPaths().getBuildDir(), "intermediates");
     File resDir = ExecutorUtils.createDir(intermediates, "res");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/PrepareAppIcon.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/PrepareAppIcon.java
@@ -3,13 +3,14 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
+
 import com.google.common.base.Strings;
 
 import java.awt.Graphics2D;
@@ -28,12 +29,12 @@ import javax.imageio.ImageIO;
  * compiler.prepareApplicationIcon()
  */
 @BuildType(apk = true, aab = true)
-public class PrepareAppIcon implements Task {
+public class PrepareAppIcon implements AndroidTask {
   private static final String ERROR_NO_SUITABLE_ICON =
       "Could not find a suitable app icon. Maybe it's not an image.";
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     // Create mipmap directories
     context.getReporter().info("Creating mipmap dirs...");
     File mipmapHdpi = ExecutorUtils.createDir(context.getPaths().getResDir(), "mipmap-hdpi");
@@ -60,7 +61,7 @@ public class PrepareAppIcon implements Task {
   /*
    * Loads the icon for the application, either a user provided one or the default one.
    */
-  private boolean prepareApplicationIcon(CompilerContext context, File outputPngFile,
+  private boolean prepareApplicationIcon(AndroidCompilerContext context, File outputPngFile,
       List<File> mipmapDirectories, List<Integer> standardSizes, List<Integer> foregroundSizes) {
     String userSpecifiedIcon = Strings.nullToEmpty(context.getProject().getIcon());
     try {

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt.java
@@ -3,16 +3,16 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.Execution;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.Signatures;
 import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.YoungAndroidConstants;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.Execution;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -23,9 +23,9 @@ import java.util.List;
  */
 // RunAapt
 @BuildType(apk = true)
-public class RunAapt implements Task {
+public class RunAapt implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     // Need to make sure assets directory exists otherwise aapt will fail.
     context.getPaths().setAssetsDir(
         ExecutorUtils.createDir(context.getProject().getBuildDirectory(),
@@ -56,7 +56,7 @@ public class RunAapt implements Task {
     aaptPackageCommandLineArgs.add(context.getResources().getAndroidRuntime());
     aaptPackageCommandLineArgs.add("-F");
     aaptPackageCommandLineArgs.add(context.getPaths().getTmpPackageName().getAbsolutePath());
-    if (context.getComponentInfo().getExplodedAarLibs().size() > 0) {
+    if (!context.getComponentInfo().getExplodedAarLibs().isEmpty()) {
       // If AARs are used, generate R.txt for later processing
       String packageName = Signatures.getPackageName(context.getProject().getMainClass());
       aaptPackageCommandLineArgs.add("-m");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
@@ -3,26 +3,28 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.Execution;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
 import com.google.appinventor.buildserver.YoungAndroidConstants;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.context.AndroidPaths;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.Execution;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 @BuildType(aab = true)
-public class RunAapt2 implements Task {
-  CompilerContext context;
+public class RunAapt2 implements AndroidTask {
+  CompilerContext<AndroidPaths> context;
   File resourcesZip;
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     this.context = context;
 
     final File buildDir = context.getPaths().getBuildDir();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkBuilder.java
@@ -3,23 +3,28 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.android.sdklib.build.ApkBuilder;
+
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
 
 import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * compiler.runApkBuilder
  */
 @BuildType(apk = true)
-public class RunApkBuilder implements Task {
+public class RunApkBuilder implements AndroidTask {
+  private static final Logger LOG = Logger.getLogger(RunApkBuilder.class.getName());
+
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     try {
       ApkBuilder apkBuilder = new ApkBuilder(
           context.getPaths().getDeployFile().getAbsolutePath(),
@@ -35,12 +40,13 @@ public class RunApkBuilder implements Task {
           }
         }
       }
-      if (context.getComponentInfo().getNativeLibsNeeded().size() != 0) {
+      if (!context.getComponentInfo().getNativeLibsNeeded().isEmpty()) {
         // Need to add native libraries...
         apkBuilder.addNativeLibraries(context.getPaths().getLibsDir());
       }
       apkBuilder.sealApk();
     } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Unable to run ApkBuilder", e);
       return TaskResult.generateError(e);
     }
     return TaskResult.generateSuccess();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
@@ -3,21 +3,21 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.Execution;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.Execution;
 
 /**
  * compiler.runApkSigner()
  */
 @BuildType(apk = true)
-public class RunApkSigner implements Task {
+public class RunApkSigner implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     int mx = context.getChildProcessRam() - 200;
     /*
       apksigner sign\

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunMultidex.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunMultidex.java
@@ -3,14 +3,14 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
 import com.google.appinventor.buildserver.DexExecTask;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
@@ -31,9 +31,9 @@ import java.util.zip.ZipInputStream;
  * compiler.runMultidex()
  */
 @BuildType(apk = true, aab = true)
-public class RunMultidex implements Task {
+public class RunMultidex implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     Set<String> mainDexClasses = new HashSet<>();
     List<File> inputList = new ArrayList<>();
     boolean success;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
@@ -3,24 +3,23 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.Execution;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
-
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
+import com.google.appinventor.buildserver.util.Execution;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import java.io.File;
 
 /**
  * compiler.runZipAlign()
  */
 @BuildType(apk = true)
-public class RunZipAlign implements Task {
+public class RunZipAlign implements AndroidTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     String zipAlignTool = context.getResources().zipalign();
     if (zipAlignTool == null) {
       return TaskResult.generateError("Could not find a suitable ZipAlign tool for this OS");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/SetupLibs.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/SetupLibs.java
@@ -3,13 +3,13 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
 import com.google.appinventor.buildserver.BuildType;
 import com.google.appinventor.buildserver.Compiler;
-import com.google.appinventor.buildserver.CompilerContext;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
 
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
@@ -21,12 +21,12 @@ import java.io.IOException;
  * Sets up any host system specific shared libraries.
  */
 @BuildType(apk = true, aab = true)
-public class SetupLibs implements Task {
+public class SetupLibs implements AndroidTask {
   public static final String RUNTIME_TOOLS_DIR =
       com.google.appinventor.buildserver.context.Resources.RUNTIME_TOOLS_DIR;
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     String osName = System.getProperty("os.name");
     if (osName.equals("Linux")) {
       ensureLib("/tmp/lib64", "libc++.so",

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/XmlConfig.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/XmlConfig.java
@@ -3,16 +3,16 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.android;
 
-import static com.google.appinventor.buildserver.ExecutorUtils.createDir;
 import static com.google.appinventor.buildserver.TaskResult.generateError;
+import static com.google.appinventor.buildserver.util.ExecutorUtils.createDir;
 
 import com.google.appinventor.buildserver.AnimationXmlConstants;
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.interfaces.AndroidTask;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -43,11 +43,11 @@ import java.util.Map;
 // createResXml
 // GenerateXmlRes
 @BuildType(apk = true, aab = true)
-public class XmlConfig implements Task {
-  CompilerContext context;
+public class XmlConfig implements AndroidTask {
+  AndroidCompilerContext context;
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(AndroidCompilerContext context) {
     this.context = context;
 
     // Create the "any" dpi dir

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/BuildFactory.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/BuildFactory.java
@@ -1,0 +1,91 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.tasks.common;
+
+import com.google.appinventor.buildserver.Compiler;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.context.Paths;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class BuildFactory<P extends Paths, T extends CompilerContext<P>> {
+  private static final Map<String, BuildFactory<?, ? extends CompilerContext<?>>> FACTORIES
+      = new HashMap<>();
+  private final String extension;
+
+  protected static void register(String extension, BuildFactory<?, ?> factory) {
+    FACTORIES.put(extension, factory);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <P extends Paths, T extends CompilerContext<P>> BuildFactory<P, T> get(
+      String extension) {
+    return (BuildFactory<P, T>) FACTORIES.get(extension);
+  }
+
+  protected BuildFactory(String extension) {
+    this.extension = extension;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  /**
+   * Creates a new Compiler that builds apps in accordance with this factory's target platform.
+   *
+   * @param context the context under which the compiler will run
+   * @return a new compiler
+   */
+  public final Compiler<P, T> makeCompiler(T context) {
+    Compiler<P, T> compiler = new Compiler.Builder<P, T>()
+        .withContext(context)
+        .withType(extension)
+        .build();
+    prepareBuild(compiler);
+    prepareAppIcon(compiler);
+    prepareMetadata(compiler);
+    attachLibraries(compiler);
+    processAssets(compiler);
+    compileSources(compiler);
+    createAppPackage(compiler);
+    signApp(compiler);
+    createOutputBundle(compiler);
+    return compiler;
+  }
+
+  protected void prepareBuild(Compiler<P, T> compiler) {
+    compiler.add(ReadBuildInfo.class);
+    compiler.add(LoadComponentInfo.class);
+  }
+
+  protected void prepareAppIcon(Compiler<P, T> compiler) {
+  }
+
+  protected void prepareMetadata(Compiler<P, T> compiler) {
+  }
+
+  protected void attachLibraries(Compiler<P, T> compiler) {
+  }
+
+  protected void processAssets(Compiler<P, T> compiler) {
+  }
+
+  protected void compileSources(Compiler<P, T> compiler) {
+  }
+
+  protected void createAppPackage(Compiler<P, T> compiler) {
+  }
+
+  protected void signApp(Compiler<P, T> compiler) {
+  }
+
+  protected void createOutputBundle(Compiler<P, T> compiler) {
+  }
+
+  public abstract Class<T> getContextClass();
+}

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
@@ -3,13 +3,13 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.common;
 
 import com.google.appinventor.buildserver.BuildType;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.interfaces.CommonTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import com.google.appinventor.buildserver.util.PermissionConstraint;
 import com.google.appinventor.components.common.ComponentDescriptorConstants;
 import com.google.common.collect.Lists;
@@ -40,8 +40,8 @@ import org.codehaus.jettison.json.JSONObject;
  * compiler.generateBroadcastReceiver();
  */
 @BuildType(apk = true, aab = true)
-public class LoadComponentInfo implements Task {
-  CompilerContext context = null;
+public class LoadComponentInfo implements CommonTask {
+  CompilerContext<?> context = null;
   private ConcurrentMap<String, Map<String, Map<String, Set<String>>>> conditionals;
   /**
    * Maps types to blocks to permissions to permission constraints.
@@ -50,7 +50,7 @@ public class LoadComponentInfo implements Task {
       conditionalPermissionConstraints = new ConcurrentHashMap<>();
 
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(CompilerContext<?> context) {
     this.context = context;
     this.conditionals = new ConcurrentHashMap<>();
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/ReadBuildInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/ReadBuildInfo.java
@@ -3,14 +3,15 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver.tasks;
+package com.google.appinventor.buildserver.tasks.common;
 
 import com.google.appinventor.buildserver.BuildType;
 import com.google.appinventor.buildserver.Compiler;
-import com.google.appinventor.buildserver.CompilerContext;
-import com.google.appinventor.buildserver.ExecutorUtils;
 import com.google.appinventor.buildserver.TaskResult;
-import com.google.appinventor.buildserver.interfaces.Task;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.context.Paths;
+import com.google.appinventor.buildserver.interfaces.CommonTask;
+import com.google.appinventor.buildserver.util.ExecutorUtils;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Sets;
 import java.io.BufferedReader;
@@ -31,9 +32,9 @@ import org.codehaus.jettison.json.JSONTokener;
  * ReadBuildInfo sets up an initial state for Android builds.
  */
 @BuildType(apk = true, aab = true)
-public class ReadBuildInfo implements Task {
+public class ReadBuildInfo implements CommonTask {
   @Override
-  public TaskResult execute(CompilerContext context) {
+  public TaskResult execute(CompilerContext<?> context) {
     final String runtimeDir = context.getResources().getRuntimeFilesDir();
     List<String> aars = new ArrayList<>();
     List<String> jars = new ArrayList<>();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
@@ -4,7 +4,7 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver;
+package com.google.appinventor.buildserver.util;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ExecutorUtils.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ExecutorUtils.java
@@ -3,8 +3,10 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.buildserver;
+package com.google.appinventor.buildserver.util;
 
+import com.google.appinventor.buildserver.Project;
+import com.google.appinventor.buildserver.YoungAndroidConstants;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
@@ -1,0 +1,101 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2009-2011 Google, All Rights reserved
+// Copyright 2011-2023 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.buildserver.util;
+
+import com.google.appinventor.buildserver.Project;
+import com.google.common.io.Files;
+import com.google.common.io.InputSupplier;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class ProjectUtils {
+  private static final Logger LOG = Logger.getLogger(ProjectUtils.class.getName());
+
+  private static final String SEPARATOR = File.separator;
+  public static final String PROJECT_DIRECTORY = "youngandroidproject";
+  public static final String PROJECT_PROPERTIES_FILE_NAME = PROJECT_DIRECTORY + SEPARATOR
+      + "project.properties";
+
+  private ProjectUtils() {
+  }
+
+  /**
+   * Creates a new directory beneath the system's temporary directory (as
+   * defined by the {@code java.io.tmpdir} system property), and returns its
+   * name. The name of the directory will contain the current time (in millis),
+   * and a random number.
+   *
+   * <p>This method assumes that the temporary volume is writable, has free
+   * inodes and free blocks, and that it will not be called thousands of times
+   * per second.
+   *
+   * @return the newly-created directory
+   * @throws IllegalStateException if the directory could not be created
+   */
+  public static File createNewTempDir() {
+    File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    String baseNamePrefix = System.currentTimeMillis() + "_" + Math.random() + "-";
+
+    final int TEMP_DIR_ATTEMPTS = 10000;
+    for (int counter = 0; counter < TEMP_DIR_ATTEMPTS; counter++) {
+      File tempDir = new File(baseDir, baseNamePrefix + counter);
+      if (tempDir.exists()) {
+        continue;
+      }
+      if (tempDir.mkdir()) {
+        return tempDir;
+      }
+    }
+    throw new IllegalStateException("Failed to create directory within "
+        + TEMP_DIR_ATTEMPTS + " attempts (tried "
+        + baseNamePrefix + "0 to " + baseNamePrefix + (TEMP_DIR_ATTEMPTS - 1) + ')');
+  }
+
+  /**
+   * Extracts the project represented by inputZip into the destination project root.
+   *
+   * @param inputZip the ZIP file containing an App Inventor project
+   * @param projectRoot the destination directory for the extracted project
+   * @return a list of files in the project
+   * @throws IOException if the project cannot be extracted
+   */
+  public static List<String> extractProjectFiles(ZipFile inputZip, File projectRoot)
+      throws IOException {
+    List<String> projectFileNames = new ArrayList<>();
+    Enumeration<? extends ZipEntry> inputZipEnumeration = inputZip.entries();
+    while (inputZipEnumeration.hasMoreElements()) {
+      ZipEntry zipEntry = inputZipEnumeration.nextElement();
+      final InputStream extractedInputStream = inputZip.getInputStream(zipEntry);
+      File extractedFile = new File(projectRoot, zipEntry.getName());
+      LOG.info("extracting " + extractedFile.getAbsolutePath() + " from input zip");
+      Files.createParentDirs(extractedFile); // Do I need this?
+      Files.copy(
+          new InputSupplier<InputStream>() {
+            public InputStream getInput() throws IOException {
+              return extractedInputStream;
+            }
+          },
+          extractedFile);
+      projectFileNames.add(extractedFile.getPath());
+    }
+    return projectFileNames;
+  }
+
+  /**
+   * Loads the project properties file of a Young Android project.
+   */
+  public static Project getProjectProperties(File projectRoot) {
+    return new Project(projectRoot.getAbsolutePath() + SEPARATOR + PROJECT_PROPERTIES_FILE_NAME);
+  }
+}

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/tasks/LoadComponentInfoTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/tasks/LoadComponentInfoTest.java
@@ -10,24 +10,44 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.appinventor.buildserver.CompilerContext;
+import com.google.appinventor.buildserver.Project;
 import com.google.appinventor.buildserver.Reporter;
+import com.google.appinventor.buildserver.context.AndroidCompilerContext;
+import com.google.appinventor.buildserver.context.CompilerContext;
+import com.google.appinventor.buildserver.tasks.common.LoadComponentInfo;
+import com.google.appinventor.buildserver.tasks.common.ReadBuildInfo;
+import com.google.appinventor.buildserver.util.ProjectUtils;
+import com.google.appinventor.common.testutils.TestUtils;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipFile;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * Tests the {@link LoadComponentInfo} class.
  */
 public class LoadComponentInfoTest {
+  private static final String HELLO_PURR_TEMPLATE =
+      TestUtils.windowsToUnix(TestUtils.APP_INVENTOR_ROOT_DIR)
+          + "/appengine/war/templates/HelloPurr/HelloPurr.zip";
   final ReadBuildInfo buildInfo = new ReadBuildInfo();
+  static Project project;
+  static File projectRoot;
+  CompilerContext.Builder<?, ?> builder;
 
-  @Test
-  public void testGeneratePermissions() {
-    CompilerContext.Builder builder = new CompilerContext.Builder(null, "apk")
+  @Before
+  public void setUp() {
+    builder = new CompilerContext.Builder<>(project, "apk")
+        .withClass(AndroidCompilerContext.class)
         .withBlocks(Collections.<String, Set<String>>emptyMap())
         .withCache(null)
         .withCompanion(false)
@@ -37,9 +57,25 @@ public class LoadComponentInfoTest {
         .withBlockPermissions(Collections.<String>emptySet())
         .withRam(2048)
         .withReporter(new Reporter(null))
+        .withKeystore("test.keystore")
         .withTypes(Collections.<String>emptySet());
+  }
 
-    CompilerContext context = builder.build();
+  @BeforeClass
+  public static void onlyOnce() throws IOException {
+    projectRoot = ProjectUtils.createNewTempDir();
+    ProjectUtils.extractProjectFiles(new ZipFile(HELLO_PURR_TEMPLATE), projectRoot);
+    project = ProjectUtils.getProjectProperties(projectRoot);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    FileUtils.deleteQuietly(new File(projectRoot.getCanonicalPath()));
+  }
+
+  @Test
+  public void testGeneratePermissions() {
+    CompilerContext<?> context = builder.build();
     LoadComponentInfo task = new LoadComponentInfo();
     buildInfo.execute(context);
     task.execute(context);
@@ -78,19 +114,9 @@ public class LoadComponentInfoTest {
     Set<String> componentTypes = Sets.newHashSet(texting);
     Map<String, Set<String>> blocks = Maps.newHashMap();
     blocks.put("Texting", Sets.newHashSet("ReceivingEnabled", "GoogleVoiceEnabled"));
-    CompilerContext.Builder builder = new CompilerContext.Builder(null, "apk")
-        .withBlocks(blocks)
-        .withCache(null)
-        .withCompanion(false)
-        .withDangerousPermissions(false)
-        .withEmulator(false)
-        .withFormOrientations(Collections.<String, String>emptyMap())
-        .withBlockPermissions(Collections.<String>emptySet())
-        .withRam(2048)
-        .withReporter(new Reporter(null))
-        .withTypes(componentTypes);
+    builder.withBlocks(blocks).withTypes(componentTypes);
 
-    CompilerContext context = builder.build();
+    CompilerContext<?> context = builder.build();
     buildInfo.execute(context);
     new LoadComponentInfo().execute(context);
 
@@ -136,19 +162,9 @@ public class LoadComponentInfoTest {
     Set<String> componentTypes = Sets.newHashSet(barcodeScanner);
     Map<String, Set<String>> blocks = Maps.newHashMap();
 
-    CompilerContext.Builder builder = new CompilerContext.Builder(null, "apk")
-        .withBlocks(blocks)
-        .withCache(null)
-        .withCompanion(false)
-        .withDangerousPermissions(false)
-        .withEmulator(false)
-        .withFormOrientations(Collections.<String, String>emptyMap())
-        .withBlockPermissions(Collections.<String>emptySet())
-        .withRam(2048)
-        .withReporter(new Reporter(null))
-        .withTypes(componentTypes);
+    builder.withBlocks(blocks).withTypes(componentTypes);
 
-    CompilerContext context = builder.build();
+    CompilerContext<?> context = builder.build();
 
     buildInfo.execute(context);
     new LoadComponentInfo().execute(context);


### PR DESCRIPTION
This PR is the second in a three PR sequence to add iOS build support to the App Inventor buildserver (the first was #2296). It reorganizes tasks as either common tasks or Android-specific tasks and introduces a BuildFactory object that is responsible for constructing the task sequence needed to build for a particular target (APK or AAB, for now, via AndroidBuildFactory). The final PR will add iOS specific tasks and an iOS build factory to complement the Android functionality.

Change-Id: Ia3db51886b97fb757b88a041f370e427a5d6e050