### PR TITLE
Implement potential fix for yail_get_simple_name crash

### DIFF
--- a/appinventor/schemekit/src/yail.m
+++ b/appinventor/schemekit/src/yail.m
@@ -1400,7 +1400,8 @@ pic_value yail_get_simple_name(pic_state *pic) {
   pic_get_args(pic, "o", &native_class);
 
   if (yail_native_class_p(pic, native_class)) {
-    const char *name = yail_native_class_name(pic, yail_native_class_ptr(pic, native_class));
+    const NSString *className = NSStringFromClass(yail_native_class_ptr(pic, native_class)->class_);
+    const char *name = [className UTF8String];
     size_t lastDot = 0;
     for (size_t i = 0; name[i] != 0; i++) {
       if (name[i] == '.') {


### PR DESCRIPTION
Change-Id: Ib3daa5b7973b40aee427c55e3aeab8081ecdba11

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

In the last year Apple reports over 11k crashes at the loop over the class name on line 1405 of yail.m. I believe that this is caused by the fact that `yail_native_class_name` creates a temporary NSString, which will immediately be allowed to be GCed by an autorelease pool. If the memory gets overwritten by another thread, then it's possible that the loop can overflow and access invalid memory. By inlining the code, it should allow the buffer to be retained until the function returns and the reference goes out of scope.

Unfortunately, I haven't been able to reliably reproduce the crash.