### PR TITLE
Update README to add git submodule instructions for vagrant workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ It may take a few minutes for Vagrant to initialize as it will pull down a virtu
 vagrant ssh
 ```
 
-This should open up a terminal within the virtual machine in the directory `/vagrant/appinventor`. This directory is the same as the `appinventor` directory in this repository, shared between your host machine and the virtual machine. Any changes made on one side will be visible in the other. This allows you to edit files on your host machine with your preferred editor, while keeping the build environment relegated to the virtual machine. To build App Inventor, you may now run:
+This should open up a terminal within the virtual machine in the directory `/vagrant/appinventor`. This directory is the same as the `appinventor` directory in this repository, shared between your host machine and the virtual machine. Any changes made on one side will be visible in the other. This allows you to edit files on your host machine with your preferred editor, while keeping the build environment relegated to the virtual machine. 
+
+Before you can build App Inventor, you will need to also obtain the dependencies as described [below](#checkout-dependencies) using `git submodule` command:
+
+```bash
+git submodule update --init
+```
+
+Now, you are ready to build App Inventor, you may now run:
 
 ```bash
 ant


### PR DESCRIPTION
The vagrant workflow was missing the instructions for pulling in dependencies before running `ant` which was resulting in a build error understandably:

```CheckBlocklyCompile:

BlocklyCompile:
     [java] Exception in thread "main" java.lang.IllegalArgumentException: File not found at: /vagrant/appinventor/blocklyeditor/../lib/closure-library/closure/goog
```