### PR TITLE
Fix missing action bar in Device Default theme

### DIFF
--- a/appinventor/blocklyeditor/src/generators/yail.js
+++ b/appinventor/blocklyeditor/src/generators/yail.js
@@ -157,7 +157,7 @@ Blockly.Yail.getFormYail_ = function(formJson, packageName, forRepl, workspace) 
 
   if (!forRepl) {
     code.push(Blockly.Yail.getYailPrelude(packageName, formName,
-      !jsonObject.Properties['Theme'] || jsonObject.Properties['Theme'] === 'Classic'));
+      jsonObject.Properties['Theme'] === 'Classic'));
   }
 
   var componentMap = workspace.buildComponentMap([], [], false, false);


### PR DESCRIPTION
Change-Id: I522e6d907dedaf8284777b6a7feb08b7720200ef

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes #3075. When the default theme was changed from Classic to Device Default, the logic for setting the `classic-mode` flag in YAIL was no longer correct since it assumes that the default setting is Classic. Now, the 'Theme' property is empty when in Device Default and we should only set the classic mode flag for 'Classic' theme.

This only affects compiled apps so it submitted against master.