### PR TITLE
Filter out deprecated methods, events and properties for typeblocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -542,33 +542,37 @@ Blockly.Blocks.component_event = {
 
     componentDb.forEachInstance(function(instance) {
       types[instance.typeName] = true;
-      componentDb.forEventInType(instance.typeName, function(_, eventName) {
-        tb.push({
-          translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_TITLE_WHEN + instance.name + '.' +
-            componentDb.getInternationalizedEventName(eventName),
-          mutatorAttributes: {
-            component_type: instance.typeName,
-            instance_name: instance.name,
-            event_name: eventName
-          }
-        });
+      componentDb.forEventInType(instance.typeName, function(eventDesc, eventName) {
+        if (!eventDesc.deprecated) {
+          tb.push({
+            translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_TITLE_WHEN + instance.name + '.' +
+                componentDb.getInternationalizedEventName(eventName),
+            mutatorAttributes: {
+              component_type: instance.typeName,
+              instance_name: instance.name,
+              event_name: eventName
+            }
+          });
+        }
       });
     });
 
     delete types['Form'];
 
     Object.keys(types).forEach(function(typeName) {
-      componentDb.forEventInType(typeName, function(_, eventName) {
-        tb.push({
-          translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_EVENT_TITLE +
-            componentDb.getInternationalizedComponentType(typeName) +  '.' +
-            componentDb.getInternationalizedEventName(eventName),
-          mutatorAttributes: {
-            component_type: typeName,
-            is_generic: true,
-            event_name: eventName
-          }
-        });
+      componentDb.forEventInType(typeName, function(eventDesc, eventName) {
+        if (!eventDesc.deprecated) {
+          tb.push({
+            translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_EVENT_TITLE +
+                componentDb.getInternationalizedComponentType(typeName) +  '.' +
+                componentDb.getInternationalizedEventName(eventName),
+            mutatorAttributes: {
+              component_type: typeName,
+              is_generic: true,
+              event_name: eventName
+            }
+          });
+        }
       });
     });
 
@@ -946,34 +950,38 @@ Blockly.Blocks.component_method = {
     var typeNameDict = {};
     componentDb.forEachInstance(function(instance) {
       typeNameDict[instance.typeName] = true;
-      componentDb.forMethodInType(instance.typeName, function(_, methodName) {
-        tb.push({
-          translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_METHOD_TITLE_CALL + instance.name +
-          '.' + componentDb.getInternationalizedMethodName(methodName),
-          mutatorAttributes: {
-            component_type: instance.typeName,
-            instance_name: instance.name,
-            method_name: methodName,
-            is_generic: 'false'
-          }
-        });
+      componentDb.forMethodInType(instance.typeName, function(methodDef, methodName) {
+        if (!methodDef.deprecated) {
+          tb.push({
+            translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_METHOD_TITLE_CALL + instance.name +
+                '.' + componentDb.getInternationalizedMethodName(methodName),
+            mutatorAttributes: {
+              component_type: instance.typeName,
+              instance_name: instance.name,
+              method_name: methodName,
+              is_generic: 'false'
+            }
+          });
+        }
       });
     });
 
     delete typeNameDict['Form'];
 
     Object.keys(typeNameDict).forEach(function (typeName) {
-      componentDb.forMethodInType(typeName, function (_, methodName) {
-        tb.push({
-          translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_METHOD_TITLE_CALL +
-              componentDb.getInternationalizedComponentType(typeName) + '.' +
-              componentDb.getInternationalizedMethodName(methodName),
-          mutatorAttributes: {
-            component_type: typeName,
-            method_name: methodName,
-            is_generic: 'true'
-          }
-        });
+      componentDb.forMethodInType(typeName, function (methodDef, methodName) {
+        if (!methodDef.deprecated) {
+          tb.push({
+            translatedName: Blockly.Msg.LANG_COMPONENT_BLOCK_GENERIC_METHOD_TITLE_CALL +
+                componentDb.getInternationalizedComponentType(typeName) + '.' +
+                componentDb.getInternationalizedMethodName(methodName),
+            mutatorAttributes: {
+              component_type: typeName,
+              method_name: methodName,
+              is_generic: 'true'
+            }
+          });
+        }
       });
     });
 
@@ -1364,22 +1372,39 @@ Blockly.Blocks.component_set_get = {
     }
 
     componentDb.forEachInstance(function(component) {
+
+      // Filter out all deprecated properties for both get and set
+      var deprecatedProperties = []
+      goog.object.forEach(componentDb.types_[component.typeName].properties, function (prop) {
+        if (prop.deprecated) {
+          deprecatedProperties.push(prop.name);
+        }
+      });
+
       var setters = componentDb.getSetterNamesForType(component.typeName),
           getters = componentDb.getGetterNamesForType(component.typeName),
           k;
-      for(k=0;k<setters.length;k++) {
-        pushBlock(Blockly.Msg.LANG_COMPONENT_BLOCK_SETTER_TITLE_SET, 'set', setters[k],
+
+      var filteredSetters = goog.array.filter(setters, function (item) {
+        return !goog.array.contains(deprecatedProperties, item);
+      });
+      var filteredGetters = goog.array.filter(getters, function (item) {
+        return !goog.array.contains(deprecatedProperties, item);
+      });
+
+      for(k=0; k<filteredSetters.length; k++) {
+        pushBlock(Blockly.Msg.LANG_COMPONENT_BLOCK_SETTER_TITLE_SET, 'set', filteredSetters[k],
           component.typeName, component.name, false);
       }
-      for(k=0;k<getters.length;k++) {
-        pushBlock('', 'get', getters[k], component.typeName, component.name, false);
+      for(k=0; k<filteredGetters.length; k++) {
+        pushBlock('', 'get', filteredGetters[k], component.typeName, component.name, false);
       }
-      for(k=0;k<setters.length;k++) {
-        pushGenericBlock(Blockly.Msg.LANG_COMPONENT_BLOCK_SETTER_TITLE_SET, 'set', setters[k],
+      for(k=0; k<filteredSetters.length; k++) {
+        pushGenericBlock(Blockly.Msg.LANG_COMPONENT_BLOCK_SETTER_TITLE_SET, 'set', filteredSetters[k],
           component.typeName);
       }
-      for(k=0;k<getters.length;k++) {
-        pushGenericBlock('', 'get', getters[k], component.typeName);
+      for(k=0; k<filteredGetters.length; k++) {
+        pushGenericBlock('', 'get', filteredGetters[k], component.typeName);
       }
     });
 


### PR DESCRIPTION
A potential fix for [#2967](https://github.com/mit-cml/appinventor-sources/issues/2967).

I thought of making the changes in component_database.js directly, for instance `forMethodInType` or `forEventInType` but because deprecations are only being hidden and not removed, I was afraid others might use those methods in a different scenario and filter out deprecated blocks that are still needed for legacy apps.
Changes would be cleaner, and especially the changes for getters and setters are rather convoluted, so happy to hear suggestions.