### PR TITLE
Bugfix/Issue #3115 - Fix iOS ListView Bugs

### DIFF
--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -574,13 +574,13 @@ open class ListView: ViewComponent, AbstractMethodsForViewComponent,
     } else if _fontTypefaceDetail == "3" {
       cell.detailTextLabel?.font = UIFont(name: "Courier", size: CGFloat(_fontSizeDetail))
     }
-
-    if cell.selectedBackgroundView == nil {
-      cell.selectedBackgroundView = UIView()
+    
+    if _selectionColor == Int32(bitPattern: Color.default.rawValue){
+      cell.selectionColor = argbToColor(Int32(bitPattern: kListViewDefaultSelectionColor.rawValue))
+    } else {
+      cell.selectionColor = argbToColor(_selectionColor)
     }
-    cell.selectedBackgroundView?.backgroundColor =
-        argbToColor(_selectionColor == Int32(bitPattern: Color.default.rawValue)
-        ? Int32(bitPattern: kListViewDefaultSelectionColor.rawValue) : _selectionColor)
+    
     return cell
   }
 
@@ -628,4 +628,19 @@ open class ListView: ViewComponent, AbstractMethodsForViewComponent,
   var elements: [String] {
     return _results ?? _elements
   }
+}
+
+  // extension of the UITableViewCell class defines a computed property selectionColor
+  // for setting and getting the background color of a cell when it is selected
+extension UITableViewCell {
+    var selectionColor: UIColor {
+        set {
+            let view = UIView()
+            view.backgroundColor = newValue
+            self.selectedBackgroundView = view
+        }
+        get {
+            return self.selectedBackgroundView?.backgroundColor ?? UIColor.clear
+        }
+    }
 }


### PR DESCRIPTION
I've fixed the SelectionColor property bug and the filtering bugs for iOS ListView mentioned in the issue #3115. The following changes were made in the ListView.swift file:

- An extension of the UITableViewCell class was created. In this extension, a computed property selectionColor was defined for setting and getting the background color of a cell when it is selected
- The search logic was added to the searchBar(_:textDidChange:) function to filter data according to the selected layout
- A Cancel button was added for a search bar to let the user hide the keyboard whenever they want. The functionality for the searchBarCancelButtonClicked(_:) function was written
- The tableView(_:numberOfRowsInSection:) function was modified to return the correct number of rows in tableView (indexPath.row value)
- The messy loading of images in ListView was fixed by clearing the previous image and loading the new one asynchronously in tableView(_:cellForRowAt:) function
- All ListView layouts were improved visually by adding new constraints and modifying the existing ones in tableView(_:cellForRowAt:) function

When testing using Xcode simulator, don't forget to toggle the simulator's software keyboard. If the search text is entered using Mac's keyboard, the scrolling of the ListView will not work well.

For convenient testing of the renewed iOS ListView, I've created an MIT App Inventor project with a ListView filled with data which is available via this link: https://gallery.appinventor.mit.edu/?galleryid=a30fbce6-b8bf-4410-83ba-13684259f0c3

@ewpatton @SusanRatiLane 

