### PR TITLE
Add custom url for map component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5375,6 +5375,14 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Terrain map type")
   String mapTypeTerrain();
 
+  @DefaultMessage("Custom")
+  @Description("Custom map type")
+  String mapTypeCustom();
+
+  @DefaultMessage("CustomUrl")
+  @Description("The URL of the custom tile layer to use as the base of the map")
+  String mapCustomUrl();
+
   @DefaultMessage("Metric")
   @Description("Display name for the metric unit system")
   String mapScaleUnitsMetric();
@@ -5442,6 +5450,22 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @DefaultMessage("The value supplied for {0} was not a valid latitude, longitude pair.")
   @Description("")
   String expectedLatLongPair(String property);
+
+  @DefaultMessage("The provided URL {0} does not contain placeholders for {1}.") // Can't use {x} here, Java compiler tries to interpret the variable x
+  @Description("")
+  String customUrlNoPlaceholders(String property, String placeholders);
+
+  @DefaultMessage("The provided URL {0}, when tested, failed authentication (with HTTP status code {1}).")
+  @Description("")
+  String customUrlBadAuthentication(String property, int statusCode);
+
+  @DefaultMessage("The provided URL {0}, when tested, returned a bad HTTP status code ({1}).")
+  @Description("")
+  String customUrlBadStatusCode(String property, int statusCode);
+
+  @DefaultMessage("The provided URL {0}, when tested, returned an exception ({1}).")
+  @Description("")
+  String customUrlException(String property, String e);
 
   @DefaultMessage("Notice!")
   @Description("Title for the Warning Dialog Box")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMap.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockMap.java
@@ -29,6 +29,7 @@ public final class MockMap extends MockContainer {
   protected static final String PROPERTY_NAME_LATITUDE = "Latitude";
   protected static final String PROPERTY_NAME_LONGITUDE = "Longitude";
   protected static final String PROPERTY_NAME_MAP_TYPE = "MapType";
+  protected static final String PROPERTY_NAME_CUSTOM_URL = "CustomUrl";
   protected static final String PROPERTY_NAME_CENTER_FROM_STRING = "CenterFromString";
   protected static final String PROPERTY_NAME_ZOOM_LEVEL = "ZoomLevel";
   protected static final String PROPERTY_NAME_SHOW_COMPASS = "ShowCompass";
@@ -181,6 +182,8 @@ public final class MockMap extends MockContainer {
       invalidateMap();
     } else if (propertyName.equals(PROPERTY_NAME_MAP_TYPE)) {
       setMapType(newValue);
+    } else if (propertyName.equals(PROPERTY_NAME_CUSTOM_URL)) {
+      setCustomUrl(newValue);
     } else if (propertyName.equals(PROPERTY_NAME_CENTER_FROM_STRING)) {
       setCenter(newValue);
     } else if (propertyName.equals(PROPERTY_NAME_ZOOM_LEVEL)) {
@@ -220,6 +223,10 @@ public final class MockMap extends MockContainer {
       ErrorReporter.reportError(MESSAGES.unknownMapTypeException(tileLayerId));
       changeProperty(PROPERTY_NAME_MAP_TYPE, Integer.toString(selectedTileLayer));
     }
+  }
+
+  private void setCustomUrl(String newCustomUrl) {
+    updateCustomUrl(newCustomUrl);
   }
 
   private void setCenter(String center) {
@@ -484,7 +491,10 @@ public final class MockMap extends MockContainer {
                    attribution: 'Satellite imagery &copy; <a href="http://mapquest.com">USGS</a>'}),
       L.tileLayer('//basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
                   {minZoom: 0, maxZoom: 15,
-                   attribution: 'Map data &copy; <a href="http://www.usgs.gov">USGS</a>'})
+                   attribution: 'Map data &copy; <a href="http://www.usgs.gov">USGS</a>'}),
+      L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  {minZoom: 0, maxZoom: 18,
+                   attribution: 'Custom map'})
     ];
     this.@com.google.appinventor.client.editor.simple.components.MockMap::tileLayers = tileLayers;
     this.@com.google.appinventor.client.editor.simple.components.MockMap::baseLayer =
