### PR TITLE
Fix hint text not showing in MockTextBoxBase

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
@@ -22,7 +22,8 @@ import com.google.gwt.user.client.ui.Widget;
  * @author sharon@google.com (Sharon Perl)
  * @author lizlooney@google.com (Liz Looney)
  */
-abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener{
+abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener {
+  protected static final String PROPERTY_NAME_HINTCOLOR = "HintColor";
 
   // GWT widget used to mock a Simple TextBox
   private final TextBox textBoxWidget;
@@ -153,21 +154,6 @@ abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener
   }
 
   /*
-   * Sets the textbox's Hint property to a new value.
-   */
-  private void setHintProperty(String text) {
-    textBoxWidget.setTitle(text);
-  }
-
-  /*
-   * Sets the textbox's Text property to a new value.
-   */
-  private void setTextProperty(String text) {
-    textBoxWidget.setText(text);
-    updatePreferredSize();
-  }
-
-  /*
    * Sets the textbox's TextColor property to a new value.
    */
   private void setTextColorProperty(String text) {
@@ -184,6 +170,27 @@ abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener
 
     MockComponentsUtil.setWidgetTextColor(textBoxWidget, text);
 
+  }
+
+  /**
+   * Updates the appearance of the textbox text based on the hint, text, and color properties.
+   */
+  private void updateAppearance() {
+    if (hasProperty(PROPERTY_NAME_TEXT) && !getPropertyValue(PROPERTY_NAME_TEXT).isEmpty()) {
+      textBoxWidget.setText(getPropertyValue(PROPERTY_NAME_TEXT));
+      if (hasProperty(PROPERTY_NAME_TEXTCOLOR)) {
+        setTextColorProperty(getPropertyValue(PROPERTY_NAME_TEXTCOLOR));
+      }
+    } else if (hasProperty(PROPERTY_NAME_HINT)) {
+      textBoxWidget.setText(getPropertyValue(PROPERTY_NAME_HINT));
+      if (hasProperty(PROPERTY_NAME_HINTCOLOR)) {
+        MockComponentsUtil.setWidgetTextColor(textBoxWidget,
+            getPropertyValue(PROPERTY_NAME_HINTCOLOR));
+      }
+    } else {
+      textBoxWidget.setText("");
+      MockComponentsUtil.setWidgetTextColor(textBoxWidget, "&HFF000000");
+    }
   }
 
   // PropertyChangeListener implementation
@@ -213,9 +220,14 @@ abstract class MockTextBoxBase extends MockWrapper implements FormChangeListener
       setFontTypefaceProperty(newValue);
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_HINT)) {
-      setHintProperty(newValue);
+      updateAppearance();
+      updatePreferredSize();
+      refreshForm();
+    } else if (propertyName.equals(PROPERTY_NAME_HINTCOLOR)) {
+      updateAppearance();
     } else if (propertyName.equals(PROPERTY_NAME_TEXT)) {
-      setTextProperty(newValue);
+      updateAppearance();
+      updatePreferredSize();
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TEXTCOLOR)) {
       setTextColorProperty(newValue);


### PR DESCRIPTION
Change-Id: Ie3b373eea228d81e5de55d917a6606f649e63ed0

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR causes changes to the Hint and HintColor properties to be accurately reflected in MockTextBoxBase and its descendants.

Fixes #3236

