### PR TITLE
Draggable property and component help popups

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
@@ -14,6 +14,7 @@ import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.PopupPanel;
@@ -35,18 +36,13 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
   // don't want the question-mark click to reopen it.
   private long lastClosureTime = 0;
 
-  private class ComponentHelpPopup extends PopupPanel {
+  private class ComponentHelpPopup extends DialogBox {
 
     private ComponentHelpPopup() {
       // Create popup panel.
-      super(true);
-      setStyleName("ode-ComponentHelpPopup");
-      setTitle(scd.getName());
-
-      // Create title from component name.
-      Label titleBar = new Label(ComponentsTranslation.getComponentName(scd.getName()));
-      setTitle(scd.getName());
-      titleBar.setStyleName("ode-ComponentHelpPopup-TitleBar");
+      super(true, true);
+      setStyleName("ode-DialogBox");
+      setText(scd.getName());
 
       // Create content from help string.
       String helpTextKey = scd.getExternal() ? scd.getHelpString() : scd.getName();
@@ -61,7 +57,6 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
       // Create panel to hold the above three widgets and act as the
       // popup's widget.
       VerticalPanel inner = new VerticalPanel();
-      inner.add(titleBar);
       inner.add(helpText);
 
       // Create link to more information.  This would be cleaner if
@@ -121,7 +116,7 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
         inner.add(viewLicenseHTML);
       }
 
-      setWidget(inner);
+      add(inner);
 
       // When the panel is closed, save the time in milliseconds.
       // This will help us avoid immediately reopening it if the user
@@ -135,26 +130,7 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
 
       // Use a Pinch Zoom aware PopupPanel.PositionCallback to handle positioning to
       // avoid the Google Chrome Pinch Zoom bug.
-      setPopupPositionAndShow(new PZAwarePositionCallback(ComponentHelpWidget.this.getElement()) {
-        @Override
-        public void setPosition(int offsetWidth, int offsetHeight) {
-          // Position the upper-left of the panel just to the right of the
-          // question-mark icon, unless that would make it too low.
-          final int X_OFFSET = 20;
-          final int Y_OFFSET = -5;
-          if(Window.Navigator.getUserAgent().contains("Chrome") && isPinchZoomed()) {
-            setPopupPosition(getTrueAbsoluteLeft() + 1 + X_OFFSET,
-                Math.min(getTrueAbsoluteTop() + 1 + Y_OFFSET,
-                    Math.max(0, Window.getClientHeight()
-                        - offsetHeight + Y_OFFSET)));
-          } else {
-            setPopupPosition(ComponentHelpWidget.this.getAbsoluteLeft() + X_OFFSET,
-                Math.min(ComponentHelpWidget.this.getAbsoluteTop() + Y_OFFSET,
-                    Math.max(0, Window.getClientHeight()
-                        - offsetHeight + Y_OFFSET)));
-          }
-        }
-      });
+      showRelativeTo(ComponentHelpWidget.this);
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
@@ -127,9 +127,7 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
             lastClosureTime = System.currentTimeMillis();
           }
         });
-
-      // Use a Pinch Zoom aware PopupPanel.PositionCallback to handle positioning to
-      // avoid the Google Chrome Pinch Zoom bug.
+      
       showRelativeTo(ComponentHelpWidget.this);
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -136,8 +136,7 @@ public class SourceStructureExplorer extends Composite {
 
     // Put a ScrollPanel around the tree.
     ScrollPanel scrollPanel = new ScrollPanel(tree);
-    scrollPanel.setWidth("200px");  // wide enough to avoid a horizontal scrollbar most of the time
-    scrollPanel.setHeight("480px"); // approximately the same height as the viewer
+    scrollPanel.setStyleName("ode-SourceScrollPanel");
 
     HorizontalPanel buttonPanel = new HorizontalPanel();
     buttonPanel.setStyleName("ode-PanelButtons");

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -1260,7 +1260,6 @@ they get cut off in Windows.
   }
   
   .ode-DialogBox .dialogContent {
-    /*padding: 5px 20px;*/
     color: context-menu-color;
   }
   

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -590,8 +590,9 @@ they get cut off in Windows.
   .ode-Designer-LeftColumn {
     min-width: 265px;
   }
