### PR TITLE
Fix TinyDB.swift due to iOS 18 changes

### DIFF
--- a/appinventor/components-ios/src/TinyDB.swift
+++ b/appinventor/components-ios/src/TinyDB.swift
@@ -11,8 +11,8 @@ open class TinyDB: NonvisibleComponent {
 
   fileprivate var _database: Connection!
   fileprivate var _table = Table("TinyDB1")
-  fileprivate let _key = Expression<String>("_key")
-  fileprivate let _value = Expression<String>("_value")
+  fileprivate let _key = SQLite.Expression<String>("_key")
+  fileprivate let _value = SQLite.Expression<String>("_value")
   private var _namespace = "TinyDB1"
 
   public override init(_ parent: ComponentContainer) {


### PR DESCRIPTION
Change-Id: Ib8446742ee18058386c2f50a3cc29b34bedd2897

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

Once upgraded to Xcode 16, the sources will no longer compile due to a change in the semantics of initializers in Swift 6. This PR fixes the issue. Jenkins will fail to compile since it's still using Xcode 15 and Swift 5. Once this is merged, everyone will need to upgrade to Xcode 16.