### PR TITLE
Change ChatBot System property to use large text area

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ChatBot.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ChatBot.java
@@ -394,7 +394,7 @@ public final class ChatBot extends AndroidNonvisibleComponent {
     return system;
   }
 
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTAREA,
     defaultValue = "")
   @SimpleProperty(description = "The \"System\" value given to ChatGPT. It is " +
     "used to set the tone of a conversation. For example: \"You are a funny person.\"",


### PR DESCRIPTION
Change-Id: Ied2ca2af6c13a2e092803555a24c42f5efe786b7

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR changes the property type of the ChatBot's System property to make it resizable in the designer property panel.