### PR TITLE
Switch to play audio via Blockly AudioManager

### DIFF
--- a/appinventor/blocklyeditor/src/blockly.js
+++ b/appinventor/blocklyeditor/src/blockly.js
@@ -95,7 +95,7 @@ Blockly.confirmDeletion = function(callback) {
       var dialog = new Blockly.Util.Dialog(Blockly.Msg.CONFIRM_DELETE, msg, deleteButton, true, cancelButton, 0, function(button) {
         dialog.hide();
         if (button == deleteButton) {
-          Blockly.common.getMainWorkspace().playAudio('delete');
+          Blockly.common.getMainWorkspace().getAudioManager().play('delete');
           callback(true);
         } else {
           callback(false);
@@ -104,13 +104,13 @@ Blockly.confirmDeletion = function(callback) {
     } else {
       var response = confirm(Blockly.Msg.WARNING_DELETE_X_BLOCKS.replace('%1', String(descendantCount)));
       if (response) {
-        Blockly.common.getMainWorkspace().playAudio('delete');
+        Blockly.common.getMainWorkspace().getAudioManager().play('delete');
       }
       callback(response);
     }
   }
   else {
-    Blockly.common.getMainWorkspace().playAudio('delete');
+    Blockly.common.getMainWorkspace().getAudioManager().play('delete');
     callback(true);
   }
 };

--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -920,7 +920,7 @@ AI.Blockly.ContextMenuItems.registerClearUnusedBlocksOption = function() {
       }
       try {
         Blockly.Events.setGroup(true);
-        scope.workspace.playAudio('delete');
+        scope.workspace.getAudioManager().play('delete');
         removeList.forEach(block => {
           block.dispose(false);
         })


### PR DESCRIPTION
Change-Id: I69aca86617cfa56da87d4c131e7033008a39b333

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

A user reported that the "Remove Unused Blocks" workspace menu item wasn't working in nb200. It turns out that this is due to us playing the audio before removing the blocks, but the playAudio method no longer exists on the workspace. Instead, we need to get a reference to the workspace's AudioManager and use it to play the audio. This PR fixes all references to playAudio in blocklyeditor.