### PR TITLE
Move XML-related code in Web to new util class

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Web.java
@@ -41,8 +41,6 @@ import com.google.appinventor.components.runtime.errors.IllegalArgumentError;
 import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.errors.RequestTimeoutException;
 
-import com.google.appinventor.components.runtime.repackaged.org.json.XML;
-
 import com.google.appinventor.components.runtime.util.AsynchUtil;
 import com.google.appinventor.components.runtime.util.BulkPermissionRequest;
 import com.google.appinventor.components.runtime.util.ChartDataSourceUtil;
@@ -54,6 +52,7 @@ import com.google.appinventor.components.runtime.util.JsonUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.XmlParser;
+import com.google.appinventor.components.runtime.util.XmlUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 import com.google.appinventor.components.runtime.util.YailList;
 
@@ -1130,7 +1129,7 @@ public class Web extends AndroidNonvisibleComponent implements Component,
   // HTML for the component documentation on the Web.  It's too long for a tooltip, anyway.
   public Object XMLTextDecode(String XmlText) {
     try {
-      return JsonTextDecode(XML.toJSONObject(XmlText).toString());
+      return JsonTextDecode(XmlUtil.xmlToJson(XmlText));
     } catch (com.google.appinventor.components.runtime.repackaged.org.json.JSONException e) {
       // We could be more precise and signal different errors for the conversion to JSON
       // versus the decoding of that JSON, but showing the actual error message should

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/XmlUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/XmlUtil.java
@@ -1,0 +1,23 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import com.google.appinventor.components.runtime.repackaged.org.json.XML;
+
+public class XmlUtil {
+  /**
+   * Converts an XML string to a JSON string.
+   *
+   * Using this function requires that a component include <code>@UsesLibraries({"json.jar"})</code>
+   * to get the XML conversion code.
+   *
+   * @param xmlText the source XML
+   * @return JSON representation of the XML
+   */
+  public static String xmlToJson(String xmlText) {
+    return XML.toJSONObject(xmlText).toString();
+  }
+}


### PR DESCRIPTION
Change-Id: I79468d41978d1d2c3c41b41f9c9992092fd22da4

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

tldr: This fixes a regression in `master` where compiling an app without a Web component causes a syntax error in Kawa.

In the PR that made it so dictionaries could be parsed directly in the Scheme code, I referenced `com.google.appinventor.components.runtime.Web` in the code since we want to call a static function on Web that handles the parsing of JSON. It seems though that by referencing the class, Kawa loads it and attempts to validate all of its types, including the class `com.google.appinventor.components.runtime.repackaged.org.json.XML`. This is provided by a library, json.jar, which is annotated on the Web component. When compiling the companion, or any other app that has a Web component, this JAR file is included and the app will build. For apps without a Web component (e.g., HelloPurr), the library is not included in the classpath and Kawa fails to compile the runtime.scm, despite the fact that none of the code in Screen1 will call the particular XML-related function. This PR moves the call to the XML library to a separate XmlUtil class, which allows the Web class to validate. Why Kawa manifests this as a SyntaxError is a mystery to me.