### PR TITLE
Fix 'Do It' not showing bubble after Blockly v10 update

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1152,9 +1152,10 @@ Blockly.ReplMgr.setDoitResult = function(block, value) {
     var patt = new RegExp(Blockly.Msg.DO_IT_RESULT + '.*?\n---\n');
     var result = Blockly.Msg.DO_IT_RESULT + ' ' + value + '\n---\n';
     var text = "";
+    var icon = block.getIcon(Blockly.icons.CommentIcon.TYPE)
 
-    if (block.comment) {
-        text = block.comment.getText().replace(oldPatt, '');
+    if (icon) {
+        text = icon.getText().replace(oldPatt, '');
     }
     if (!text) {
         text = result;
@@ -1164,7 +1165,7 @@ Blockly.ReplMgr.setDoitResult = function(block, value) {
         text = result + text;
     }
     block.setCommentText(text);
-    block.comment.setVisible(true);
+    block.getIcon(Blockly.icons.CommentIcon.TYPE).setVisible(true);
 };
 
 Blockly.ReplMgr.startAdbDevice = function(rs, usb) {


### PR DESCRIPTION
Change-Id: I22fe8a21c641c57d55dd61e8892f9a8d58f6f75b

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes an issue where using Do It after the Blockly v10 update does not show the comment bubble. Previously, `block.comment` referenced the icon but now with the icon registry we have to retrieve the icon based on its type. In a future version we should probably introduce a new Do It icon rather than overloading the comment icon.