### PR TITLE
Delay CDN warning message by 2 seconds

### DIFF
--- a/appinventor/appengine/extra/cdnok.js
+++ b/appinventor/appengine/extra/cdnok.js
@@ -1,4 +1,7 @@
 function cdnok() {
-  document.getElementById("odeblock").remove()
+  var block = document.getElementById("odeblock");
+  if (block) {
+    block.remove();
+  }
 }
 cdnok();

--- a/appinventor/appengine/war/index.jsp
+++ b/appinventor/appengine/war/index.jsp
@@ -65,13 +65,23 @@
       </ul>
     </div>
     <% if (!odeBase.isEmpty()) { %>
-    <div id=odeblock>
+    <div id=odeblock style="display: none;">
         <h1>If you see this message for an extended period of time, it might be because
         your internet service is blocking requests to <%= odeBase %>. Contact your
         administrator to check on this and remove the block.
         </h1>
     </div>
     <% } %>
+    <script type="text/javascript">
+      (function() {
+        setTimeout(function() {
+          var block = document.getElementById('odeblock');
+          if (block) {
+            block.style.display = 'block';
+          }
+        }, 2000);
+      })();
+    </script>
     <script type="text/javascript" src="static/closure-library/closure/goog/base.js"></script>
     <script type="text/javascript" src="<%= odeBase %>ode/cdnok.js"></script>
     <script type="text/javascript" src="<%= odeBase %>ode/ode.nocache.js"></script>


### PR DESCRIPTION
This change adds a two second delay to show the warning message about potential interference when loading App Inventor via a CDN. I figured 2 seconds is probably good enough as the cdnok.js file is fairly small so unless there is a significant latency on the network it should come through pretty quickly. One improvement that we should decide whether to implement is if we want the timing to be configurable by appengine-web.xml.

Change-Id: I16d862be1111e254dc7ecb4ac6726c4d0310d841