### PR TITLE
Fix iOS issue with 0, 1 being interpreted as JSON bools

### DIFF
--- a/appinventor/components-ios/src/JsonUtil.swift
+++ b/appinventor/components-ios/src/JsonUtil.swift
@@ -89,12 +89,16 @@ fileprivate func convertJsonItem(_ item: AnyObject?, _ useDicts: Bool) -> AnyObj
     }
   } else if let jsonArray = item as? NSArray {
     return getListFromJsonArray(jsonArray, useDicts) as AnyObject
-  } else if let bool = item as? Bool {
-    return bool as AnyObject
+  } else if let number = item as? NSNumber {
+    if number.isEqual(to: true as NSValue) {
+      return true as AnyObject
+    } else if number.isEqual(to: false as NSValue) {
+      return false as AnyObject
+    } else {
+      return number as AnyObject
+    }
   } else if let string = item as? String {
     return string as AnyObject
-  } else if let number = item as? NSNumber {
-    return number as AnyObject
   }
   return item.debugDescription as AnyObject
 }

--- a/appinventor/schemekit/src/SCMValue.m
+++ b/appinventor/schemekit/src/SCMValue.m
@@ -353,8 +353,10 @@ static NSString *kValueKey = @"value";
 }
 
 - (pic_value)value {
-  if (self.isBool) {
-    return self.boolValue ? pic_true_value(nil) : pic_false_value(nil);
+  if ([self isEqualToValue:[NSNumber numberWithBool:YES]]) {
+    return pic_true_value(nil);
+  } else if ([self isEqualToValue:[NSNumber numberWithBool:NO]]) {
+    return pic_false_value(nil);
   } else if (self.objCType[0] == 'f' || self.objCType[0] == 'd') {
     return pic_float_value(nil, self.doubleValue);
   } else {


### PR DESCRIPTION
Change-Id: I6131fad2c7096d462b39dfb2214edaf36db949a0

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

Fixes #3284 by handling edge cases where ObjC can sometimes treat 0==false and 1==true.

Test app: [iOSJsonTest.aia.zip](https://github.com/user-attachments/files/18070245/iOSJsonTest.aia.zip)
