### PR TITLE
Make empty state a computable property for better multiline support

### DIFF
--- a/appinventor/components-ios/src/TextBox.swift
+++ b/appinventor/components-ios/src/TextBox.swift
@@ -17,7 +17,6 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   private var _numbersOnly = false
 
   private var _multiLine = false
-  private var _empty = true
   private var _readOnly = false
   private weak var _base: TextBoxBase? = nil
   private var _placeholderColor: Int32 = Color.default.int32
@@ -54,6 +53,10 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     _field.inputAccessoryView = getAccesoryView(selector)
   }
 
+  var isEmpty: Bool {
+    _field.text?.isEmpty ?? true
+  }
+
   open var view: UIView {
     get {
       return _wrapper
@@ -86,7 +89,7 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     }
     set(color) {
       _field.textColor = color
-      _view.textColor = _empty ? kDefaultPlaceholderColor : color
+      _view.textColor = isEmpty ? kDefaultPlaceholderColor : color
     }
   }
 
@@ -111,11 +114,11 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   }
 
   open func updatePlaceholder() {
-    var newPlaceholder = NSAttributedString(string: placeholderText ?? "",
+    let newPlaceholder = NSAttributedString(string: placeholderText ?? "",
         attributes: [NSAttributedString.Key.foregroundColor:argbToColor(_placeholderColor),
-                     NSAttributedString.Key.font: _field.font])
+                     NSAttributedString.Key.font: _field.font as Any])
     _field.attributedPlaceholder = newPlaceholder
-    if _empty {
+    if isEmpty {
       _view.attributedText = newPlaceholder
     }
   }
@@ -126,7 +129,7 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     }
     set(text) {
       _field.placeholder = text
-      if _empty {
+      if isEmpty {
         _view.text = text
       }
       updatePlaceholder()
@@ -147,9 +150,11 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     get {
       return _multiLine ? _view.text: _field.text
     }
-    set(text) {
+    set {
+      let text = newValue ?? ""
       _field.text = text
-      _view.text = text
+      _view.text = isEmpty ? _field.placeholder : text
+      _view.textColor = isEmpty ? kDefaultPlaceholderColor : _field.textColor
     }
   }
 
@@ -186,9 +191,8 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   }
 
   fileprivate func setEmpty(_ shouldEmpty: Bool) {
-    _empty = shouldEmpty
-    _view.text = _empty ? _field.placeholder: nil
-    _view.textColor = _empty ? kDefaultPlaceholderColor : _field.textColor
+    _view.text = shouldEmpty ? _field.placeholder : nil
+    _view.textColor = shouldEmpty ? kDefaultPlaceholderColor : _field.textColor
   }
 
   private func makeMultiLine() {
@@ -212,7 +216,7 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   }
 
   func textViewDidBeginEditing(_ textView: UITextView) {
-    if _empty {
+    if isEmpty {
       setEmpty(false)
     }
   }
@@ -226,7 +230,7 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   }
 
   func textFieldDidBeginEditing(_ textField: UITextField) {
-    if _empty {
+    if isEmpty {
       setEmpty(false)
     }
     _base?.GotFocus()


### PR DESCRIPTION
Change-Id: I9ed27078bae492de15aa7c77848138fef4d36008

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

The current code in production for iOS has maintains the empty state of the underlying views powering the TextBox component. However, this state isn't correctly maintained under all circumstances which lead to bugs. This PR changes the empty state to be a computable property based on the views themselves to address this.

Fixes #3282 