### PR TITLE
Make java_dev_appserver.sh command single-line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,7 @@ There are two servers in App Inventor, the main server that deals with project i
 
 ### Running the main server
 
-    $ your-google-cloud-SDK-folder/bin/java_dev_appserver.sh
-            --port=8888 --address=0.0.0.0 appengine/build/war/
+    $ your-google-cloud-SDK-folder/bin/java_dev_appserver.sh --port=8888 --address=0.0.0.0 appengine/build/war/
 
 Make sure you change *your-google-cloud-SDK-folder* to wherever in your hard drive you have placed the Google Cloud SDK.
 


### PR DESCRIPTION
Currently the README.md file shows the java_dev_appserver.sh file on two different lines. On Windows this will not work as if we directly copy-and-paste it into our terminal, we will find this error message.

```
At line:1 char:15
+             --port=8888 --address=0.0.0.0 appengine/build/war/
+               ~
Missing expression after unary operator '--'.
At line:1 char:15
+             --port=8888 --address=0.0.0.0 appengine/build/war/
+               ~~~~~~~~~
Unexpected token 'port=8888' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterOperator
```

This small PR hopefully fixes the issue and makes it a little bit more clear on how to run the appserver.