### PR TITLE
Fix miscellaneous bugs in iOS AI components

### DIFF
--- a/appinventor/components-ios/src/FaceExtension.swift
+++ b/appinventor/components-ios/src/FaceExtension.swift
@@ -246,6 +246,7 @@ fileprivate let MODEL_PATH_SUFFIX = ".tflite"
 
   @objc open override func ModelReady() {
     super.ModelReady()
+    EventDispatcher.dispatchEvent(of: self, called: "ModelReady")
     if _enabled {
       let frontFacing = _FRONT_CAMERA == _cameraMode
       _webview?.evaluateJavaScript("setCameraFacingMode(\(frontFacing))")

--- a/appinventor/components-ios/src/PosenetExtension.swift
+++ b/appinventor/components-ios/src/PosenetExtension.swift
@@ -18,7 +18,6 @@ fileprivate let FRONT_CAMERA = "Front"
   fileprivate var _minPoseConfidence: Double = 0.1
   fileprivate var _minPartConfidence: Double = 0.5
   fileprivate lazy var _cameraMode: String = FRONT_CAMERA
-  fileprivate var _initialized: Bool = false
   fileprivate var _enabled: Bool = true
   fileprivate var _backgroundImage: String = ""
 
@@ -61,7 +60,7 @@ fileprivate let FRONT_CAMERA = "Front"
     }
     set {
       _minPoseConfidence = newValue
-      if _initialized {
+      if isInitialized {
         do {
           try assertWebView("MinPoseConfidence")
         } catch {
@@ -77,7 +76,7 @@ fileprivate let FRONT_CAMERA = "Front"
     }
     set {
       _minPartConfidence = newValue
-      if _initialized {
+      if isInitialized {
         do {
           try assertWebView("MinPartConfidence")
         } catch {
@@ -213,7 +212,7 @@ fileprivate let FRONT_CAMERA = "Front"
     }
     set {
       _enabled = newValue
-      if _initialized {
+      if isInitialized {
         do {
           try assertWebView("Enabled")
         } catch {
@@ -230,7 +229,7 @@ fileprivate let FRONT_CAMERA = "Front"
     set {
       if newValue == BACK_CAMERA || newValue == FRONT_CAMERA {
         _cameraMode = newValue
-        if _initialized {
+        if isInitialized {
           do {
             let frontFacing = (newValue == FRONT_CAMERA)
             try assertWebView("UseCamera", frontFacing)

--- a/appinventor/components-ios/src/PosenetExtension.swift
+++ b/appinventor/components-ios/src/PosenetExtension.swift
@@ -135,71 +135,71 @@ fileprivate let FRONT_CAMERA = "Front"
   }
   
   @objc open var Nose: [Double] {
-    return _keyPoints["nose"]!
+    return _keyPoints["nose"] ?? []
   }
   
   @objc open var LeftEye: [Double] {
-    return _keyPoints["leftEye"]!
+    return _keyPoints["leftEye"] ?? []
   }
   
   @objc open var RightEye: [Double] {
-    return _keyPoints["rightEye"]!
+    return _keyPoints["rightEye"] ?? []
   }
   
   @objc open var LeftEar: [Double] {
-    return _keyPoints["leftEar"]!
+    return _keyPoints["leftEar"] ?? []
   }
   
   @objc open var RightEar: [Double] {
-    return _keyPoints["rightEar"]!
+    return _keyPoints["rightEar"] ?? []
   }
   
   @objc open var LeftShoulder: [Double] {
-    return _keyPoints["leftShoulder"]!
+    return _keyPoints["leftShoulder"] ?? []
   }
   
   @objc open var RightShoulder: [Double] {
-    return _keyPoints["rightShoulder"]!
+    return _keyPoints["rightShoulder"] ?? []
   }
   
   @objc open var LeftElbow: [Double] {
-    return _keyPoints["leftElbow"]!
+    return _keyPoints["leftElbow"] ?? []
   }
   
   @objc open var RightElbow: [Double] {
-    return _keyPoints["rightElbow"]!
+    return _keyPoints["rightElbow"] ?? []
   }
   
   @objc open var LeftWrist: [Double] {
-    return _keyPoints["leftWrist"]!
+    return _keyPoints["leftWrist"] ?? []
   }
   
   @objc open var RightWrist: [Double] {
-    return _keyPoints["rightWrist"]!
+    return _keyPoints["rightWrist"] ?? []
   }
   
   @objc open var LeftHip: [Double] {
-    return _keyPoints["leftHip"]!
+    return _keyPoints["leftHip"] ?? []
   }
   
   @objc open var RightHip: [Double] {
-    return _keyPoints["rightHip"]!
+    return _keyPoints["rightHip"] ?? []
   }
   
   @objc open var LeftKnee: [Double] {
-    return _keyPoints["leftKnee"]!
+    return _keyPoints["leftKnee"] ?? []
   }
   
   @objc open var RightKnee: [Double] {
-    return _keyPoints["rightKnee"]!
+    return _keyPoints["rightKnee"] ?? []
   }
   
   @objc open var LeftAnkle: [Double] {
-    return _keyPoints["leftAnkle"]!
+    return _keyPoints["leftAnkle"] ?? []
   }
   
   @objc open var RightAnkle: [Double] {
-    return _keyPoints["rightAnkle"]!
+    return _keyPoints["rightAnkle"] ?? []
   }
   
   @objc open var BackgroundImage: String {

--- a/appinventor/components-ios/src/PosenetExtension.swift
+++ b/appinventor/components-ios/src/PosenetExtension.swift
@@ -259,6 +259,7 @@ fileprivate let FRONT_CAMERA = "Front"
 
   @objc open override func ModelReady() {
     super.ModelReady()
+    EventDispatcher.dispatchEvent(of: self, called: "ModelReady")
     if _enabled, let webview = _webview {
       webview.evaluateJavaScript("minPoseConfidence = \(_minPoseConfidence);")
       webview.evaluateJavaScript("minPartConfidence = \(_minPartConfidence);")

--- a/appinventor/components-ios/src/Sprite.swift
+++ b/appinventor/components-ios/src/Sprite.swift
@@ -423,7 +423,13 @@ open class Sprite: ViewComponent, UIGestureRecognizerDelegate {
     }
 
     if moved {
-      registerChanges()
+      // Originally registerChanges was called directly, but if the sprite is larger than the
+      // canvas, this will result in a stack overflow as we keep trying to move the sprite in
+      // bounds, which is impossible. We defer the change update so at least the app remains
+      // responsive in case the sizes are being updated in an event handler.
+      DispatchQueue.main.async {
+        self.registerChanges()
+      }
     }
   }
 

--- a/appinventor/components-ios/src/WebViewer.swift
+++ b/appinventor/components-ios/src/WebViewer.swift
@@ -315,7 +315,12 @@ open class WebViewer: ViewComponent, AbstractMethodsForViewComponent, WKUIDelega
     if let url = navigationAction.request.url?.absoluteString {
       _temporaryLink = url
     }
-    decisionHandler((_followLinks || _wantLoad) ? .allow: .cancel)
+    // We want to load the page if any of the following is true:
+    // 1. FollowLinks is turned on
+    // 2. The blocks have explicitly requested a URL be loaded
+    // 3. We are a WebView running AI extensions
+    // Otherwise, do not load the page
+    decisionHandler((_followLinks || _wantLoad || aiSchemeHandler != nil) ? .allow: .cancel)
   }
 
   open func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

There are a number of issues in apps sent to me by @stezelMIT. This PR contains the following fixes:

1. Fix an issue where the app would crash if sprites were larger than the canvas, resulting in a stack overflow as we tried to move the impossibly large sprites into bounds recursively looping until crashing.
2. Force the WebViewer to be visible but of zero size on iOS since WKWebView will not run Javascript if it's not attached to the view hierarchy
3. Fix an issue where setting FollowLinks to false on a WebViewer would prevent the AI extensions from loading

I also cleaned up a redundant flag in the Posenet Extension that is no longer needed as that state is maintained in the BaseAiComponent class.