@@ -603,6 +613,23 @@ public final class MockMap extends MockContainer {
         baseLayer.bringToBack();
         this.@com.google.appinventor.client.editor.simple.components.MockMap::baseLayer = baseLayer;
       }
+    }
+  }-*/;
+
+  private native void updateCustomUrl(String customUrl)/*-{
+    var L = $wnd.top.L;
+    var map = this.@com.google.appinventor.client.editor.simple.components.MockMap::mapInstance;
+    var tileLayers = this.@com.google.appinventor.client.editor.simple.components.MockMap::tileLayers;
+    var baseLayer = this.@com.google.appinventor.client.editor.simple.components.MockMap::baseLayer;
+    if (map && baseLayer && tileLayers) {
+      tileLayers[4] = L.tileLayer(customUrl,
+                  {minZoom: 0, maxZoom: 18,
+                   attribution: 'Custom map data'});
+      map.removeLayer(baseLayer);
+      baseLayer = tileLayers[4];
+      map.addLayer(baseLayer);
+      baseLayer.bringToBack();
+      this.@com.google.appinventor.client.editor.simple.components.MockMap::tileLayers = tileLayers;
     }
   }-*/;
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -45,6 +45,7 @@ import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroid
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidListViewLayoutChoicePropertyEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidMapScaleUnitsPropertyEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidMapTypePropertyEditor;
+import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidMapCustomUrlPropertyEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidNavigationMethodChoicePropertyEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidRecyclerViewOrientationPropertyEditor;
 import com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidScreenAnimationChoicePropertyEditor;
@@ -266,6 +267,8 @@ public class PropertiesUtil {
       return new YoungAndroidFloatRangePropertyEditor(-180, 180);
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MAP_TYPE)) {
       return new YoungAndroidMapTypePropertyEditor();
+    } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MAP_CUSTOMURL)) {
+      return new YoungAndroidMapCustomUrlPropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MAP_UNIT_SYSTEM)) {
       return new YoungAndroidMapScaleUnitsPropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MAP_ZOOM)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMapCustomUrlPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMapCustomUrlPropertyEditor.java
