### PR TITLE
Fix disappearing extensions category in collapsable palette

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
@@ -93,6 +93,7 @@ public class CollapsablePanel extends Composite{
 
     public void clear() {
         categoryPanels.clear();
+        panel.clear();
     }
 
     /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
@@ -15,92 +15,99 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import java.util.HashMap;
 import java.util.logging.Logger;
 
-public class CollapsablePanel extends Composite{
-    private static final Logger LOG = Logger.getLogger(PropertiesPanel.class.getName());
+public class CollapsablePanel extends Composite {
+  private static final Logger LOG = Logger.getLogger(PropertiesPanel.class.getName());
 
-    // UI elements
-    private final VerticalPanel panel;
-    private final HashMap<ComponentCategory, DisclosurePanel> categoryPanels;
+  // UI elements
+  private final VerticalPanel panel;
+  private final HashMap<ComponentCategory, DisclosurePanel> categoryPanels;
 
-    /**
-     * Creates a new Collapsable Panel.
-     */
-    public CollapsablePanel() {
-        // Initialize UI
-        panel = new VerticalPanel();
-        panel.setWidth("100%");
+  /**
+   * Creates a new Collapsable Panel.
+   */
+  public CollapsablePanel() {
+    // Initialize UI
+    panel = new VerticalPanel();
+    panel.setWidth("100%");
 
-        categoryPanels = new HashMap<>();
+    categoryPanels = new HashMap<>();
 
-        initWidget(panel);
+    initWidget(panel);
+  }
+
+  /**
+   * Add the given category of components to the panel with title `title`
+   *
+   * @param category a component category
+   * @param title    the name of the component category
+   */
+  public void add(VerticalPanel componentPanel, ComponentCategory category, String title) {
+    // create the DP for the component category
+    DisclosurePanel innerPanel = new DisclosurePanel(title);
+    innerPanel.add(componentPanel);
+    innerPanel.setWidth("100%");
+    // find new idx TODO should think abot this
+    categoryPanels.put(category, innerPanel);
+
+    // add the DP to the panel
+    panel.add(innerPanel);
+  }
+
+  /**
+   * Insert a component category into the panel
+   *
+   * @param components the components within the category
+   * @param category   the abstract category
+   * @param title      the category name to be displayed on the panel
+   * @param insertIdx  where to insert the category
+   */
+  public void insert(VerticalPanel componentPanel, ComponentCategory category, String title,
+      int insertIdx) {
+    // create the DP for the component category
+    DisclosurePanel innerPanel = new DisclosurePanel(title);
+    innerPanel.add(componentPanel);
+    innerPanel.setWidth("100%");
+    categoryPanels.put(category, innerPanel);
+    // add the DP to the panel
+    panel.insert(innerPanel, insertIdx);
+  }
+
+  public VerticalPanel getCategory(ComponentCategory category) {
+    if (categoryPanels.containsKey(category)) {
+      return (VerticalPanel) categoryPanels.get(category).getContent();
+    } else {
+      return null;
     }
+  }
 
-    /**
-     * Add the given category of components to the panel with title `title`
-     * @param category a component category
-     * @param title the name of the component category
-     */
-    public void add(VerticalPanel componentPanel, ComponentCategory category, String title){
-        // create the DP for the component category
-        DisclosurePanel innerPanel = new DisclosurePanel(title);
-        innerPanel.add(componentPanel);
-        innerPanel.setWidth("100%");
-        // find new idx TODO should think abot this
-        categoryPanels.put(category, innerPanel);
+  /**
+   * remove the component category from the panel
+   * The user should clean the panel that was add to the disclosure panel
+   * to be added to the collapsable panel before removing it from the
+   * collapsable panel
+   *
+   * @param category the componenet category to be removed - should be in the panel
+   */
+  public void remove(VerticalPanel componentPanel, ComponentCategory category) {
+    DisclosurePanel categoryPanel = categoryPanels.get(category);
 
-        // add the DP to the panel
-        panel.add(innerPanel);
-    }
+    categoryPanel.remove(componentPanel);
+    panel.remove(categoryPanel);
+    // remove from the data
+    categoryPanels.remove(category);
+  }
 
-    /**
-     * Insert a component category into the panel
-     * @param components the components within the category
-     * @param category the abstract category
-     * @param title the category name to be displayed on the panel
-     * @param insertIdx where to insert the category
-     */
-    public void insert(VerticalPanel componentPanel, ComponentCategory category, String title, Integer insertIdx){
-        // create the DP for the component category
-        DisclosurePanel innerPanel = new DisclosurePanel(title);
-        innerPanel.add(componentPanel);
-        innerPanel.setWidth("100%");
-        categoryPanels.put(category, innerPanel);
-        // add the DP to the panel
-        panel.insert(innerPanel, insertIdx);
-    }
+  public void clear() {
+    categoryPanels.clear();
+    panel.clear();
+  }
 
-    public VerticalPanel getCategory(ComponentCategory category) {
-        if (categoryPanels.containsKey(category)) {
-            return (VerticalPanel) categoryPanels.get(category).getContent();
-        }
-        else return null;
-    }
-    /**
-     * remove the component category from the panel
-     * The user should clean the panel that was add to the disclosure panel
-     * to be added to the collapsable panel before removing it from the
-     * collapsable panel
-     * @param category the componenet category to be removed - should be in the panel
-     */
-    public void remove(VerticalPanel componentPanel, ComponentCategory category){
-        DisclosurePanel categoryPanel = categoryPanels.get(category);
-
-        categoryPanel.remove(componentPanel);
-        panel.remove(categoryPanel);
-        // remove from the data
-        categoryPanels.remove(category);
-    }
-
-    public void clear() {
-        categoryPanels.clear();
-        panel.clear();
-    }
-
-    /**
-     * Show the category at idx
-     * @param idx the component category location
-     */
-    public void show(Integer idx){
-        ((DisclosurePanel)panel.getWidget(idx)).setOpen(true);
-    }
+  /**
+   * Show the category at idx
+   *
+   * @param idx the component category location
+   */
+  public void show(int idx) {
+    ((DisclosurePanel) panel.getWidget(idx)).setOpen(true);
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/CollapsablePanel.java
@@ -13,17 +13,14 @@ import com.google.gwt.user.client.ui.DisclosurePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Logger;
-import java.util.ArrayList;
 
 public class CollapsablePanel extends Composite{
     private static final Logger LOG = Logger.getLogger(PropertiesPanel.class.getName());
 
     // UI elements
     private final VerticalPanel panel;
-    private final ArrayList<DisclosurePanel> categoryPanels;
-    private final Map<ComponentCategory, Integer> categoryLocations;
+    private final HashMap<ComponentCategory, DisclosurePanel> categoryPanels;
 
     /**
      * Creates a new Collapsable Panel.
@@ -33,8 +30,7 @@ public class CollapsablePanel extends Composite{
         panel = new VerticalPanel();
         panel.setWidth("100%");
 
-        categoryPanels = new ArrayList<>();
-        categoryLocations = new HashMap<ComponentCategory, Integer>();
+        categoryPanels = new HashMap<>();
 
         initWidget(panel);
     }
@@ -50,14 +46,12 @@ public class CollapsablePanel extends Composite{
         innerPanel.add(componentPanel);
         innerPanel.setWidth("100%");
         // find new idx TODO should think abot this
-        Integer newIdx = categoryPanels.size();
-        categoryLocations.put(category, newIdx);
-        categoryPanels.add(innerPanel);
-        // categoryPanels.put(newIdx, innerPanel);
+        categoryPanels.put(category, innerPanel);
 
         // add the DP to the panel
         panel.add(innerPanel);
     }
+
     /**
      * Insert a component category into the panel
      * @param components the components within the category
@@ -70,13 +64,16 @@ public class CollapsablePanel extends Composite{
         DisclosurePanel innerPanel = new DisclosurePanel(title);
         innerPanel.add(componentPanel);
         innerPanel.setWidth("100%");
-        if (categoryPanels.size() > insertIdx) {
-            this.shift(insertIdx);
-        }
-        categoryPanels.add(insertIdx, innerPanel);
-        categoryLocations.put(category, insertIdx);
+        categoryPanels.put(category, innerPanel);
         // add the DP to the panel
         panel.insert(innerPanel, insertIdx);
+    }
+
+    public VerticalPanel getCategory(ComponentCategory category) {
+        if (categoryPanels.containsKey(category)) {
+            return (VerticalPanel) categoryPanels.get(category).getContent();
+        }
+        else return null;
     }
     /**
      * remove the component category from the panel
@@ -86,14 +83,16 @@ public class CollapsablePanel extends Composite{
      * @param category the componenet category to be removed - should be in the panel
      */
     public void remove(VerticalPanel componentPanel, ComponentCategory category){
-        Integer categoryIdx = categoryLocations.get(category);
-        DisclosurePanel categoryPanel = categoryPanels.get(categoryIdx);
+        DisclosurePanel categoryPanel = categoryPanels.get(category);
 
         categoryPanel.remove(componentPanel);
         panel.remove(categoryPanel);
         // remove from the data
-        categoryPanels.remove(categoryIdx);
-        categoryLocations.remove(categoryPanel);
+        categoryPanels.remove(category);
+    }
+
+    public void clear() {
+        categoryPanels.clear();
     }
 
     /**
@@ -101,19 +100,6 @@ public class CollapsablePanel extends Composite{
      * @param idx the component category location
      */
     public void show(Integer idx){
-        DisclosurePanel categoryPanel = categoryPanels.get(idx);
-        categoryPanel.setOpen(true);
+        ((DisclosurePanel)panel.getWidget(idx)).setOpen(true);
     }
-
-    /**
-     * terrible idea, but shift all values at idx
-     */
-    private void shift(Integer idx){
-        categoryLocations.forEach((key, value) -> {
-            if (value >= idx) {
-                categoryLocations.put(key, value + 1);
-            }
-        });
-    }
-
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -586,15 +586,10 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
       } catch (Exception e) {
         LOG.log(Level.SEVERE, "invalid subset string", e);
       }
-      // Toolkit does not currently support Extensions. The Extensions palette should be left alone.
-      palettePanel.clearComponentsExceptExtension();
     } else {
       shownComponents = COMPONENT_DATABASE.getComponentNames();
-      palettePanel.clearComponents();
     }
-    for (String component : shownComponents) {
-      palettePanel.addComponent(component);
-    }
+    palettePanel.reloadComponentsFromSet(shownComponents);
   }
 
   private native String getShownComponents(String subsetString)/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -583,13 +583,13 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
         if (shownComponentsStr.length() > 0) {
           shownComponents = new HashSet<String>(Arrays.asList(shownComponentsStr.split(",")));
         }
+        palettePanel.reloadComponentsFromSet(shownComponents);
       } catch (Exception e) {
         LOG.log(Level.SEVERE, "invalid subset string", e);
       }
     } else {
-      shownComponents = COMPONENT_DATABASE.getComponentNames();
+      palettePanel.reloadComponents();
     }
-    palettePanel.reloadComponentsFromSet(shownComponents);
   }
 
   private native String getShownComponents(String subsetString)/*-{

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
@@ -70,12 +70,11 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
   private final Map<ComponentCategory, PaletteHelper> paletteHelpers;
 
   private final CollapsablePanel stackPalette;
-  private final Map<ComponentCategory, VerticalPanel> categoryPanels;
+
   // store Component Type along with SimplePaleteItem to enable removal of components
   private final Map<String, SimplePaletteItem> simplePaletteItems;
 
   private DropTargetProvider dropTargetProvider;
-  private List<Integer> categoryOrder;
 
   // panel that holds all palette items
   final VerticalPanel panel;
@@ -161,11 +160,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
     paletteHelpers = new HashMap<ComponentCategory, PaletteHelper>();
     // If a category has a palette helper, add it to the paletteHelpers map here.
     paletteHelpers.put(ComponentCategory.LEGOMINDSTORMS, new LegoPaletteHelper());
-
-    categoryPanels = new HashMap<ComponentCategory, VerticalPanel>();
     simplePaletteItems = new HashMap<String, SimplePaletteItem>();
-    categoryOrder = new ArrayList<Integer>();
-
     translationMap = new HashMap<String, String>();
     panel = new VerticalPanel();
     panel.setWidth("100%");
@@ -211,16 +206,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
 
     for (ComponentCategory category : ComponentCategory.values()) {
       if (showCategory(category)) {
-        VerticalPanel categoryPanel = new VerticalPanel();
-        categoryPanel.setWidth("100%");
-        categoryPanels.put(category, categoryPanel);
-        // The production version will not include a mapping for Extension because
-        // only compile-time categories are included. This allows us to i18n the
-        // Extension title for the palette.
-        String title = ComponentCategory.EXTENSION.equals(category) ?
-          MESSAGES.extensionComponentPallette() :
-          ComponentsTranslation.getCategoryName(category.getName());
-        stackPalette.add(categoryPanel, category, title);
+        addComponentCategory(category);
       }
     }
     stackPalette.show(0);
@@ -341,6 +327,14 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
     }
   }
 
+  public void reloadComponentsFromSet(Set<String> set) {
+    clearComponents();
+    for (String component : set) {
+      addComponent(component);
+    }
+    initExtensionPanel();
+  }
+
   @Override
   public void configureComponent(MockComponent mockComponent) {
     String componentType = mockComponent.getType();
@@ -407,7 +401,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
    * Adds a component entry to the palette.
    */
   private void addPaletteItem(SimplePaletteItem component, ComponentCategory category) {
-    VerticalPanel panel = categoryPanels.get(category);
+    VerticalPanel panel = stackPalette.getCategory(category);
     if (panel == null) {
       panel = addComponentCategory(category);
     }
@@ -422,32 +416,22 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
   private VerticalPanel addComponentCategory(ComponentCategory category) {
     VerticalPanel panel = new VerticalPanel();
     panel.setWidth("100%");
-    categoryPanels.put(category, panel);
-    // The production version will not include a mapping for Extension because
-    // only compile-time categories are included. This allows us to i18n the
-    // Extension title for the palette.
-    int insert_index = Collections.binarySearch(categoryOrder, category.ordinal());
-    insert_index = - insert_index - 1;
     String title = "";
     if (ComponentCategory.EXTENSION.equals(category)) {
       title = MESSAGES.extensionComponentPallette();
-      initExtensionPanel();
     } else {
       title = ComponentsTranslation.getCategoryName(category.getName());
     }
-    stackPalette.insert(panel, category, title, insert_index);
-    categoryOrder.add(insert_index, category.ordinal());
+    stackPalette.add(panel, category, title);
     // When the categories are loaded, we want the first one open, which will almost always be User Interface
-    stackPalette.show(0);
     return panel;
   }
 
   private void removePaletteItem(SimplePaletteItem component, ComponentCategory category) {
-    VerticalPanel panel = categoryPanels.get(category);
+    VerticalPanel panel = stackPalette.getCategory(category);
     panel.remove(component);
     if (panel.getWidgetCount() < 1) {
       stackPalette.remove(panel, category);
-      categoryPanels.remove(category);
     }
   }
 
@@ -461,8 +445,12 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
       }
     });
 
