### PR TITLE
Standardization of all the icon sizes to 16px

### DIFF
--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -44,12 +44,6 @@ body, html {
   min-height: 100vh;
 }
 
-/* Standardization of icon sizes to 16px */
-.gwt-Tree img, .ode-Icon img, .ode-Icon-selected img {
-  width: 16px;
-  height: 16px;
-}
-
 /* Needed for Safari to position comments correctly */
 body.blocklyMinimalBody {
   min-width: auto;

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -44,6 +44,12 @@ body, html {
   min-height: 100vh;
 }
 
+/* Standardization of icon sizes to 16px */	
+.gwt-Tree img, .ode-Icon img, .ode-Icon-selected img {	
+  width: 16px;	
+  height: 16px;	
+}
+
 /* Needed for Safari to position comments correctly */
 body.blocklyMinimalBody {
   min-width: auto;

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -44,6 +44,12 @@ body, html {
   min-height: 100vh;
 }
 
+/* Standardization of icon sizes to 16px */
+.gwt-Tree img, .ode-Icon img, .ode-Icon-selected img {
+  width: 16px;
+  height: 16px;
+}
+
 /* Needed for Safari to position comments correctly */
 body.blocklyMinimalBody {
   min-width: auto;

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -665,6 +665,11 @@ Blockly.WorkspaceSvg.prototype.hideChaff = function(opt_allowToolbox) {
     this.backpack_ && this.backpack_.hide();
   }
   this.setScrollbarsVisible(true);
+  
+  if(this.drawer_.isShowing())
+  {
+    this.setScrollbarsVisible(false);
+  }
 };
 
 /**
@@ -1243,6 +1248,7 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
       var position = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
         this.getInverseScreenCTM());
       this.zoom(position.x, position.y, delta);
+      this.setScrollbarsVisible(true);
     } else {
       // pan using mouse wheel
       this.scrollX -= e.deltaX;


### PR DESCRIPTION
The added code standardizes all icon sizes to 16px, relieving extension makers from concerns about their extension's icon size.

The problem that this PR solves is that a few extension icons have larger sizes than 16x16px and this PR standardizes all the icons across the app inventor to 16px.

Example of this issue :
![LargeIcon](https://github.com/mit-cml/appinventor-sources/assets/116882464/6e2d9d8b-a29e-463a-ad96-404d691e1ba8)
