### PR TITLE
Fix alist to dict handling in iOS 2.73

### DIFF
--- a/appinventor/schemekit/src/yail.m
+++ b/appinventor/schemekit/src/yail.m
@@ -1430,12 +1430,25 @@ yail_dictionary_alist_to_dict(pic_state *pic) {
 
   pic_get_args(pic, "o", &entries);
 
-  if (!yail_list_p(pic, entries)) {
+  YailDictionary *dict = nil;
+  if (yail_list_p(pic, entries)) {
+    YailList *listOfEntries = yail_list_objc(pic, entries);
+    dict = [YailDictionary dictionaryFromPairs:pic_cdr(pic, listOfEntries.value)];
+  } else if (pic_pair_p(pic, entries)) {
+    pic_value car = pic_car(pic, entries);
+    if (pic_eq_p(pic, pic_intern(pic, pic_str_value(pic, "*list*", 6)), car)) {
+      dict = [YailDictionary dictionaryFromPairs:pic_cdr(pic, entries)];
+    } else {
+      pic_error(pic, "YailDictionary:alistToDict: Received malformed list", 1, entries);
+    }
+  } else {
     pic_error(pic, "YailDictionary:alistToDict: YailList required", 1, entries);
   }
-  YailList *listOfEntries = yail_list_objc(pic, entries);
-  YailDictionary *dict = [YailDictionary dictionaryFromPairs:pic_cdr(pic, listOfEntries.value)];
-  return yail_make_native_yaildictionary(pic, dict);
+  if (dict != nil) {
+    return yail_make_native_yaildictionary(pic, dict);
+  } else {
+    return pic_nil_value(pic);
+  }
 }
 
 static pic_value


### PR DESCRIPTION
Change-Id: Ibc83e0aae5d5fb58c89591079cb8117a08c105b9

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This fixes an issue where a raw Scheme list that looks like a YailList but isn't a YailList is passed to the alistToDict method. This manifests as an error at the user level.

Fixes #3340 