### PR TITLE
Make the definition of DEFAULT_THEME match project.properties

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -85,7 +85,7 @@ public class ComponentConstants {
   /**
    * Themeing
    */
-  public static final String DEFAULT_THEME = "Classic";
+  public static final String DEFAULT_THEME = "AppTheme.Light.DarkActionBar";
   public static final String DEFAULT_PRIMARY_COLOR = "&HFF3F51B5";
   public static final String DEFAULT_PRIMARY_DARK_COLOR = "&HFF303F9F";
   public static final String DEFAULT_ACCENT_COLOR = "&HFFFF4081";


### PR DESCRIPTION
Make the value of DEFAULT_THEME in ComponentConstants.java match the value in project.properties. This resolves an issue where Dark Mode on Samsung devices did not display properly on the device when using the Companion App.

Change-Id: I585d2916167e3354098036ff9b31fd79480c0314