### PR TITLE
Fix bugs in iOS collision detection

### DIFF
--- a/appinventor/components-ios/src/Ball.swift
+++ b/appinventor/components-ios/src/Ball.swift
@@ -65,6 +65,14 @@ open class Ball: Sprite {
     }
   }
 
+  @objc open override var XCenter: Double {
+    return _xLeft + CGFloat(Radius)
+  }
+
+  @objc open override var YCenter: Double {
+    return _yTop + CGFloat(Radius)
+  }
+
   // Changes to width and height are only allowed via changes to radius.
   override open var Width: Int32 {
     get {

--- a/appinventor/components-ios/src/Vector2D.swift
+++ b/appinventor/components-ios/src/Vector2D.swift
@@ -35,7 +35,7 @@ public struct Vector2D: Comparable, AdditiveArithmetic {
   }
 
   public func closestVector(in vectors: [Vector2D]) -> Vector2D? {
-    var result: (vector: Vector2D?, d: Double) = (nil, 0.0)
+    var result: (vector: Vector2D?, d: Double) = (nil, Double.infinity)
     result = vectors.reduce(result) { partialResult, v in
       let d = (self - v).magnitudeSquared
       if d < partialResult.d {


### PR DESCRIPTION
Change-Id: I4fe8410a4555f1cf87993f9b1e20c528860a5d7c

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This fixes two bugs in the iOS collision code between Ball and ImageSprite components. One issue is that the XCenter and YCenter properties of the Ball were returning 0. The second issue is that the `closestVector` method in Vector2D had a logical bug by starting with every vector trying to beat a distance of 0 (which is impossible). Instead, it should have started from +infinity.