### PR TITLE
Use addStyleName rather than setStyleName in GWT Trees

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -145,7 +145,7 @@ public class SourceStructureExplorer extends Composite {
     tree.addFocusHandler(new FocusHandler() {
       @Override
       public void onFocus(FocusEvent event) {
-        tree.getParent().setStyleName("gwt-Tree-focused");
+        tree.getParent().addStyleName("gwt-Tree-focused");
       }
     });
     tree.addBlurHandler(new BlurHandler() {

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/MoveProjectsWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/MoveProjectsWizard.java
@@ -59,7 +59,7 @@ public final class MoveProjectsWizard {
     tree.addFocusHandler(new FocusHandler() {
       @Override
       public void onFocus(FocusEvent event) {
-        tree.getParent().setStyleName("gwt-Tree-focused");
+        tree.getParent().addStyleName("gwt-Tree-focused");
       }
     });
     

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
@@ -100,7 +100,7 @@ public final class NewFolderWizard {
     tree.addFocusHandler(new FocusHandler() {
       @Override
       public void onFocus(FocusEvent event) {
-        tree.getParent().setStyleName("gwt-Tree-focused");
+        tree.getParent().addStyleName("gwt-Tree-focused");
       }
     });
 


### PR DESCRIPTION
Change-Id: I611dc4d2c7c616e83c3582fb7e5c253cf4f60cfe

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes an issue where selecting a component or category in the structure explorer (designer or blocks) causes the explorer to lose its size. The root issue was using setStyleName rather than addStyleName, which causes existing CSS class names to be lost. This seems to happen in a few different places so I adjusted all of them.

Fixes #3332 