### PR TITLE
Fix extension loading for Android versions < 14

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ReplForm.java
@@ -463,8 +463,17 @@ public class ReplForm extends Form {
         if (!extensions.contains(compFolder.getName())) {
           continue;  // Skip extensions on the phone but not required by the project
         }
-        File loadComponent = new File(compFolder.getPath() + File.separator
+        File loadComponent;
+        // If we are on Android 14 or higher, the final jar file's name is based
+        // on the name of the extension.
+        // Older versions just name it classes.jar
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+          loadComponent = new File(compFolder.getPath() + File.separator
             + compFolder.getName() + ".jar");
+        } else {
+          loadComponent = new File(compFolder.getPath() + File.separator
+            + "classes.jar");
+        }
         if (loadComponent.canWrite() && !loadComponent.setReadOnly()) {
           throw new YailRuntimeError("Unable to set " + loadComponent.getName() + " to read only",
               "Permission Error");

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AssetFetcher.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AssetFetcher.java
@@ -205,6 +205,11 @@ public class AssetFetcher {
           throw new IOException("Unable to create assets directory " + parentOutFile);
         }
 
+        // Before we attempt to write to the outFile, make sure that we can. If it is a classes.jar
+        // file, we may already have a read-only version stored.
+        if (!outFile.canWrite()) {
+          outFile.setWritable(true);
+        }
         BufferedInputStream in = new BufferedInputStream(connection.getInputStream(), 0x1000);
         BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outFile), 0x1000);
         //noinspection TryFinallyCanBeTryWithResources


### PR DESCRIPTION
If we are on Android 14 or higher, the final jar file's name is based on the name of the extension.

Older versions just name it classes.jar

Change-Id: I4295815718eaeb91d504b478c6e44f695dcac488

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
