### PR TITLE
Make iOS Map.LongPress fire as soon as recognized

### DIFF
--- a/appinventor/components-ios/src/Map.swift
+++ b/appinventor/components-ios/src/Map.swift
@@ -712,7 +712,7 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
 
       }
       _lastPoint = coordinate
-    case .ended:
+    case .recognized:
       if let overlay = _activeOverlay {
         if overlay.feature!.Draggable {
           overlay.feature!.StopDrag()


### PR DESCRIPTION
Change-Id: I7976b7c52003919a7b25b153634fd29da670d173

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR adjusts the LongPress event to fire when the long press gesture is recognized rather than ended. See the discussion on #3309 for more information.

Fixes #3313 