### PR TITLE
fix action versions and use java 11

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -7,11 +7,12 @@ jobs:
     name: 'Build'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: 'Set up JDK 1.8'
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: 'Set up JDK 11'
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
+          distribution: 'temurin'
+          java-version: 11
       - name: 'Checkout submodules'
         run: git submodule update --init --recursive
       - name: 'Install 32-bit dependencies'
@@ -23,7 +24,7 @@ jobs:
       - name: 'Untar and add to PATH'
         run: |
           tar -xf /tmp/phantomJS/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /tmp/phantomJS/
-          echo "/tmp/phantomJS/phantomjs-2.1.1-linux-x86_64/bin" >> $GITHUB_PATH
+          echo '/tmp/phantomJS/phantomjs-2.1.1-linux-x86_64/bin' >> $GITHUB_PATH
       - name: 'Make Auth Key'
         run: ant MakeAuthKey
         working-directory: appinventor
@@ -34,7 +35,7 @@ jobs:
         run: ant tests
         working-directory: appinventor
       - name: 'Upload Test Reports to Artifacts'
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: Test Reports
           path: appinventor/reports
@@ -42,7 +43,7 @@ jobs:
         run: ant PlayApp
         working-directory: appinventor
       - name: 'Upload Companion to Artifacts'
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: MIT AI2 Companion
           path: appinventor/build/buildserver/MIT AI2 Companion.apk


### PR DESCRIPTION
General items:

- [ N/A ] I have updated the relevant documentation files under docs/
- [  N/A ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [X] `ant tests` passes on my machine

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

The github action stopped working due to using older versions of the artifact upload extension. I have also updated a few other extensions (checkout, java) and upgraded to use Java v11.

The action failing can be seen here: https://github.com/josmas/app-inventor/actions/runs/12123094447

And subsequently passing with these changes, here: 
https://github.com/josmas/app-inventor/actions/runs/12136662289