### PR TITLE
Set designer sidebars to fixed width in Neo

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -28,15 +28,15 @@
           <g:FlowPanel ui:field="workColumns" styleName="ode-WorkColumns" >
             <box:PaletteBox width="265px" ui:field="paletteBox"/>
             <box:ViewerBox ui:field="viewerBox" />
-            <g:FlowPanel ui:field="structureAndAssets">
-              <box:SourceStructureBox ui:field="sourceStructureBox" />
+            <g:FlowPanel ui:field="structureAndAssets" styleName="ode-Designer-RightColumns">
+              <box:SourceStructureBox ui:field="sourceStructureBox"  />
               <box:BlockSelectorBox />
               <g:FlowPanel>
                 <g:Label text="{messages.assetListBoxCaption}" styleName="ode-AssetsTitle" />
                 <box:AssetListBox  ui:field="assetListBox" />
               </g:FlowPanel>
             </g:FlowPanel>
-            <box:PropertiesBox ui:field="propertiesBox" width="222px"  />
+            <box:PropertiesBox ui:field="propertiesBox"  styleName="Designer-RightColumns" />
           </g:FlowPanel>
         </g:FlowPanel>
         <g:FlowPanel width="100%">

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -36,7 +36,7 @@
                 <box:AssetListBox  ui:field="assetListBox" />
               </g:FlowPanel>
             </g:FlowPanel>
-            <box:PropertiesBox ui:field="propertiesBox"  styleName="Designer-RightColumns" />
+            <box:PropertiesBox ui:field="propertiesBox"  styleName="ode-Designer-RightColumns" />
           </g:FlowPanel>
         </g:FlowPanel>
         <g:FlowPanel width="100%">

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -26,7 +26,7 @@
         <g:FlowPanel styleName="ode-ProjectEditor" ui:field="projectEditor">
           <neo:DesignToolbarNeo ui:field="designToolbar" />
           <g:FlowPanel ui:field="workColumns" styleName="ode-WorkColumns" >
-            <box:PaletteBox width="265px" ui:field="paletteBox"/>
+            <box:PaletteBox ui:field="paletteBox" styleName="ode-Designer-LeftColumn" />
             <box:ViewerBox ui:field="viewerBox" />
             <g:FlowPanel ui:field="structureAndAssets" styleName="ode-Designer-RightColumns">
               <box:SourceStructureBox ui:field="sourceStructureBox"  />

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -587,6 +587,10 @@ they get cut off in Windows.
     display: flex;
   }
 
+  .ode-Designer-RightColumns {
+    min-width: 222px;
+  }
+
   .ode-NavArrow {
     background: #C2C2C2;}
   

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -587,6 +587,9 @@ they get cut off in Windows.
     display: flex;
   }
 
+  .ode-Designer-LeftColumn {
+    min-width: 265px;
+  }
   .ode-Designer-RightColumns {
     min-width: 222px;
   }


### PR DESCRIPTION
Large numbers of non-visible components on a screen and some browser resizing was causing the designer sidebars to shrink smaller than their specified widths. This css change should fix that.