### PR TITLE
Remove extra comma in json example

### DIFF
--- a/appinventor/docs/html/reference/blocks/dictionaries.html
+++ b/appinventor/docs/html/reference/blocks/dictionaries.html
@@ -312,7 +312,7 @@ This block reverses the conversion performed by the <a href="#list-of-pairs-to-d
     </span><span class="s2">"last_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Beaver"</span><span class="w">
   </span><span class="p">},{</span><span class="w">
     </span><span class="s2">"first_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"John"</span><span class="p">,</span><span class="w">
-    </span><span class="s2">"last_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Smith"</span><span class="p">,</span><span class="w">
+    </span><span class="s2">"last_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Smith"</span><span class="w">
   </span><span class="p">},{</span><span class="w">
     </span><span class="s2">"first_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Jane"</span><span class="p">,</span><span class="w">
     </span><span class="s2">"last_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Doe"</span><span class="w">

--- a/appinventor/docs/markdown/reference/blocks/dictionaries.md
+++ b/appinventor/docs/markdown/reference/blocks/dictionaries.md
@@ -191,7 +191,7 @@ Consider the following JSON and blocks:
     "last_name": "Beaver"
   },{
     "first_name": "John",
-    "last_name": "Smith",
+    "last_name": "Smith"
   },{
     "first_name": "Jane",
     "last_name": "Doe"


### PR DESCRIPTION
There is in extra comma in a json example in the dictionaries documentation. This change removes it.