### PR TITLE
Fix Neo box css pushing Assets box below fold

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -21,7 +21,7 @@
       <g:DeckPanel ui:field="deckPanel" animationEnabled="true" styleName="ode-DeckPanel">
         <g:FlowPanel width="100%" >
           <neo:ProjectToolbarNeo ui:field="projectToolbar" />
-          <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box-height-100" />
+          <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box ode-Box-height-100" />
         </g:FlowPanel>
         <g:FlowPanel styleName="ode-ProjectEditor" ui:field="projectEditor">
           <neo:DesignToolbarNeo ui:field="designToolbar" />

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -21,7 +21,7 @@
       <g:DeckPanel ui:field="deckPanel" animationEnabled="true" styleName="ode-DeckPanel">
         <g:FlowPanel width="100%" >
           <neo:ProjectToolbarNeo ui:field="projectToolbar" />
-          <box:ProjectListBox ui:field="projectListbox" />
+          <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box-height-100" />
         </g:FlowPanel>
         <g:FlowPanel styleName="ode-ProjectEditor" ui:field="projectEditor">
           <neo:DesignToolbarNeo ui:field="designToolbar" />

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -78,10 +78,9 @@ they get cut off in Windows.
     padding-left: unset;
   }
 
-  .ode-Box {
+  .ode-Box-height-100 {
     height: 100%;
   }
-
 
   .ode-Box-content {
     /*all:unset;*/

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/SubsetJSONPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/SubsetJSONPropertyEditor.java
@@ -129,7 +129,7 @@ public class SubsetJSONPropertyEditor  extends PropertyEditor
         updateValue();
       }}));
 
-    items.add(new DropDownItem("Subset Property Editor", MESSAGES.expertToolkitButton(), new Command() {
+    items.add(new DropDownItem("Subset Property Editor", MESSAGES.defaultText(), new Command() {
       @Override
       public void execute() {
         property.setValue("");
@@ -642,7 +642,7 @@ public class SubsetJSONPropertyEditor  extends PropertyEditor
   protected void updateValue() {
     LOG.info(property.getValue());
     if (StringUtils.isNullOrEmpty(property.getValue())) {
-      dropDownButton.setCaption(MESSAGES.expertToolkitButton());
+      dropDownButton.setCaption(MESSAGES.defaultText());
       dropDownButton.setWidth("");
     } else if (Objects.equals(property.getValue().replaceAll("\\s+",""), BeginnerToolkit.INSTANCE.getToolkit().getText().replaceAll("\\s+",""))){
       dropDownButton.setCaption(MESSAGES.beginnerToolkitButton());


### PR DESCRIPTION
The fix to the Neo style project list scrolling problem was too broad and caused a different Box (Assets on the Designer) to be pushed below the fold.

This makes the css fix for the project list specific to the project list.