+
   .ode-Designer-RightColumns {
-    min-width: 222px;
+    width: 222px;
   }
 
   .ode-NavArrow {
@@ -771,6 +772,11 @@ they get cut off in Windows.
   .destructive-action[disabled]:hover {
     background: #faa;
     color: #888;
+  }
+
+  .ode-SourceScrollPanel {
+    width: 222px;
+    height: 480px;
   }
   
   .ode-PanelButtons .ode-TextButton {

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -1260,7 +1260,7 @@ they get cut off in Windows.
   }
   
   .ode-DialogBox .dialogContent {
-    padding: 5px 20px;
+    /*padding: 5px 20px;*/
     color: context-menu-color;
   }
   

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/LabeledTextBox.java
@@ -44,7 +44,6 @@ public class LabeledTextBox extends Composite {
     panel.setCellVerticalAlignment(captionLabel, HasVerticalAlignment.ALIGN_MIDDLE);
     textbox = new TextBox();
     textbox.setStylePrimaryName("ode-LabeledTextBox");
-    textbox.setWidth("100%");
     panel.add(textbox);
     panel.setCellWidth(captionLabel, "45%");
     panel.setCellVerticalAlignment(textbox, HasVerticalAlignment.ALIGN_MIDDLE);
@@ -90,8 +89,6 @@ public class LabeledTextBox extends Composite {
       errorPanel.add(errorLabel);
       VerticalPanel vp = (VerticalPanel) getWidget();
       vp.add(errorPanel);
-      vp.setHeight("85px");
-      vp.setWidth("100%");
     }
   }
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
@@ -12,6 +12,7 @@ import com.google.appinventor.client.Ode;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.AbstractImagePrototype;
 import com.google.gwt.user.client.ui.ClickListener;
+import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
@@ -34,19 +35,16 @@ public final class PropertyHelpWidget extends Image {
   // don't want the question-mark click to reopen it.
   private long lastClosureTime = 0;
 
-  private class PropertyHelpPopup extends PopupPanel {
+  private class PropertyHelpPopup extends DialogBox {
 
     private PropertyHelpPopup(final EditableProperty prop,
                                final Widget sender) {
       // Create popup panel.
-      super(true);
-      setStyleName("ode-ComponentHelpPopup");
-      setTitle(ComponentsTranslation.getPropertyName(prop.getName()));
+      super(true, true);
+      setStyleName("ode-DialogBox");
 
       // Create title from component name.
-      Label titleBar = new Label(ComponentsTranslation.getPropertyName(prop.getName()));
-      setTitle(ComponentsTranslation.getPropertyName(prop.getName()));
-      titleBar.setStyleName("ode-ComponentHelpPopup-TitleBar");
+      setText(ComponentsTranslation.getPropertyName(prop.getName()));
 
       // Create content from help string.
       HTML helpText = new HTML(prop.getDescription());
@@ -55,10 +53,9 @@ public final class PropertyHelpWidget extends Image {
       // Create panel to hold the above three widgets and act as the
       // popup's widget.
       final VerticalPanel inner = new VerticalPanel();
-      inner.add(titleBar);
+      inner.setStyleName("ode-ComponentHelpPopup-Body");
       inner.add(helpText);
-      inner.setWidth("100%");
-      setWidget(inner);
+      add(inner);
 
       // When the panel is closed, save the time in milliseconds.
       // This will help us avoid immediately reopening it if the user
@@ -70,22 +67,6 @@ public final class PropertyHelpWidget extends Image {
           }
         });
 
-//      setPopupPositionAndShow(new PopupPanel.PositionCallback() {
-//          @Override
-//          public void setPosition(int offsetWidth, int offsetHeight) {
-//            // Position the upper-left of the panel just to the right of the
-//            // question-mark icon, unless that would make it too low.
-//            final int X_OFFSET = 20;
-//            final int Y_OFFSET = -5;
-//            setPopupPosition(sender.getAbsoluteLeft() - X_OFFSET - inner.getOffsetWidth(),
-//                             Math.min(
-//                                 sender.getAbsoluteTop() + Y_OFFSET,
-//                                 Math.max(
-//                                     0,
-//                                     Window.getClientHeight() - offsetHeight
-//                                     + Y_OFFSET)));
-//          }
-//        });
       showRelativeTo(PropertyHelpWidget.this);
     }
   }

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -700,6 +700,11 @@ div.StatusPanel {
   flex-flow: column;
 }
 
+.ode-SourceScrollPanel {
+  width: 200px;
+  height: 480px;
+}
+
 .ode-NavArrow {
   border: transparent;
   background: #C2C2C2;

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -1522,9 +1522,9 @@ path.ode-SimpleMockMapFeature-selected {
 }
 
 .ode-ComponentHelpPopup-Body {
-  padding: 10px;
   color: #555;
   font-size: 12px;
+  width: 250px;
 }
 
 .ode-ComponentHelpPopup-Link {
@@ -1861,10 +1861,6 @@ path.ode-SimpleMockMapFeature-selected {
   min-height: 40px;
 }
 
-.ode-DialogBox, .ode-DialogBox .dialogContent {
-  min-width: 340px;
-}
-
 .DialogBox-message {}
 
 .ode-DialogBox .gwt-CheckBox {
@@ -1936,7 +1932,7 @@ path.ode-SimpleMockMapFeature-selected {
 }
 
 .ode-DialogBox .dialogContent td {
-  padding: 2px 10px;
+  padding: 2px 2px;
   font-size: 12px;
   color: #555;
 }
@@ -1947,6 +1943,7 @@ path.ode-SimpleMockMapFeature-selected {
 
 .ode-DialogBox .ode-LabeledTextBox {
   margin-bottom: 0;
+  padding: 5px 10px;
 }
 
 .ode-DialogBox .buttonRow {

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -1528,7 +1528,7 @@ path.ode-SimpleMockMapFeature-selected {
 }
 
 .ode-ComponentHelpPopup-Link {
-  padding: 0 10px 10px 10px;
+  padding: 0 10px 10px 0;
   font-size: 12px;
 
 }


### PR DESCRIPTION
This changes help popups (under the "?" buttons on the palette and properties panels) to inherit from GWT DialogBox, which is draggable. These classes previously inherited from PopupPanel, which did not drag. Dragging was requested on the community forum, particularly for the newer property popups because the popup usually covered part of the property editor when open.

Making the popups match their previous version involved moving some formatting out of the java code and into css, which ought to be a good thing.

In addition, I shuffled some css to prevent the properties panel in Neo from expanding when the variable name is too long.