### PR TITLE
Fix use of UIKit on background thread in AssetFetcher

### DIFF
--- a/appinventor/components-ios/src/AssetFetcher.swift
+++ b/appinventor/components-ios/src/AssetFetcher.swift
@@ -19,12 +19,14 @@ class AssetLoadError: Error {
         if success {
           RetValManager.shared().assetTransferred(asset)
         } else if let error = error {
-          guard let window = UIApplication.shared.keyWindow else {
-            return
+          DispatchQueue.main.async {
+            guard let window = UIApplication.shared.keyWindow else {
+              return
+            }
+            let center = CGPoint(x: window.frame.size.width / 2.0, y: window.frame.size.height / 2.0)
+            window.makeToast("Unable to load \(asset) with error \(error)", point: center,
+                             title: nil, image: nil, completion: nil)
           }
-          let center = CGPoint(x: window.frame.size.width / 2.0, y: window.frame.size.height / 2.0)
-          window.makeToast("Unable to load \(asset) with error \(error)", point: center,
-                           title: nil, image: nil, completion: nil)
         }
       }
     }


### PR DESCRIPTION
Change-Id: Ib350e92434fa04721ab034da8a81fbc463b141f1

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

I encountered this issue a while back when testing another branch. When content is being loaded by the asset fetcher on iOS and an issue occurs, we try to post an error message. However, the AssetFetcher is running on a different thread than the UI thread, which causes issues. This change wraps the existing code in an async dispatch via the main queue to ensure it's run on the UI (main) thread.