### PR TITLE
Fix bug where ListPicker won't open without a BeforePicking event

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -450,7 +450,7 @@
                                    (apply handler (gnu.lists.LList:makeList args 0))
                                    #t)
                                  (exception com.google.appinventor.components.runtime.errors.StopBlocksExecution
-                                   #f)
+                                   (throw exception))
                                  ;; PermissionException should be caught by a permissions-aware component and
                                  ;; handled correctly at the point it is caught. However, older extensions
                                  ;; might not be updated yet for SDK 23's dangerous permissions model, so if

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Picker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Picker.java
@@ -9,6 +9,7 @@ package com.google.appinventor.components.runtime;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
+import com.google.appinventor.components.runtime.errors.StopBlocksExecution;
 import com.google.appinventor.components.runtime.util.AnimationUtil;
 import android.content.Intent;
 
@@ -65,10 +66,13 @@ public abstract class Picker extends ButtonBase implements ActivityResultListene
    * Event to raise when the `%type%` is clicked or the picker is shown
    * using the {@link #Open()} method.  This event occurs before the picker is displayed, and
    * can be used to prepare the picker before it is shown.
+   *
+   * @return true if the picker should be opened, false if it should not.
    */
   @SimpleEvent
   public boolean BeforePicking() {
-    return EventDispatcher.dispatchEvent(this, "BeforePicking");
+    Object result = EventDispatcher.dispatchFallibleEvent(this, "BeforePicking");
+    return !(result instanceof StopBlocksExecution);
   }
 
   /**


### PR DESCRIPTION
So the last change I made to the list picker broke opening the picker when the BeforePicker event wasn't defined in the blocks. This is because that change conflated `#f` with being both "failed due to an exception" and "failed due to not being defined." This change introduces a new method in EventDispatcher called `dispatchFallibleEvent`, which returns true if the event was dispatched, false if it wasn't defined, and an exception if it occurred. To prevent repeating logic, I redefined `dispatchEvent` to call this new version (exceptions are considered failures as seen in runtime.scm). In my testing, this fixed the issue reported by @jisqyv. I also tested the logic with BluetoothClient.AddressesAndNames that prompted the initial (broken) fix currently on ucr and ai2-test.

Change-Id: I8d25acad2eafb017f8203c6827394bfd0dd4d611