### PR TITLE
Fix YaClientApp.uptodate computation to not include Blockly i18n

### DIFF
--- a/appinventor/appengine/build.xml
+++ b/appinventor/appengine/build.xml
@@ -206,7 +206,7 @@
     </copy>
     <filter token="blocklyeditor_BlocklyChecksum" value="${blocklyeditor_BlocklyChecksum}.${blocklyeditor_postfix}" />
     <filter token="blocklyeditor_isRelease" value="${release}" />
-    <copy todir="${build.war.dir}" filtering="true">
+    <copy todir="${build.war.dir}" filtering="true" overwrite="true">
       <fileset dir="war">
         <include name="index.jsp"/>
       </fileset>
@@ -604,7 +604,10 @@
          Otherwise, set YaClientApp.uptodate to false -->
     <uptodate property="YaClientApp.uptodate"
               targetfile="${build.war.dir}/ode/ode.nocache.js">
-      <srcfiles dir="${build.war.dir}/WEB-INF/classes"/>
+      <srcfiles dir="${build.war.dir}/WEB-INF/classes">
+        <!-- This is compiled after YaClientApp in CopyToBuildWarPost -->
+        <exclude name="msg/i18n.class"/>
+      </srcfiles>
       <srcfiles file="${local.build.dir}/AiRebindLib.jar" />
       <srcfiles file="${build.dir}/common/CommonUtils-gwt.jar" />
       <srcfiles file="${build.dir}/common/CommonVersion-gwt.jar" />


### PR DESCRIPTION
Change-Id: I5537dc0d1a144bce657e2a59087e73fb0f2f34ca

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes an issue in the Blockly update noted by @mark-friedman.

Previously, the compiled blocklyeditor module was dumped into appengine/build/war/static. In order to support loading it from the CDN and leverage the rules around .cache.js and .nocache.js, the files were moved to being in appengine/build/war/ode. I discovered as part of this that the GWT compiler wipes that directory empty before outputting its contents, so I moved that logic to a new CopyToBuildWarPost target that moves the files into the ode direct after GWT has done its work. The side-effect of this move is it broke the logic of the CheckYaClientApp target since the i18n class used to determine what messages file to load would always be newer than ode.nocache.js, triggering a worthless recompile of YaClientApp. Therefore, this PR excludes that file since we know it will always be compiled later.