### PR TITLE
Added DataFile component description in documentation

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/DataFile.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/DataFile.java
@@ -33,6 +33,12 @@ import java.util.concurrent.Future;
 
 import org.json.JSONException;
 
+/**
+ * Component that allows reading CSV and JSON data. The DataFile contains functionality relevant to accessing CSV or
+ * JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
+ * directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
+ * selected and parsed successfully to create ChartData components automatically from the file onto the Chart.
+ */
 @DesignerComponent(version = YaVersion.DATA_FILE_COMPONENT_VERSION,
     description = "Component that allows reading CSV and JSON data. "
         + "The DataFile contains functionality relevant to accessing "

--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -216,9 +216,9 @@
 <h2 id="DataFile">DataFile</h2>
 
 <p>Component that allows reading CSV and JSON data. The DataFile contains functionality relevant to accessing CSV or
-JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
-directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
-selected and parsed successfully to create ChartData components automatically from the file onto the Chart.</p>
+ JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
+ directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
+ selected and parsed successfully to create ChartData components automatically from the file onto the Chart.</p>
 
 <h3 id="DataFile-Properties">Properties</h3>
 

--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -215,7 +215,10 @@
 
 <h2 id="DataFile">DataFile</h2>
 
-<p>Component for DataFile</p>
+<p>Component that allows reading CSV and JSON data. The DataFile contains functionality relevant to accessing CSV or
+JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
+directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
+selected and parsed successfully to create ChartData components automatically from the file onto the Chart.</p>
 
 <h3 id="DataFile-Properties">Properties</h3>
 

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -109,9 +109,9 @@ The `CloudDB` component is a Non-visible component that allows you to store data
 ## DataFile  {#DataFile}
 
 Component that allows reading CSV and JSON data. The DataFile contains functionality relevant to accessing CSV or
-JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
-directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
-selected and parsed successfully to create ChartData components automatically from the file onto the Chart.
+ JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
+ directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
+ selected and parsed successfully to create ChartData components automatically from the file onto the Chart.
 
 
 

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -108,8 +108,10 @@ The `CloudDB` component is a Non-visible component that allows you to store data
 
 ## DataFile  {#DataFile}
 
-Component for DataFile
-
+Component that allows reading CSV and JSON data. The DataFile contains functionality relevant to accessing CSV or
+JSON parsed data in the form of rows or columns. Can be used together with the ChartData2D component to import data
+directly from a file to the Chart. The component may also be dragged and dropped on a Chart after a file has been
+selected and parsed successfully to create ChartData components automatically from the file onto the Chart.
 
 
 ### Properties  {#DataFile-Properties}

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -114,6 +114,7 @@ directly from a file to the Chart. The component may also be dragged and dropped
 selected and parsed successfully to create ChartData components automatically from the file onto the Chart.
 
 
+
 ### Properties  {#DataFile-Properties}
 
 {:.properties}


### PR DESCRIPTION
Added a component description for the DataFile component in the Storage documentation. It used to be "Component for DataFile".