### PR TITLE
Add recyclerview.aar to support additional APIs for extension development

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -67,7 +67,7 @@ import java.util.List;
     nonVisible = false,
     iconName = "images/listView.png")
 @SimpleObject
-@UsesLibraries(libraries ="recyclerview.jar, cardview.jar, cardview.aar")
+@UsesLibraries(libraries ="recyclerview.jar, recyclerview.aar, cardview.jar, cardview.aar")
 @UsesPermissions(permissionNames = "android.permission.INTERNET," +
         "android.permission.READ_EXTERNAL_STORAGE")
 public final class ListView extends AndroidViewComponent implements AdapterView.OnItemClickListener {


### PR DESCRIPTION
**Description:**  
This pull request adds `recyclerview.aar` to fix a `java.lang.NoClassDefFoundError` for `androidx/recyclerview/R$dimen`, which occurs when building extensions that use extra `recyclerview` APIs. The in-built ListView component works fine without this, but `recyclerview.aar` is necessary for extension developers to access all features without crashes. This update ensures compatibility and stability for those building with advanced `recyclerview` functionality.