### PR TITLE
Implement fix for ElementColor in nb199

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1515,8 +1515,23 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 7;
     }
     if (srcCompVersion < 8) {
-      // Added HintText property, performance optimization
-      srcCompVersion = 8;
+      // Added HintText property, performance optimization.
+
+      // !!! NB: Note that because of a behavior issue introduced in nb199, if we get to this point
+      // we immediately jump to version 9 since this project predates the introduction of the
+      // ElementColor property.
+      srcCompVersion = 9;
+    }
+    if (srcCompVersion < 9) {
+      srcCompVersion = 9;
+      if (componentProperties.containsKey("ElementColor")) {
+        // ElementColor default was changed to None. If the user manually changed it to None,
+        // remove it to keep the project size down.
+        String elementColor = componentProperties.get("ElementColor").asString().getString();
+        if ("&H00FFFFFF".equals(elementColor)) {
+          componentProperties.remove("ElementColor");
+        }
+      }
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2457,7 +2457,9 @@ Blockly.Versioning.AllUpgradeMaps =
     7: "noUpgrade",
     // AI2:
     // - Added HintText property, performance optimization
-    8: "noUpgrade"
+    8: "noUpgrade",
+    // AI2: Fixed a designer property issue with ElementColor
+    9: "noUpgrade"
 
   }, // End ListView upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -601,7 +601,9 @@ public class YaVersion {
   // For YOUNG_ANDROID_VERSION 230:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 37.
   // - LISTVIEW_COMPONENT_VERSION was incremented to 8.
-  public static final int YOUNG_ANDROID_VERSION = 230;
+  // For YOUNG_ANDROID_VERSION 231:
+  // - LISTVIEW_COMPONENT_VERSION was incremented to 9.
+  public static final int YOUNG_ANDROID_VERSION = 231;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -1183,8 +1185,10 @@ public class YaVersion {
   // For LISTVIEW_COMPONENT_VERSION 7:
   // - Added RemoveItemAtIndex method
   // For LISTVIEW_COMPONENT_VERSION 8:
-  // Added HintText property, performance optimization
-  public static final int LISTVIEW_COMPONENT_VERSION = 8;
+  // - Added HintText property, performance optimization
+  // For LISTVIEW_COMPONENT_VERSION 9:
+  // - Changed the default ElementColor from Black to None
+  public static final int LISTVIEW_COMPONENT_VERSION = 9;
 
   // For LOCATIONSENSOR_COMPONENT_VERSION 2:
   // - The TimeInterval and DistanceInterval properties were added.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -148,8 +148,8 @@ public class ListAdapterWithRecyclerView
     cardView.setMaxCardElevation(3f);
     cardView.setCardBackgroundColor(backgroundColor);
     cardView.setRadius(radius);
-    cardView.setCardElevation(2.1f);
-    ViewCompat.setElevation(cardView, 20);
+    cardView.setCardElevation(0.0f);
+    ViewCompat.setElevation(cardView, 0);
 
     cardView.setClickable(true);
     final int idCard = ViewCompat.generateViewId();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -98,7 +98,7 @@ public final class ListView extends AndroidViewComponent {
   private int backgroundColor;
   private static final int DEFAULT_BACKGROUND_COLOR = Component.COLOR_BLACK;
 
-  private int elementColor;
+  private int elementColor = COLOR_NONE;
 
   private int textColor;
   private int detailTextColor;
@@ -217,7 +217,6 @@ public final class ListView extends AndroidViewComponent {
     // note that the TextColor and ElementsFromString setters
     // need to have the textColor set first, since they reset the
     // adapter
-    ElementColor(Component.COLOR_BLACK);
     BackgroundColor(Component.COLOR_BLACK);
     SelectionColor(Component.COLOR_LTGRAY);
     TextColor(Component.COLOR_WHITE);
@@ -525,6 +524,7 @@ public final class ListView extends AndroidViewComponent {
     backgroundColor = argb;
     recyclerView.setBackgroundColor(backgroundColor);
     linearLayout.setBackgroundColor(backgroundColor);
+    setAdapterData();
   }
 
   /**
@@ -552,7 +552,7 @@ public final class ListView extends AndroidViewComponent {
    * indicates fully transparent and {@code FF} means opaque.
    */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
-      defaultValue = Component.DEFAULT_VALUE_COLOR_BLACK)
+      defaultValue = Component.DEFAULT_VALUE_COLOR_NONE)
   @SimpleProperty
   public void ElementColor(int argb) {
     elementColor = argb;
@@ -1271,7 +1271,9 @@ public final class ListView extends AndroidViewComponent {
    * Create a new adapter and apply visual changes, load data if it exists.
    */
   public void setAdapterData() {
-    listAdapterWithRecyclerView = new ListAdapterWithRecyclerView(container, items, layout, textColor, detailTextColor, fontSizeMain, fontSizeDetail, fontTypeface, fontTypeDetail, elementColor, selectionColor, imageWidth, imageHeight, radius);
+    listAdapterWithRecyclerView = new ListAdapterWithRecyclerView(container, items, layout,
+        textColor, detailTextColor, fontSizeMain, fontSizeDetail, fontTypeface, fontTypeDetail,
+        elementColor, selectionColor, imageWidth, imageHeight, radius);
     listAdapterWithRecyclerView.setOnItemClickListener(new ListAdapterWithRecyclerView.ClickListener() {
       @Override
       public void onItemClick(int position, View v) {


### PR DESCRIPTION
Change-Id: I7e72b548130b65c29fd22c30a24a92e282fc6dbc

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in YaVersion.java
- [x] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

Per the discussion on the forum, ElementColor defaults to Black, which is fine except for when people change the BackgroundColor of the ListView. This only affects Android companion 2.73 for now. Android versions prior to 2.73 and all iOS versions do not have the ElementColor property so BackgroundColor is the only color to customize the ListView. By changing the ElementColor to be transparent by default, it causes the elements to be invisible (making BackgroundColor match existing behavior) unless the user changes it to something opaque.