### PR TITLE
Added documentation for special regex characters in 'replace all' block

### DIFF
--- a/appinventor/docs/html/reference/blocks/text.html
+++ b/appinventor/docs/html/reference/blocks/text.html
@@ -279,17 +279,13 @@
 
 <p>Replace all with <em>She loves eating. She loves writing. She loves coding</em> as the text, <em>She</em> as the segment, and <em>Hannah</em> as the replacement would result in <em>Hannah loves eating. Hannah loves writing. Hannah loves coding</em>.</p>
 
-<p>Note:</p>
+<p>Note:
+Regular expressions (regex) are patterns used for matching character combinations in strings. When using the “replace all” block, it’s essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions.
+If you want to use these characters as literal characters in your pattern, you need to escape them with a backslash (\).</p>
 
-<p>Regular expressions (regex) are patterns used for matching character combinations in strings. When using the "replace all" block, it's essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions.</p>
-
-<p>If you want to use these characters as literal characters in your pattern, you need to escape them with a backslash (\).</p>
-    
-<p>Example:</p>
-
-<p>replace all with <em>Price: $50.00</em> as the text,  <em>\$</em> as the segment, <em>€</em> as the replacement</p>
-
-<p>this would result in *Price: €50.00*</p>
+<p>Example:
+replace all with <em>Price: $50.00</em> as the text,  <em>$</em> as the segment, <em>€</em> as the replacement
+this would result in <em>Price: €50.00</em></p>
 
 <h3 id="obfuscatetext">obfuscated text</h3>
 

--- a/appinventor/docs/html/reference/blocks/text.html
+++ b/appinventor/docs/html/reference/blocks/text.html
@@ -279,6 +279,18 @@
 
 <p>Replace all with <em>She loves eating. She loves writing. She loves coding</em> as the text, <em>She</em> as the segment, and <em>Hannah</em> as the replacement would result in <em>Hannah loves eating. Hannah loves writing. Hannah loves coding</em>.</p>
 
+<p>Note:</p>
+
+<p>Regular expressions (regex) are patterns used for matching character combinations in strings. When using the "replace all" block, it's essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions.</p>
+
+<p>If you want to use these characters as literal characters in your pattern, you need to escape them with a backslash (\).</p>
+    
+<p>Example:</p>
+
+<p>replace all with <em>Price: $50.00</em> as the text,  <em>\$</em> as the segment, <em>€</em> as the replacement</p>
+
+<p>this would result in *Price: €50.00*</p>
+
 <h3 id="obfuscatetext">obfuscated text</h3>
 
 <p><img src="images/text/obfuscatetext.png" alt="" /></p>

--- a/appinventor/docs/markdown/reference/blocks/text.md
+++ b/appinventor/docs/markdown/reference/blocks/text.md
@@ -155,6 +155,14 @@ Returns a new text string obtained by replacing all occurrences of the substring
 
 Replace all with *She loves eating. She loves writing. She loves coding* as the text, *She* as the segment, and *Hannah* as the replacement would result in *Hannah loves eating. Hannah loves writing. Hannah loves coding*.
 
+Note:
+Regular expressions (regex) are patterns used for matching character combinations in strings. When using the "replace all" block, it's essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions. 
+If you want to use these characters as literal characters in your pattern, you need to escape them with a backslash (\\). 
+
+Example:
+replace all with *Price: $50.00* as the text,  *\$* as the segment, *€* as the replacement
+this would result in *Price: €50.00*
+
 ### obfuscated text   {#obfuscatetext}
 
 ![](images/text/obfuscatetext.png)

--- a/appinventor/docs/markdown/reference/blocks/text.md
+++ b/appinventor/docs/markdown/reference/blocks/text.md
@@ -156,7 +156,7 @@ Returns a new text string obtained by replacing all occurrences of the substring
 Replace all with *She loves eating. She loves writing. She loves coding* as the text, *She* as the segment, and *Hannah* as the replacement would result in *Hannah loves eating. Hannah loves writing. Hannah loves coding*.
 
 Note:
-Regular expressions (regex) are patterns used for matching character combinations in strings. When using the "replace all" block, it's essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions. 
+Regular expressions (regex) are patterns used for matching character combinations in strings. When using the "replace all" block, it's essential to be aware of special characters in regular expressions.Special characters like $, *, ., etc., have special meanings in regular expressions.
 If you want to use these characters as literal characters in your pattern, you need to escape them with a backslash (\\). 
 
 Example:


### PR DESCRIPTION
fixes: #2360
I have added the required explanations about how to use special regex characters in 'replace all' block
A short intro about  regex, special characters followed by an example was also added 

I hope that the changes  fulfill the requirements

This is one of my first time contributing to opensource organizations
So, if you would like to add any corrections or best practices for me to follow, I am happy to listen
