### PR TITLE
Deprecate the Edit Image block without a mask

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ImageBot.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ImageBot.java
@@ -312,6 +312,7 @@ public class ImageBot extends AndroidNonvisibleComponent {
    * @param description the description of how to edit the image
    */
   @SimpleFunction
+  @Deprecated
   public void EditImage(Object source, final String description) {
     try {
       // Load the image on the main thread. This isn't ideal but prevents the image from being

--- a/appinventor/docs/html/reference/components/experimental.html
+++ b/appinventor/docs/html/reference/components/experimental.html
@@ -308,10 +308,6 @@
 <dl class="methods">
   <dt id="ImageBot.CreateImage" class="method"><i></i> CreateImage(<em class="text">description</em>)</dt>
   <dd>Create an image using the given description.</dd>
-  <dt id="ImageBot.EditImage" class="method"><i></i> EditImage(<em class="any">source</em>,<em class="text">description</em>)</dt>
-  <dd>Edit the source image using the given description. Editable areas of the image should have
- a transparent alpha. The source can be a Canvas component, an Image component, or a string
- representing the path to a file.</dd>
   <dt id="ImageBot.EditImageWithMask" class="method"><i></i> EditImageWithMask(<em class="any">imageSource</em>,<em class="any">maskSource</em>,<em class="text">prompt</em>)</dt>
   <dd>Edit the imageSource using the given description. The editable area of the image should be
  indicated by the maskSource. The sources can be a Canvas, an Image, or a string

--- a/appinventor/docs/markdown/reference/components/experimental.md
+++ b/appinventor/docs/markdown/reference/components/experimental.md
@@ -210,11 +210,6 @@ The ImageBot is a non-visible component that uses DALL-E 2 to create and edit im
 {:id="ImageBot.CreateImage" class="method"} <i/> CreateImage(*description*{:.text})
 : Create an image using the given description.
 
-{:id="ImageBot.EditImage" class="method"} <i/> EditImage(*source*{:.any},*description*{:.text})
-: Edit the source image using the given description. Editable areas of the image should have
- a transparent alpha. The source can be a Canvas component, an Image component, or a string
- representing the path to a file.
-
 {:id="ImageBot.EditImageWithMask" class="method"} <i/> EditImageWithMask(*imageSource*{:.any},*maskSource*{:.any},*prompt*{:.text})
 : Edit the imageSource using the given description. The editable area of the image should be
  indicated by the maskSource. The sources can be a Canvas, an Image, or a string


### PR DESCRIPTION
ChatGPT does not support image editing without a mask. Using this block simply results in an error being generated from the ChatBot proxy.

We have marked it as deprecated, so projects that have it in them will still load properly, but the block will be disabled. The block will also not appear in the blocks drawer.

If in the future ChatGPT, or another provider supports image editing without requiring a mask, we can "un" deprecate it.

Change-Id: I7cd625ecf68b1db43b90488f385489cb8acbcd02