### PR TITLE
Fix accessibility footer in Neo

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -19,9 +19,9 @@
     <g:FlowPanel styleName="ode-TutorialWrapper" ui:field="overDeckPanel">
       <ed:TutorialPanel ui:field="tutorialPanel" width="100%" height="100%" visible="false" />
       <g:DeckPanel ui:field="deckPanel" animationEnabled="true" styleName="ode-DeckPanel">
-        <g:FlowPanel width="100%" >
+        <g:FlowPanel width="100%" height="100%" styleName="ode-Project-FlexColumn">
           <neo:ProjectToolbarNeo ui:field="projectToolbar" />
-          <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box ode-Box-height-100" />
+          <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box ode-Box-projectlist" />
         </g:FlowPanel>
         <g:FlowPanel styleName="ode-ProjectEditor" ui:field="projectEditor">
           <neo:DesignToolbarNeo ui:field="designToolbar" />

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/ProjectListNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/ProjectListNeo.ui.xml
@@ -36,7 +36,7 @@
                        styleName="gwt-Label ode-ProjectHeaderLabel"/>
       </g:FlowPanel>
     </g:FlowPanel>
-    <g:FlowPanel styleName="ode-ProjectRowList" ui:field='container'>
+    <g:FlowPanel styleName="ode-ProjectRowList ode-Project-FlexColumn" ui:field='container'>
 
     </g:FlowPanel>
   </g:FlowPanel>

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -306,8 +306,6 @@ they get cut off in Windows.
 
 .ode-ProjectRowList {
   overflow: scroll;
-  display: flex;
-  flex-direction: column;
   flex-grow: 1;
   width: 100%;
   height: 40px;

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -78,8 +78,11 @@ they get cut off in Windows.
     padding-left: unset;
   }
 
-  .ode-Box-height-100 {
-    height: 100%;
+  .ode-Box-projectlist {
+    flex-grow: 1;
+    flex-shrink: 0;
+    height: 40px;
+    overflow: hidden;
   }
 
   .ode-Box-content {
@@ -284,17 +287,31 @@ they get cut off in Windows.
     height: 30px;
     align-items: center;
     display: inline-flex;
-  
   }
-  
+
+  .ode-Project-FlexColumn {
+    display: flex;
+    flex-direction: column;
+  }
+
   .ode-ProjectTable {
-    /*all: unset;*/
     border: 1px solid border-color;
     border-radius: 4px;
-    overflow: auto;
-    height: auto;
-    width:auto;
+    overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
   }
+
+
+.ode-ProjectRowList {
+  overflow: scroll;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  width: 100%;
+  height: 40px;
+}
   
   .ode-ProjectRowHighlighted {
     background-color: highlight-color !important;
@@ -325,6 +342,8 @@ they get cut off in Windows.
     background: background-color;
     font-weight: 600;
     font-size: 1.15em;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
   
   .ode-ProjectCheckBox {


### PR DESCRIPTION
- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Previously, the accessibility footer overlapped the bottom of the project list in the explorer when there were enough projects to cause scrolling.

These css changes should resolve that issue.

Additionally, the column headers of the project list are now stationary, and only the list itself scrolls.
