### PR TITLE
Fix crashes reported by Google

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FroyoUtil.java
@@ -16,6 +16,8 @@ import com.google.appinventor.components.runtime.Component;
 import com.google.appinventor.components.runtime.Form;
 import com.google.appinventor.components.runtime.Player;
 
+import java.io.IOException;
+
 /**
  * Helper methods for calling methods added in Froyo (2.2, API level 8).
  *
@@ -123,6 +125,18 @@ public class FroyoUtil {
   public static WebViewClient getWebViewClient(final boolean ignoreErrors,
       final boolean followLinks, final Form form, final Component component) {
     return new FroyoWebViewClient(followLinks, ignoreErrors, form, component);
+  }
+
+  /**
+   * Prior to SDK 9, java.io.IOException did not take a throwable as an argument.
+   * This function accepts a Throwable, calls toString and throws an IOException with
+   * just the string, which is supported.
+   *
+   * @param throwable the Throwable to re-throw (sort of)
+   */
+
+  public static void throwIOException(Throwable e) throws IOException {
+    throw new IOException(e.toString());
   }
 
 }


### PR DESCRIPTION
Google reports out crash statistics in the Play Store console. If we have too many crashes, Google threatens to negatively impact our store listing. This change addresses the top two crashes we are seeing in the console.

1. ConcurrentModificationException in the EventDispatcher.

   I was unable to reproduce this behavior. This fix just synchronizes access to the HashMap, which will hopefully address this problem. Given that the HashMap is only modified when components are added and removed, which is not an inner-loop operation, this should be fine.

2. Crash out of MediaUtil.

   I was able to reproduce this one by attempting to set an image to the string "\/\/" which results in an IllegalArgumentException out of URI.create(), at least on Android 10, which this is most reported.

   This change converts the IllegalArgumentException into an IOException which we handle (at least by logged it). More importantly, we don't crash the Companion on an IOException.

Future work might want to better handle exceptions on background threads, where [2] happens. Perhaps by doing a Notification on the UI thread. But that is a change for another time.

Change-Id: I954ef77b1d4ba63f43de04c2fa344b29dc36af23