### PR TITLE
Download phantomJS during build on github action

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -16,6 +16,14 @@ jobs:
         run: git submodule update --init --recursive
       - name: 'Install 32-bit dependencies'
         run: sudo apt-get install -y libc6-i386 lib32z1 lib32stdc++6
+      - name: 'Download phantomJS'
+        run: |
+          mkdir /tmp/phantomJS
+          wget -P /tmp/phantomJS/ https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+      - name: 'Untar and add to PATH'
+        run: |
+          tar -xf /tmp/phantomJS/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /tmp/phantomJS/
+          echo "/tmp/phantomJS/phantomjs-2.1.1-linux-x86_64/bin" >> $GITHUB_PATH
       - name: 'Make Auth Key'
         run: ant MakeAuthKey
         working-directory: appinventor


### PR DESCRIPTION
Build fails when running tests because phantomJS is not available.

Initial failures and current passing build can be seen in my [Actions dashboard](https://github.com/josmas/app-inventor/actions).