### PR TITLE
Force use of UTF-8 encoding for BlocklyTranslationGenerator

### DIFF
--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -79,30 +79,31 @@
     </uptodate>
   </target>
 
-	<target name="BlocklyTranslationGenerator"
-			description="This is the script for creating combined i18n files from blockly and app inventor"
-			depends="CheckBlocklyTranslations,BlocklyCompile"
-			unless="Blocklyi18n.uptodate">
-		<mkdir dir="${BlocklyTranslator-class.dir}" />
-		<mkdir dir="${BlocklyTranslations.dir}" />
-		<ai.javac destdir="${BlocklyTranslator-class.dir}">
-			<include name="msg/BlocklyTranslationGenerator.java" />
-			<classpath>
-				<pathelement location="${gwt.sdk}/gwt-dev.jar"/>
-				<pathelement location="${lib.dir}/json/json.jar" />
-			</classpath>
-		</ai.javac>
-		<java failonerror="true" classname="msg.BlocklyTranslationGenerator">
-                      <arg value="${ai.i18n.src.dir}"/>
-                      <arg value="${lib.dir}/blockly/msg/json"/>
-                      <arg value="${BlocklyTranslations.dir}"/>
-			<classpath>
-				<pathelement location="${BlocklyTranslator-class.dir}"/>
-				<pathelement location="${gwt.sdk}/gwt-dev.jar"/>
-				<pathelement location="${lib.dir}/json/json.jar" />
-			</classpath>
-		</java>
-	</target>
+  <target name="BlocklyTranslationGenerator"
+	  description="This is the script for creating combined i18n files from blockly and app inventor"
+	  depends="CheckBlocklyTranslations,BlocklyCompile"
+	  unless="Blocklyi18n.uptodate">
+    <mkdir dir="${BlocklyTranslator-class.dir}" />
+    <mkdir dir="${BlocklyTranslations.dir}" />
+    <ai.javac destdir="${BlocklyTranslator-class.dir}">
+      <include name="msg/BlocklyTranslationGenerator.java" />
+      <classpath>
+	<pathelement location="${gwt.sdk}/gwt-dev.jar"/>
+	<pathelement location="${lib.dir}/json/json.jar" />
+      </classpath>
+    </ai.javac>
+    <java failonerror="true" classname="msg.BlocklyTranslationGenerator" fork="true">
+      <jvmarg value="-Dfile.encoding=UTF-8"/>
+      <arg value="${ai.i18n.src.dir}"/>
+      <arg value="${lib.dir}/blockly/msg/json"/>
+      <arg value="${BlocklyTranslations.dir}"/>
+      <classpath>
+	<pathelement location="${BlocklyTranslator-class.dir}"/>
+	<pathelement location="${gwt.sdk}/gwt-dev.jar"/>
+	<pathelement location="${lib.dir}/json/json.jar" />
+      </classpath>
+    </java>
+  </target>
 
         <target name="CheckBlocklyCompile">
           <uptodate property="BlocklyCompile.uptodate" targetfile="${public.build.dir}/blockly-all.js">


### PR DESCRIPTION
Change-Id: I0d64b490e12683f40f33acec75d514e56b039ac9

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR makes the invocation of BlocklyTranslationGenerator always use UTF-8. On Linux and macOS this isn't an issue since UTF-8 the default charset. Windows is another story. By forcing the file.encoding property to be UTF-8 it ensures that translations are appropriately managed.

Fixes #3155