### PR TITLE
Fix Wifi prompt bug in iOS companion

### DIFF
--- a/appinventor/aicompanionapp/src/ViewController.swift
+++ b/appinventor/aicompanionapp/src/ViewController.swift
@@ -397,7 +397,10 @@ public class ViewController: UINavigationController, UITextFieldDelegate {
 
   // Implemented in Swift based on aiplayapp/src/edu/mit/appinventor/aicompanion3/Screen1.yail
   private func checkWifi() {
-    self.didWifiCheck = true
+    guard !didWifiCheck else {
+      return
+    }
+    didWifiCheck = true
     if PhoneStatus.GetWifiIpAddress().hasPrefix("Error") {
       notifier1.ShowChooseDialog("Your Device does not appear to have a Wifi Connection",
                                  "No WiFi", "Continue without WiFi", "Exit", false)

--- a/appinventor/components-ios/src/Notifier.swift
+++ b/appinventor/components-ios/src/Notifier.swift
@@ -501,9 +501,6 @@ open class Notifier: NonvisibleComponent {
 
   @objc fileprivate func afterChoosing(sender: UIButton) {
     _activeAlert?.dismiss(animated: true)
-    if let activeAlert = _activeAlert, let index = _activeAlerts.firstIndex(of: activeAlert) {
-      _activeAlerts.remove(at: index) // Remove the dismissed alert from the array
-    }
     if let button = sender as? CustomButton, let choice = button.value as? String {
       if choice == "Cancel" {
         ChoosingCanceled()


### PR DESCRIPTION
Change-Id: I81f0e9dac8e677074f08cdebc035a235c8b5048d

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR fixes a critical bug in the iOS companion whereby if the user starts the companion without Wifi, the dialog warning about this fact isn't dismissable except by exiting.

There are two separate bugs that contribute to this problem:

1. We didn't properly guard against showing the dialog between the introductory screen and the regular check, causing 2 dialogs to be shown.
2. The fix for dismissing multiple dialogs by accidentally removes two screens from the stack at the same time, while only the topmost view disappears. This leaves the second view visible but undismissable.

1 is fixed by introducing a guard statement in the ViewController
2 is fixed by deleting one of the removal calls in the Notifier since promoteNextAlert will pop the last view from the stack