### PR TITLE
Fix WriteRange bug on iOS appending instead of overwriting

### DIFF
--- a/appinventor/components-ios/src/Spreadsheet.swift
+++ b/appinventor/components-ios/src/Spreadsheet.swift
@@ -928,14 +928,16 @@ import GoogleAPIClientForREST
     
     for elem in data {
       // if elem is not a YailList, then skip
-      if elem is YailList<AnyObject> == false {
+      guard let row = elem as? YailList<AnyObject> else {
         continue
       }
-      var row: YailList<AnyObject> = elem as! YailList<AnyObject>
       // construct the row that we will add to the list of rows
       var r: Array<AnyObject> = []
       for o in row {
-        r.append(o as! AnyObject)
+        if o is SCMSymbol {  // skip *list*
+          continue
+        }
+        r.append(o as AnyObject)
       }
       values.append(r)
       // catch rows of unequal length
@@ -961,7 +963,7 @@ import GoogleAPIClientForREST
     // wrap the API call in an Async Utility
     _workQueue.async {
       // create and execute query to write values
-      let query = GTLRSheetsQuery_SpreadsheetsValuesAppend.query(withObject: body, spreadsheetId:  self.SpreadsheetID, range: rangeRef)
+      let query = GTLRSheetsQuery_SpreadsheetsValuesUpdate.query(withObject: body, spreadsheetId: self.SpreadsheetID, range: rangeRef)
       query.valueInputOption = "USER_ENTERED"
       self._service.executeQuery(query) { ticket, result, error in
         if let error = error {


### PR DESCRIPTION
Change-Id: I478be193e0725227363d288ea83ab42d9a9b5c53

General items:

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

As reported by @bobparks in mit-cml/appinventor-sources-ios#764, the WriteRange function on iOS appends rather than writes. So it looks like it works on the first attempt, but then future attempts append to the spreadsheet. This PR fixes that bug.