-    categoryPanels.get(ComponentCategory.EXTENSION).add(addComponentAnchor);
-    categoryPanels.get(ComponentCategory.EXTENSION).setCellHorizontalAlignment(
+    VerticalPanel categoryPanel = stackPalette.getCategory(ComponentCategory.EXTENSION);
+    if (categoryPanel == null) {
+      categoryPanel = addComponentCategory(ComponentCategory.EXTENSION);
+    }
+    categoryPanel.add(addComponentAnchor);
+    categoryPanel.setCellHorizontalAlignment(
         addComponentAnchor, HasHorizontalAlignment.ALIGN_CENTER);
   }
 
@@ -494,39 +482,13 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
 
   @Override
   public void clearComponents() {
-    for (ComponentCategory category : categoryPanels.keySet()) {
-      VerticalPanel panel = categoryPanels.get(category);
-      panel.clear();
-      stackPalette.remove(panel, category);
-    }
+    stackPalette.clear();
     for (PaletteHelper pal : paletteHelpers.values()) {
       pal.clear();
     }
-    categoryPanels.clear();
     paletteHelpers.clear();
-    categoryOrder.clear();
     simplePaletteItems.clear();
   }
-
-  // Intended for use by Blocks Toolkit, which needs to be able to refresh without
-  // bothering the loaded extensions
-  public void clearComponentsExceptExtension() {
-    for (ComponentCategory category : categoryPanels.keySet()) {
-      if (!ComponentCategory.EXTENSION.equals(category)) {
-        VerticalPanel panel = categoryPanels.get(category);
-        panel.clear();
-        stackPalette.remove(panel, category);
-      }
-    }
-    for (PaletteHelper pal : paletteHelpers.values()) {
-      pal.clear();
-    }
-    categoryPanels.clear();
-    paletteHelpers.clear();
-    categoryOrder.clear();
-    simplePaletteItems.clear();
-  }
-
 
   @Override
   public void reloadComponents() {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
@@ -327,6 +327,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
         addComponentCategory(category);
       }
     }
+    initExtensionPanel();
     for (String component : COMPONENT_DATABASE.getComponentNames()) {
       this.addComponent(component);
     }
@@ -335,10 +336,10 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
 
   public void reloadComponentsFromSet(Set<String> set) {
     clearComponents();
+    initExtensionPanel();
     for (String component : set) {
       addComponent(component);
     }
-    initExtensionPanel();
     stackPalette.show(0);
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/palette/YoungAndroidPalettePanel.java
@@ -322,9 +322,15 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
   }
 
   public void loadComponents() {
+    for (ComponentCategory category : ComponentCategory.values()) {
+      if (showCategory(category)) {
+        addComponentCategory(category);
+      }
+    }
     for (String component : COMPONENT_DATABASE.getComponentNames()) {
       this.addComponent(component);
     }
+    stackPalette.show(0);
   }
 
   public void reloadComponentsFromSet(Set<String> set) {
@@ -333,6 +339,7 @@ public class YoungAndroidPalettePanel extends Composite implements SimplePalette
       addComponent(component);
     }
     initExtensionPanel();
+    stackPalette.show(0);
   }
 
   @Override


### PR DESCRIPTION
This should fix the extensions category on the component palette disappearing when the palette is refreshed. I also did some refactoring of the collapsable palette code.