### PR TITLE
Make the iOS bundle identifier customizable by downstream builders

### DIFF
--- a/appinventor/AICompanionApp.xcconfig.sample
+++ b/appinventor/AICompanionApp.xcconfig.sample
@@ -2,3 +2,4 @@
 // Copyright 2023 MIT, All rights reserved.
 
 DEVELOPMENT_TEAM = "Your Team ID here"
+BUNDLE_IDENTIFIER = "Your custom package here"

--- a/appinventor/AICompanionApp.xcodeproj/project.pbxproj
+++ b/appinventor/AICompanionApp.xcodeproj/project.pbxproj
@@ -814,7 +814,7 @@
 				INFOPLIST_FILE = aicompanionapp/src/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "9c96ca04-1d70-4a2b-bb01-28f545b35d28";
 				PROVISIONING_PROFILE_SPECIFIER = "MIT App Inventor Development";
@@ -836,7 +836,7 @@
 				INFOPLIST_FILE = aicompanionapp/src/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "9c96ca04-1d70-4a2b-bb01-28f545b35d28";
 				PROVISIONING_PROFILE_SPECIFIER = "MIT App Inventor Production";
@@ -854,7 +854,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = aicompanionapp/tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AICompanionApp.app/AICompanionApp";
@@ -869,7 +869,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = aicompanionapp/tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AICompanionApp.app/AICompanionApp";
@@ -883,7 +883,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = aicompanionapp/uitests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3UITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = AICompanionApp;
@@ -897,7 +897,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = aicompanionapp/uitests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.mit.appinventor.aicompanion3UITests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_IDENTIFIER)UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = AICompanionApp;


### PR DESCRIPTION
Change-Id: Ib2f16454f0d72750ce7f0bca3c050159a9a7807a

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

Because the iOS bundle identifier is a global identifier in Apple's developer portal, having it default to `edu.mit.appinventor.aicompanion3` makes it difficult for external contributors to participate in development. This moves the identifier to the AICompanionApp.xcconfig file, which non-MIT contributors can use to specify their own bundle ID.