### PR TITLE
buildtools doctor to check for Java 11 and not 8

### DIFF
--- a/buildtools
+++ b/buildtools
@@ -137,18 +137,18 @@ doctor() {
     ((pass++))
     echo [PASS] Java is installed.
     # Check Java version
-    if java -version 2>&1 | grep -q "version \"1.8" &> /dev/null; then
+    if java -version 2>&1 | grep -q "version \"11." &> /dev/null; then
       ((pass++))
       echo [PASS] Required version of Java is installed.
     else
       ((fail++))
       echo [FAIL] Required version of Java is not installed or not found on PATH.
-      echo _______Please install Java 8 and try again.
+      echo _______Please install Java 11 and try again.
     fi
   else
     ((fail++))
     echo [FAIL] Java is not installed or not found on PATH.
-    echo _______Please install Java 8 and try again.
+    echo _______Please install Java 11 and try again.
   fi
   # Check if git is installed
   if command -v git &> /dev/null; then

--- a/buildtools.cmd
+++ b/buildtools.cmd
@@ -151,19 +151,19 @@ if /i "%ERRORLEVEL%" equ "0" (
     set /a pass=pass+1
     echo [PASS] Java is installed.
     :: Check Java version
-    java -version 2>&1 | find "version ""1.8" > nul 2>&1
+    java -version 2>&1 | find "version ""11." > nul 2>&1
     if /i "%ERRORLEVEL%" equ "0" (
         set /a pass=pass+1
         echo [PASS] Required version of Java is installed.
     ) else (
         set /a fail=fail+1
         echo [FAIL] Required version of Java is not installed or not found on PATH.
-        echo _______Please install Java 8 and try again.
+        echo _______Please install Java 11 and try again.
     )
 ) else (
     set /a fail=fail+1
     echo [FAIL] Java is not installed or not found on PATH.
-    echo _______Please install Java 8 and try again.
+    echo _______Please install Java 11 and try again.
 )
 :: Check if git is installed
 where git > nul 2>&1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [X] `ant tests` passes on my machine


<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
buildtools doctor is checking for version 8 of Java, but the current version is 11

