### PR TITLE
Allow style switch in read only, fix Neo buttons

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
@@ -121,15 +121,16 @@
 
     <!-- Settings Menu -->
     <ai:DropDownButton name="Settings" caption="{messages.settingsTabName}"
-                       styleName="ode-TopPanelButton" ui:field="settingsDropDown"
-                       visible="{hasWriteAccess}">
+                       styleName="ode-TopPanelButton" ui:field="settingsDropDown">
       <ai:DropDownItem name="UISettings" caption="{messages.uiSettings}">
         <actions:UISettingsAction/>
       </ai:DropDownItem>
-      <ai:DropDownItem name="AutoloadLastProject" caption="{messages.disableAutoload}">
+      <ai:DropDownItem name="AutoloadLastProject" caption="{messages.disableAutoload}"
+          visible="{hasWriteAccess}">
         <actions:DisableAutoloadAction/>
       </ai:DropDownItem>
-      <ai:DropDownItem name="DyslexicFont" caption="{messages.disableOpenDyslexic}">
+      <ai:DropDownItem name="DyslexicFont" caption="{messages.disableOpenDyslexic}"
+          visible="{hasWriteAccess}">
         <actions:SetFontRegularAction/>
       </ai:DropDownItem>
     </ai:DropDownButton>

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
@@ -36,6 +36,7 @@ public class ProjectToolbar extends Toolbar {
   private static final String WIDGET_NAME_LOGINTOGALLERY = "Login to Gallery";
 
   private final boolean isReadOnly;
+  private final boolean isGalleryReadyOnly;
   private final boolean galleryEnabled;
   @UiField protected Label projectLabel;
   @UiField protected Label trashLabel;
@@ -48,12 +49,13 @@ public class ProjectToolbar extends Toolbar {
   public ProjectToolbar() {
     super();
     isReadOnly = Ode.getInstance().isReadOnly();
+    isGalleryReadyOnly = Ode.getInstance().getGalleryReadOnly();
     // Is the new gallery enabled
     galleryEnabled = Ode.getSystemConfig().getGalleryEnabled();
     bindProjectToolbar();
     if (galleryEnabled) {
       setButtonVisible(WIDGET_NAME_LOGINTOGALLERY, true);
-      if (!Ode.getInstance().getGalleryReadOnly()) {
+      if (!isGalleryReadyOnly) {
         setButtonVisible(WIDGET_NAME_SENDTONG, true);
       }
     }
@@ -85,7 +87,8 @@ public class ProjectToolbar extends Toolbar {
     setButtonVisible("ImportProject", visible);
     setButtonVisible("ImportTemplate", visible);
     setButtonVisible("Move", visible);
-    setButtonVisible("Publish", visible);
+    setButtonVisible(WIDGET_NAME_SENDTONG, visible && galleryEnabled && !isGalleryReadyOnly);
+    setButtonVisible(WIDGET_NAME_LOGINTOGALLERY, visible && galleryEnabled);
     setDropDownButtonVisible("Export", visible);
     projectLabel.setVisible(visible);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
@@ -18,10 +18,6 @@
       <ca:SwitchToProjectAction/>
     </ai:ToolbarItem>
     <g:Label ui:field="projectNameLabel" styleName="ya-ProjectName"/>
-    <ai:ToolbarItem name="TutorialToggle" caption="{messages.toggleTutorialButton}"
-                    visible="false">
-      <ya:ToggleTutorialAction/>
-    </ai:ToolbarItem>
 
     <ai:ToolbarItem styleName="ya-ProjectName" caption="Screens: " align="center" enabled="false"/>
     <ai:DropDownButton name="ScreensDropdown" caption="{messages.screensButton}"
@@ -35,6 +31,11 @@
                     align="center" styleName="ode-ProjectListButton inline bright primary"
                     tooltip="{messages.removeFormButton}">
       <ya:RemoveFormAction/>
+    </ai:ToolbarItem>
+
+    <ai:ToolbarItem name="TutorialToggle" icon="school" tooltip="{messages.toggleTutorialButton}"
+        visible="false" align="center" styleName="ode-ProjectListButton inline">
+      <ya:ToggleTutorialAction/>
     </ai:ToolbarItem>
 
     <ai:ToolbarItem name="ProjectPropertiesDialog" icon="manufacturing"

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/ProjectToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/ProjectToolbarNeo.ui.xml
@@ -73,9 +73,6 @@
                     tooltip="{messages.deleteFromTrashButton}">
       <actions:DeleteForeverProjectAction/>
     </ai:ToolbarItem>
-    <ai:ToolbarItem name="Send to Gallery" caption="{messages.publishToGalleryButton}" visible="false">
-      <actions:SendToGalleryAction/>
-    </ai:ToolbarItem>
 
   </ai:Toolbar>
 </ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
@@ -109,15 +109,16 @@
 
     <!-- Settings Menu -->
     <ai:DropDownButton name="Settings" styleName="ode-TopPanelButton"
-                       ui:field="settingsDropDown" align="left" icon="settings"
-                       visible="{hasWriteAccess}" caption="{messages.settingsTabName}">
+        ui:field="settingsDropDown" align="left" icon="settings" caption="{messages.settingsTabName}">
       <ai:DropDownItem name="UISettings" caption="{messages.uiSettings}">
         <actions:UISettingsAction/>
       </ai:DropDownItem>
-      <ai:DropDownItem name="AutoloadLastProject" caption="{messages.disableAutoload}">
+      <ai:DropDownItem name="AutoloadLastProject" caption="{messages.disableAutoload}"
+          visible="{hasWriteAccess}" >
         <actions:DisableAutoloadAction/>
       </ai:DropDownItem>
-      <ai:DropDownItem name="DyslexicFont" caption="{messages.disableOpenDyslexic}">
+      <ai:DropDownItem name="DyslexicFont" caption="{messages.disableOpenDyslexic}"
+          visible="{hasWriteAccess}" >
         <actions:SetFontRegularAction/>
       </ai:DropDownItem>
       <hr/>


### PR DESCRIPTION
Miscellaneous minor fixes:

1. Settings menu was set to invisible when the project is read only, but the UI Settings dialog now needs to be accessed there to switch between styles. Fixed so that the Settings menu always appears and the menu items are restricted by write access.

2. Fixed tutorial and gallery-related toolbar buttons that were not displaying with their icons properly in Neo.