### PR TITLE
Fix RunD8 errors when using Windows with Java 11

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
@@ -120,7 +120,7 @@ public class RunBundletool implements AndroidTask {
     File[] dexFiles = context.getPaths().getTmpDir().listFiles();
     if (dexFiles != null) {
       for (File dex : dexFiles) {
-        if (dex.isFile()) {
+        if (dex.isFile() && dex.getName().endsWith(".dex")) {
           try {
             Files.move(dex, new File(aab.getDexDir(), dex.getName()));
           } catch (IOException e) {

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
@@ -12,6 +12,7 @@ import com.google.common.io.InputSupplier;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -46,6 +47,7 @@ public class ProjectUtils {
   public static File createNewTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
     long random = (long) (Math.random() * Long.MAX_VALUE);
+    random = Math.abs(random);
     String baseNamePrefix = System.currentTimeMillis() + "_" + random + "-";
 
     final int TEMP_DIR_ATTEMPTS = 10000;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/ProjectUtils.java
@@ -45,7 +45,8 @@ public class ProjectUtils {
    */
   public static File createNewTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
-    String baseNamePrefix = System.currentTimeMillis() + "_" + Math.random() + "-";
+    long random = (long) (Math.random() * Long.MAX_VALUE);
+    String baseNamePrefix = System.currentTimeMillis() + "_" + random + "-";
 
     final int TEMP_DIR_ATTEMPTS = 10000;
     for (int counter = 0; counter < TEMP_DIR_ATTEMPTS; counter++) {


### PR DESCRIPTION
This is a workaround for an issue in the buildserver using Java 11 on Windows where the classpath for d8 is so long it causes an exception spawning the d8 process. We make use of a new feature of Java 9 onward that allows for specifying command line arguments in a file and then inserting them into the argument list by using the `@` symbol and the filename to splice the arguments into the list.

Tested on Windows 11 using Java 11 and on macOS 14 using Java 11.