### PR TITLE
Fix memory leak in SimplePaletteItem

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePaletteItem.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePaletteItem.java
@@ -127,7 +127,7 @@ public class SimplePaletteItem extends DragSourcePanel {
     cacheInternalComponentPrototype();
 
     MockComponent returnedComponentPrototype = componentPrototype;
-    componentPrototype = null;
+    // componentPrototype = null;
     return returnedComponentPrototype;
   }
 


### PR DESCRIPTION
For some reason, App Inventor was creating 2 instances of components every time a component was being dragged. However, the extra instance was not being deleted or cleaned up, losing access to the instance as no pointer was ever referring to it again.  
Tracing down this variable's usage, it seems to be restricted to this file, and no further usage of the "extra" component is being made. This code has been in AI2 since 2011, without major updates besides 2018 and 2023 being the most recent updates.

The current flow was:

* `createMockComponent` was invoked when the user started dragging the component. The created component resets its reference, hence `SimplePaletteItem` thinks it was not yet initialized.
* Any further event, like the component entering the mock area or just being dropped, causes `isVisibleComponent` to be triggered, and it creates another instance. This new instance is now preserved.
* This new instance is the one being triggered through updates, and the one being deleted.

See below the debug logs:

![image](https://github.com/user-attachments/assets/6438ca6f-b920-466f-9f91-738a4e7683f7)

Two `createMockComponentFromPalette` events are triggered for the components, but just a single one triggers its `delete` method. One of the copies is left in memory somewhere, which would cause "long development sessions" to become laggier as those components are not cleaned up.

> I'm just raising the PR for tracking purposes, as I would like to discuss it at Wednesday's meeting. It is very old code, so probably some context is needed here to understand the rationale for this null-pointer logic resetting it.