### PR TITLE
Conditionally save project.properties

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -238,12 +238,17 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     YoungAndroidSettingsBuilder oldProperties = new YoungAndroidSettingsBuilder(properties);
 
 
+    // Project settings do not include the name and package (main). So we add them
+    // here so the comparison below is accurate. Before this change, we always write out the
+    // project properties file, even when there are no changes to it.
+    String projectName = properties.getProperty("name");
+    String qualifiedName = properties.getProperty("main");
+    newProperties.setProjectName(projectName)
+      .setQualifiedFormName(qualifiedName);
+
     if (!oldProperties.equals(newProperties)) {
       // Recreate the project.properties and upload it to storageIo.
-      String projectName = properties.getProperty("name");
-      String qualifiedName = properties.getProperty("main");
-      String newContent = newProperties.setProjectName(projectName)
-          .setQualifiedFormName(qualifiedName).toProperties();
+      String newContent = newProperties.toProperties();
       storageIo.uploadFileForce(projectId, PROJECT_PROPERTIES_FILE_NAME, userId,
           newContent, StorageUtil.DEFAULT_CHARSET);
     }


### PR DESCRIPTION
We were always saving project.properties every time we loaded a project, even when there are no changes. This is because the computed settings don't store the qualifiedName (package name, called "main") as well as the project name itself. We add them here before the comparison.

Change-Id: I6b0e206dbef6bfc100c5c3ce89db1ca7395e17e0

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine (except the Blockly Tests, which don't run on my machine, yet.)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Reduces the I/O between the client and server by not saving project.properties when it really hasn't changed.

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
