### PR TITLE
Fix: Prevent dynamic resizing in NewFolder dialog (#3346)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
@@ -58,6 +58,8 @@ public final class NewFolderWizard {
     FolderTreeItem root = renderFolder(manager.getGlobalFolder());
     tree.addItem(root);
     tree.setSelectedItem(root);
+    addDialog.setWidth("400px");
+    addDialog.setAutoWidth(false); 
     addDialog.center();
     input.setFocus(true);
     input.setValidator(new Validator() {


### PR DESCRIPTION
- Set fixed width (400px) for NewFolder dialog.
- Disabled auto width behavior to ensure consistent UI design.
- Resolves issue #3346 where error messages caused the dialog to expand dynamically.

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/ (Not applicable, no documentation changes required).
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (Not applicable, no JavaScript changes made).
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr` (Not applicable, no changes to companion code).
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
This PR fixes the issue where the "New Folder" dialog dynamically resized based on error messages. The changes ensure the dialog has a fixed width of 400px, maintaining a consistent UI design.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3346.

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3346.
