### PR TITLE
Fix for the overlapping of workspace scrollbar onto the blocks drawer.

### DIFF
--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -665,6 +665,11 @@ Blockly.WorkspaceSvg.prototype.hideChaff = function(opt_allowToolbox) {
     this.backpack_ && this.backpack_.hide();
   }
   this.setScrollbarsVisible(true);
+
+  if(this.drawer_.isShowing())
+  {
+    this.setScrollbarsVisible(false);
+  }
 };
 
 /**
@@ -1243,6 +1248,7 @@ Blockly.WorkspaceSvg.prototype.onMouseWheel_ = function(e) {
       var position = Blockly.utils.mouseToSvg(e, this.getParentSvg(),
         this.getInverseScreenCTM());
       this.zoom(position.x, position.y, delta);
+      this.setScrollbarsVisible(true);
     } else {
       // pan using mouse wheel
       this.scrollX -= e.deltaX;


### PR DESCRIPTION
1. I've implemented functionality to detect whether the drawer within the workspace is opened. If it is open, I've ensured that the scrollbar gets hidden to provide a seamless user experience to interact with the last block. (changes made in the hideChaff() function).

2. I've added code to set the scrollbar visibility upon zooming in or out if the user wants to position the existing blocks properly. (changes made in the onMouseWheel_() function).

BEFORE:
Link: https://github.com/mit-cml/appinventor-sources/assets/116882464/88a26769-242b-409d-ae9b-5da3c93f941f

**AFTER: **
Link: https://github.com/mit-cml/appinventor-sources/assets/116882464/42a95582-9173-4ee6-ac9e-fc66a12203fc

Would love to hear any other possible better solutions or suggestions.