@@ -1,0 +1,65 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.properties;
+
+import com.google.appinventor.client.widgets.properties.TextPropertyEditor;
+import static com.google.appinventor.client.Ode.MESSAGES;
+import com.google.gwt.http.client.*;
+import com.google.gwt.user.client.Window;
+
+/**
+ * Property editor for Map custom URL matching a particular format.
+ */
+public class YoungAndroidMapCustomUrlPropertyEditor extends TextPropertyEditor {
+
+  public YoungAndroidMapCustomUrlPropertyEditor() {
+  }
+
+  @Override
+  protected void validate(String text) throws InvalidTextException {
+    // Check that the custom URL looks vaguely correct
+    if (!(text.startsWith("https://") || text.startsWith("http://"))
+        || !text.contains("{x}")
+        || !text.contains("{y}")
+        || !text.contains("{z}")) {
+      throw new InvalidTextException(MESSAGES.customUrlNoPlaceholders(text, "{x}, {y} and {z}"));
+    }
+
+    // Try to request a single tile from the custom URL source as a final validation, only report errors
+    String urlString = text.replace("{x}", "0")
+                           .replace("{y}", "0")
+                           .replace("{z}", "0");
+    RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, urlString);
+    try {
+      builder.sendRequest(null, new RequestCallback() {
+        @Override
+        public void onResponseReceived(Request request, Response response) {
+          handleResponseCode(urlString, response.getStatusCode());
+        }
+
+        @Override
+        public void onError(Request request, Throwable exception) {
+          handleRequestError(urlString, exception);
+        }
+      });
+    } catch (RequestException e) {
+      throw new InvalidTextException(MESSAGES.customUrlException(urlString, e.getMessage()));
+    }
+  }
+
+  // Window.alert is used here, rather than throw InvalidTextException, due to RequestBuilder Override signatures
+  private void handleResponseCode(String urlString, int responseCode) {
+    if (responseCode == 401 || responseCode == 403) {
+      Window.alert(MESSAGES.customUrlBadAuthentication(urlString, responseCode));
+    } else if (responseCode >= 400) {
+      Window.alert(MESSAGES.customUrlBadStatusCode(urlString, responseCode));
+    }
+  }
+
+  private void handleRequestError(String urlString, Throwable exception) {
+    Window.alert(MESSAGES.customUrlException(urlString, exception.getMessage()));
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMapTypePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMapTypePropertyEditor.java
@@ -19,7 +19,8 @@ public class YoungAndroidMapTypePropertyEditor extends ChoicePropertyEditor {
   private static final Choice[] mapTypes = new Choice[] {
     new Choice(MESSAGES.mapTypeRoads(), "1"),
     new Choice(MESSAGES.mapTypeAerial(), "2"),
-    new Choice(MESSAGES.mapTypeTerrain(), "3")
+    new Choice(MESSAGES.mapTypeTerrain(), "3"),
+    new Choice(MESSAGES.mapTypeCustom(), "4")
   };
 
   public YoungAndroidMapTypePropertyEditor() {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -2070,6 +2070,10 @@ public final class YoungAndroidFormUpgrader {
       // Adds ScaleUnits and MapType dropdowns.
       srcCompVersion = 6;
     }
+    if (srcCompVersion < 7) {
+      // Adds CustomUrl (MapType 4).
+      srcCompVersion = 7;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2511,9 +2511,13 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2:
     // - Adds Units and MapType dropdowns.
     6: [Blockly.Versioning.makeSetterUseDropdown(
-          'Map', 'ScaleUnits', 'ScaleUnits'),
-        Blockly.Versioning.makeSetterUseDropdown(
-          'Map', 'MapType', 'MapType')]
+      'Map', 'ScaleUnits', 'ScaleUnits'),
+    Blockly.Versioning.makeSetterUseDropdown(
+      'Map', 'MapType', 'MapType')],
+
+    // AI2:
+    // - Adds CustomUrl (MapType 4).
+    7: "noUpgrade"
 
   }, // End Map upgraders
 

--- a/appinventor/components-ios/src/ErrorMessages.swift
+++ b/appinventor/components-ios/src/ErrorMessages.swift
@@ -320,7 +320,7 @@ import Foundation
     case .ERROR_INVALID_ANCHOR_HORIZONTAL:
       return "Invalid value %d given for AnchorHorizontal. Valid settings are 1, 2, or 3."
     case .ERROR_INVALID_MAP_TYPE:
-      return "The MapType must be 1, 2, or 3"
+      return "The MapType must be 1, 2, 3, or 4"
 
     // File Errors
     case .ERROR_CANNOT_FIND_FILE:

--- a/appinventor/components-ios/src/Map.swift
+++ b/appinventor/components-ios/src/Map.swift
@@ -28,6 +28,7 @@ enum AIMapType: Int32 {
   case roads = 1
   case aerial = 2
   case terrain = 3
+  case custom = 4
 }
 
 typealias CLLocationDirection = Double
@@ -76,7 +77,8 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
   private var _featuresState = 0
   private var _boundsChangeReady: Bool = false
   private var _terrainOverlay: MKTileOverlay?
-
+  private var _customUrlOverlay: MKTileOverlay?
+  private var _customURL = ""
   private var _activeOverlay: MapOverlayShape? = nil
   private var _lastPoint: CLLocationCoordinate2D? = nil
   private var _activeMarker: Marker? = nil
@@ -158,6 +160,7 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
     EnableZoom = true
     EnablePan = true
     MapType = 1
+    CustomUrl = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
     Rotation = 0.0
     ScaleUnits = 1
     ShowZoom = false
@@ -347,7 +350,7 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
       return _mapType.rawValue
     }
     set(type) {
-      if !(1...3 ~= type) {
+      if !(1...4 ~= type) {
         form?.dispatchErrorOccurredEvent(self, "MapType", ErrorMessage.ERROR_INVALID_MAP_TYPE.code,
            ErrorMessage.ERROR_INVALID_MAP_TYPE.message)
         return
@@ -357,17 +360,38 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
       switch _mapType {
       case .roads:
         removeTerrainTileRenderer()
+        removeCustomUrlTileRenderer()
         mapView.mapType = .standard
       case .aerial:
         removeTerrainTileRenderer()
+        removeCustomUrlTileRenderer()
         mapView.mapType = .satellite
       case .terrain:
+        removeCustomUrlTileRenderer()
         mapView.mapType = .standard // set that way zooming in too far displays a visible grid
         setupTerrainTileRenderer()
+      case .custom:
+        removeTerrainTileRenderer()
+        mapView.mapType = .standard
+        setupCustomUrlTileRenderer()
       }
     }
   }
   
+  @objc open var CustomUrl: String? {
+      get {
+        return _customURL
+      }
+      set(newUrl) {
+        guard let newUrl = newUrl, newUrl != CustomUrl else {
+            return
+        }
+        _customURL = newUrl
+        removeCustomUrlTileRenderer()
+        setupCustomUrlTileRenderer()
+      }
+  }
+
   @objc open var ScaleUnits: Int32 {
     get {
       return _scaleUnits
@@ -887,9 +911,24 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
     }
   }
 
+  /**
+   * Adds a custom tile overlay that matches the CustomUrl overlay on Android
+   */
+  private func setupCustomUrlTileRenderer() {
+    _customUrlOverlay = MKTileOverlay(urlTemplate: CustomUrl)
+    _customUrlOverlay!.canReplaceMapContent = true
+    mapView.insertOverlay(_customUrlOverlay!, at: 0, level: .aboveLabels)
+  }
+
+  private func removeCustomUrlTileRenderer() {
+    if let overlay = _customUrlOverlay {
+      mapView.removeOverlay(overlay)
+    }
+  }
+
   public func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
     if let tileOverlay = overlay as? MKTileOverlay {
-      return _mapType == .terrain ? MKTileOverlayRenderer(tileOverlay: tileOverlay) : MKOverlayRenderer()
+      return (_mapType == .terrain || _mapType == .custom) ? MKTileOverlayRenderer(tileOverlay: tileOverlay) : MKOverlayRenderer()
     } else if let shape = overlay as? MapCircleOverlay {
       let renderer = MKCircleRenderer(circle: shape)
       shape.renderer = renderer

--- a/appinventor/components-ios/src/MapFactory.swift
+++ b/appinventor/components-ios/src/MapFactory.swift
@@ -142,4 +142,5 @@ enum MapType: Int32 {
   case ROADS = 1
   case AERIAL = 2
   case TERRAIN = 3
+  case CUSTOM = 4
 }

--- a/appinventor/components/src/com/google/appinventor/components/common/MapType.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/MapType.java
@@ -14,7 +14,8 @@ import java.util.Map;
 public enum MapType implements OptionList<Integer> {
   Road(1),
   Aerial(2),
-  Terrain(3);
+  Terrain(3),
+  Custom(4);
 
   private final Integer value;
 

--- a/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
@@ -194,6 +194,13 @@ public class PropertyTypeConstants {
    */
   public static final String PROPERTY_TYPE_MAP_TYPE = "map_type";
 
+ /**
+   * Map custom URL template required by the Map component.
+   * @see
+   * com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidMapCustomUrlPropertyEditor
+   */
+  public static final String PROPERTY_TYPE_MAP_CUSTOMURL = "map_customurl";
+
   /**
    * Integer values limited to the range of valid map zoom levels [1, 18].
    * @see com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidMapZoomPropertyEditor

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1216,7 +1216,9 @@ public class YaVersion {
   // - Added ScaleUnits property
   // For MAP_COMPONENT_VERSION 6:
   // - Adds ScaleUnits and MapType dropdowns.
-  public static final int MAP_COMPONENT_VERSION = 6;
+  // For MAP_COMPONENT_VERSION 7:
+  // - Adds CustomUrl (MapType 4).
+  public static final int MAP_COMPONENT_VERSION = 7;
 
   // For MARKER_COMPONENT_VERSION 1:
   // - Initial Marker implementation using OpenStreetMap

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -62,7 +62,7 @@ import org.osmdroid.util.BoundingBox;
 /**
  * A two-dimensional container that renders map tiles in the background and allows for multiple
  * {@link Marker} elements to identify points on the map. Map tiles are supplied by OpenStreetMap
- * contributors and the the United States Geological Survey.
+ * contributors and the the United States Geological Survey, or a custom basemap URL can be provided.
  *
  * The `Map` component provides three utilities for manipulating its boundaries with App Inventor.
  * First, a locking mechanism is provided to allow the map to be moved relative to other components
@@ -80,7 +80,7 @@ import org.osmdroid.util.BoundingBox;
   androidMinSdk = 8,
   description = "<p>A two-dimensional container that renders map tiles in the background and " +
     "allows for multiple Marker elements to identify points on the map. Map tiles are supplied " +
-    "by OpenStreetMap contributors and the United States Geological Survey.</p>" +
+    "by OpenStreetMap contributors and the United States Geological Survey, or a custom basemap URL can be provided.</p>" +
     "<p>The Map component provides three utilities for manipulating its boundaries within App " +
     "Inventor. First, a locking mechanism is provided to allow the map to be moved relative to " +
     "other components on the Screen. Second, when unlocked, the user can pan the Map to any " +
@@ -123,6 +123,7 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
     EnableZoom(true);
     EnablePan(true);
     MapTypeAbstract(MapType.Road);
+    CustomUrl("https://tile.openstreetmap.org/{z}/{x}/{y}.png");
     ShowCompass(false);
     LocationSensor(new LocationSensor(container.$form(), false));
     ShowUser(false);
@@ -301,6 +302,7 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
    *   1. Roads
    *   2. Aerial
    *   3. Terrain
+   *   4. Custom
    *
    * @param type Integer identifying the tile set to use for the map's base layer.
    */
@@ -321,6 +323,7 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
    *   1. Roads
    *   2. Aerial
    *   3. Terrain
+   *   4. Custom
    *
    *   **Note:** Road layers are provided by OpenStreetMap and aerial and terrain layers are
    * provided by the U.S. Geological Survey.
@@ -329,7 +332,7 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
    */
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       description = "The type of tile layer to use as the base of the map. Valid values " +
-          "are: 1 (Roads), 2 (Aerial), 3 (Terrain)")
+          "are: 1 (Roads), 2 (Aerial), 3 (Terrain), 4 (Custom)")
   public @Options(MapType.class) int MapType() {
     return MapTypeAbstract().toUnderlyingValue();
   }
@@ -348,6 +351,30 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
   @SuppressWarnings("RegularMethodName")
   public void MapTypeAbstract(MapType type) {
     mapController.setMapTypeAbstract(type);
+  }
+
+  /**
+   * @return Returns the custom URL of the base tile layer in use by the map.
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_MAP_CUSTOMURL,
+      defaultValue = "https://tile.openstreetmap.org/{z}/{x}/{y}.png")
+  @SimpleProperty(category = PropertyCategory.ADVANCED,
+      description = "The URL of the custom tile layer to use as the base of the map. Valid URLs " +
+          "should include &#123;z}, &#123;x} and &#123;y} placeholders and any authentication required. </p></p>" + 
+          "e.g. https://tile.openstreetmap.org/&#123;z}/&#123;x}/&#123;y}.png </p>" +
+          "or https://example.com/geoserver/gwc/service/tms/1.0.0/workspace:layername&#64;EPSG:3857&#64;jpeg/&#123;z}/&#123;x}/&#123;y}.jpeg&#63;flipY=true&authkey=123")
+  public String CustomUrl() {
+    return mapController.getCustomUrl();
+  }
+
+  /**
+   * Update the custom URL of the base tile layer in use by the map.
+   * e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png
+   * e.g. https://example.com/geoserver/gwc/service/tms/1.0.0/workspace:layername@EPSG:3857@jpeg/{z}/{x}/{y}.jpeg?flipY=true&authkey=123
+   */
+  @SimpleProperty(category = PropertyCategory.ADVANCED)
+  public void CustomUrl(String url) {
+    mapController.setCustomUrl(url);
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/DummyMapController.java
@@ -65,6 +65,14 @@ class DummyMapController implements MapController {
     throw new UnsupportedOperationException();
   }
 
+  public void setCustomUrl(String url) {
+    throw new UnsupportedOperationException();
+  }
+
+  public String getCustomUrl() {
+    throw new UnsupportedOperationException();
+  }
+
   public void setMapTypeAbstract(MapType type) {
     throw new UnsupportedOperationException();
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/MapFactory.java
@@ -202,6 +202,20 @@ public final class MapFactory {
     void setMapTypeAbstract(com.google.appinventor.components.common.MapType type);
 
     /**
+     * Get the customUrl of the map being used.
+     *
+     * @return the customUrl of the map's active tile layer
+     */
+    String getCustomUrl();
+
+    /**
+     * Set the customUrl of the map being used.
+     *
+     * @param Set the new map customUrl for the map
+     */
+    void setCustomUrl(String url);
+
+    /**
      * Set whether the compass is displayed on the map.
      *
      * @param enable true if the compass overlay should be shown, otherwise false.
@@ -1313,6 +1327,7 @@ public final class MapFactory {
      * prior to official release. Some apps developed using earlier versions of Maps on test servers
      * may reference this property, but it may be removed in a future version of App Inventor.
      */
+    @Deprecated
     @SuppressWarnings("squid:S00100")
     void ShowShadow(boolean show);
 
@@ -1321,6 +1336,7 @@ public final class MapFactory {
      * @return true if the marker should have a shadow, otherwise false.
      * @deprecated See the deprecation message for {@link #ShowShadow(boolean)}.
      */
+    @Deprecated
     @SuppressWarnings("squid:S00100")
     boolean ShowShadow();
 
@@ -1577,7 +1593,12 @@ public final class MapFactory {
     /**
      * Terrain tile layer.
      */
-    TERRAIN
+    TERRAIN,
+
+    /**
+     * Custom tile layer.
+     */
+    CUSTOM
   }
 
   /**

--- a/appinventor/docs/html/reference/components/maps.html
+++ b/appinventor/docs/html/reference/components/maps.html
@@ -432,7 +432,7 @@
 
 <p>A two-dimensional container that renders map tiles in the background and allows for multiple
  <a href="#Marker"><code class="highlighter-rouge">Marker</code></a> elements to identify points on the map. Map tiles are supplied by OpenStreetMap
- contributors and the the United States Geological Survey.</p>
+ contributors and the the United States Geological Survey, or a custom basemap URL can be provided.</p>
 
 <p>The <code class="highlighter-rouge">Map</code> component provides three utilities for manipulating its boundaries with App Inventor.
  First, a locking mechanism is provided to allow the map to be moved relative to other components
@@ -458,6 +458,10 @@
  <a href="#Map.PanTo"><code class="highlighter-rouge">PanTo</code></a> with numerical latitude and longitude rather than convert
  to the string representation for use with this property.</p>
   </dd>
+  <dt id="Map.CustomUrl" class="text"><em>CustomUrl</em></dt>
+  <dd>Update the custom URL of the base tile layer in use by the map.
+ e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png
+ e.g. https://example.com/geoserver/gwc/service/tms/1.0.0/workspace:layername</dd>
   <dt id="Map.EnablePan" class="boolean"><em>EnablePan</em></dt>
   <dd>Enables or disables the ability of the user to move the Map.</dd>
   <dt id="Map.EnableRotation" class="boolean"><em>EnableRotation</em></dt>
@@ -490,6 +494,7 @@
       <li>Roads</li>
       <li>Aerial</li>
       <li>Terrain</li>
+      <li>Custom</li>
     </ol>
 
     <p><strong>Note:</strong> Road layers are provided by OpenStreetMap and aerial and terrain layers are

--- a/appinventor/docs/markdown/reference/components/maps.md
+++ b/appinventor/docs/markdown/reference/components/maps.md
@@ -363,7 +363,7 @@ A `FeatureCollection` groups one or more map features together. Any events that 
 
 A two-dimensional container that renders map tiles in the background and allows for multiple
  [`Marker`](#Marker) elements to identify points on the map. Map tiles are supplied by OpenStreetMap
- contributors and the the United States Geological Survey.
+ contributors and the the United States Geological Survey, or a custom basemap URL can be provided.
 
  The `Map` component provides three utilities for manipulating its boundaries with App Inventor.
  First, a locking mechanism is provided to allow the map to be moved relative to other components
@@ -392,6 +392,11 @@ A two-dimensional container that renders map tiles in the background and allows 
    In blocks code, it is recommended for performance reasons to use
  [`PanTo`](#Map.PanTo) with numerical latitude and longitude rather than convert
  to the string representation for use with this property.
+
+{:id="Map.CustomUrl" .text} *CustomUrl*
+: Update the custom URL of the base tile layer in use by the map.
+ e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png
+ e.g. https://example.com/geoserver/gwc/service/tms/1.0.0/workspace:layername
 
 {:id="Map.EnablePan" .boolean} *EnablePan*
 : Enables or disables the ability of the user to move the Map.
@@ -433,6 +438,7 @@ A two-dimensional container that renders map tiles in the background and allows 
    1. Roads
    2. Aerial
    3. Terrain
+   4. Custom
 
    **Note:** Road layers are provided by OpenStreetMap and aerial and terrain layers are
  provided by the U.S. Geological Survey.


### PR DESCRIPTION
Dear MIT App Inventor community

Firstly, thanks for an awesome project.  My kids love it!

I was checking out the Map component, and I see that it makes use of the `osmdroid` library which in turn connects to 1 of 3 tile sources: OpenStreetMap and United States Geological Survey.  I observe the OpenStreetMap terms and conditions for using their tile servers: 

https://operations.osmfoundation.org/policies/tiles/#:~:text=As%20a%20result%2C%20we%20require,free%20for%20everyone%20to%20use.%20Our%20tile%20servers%20are%20not.

> As a result, we require that users of the tiles abide by this tile usage policy.
> 
> OpenStreetMap data is free for everyone to use. Our tile servers are not.

With this in mind, I propose a 4th MapType (in addition to Roads, Aerial and Terrain), being Custom, which allows a diligent/heavy/commercial user to set a custom URL using the standard TMS format e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png.  The default map (Roads using OpenStreetMap) will still work for the majority of App Inventor users just exploring the functionality.

A bonus side effect of this fix is that users can now connect to any other online basemaps that they find interesting, and possibly the Map component will be further enhanced in the future to include overlay layers too.

I ask that you please review the changes that I have made, noting that I still need to write the accompanying documentation etc.  All the `ant tests` pass.  I do not have a local copy of the buildserver running.


One possible bug that I discovered is https://community.appinventor.mit.edu/t/literal-left-curly-bracket-cannot-exist-in-simpleproperty-description/112129 which states that a literal `{` cannot exist in the description of a property, e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png.  I have had to include an ugly workaround with square brackets, but I would like to know if there is a better solution.
EDIT: resolved with [this hint](https://community.appinventor.mit.edu/t/literal-left-curly-bracket-cannot-exist-in-simpleproperty-description/112129/3)
		  
Another problem that I am facing is in the Designer GUI (ODE), under Appearance > MapType, the dropdown box still only shows the original 3 types (Roads, Aerial, Terrain) even though the code works perfectly and the Blocks GUI shows all 4 types correctly.  I am sure an experienced developer will be able to point out the solution to this novice very easily.
EDIT: resolved with [this hint](https://github.com/mit-cml/appinventor-sources/pull/3160#discussion_r1576555538) 

![image](https://github.com/mit-cml/appinventor-sources/assets/5699667/ee78f7e3-2fb4-48b5-bc72-6e223bd88a4c)
![image](https://github.com/mit-cml/appinventor-sources/assets/5699667/564eeebb-c2b7-443a-874a-eefd2ab73937)


Kindly guide me through the remainder of your contribution process, please.  I understand that there is a new release coming up in a week's time - it is possible to incorporate it in there?

