### PR TITLE
Implement a default uncaught exception handler

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -318,8 +318,13 @@ public class Form extends AppInventorCompatActivity
       @Override
       public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
         Log.e(LOG_TAG, "Uncaught Exception", e);
-        ErrorOccurred(Form.this, "<unknown>",
-            ErrorMessages.ERROR_UNCAUGHT_EXCEPTION_IN_THREAD, e.toString());
+        runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            ErrorOccurred(Form.this, "<unknown>",
+                ErrorMessages.ERROR_UNCAUGHT_EXCEPTION_IN_THREAD, e.toString());
+          }
+        });
       }
     });
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -39,6 +39,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.FrameLayout;
 import android.widget.ScrollView;
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -310,6 +311,17 @@ public class Form extends AppInventorCompatActivity
   public void onCreate(Bundle icicle) {
     // Called when the activity is first created
     super.onCreate(icicle);
+
+    // This version is for production apps. See {@link ReplForm#onCreate} for the REPL version,
+    // which overrides this method.
+    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      @Override
+      public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
+        Log.e(LOG_TAG, "Uncaught Exception", e);
+        ErrorOccurred(Form.this, "<unknown>",
+            ErrorMessages.ERROR_UNCAUGHT_EXCEPTION_IN_THREAD, e.toString());
+      }
+    });
 
     // Figure out the name of this form.
     String className = getClass().getName();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
@@ -22,6 +22,7 @@ import android.view.MenuItem.OnMenuItemClickListener;
 
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import com.google.appinventor.common.version.AppInventorFeatures;
 
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -41,10 +42,12 @@ import dalvik.system.DexClassLoader;
 
 import gnu.expr.Language;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -127,6 +130,18 @@ public class ReplForm extends Form {
     replAssetDir = QUtil.getReplAssetPath(this, true);
     replCompDir = replAssetDir + "external_comps/";
     super.onCreate(icicle);
+    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      @Override
+      public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
+        Log.e(LOG_TAG, "Uncaught exception", e);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream temp = new PrintStream(baos);
+        e.printStackTrace(temp);
+        temp.flush();
+        RetValManager.sendError(baos.toString());
+        temp.close();
+      }
+    });
     loadedExternalDexs = new ArrayList<String>();
     Intent intent = getIntent();
     processExtrasAndData(intent, false);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/ErrorMessages.java
@@ -122,6 +122,7 @@ public final class ErrorMessages {
   public static final int ERROR_NO_FOCUSABLE_VIEW_FOUND = 906;
   public static final int ERROR_ACTIONBAR_NOT_SUPPORTED = 907;
   public static final int ERROR_PERMISSION_DENIED = 908;
+  public static final int ERROR_UNCAUGHT_EXCEPTION_IN_THREAD = 909;
   // Canvas errors
   public static final int ERROR_CANVAS_BITMAP_ERROR = 1001;
   public static final int ERROR_CANVAS_WIDTH_ERROR = 1002;
@@ -527,6 +528,8 @@ public final class ErrorMessages {
         "ActionBar is not supported on this device.");
     errorMessages.put(ERROR_PERMISSION_DENIED,
         "The permission %s has been denied. Please enable it in the Settings app.");
+    errorMessages.put(ERROR_UNCAUGHT_EXCEPTION_IN_THREAD,
+        "Uncaught exception on %s thread: %s");
     // Canvas errors
     errorMessages.put(ERROR_CANVAS_BITMAP_ERROR, "Error getting Canvas contents to save");
     errorMessages.put(ERROR_CANVAS_WIDTH_ERROR, "Canvas width cannot be set to non-positive number");


### PR DESCRIPTION
Change-Id: Icb5517fad7968978e2a21a4de6078d1407308829

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Fixes #3179 by setting a custom handler for when threads throw uncaught exceptions. Note that the behavior is different between Form and ReplForm, where the latter reports errors back to the editor via RetValManager.