### PR TITLE
Fix backpack rendering issue when extension blocks present

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -459,7 +459,7 @@ Blockly.Blocks.component_event = {
           {name:'notAlreadyHandled', type: 'boolean'}
         ].concat((eventType && eventType.parameters) || []);
     }
-    return eventType && eventType.parameters;
+    return (eventType && eventType.parameters) || [];
   },
   getExplicitParameterNames_: function () {
     return this.parameterNames;
@@ -1188,7 +1188,7 @@ Blockly.Blocks.component_set_get = {
         thisBlock.propertyName = selection;
         thisBlock.propertyObject = thisBlock.getPropertyObject(selection);
         thisBlock.setTypeCheck();
-        if (thisBlock.propertyName) {
+        if (thisBlock.propertyName && thisBlock.propertyObject) {
           thisBlock.setTooltip(componentDb.getInternationalizedPropertyDescription(thisBlock.getTypeName(),
               thisBlock.propertyName, thisBlock.propertyObject.description));
         } else {


### PR DESCRIPTION
Change-Id: I36c7e4ab5b9e9c7ebba0303ca2a84ce23a7ccd20

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This addresses the issue reported [here]() where the backpack fails to render properly. To replicate the issue, create a project with an extension, such as the BLE extension. Add an event block, a property block, and a method block to backpack. Then, create a new project and in that project (sans extension) try to open the backpack. With master this will fail but should work with this patch.