### PR TITLE
Fix nested list rendering in iOS ListView

### DIFF
--- a/appinventor/components-ios/src/StringUtil.swift
+++ b/appinventor/components-ios/src/StringUtil.swift
@@ -24,6 +24,16 @@ public func toString(_ object: Any?) -> String {
     } else {
       return String(describing: num)
     }
+  } else if let object = object as? YailList<SCMValueProtocol> {
+    if ReplForm.activeForm?.ShowListsAsJson ?? true {
+      if let json = try? JSONSerialization.data(withJSONObject: object) {
+        return String(data: json, encoding: .utf8) ?? "[]"
+      } else {
+        return "[]"
+      }
+    } else {
+      return "(" + StringUtil.joinStrings(object, " ") + ")"
+    }
   } else if let object = object as? String {
     return object
   } else {


### PR DESCRIPTION
Change-Id: I4a7a8abd285b6658d8c4266361d6ec69c2b6d660

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR addresses an issue where assigning a list of lists to ListView.Elements renders the internal `*list*` symbol. It also updates the serialization to respect the ShowListsAsJson flag in the project properties. See previous discussion on #3287.