### PR TITLE
Fix iOS marker moves

### DIFF
--- a/appinventor/components-ios/src/MapFeatureBase.swift
+++ b/appinventor/components-ios/src/MapFeatureBase.swift
@@ -16,7 +16,7 @@ import GEOSwift
   /**
    * The location of the feature on the map. The annotation view will be positioned at this point.
    */
-  public var coordinate = CLLocationCoordinate2D()
+  @objc dynamic public var coordinate = CLLocationCoordinate2D()
 
   /**
    * The title shown in the annotation's detail view.


### PR DESCRIPTION
Change-Id: I037f1c09691d97c2eaa53f0b8cd0f217b1da9d70

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR marks the `coordinate` property of MapFeatureBase to be dynamic. I believe in earlier versions of Swift (Swift 2 or Swift 3), this was the default for objects marked `@objc`, and so the marker moves worked in that case. However, that is not true in Swift 5 and we have to manually mark the property so that the MKAnnotationView class is able to listen to changes on the coordinate.

Fixes #3308 
