### PR TITLE
Fixed FontSize bugs of CheckBox and Switch in the Designer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
@@ -7,6 +7,7 @@
 package com.google.appinventor.client.editor.simple.components;
 
 import com.google.appinventor.client.editor.simple.SimpleEditor;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
 import com.google.appinventor.client.editor.simple.components.utils.SVGPanel;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -139,6 +140,20 @@ public final class MockCheckBox extends MockToggleBase<HorizontalPanel> {
   private void setCheckedProperty(String text) {
     checked = Boolean.parseBoolean(text);
     paintCheckBox(checked);
+  }
+
+  @Override
+  protected void setFontSizeProperty(String text) {
+    MockForm form = ((YaFormEditor) editor).getForm();
+    if (Float.parseFloat(text) == FONT_DEFAULT_SIZE
+          && form != null
+          && form.getPropertyValue("BigDefaultText").equals("True")) {
+      MockComponentsUtil.setWidgetFontSize(toggleWidget.getWidget(1), "24");
+    } else {
+      MockComponentsUtil.setWidgetFontSize(toggleWidget.getWidget(1), text);
+    }
+
+    updatePreferredSize();
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCheckBox.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2020 MIT, All rights reserved
+// Copyright 2011-2024 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2018-2020 MIT, All rights reserved
+// Copyright 2018-2024 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockSwitch.java
@@ -6,6 +6,7 @@
 package com.google.appinventor.client.editor.simple.components;
 
 import com.google.appinventor.client.editor.simple.SimpleEditor;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
 import com.google.appinventor.client.editor.simple.components.utils.SVGPanel;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
@@ -157,7 +158,15 @@ public final class MockSwitch extends MockToggleBase<HorizontalPanel> {
 
   @Override
   protected void setFontSizeProperty(String text) {
-    MockComponentsUtil.setWidgetFontSize(toggleWidget.getWidget(0), text);
+    MockForm form = ((YaFormEditor) editor).getForm();
+    if (Float.parseFloat(text) == FONT_DEFAULT_SIZE
+          && form != null
+          && form.getPropertyValue("BigDefaultText").equals("True")) {
+      MockComponentsUtil.setWidgetFontSize(toggleWidget.getWidget(0), "24");
+    } else {
+      MockComponentsUtil.setWidgetFontSize(toggleWidget.getWidget(0), text);
+    }
+
     updatePreferredSize();
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
@@ -30,6 +30,18 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper implements F
     super(editor, type, icon);
   }
 
+  @Override
+  protected void onAttach() {
+    super.onAttach();
+    ((YaFormEditor) editor).getForm().addFormChangeListener(this);
+  }
+
+  @Override
+  protected void onDetach() {
+    super.onDetach();
+    ((YaFormEditor) editor).getForm().removeFormChangeListener(this);
+  }
+
   protected final Widget createClonedWidget() {
     // We override updatePreferredSize directly, so this shouldn't be called.
     throw new UnsupportedOperationException();
@@ -46,6 +58,12 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper implements F
     int hint = super.getHeightHint();
     if (hint == MockVisibleComponent.LENGTH_PREFERRED) {
       float height = Float.parseFloat(getPropertyValue(MockVisibleComponent.PROPERTY_NAME_FONTSIZE));
+      MockForm form = ((YaFormEditor) editor).getForm();
+      if (height == FONT_DEFAULT_SIZE
+          && form != null
+          && form.getPropertyValue("BigDefaultText").equals("True")) {
+        return 24;
+      }
       return Math.round(height);
     } else {
       return hint;
@@ -169,6 +187,7 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper implements F
   public void onComponentPropertyChanged(MockComponent component, String propertyName, String propertyValue) {
     if (component.getType().equals(MockForm.TYPE) && propertyName.equals("BigDefaultText")) {
       setFontSizeProperty(getPropertyValue(PROPERTY_NAME_FONTSIZE));
+      updatePreferredSize();
       refreshForm();
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2016-2020 MIT, All rights reserved
+// Copyright 2016-2024 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
**Bugs fixed:**
- Fixed a bug where modifying the FontSize property of a CheckBox in the Designer had no effect on the CheckBox's appearance in the Designer.
- Fixed a bug where modifying the BigDefaultText property of the Screen in the Designer had no effect on the appearances of the Screen's CheckBoxes and Switches in the Designer. (issue: #2964)