### PR TITLE
Make iOS ChartDataBase return an event dispatcher

### DIFF
--- a/appinventor/components-ios/src/ChartDataBase.swift
+++ b/appinventor/components-ios/src/ChartDataBase.swift
@@ -26,6 +26,10 @@ import DGCharts
     return dataModel as? ChartDataModel
   }
 
+  public var dispatchDelegate: HandlesEventDispatching? {
+    return container?.form
+  }
+
   @objc public init(_ chartContainer: Chart) {
     super.init(chartContainer)
     chartContainer.addDataComponent(self)
@@ -164,8 +168,6 @@ import DGCharts
   func DataSourceKey(_ key: String) {
     dataSourceKey = key
   }
-
-  public var dispatchDelegate: HandlesEventDispatching?
 
   func uiColorFromHex(rgbValue: Int) -> UIColor {
 


### PR DESCRIPTION
Change-Id: I555b2dc4987883f9debb5d58408cbfb568fda96d

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

The ChartDataBase class should be returning a dispatchDelegate but it does not. This prevents events from being dispatched on ChartData2D elements. This PR corrects the problem by having the property return the `form`, which is responsible for dispatching all events of its descendants.
