### PR TITLE
Fix block workspace not saving after component deletion

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentRemoveWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentRemoveWidget.java
@@ -5,13 +5,14 @@
 
 package com.google.appinventor.client.editor.simple.palette;
 
+import static com.google.appinventor.client.Ode.MESSAGES;
+
 import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
-
-import static com.google.appinventor.client.Ode.MESSAGES;
 
 /**
  * Defines a widget that has the appearance of a red close button.
@@ -35,7 +36,9 @@ public class ComponentRemoveWidget extends AbstractPaletteItemWidget {
       YaProjectEditor projectEditor = (YaProjectEditor) ode.getEditorManager().getOpenProjectEditor(projectId);
       SimpleComponentDatabase componentDatabase = SimpleComponentDatabase.getInstance();
       componentDatabase.addComponentDatabaseListener(projectEditor);
-      componentDatabase.removeComponent(name);
+      if (componentDatabase.removeComponent(name)) {
+        Scheduler.get().scheduleDeferred(() -> ode.getEditorManager().saveDirtyEditors(null));
+      }
     }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -735,6 +735,9 @@ public final class YaBlocksEditor extends FileEditor
   public void onComponentTypeRemoved(Map<String, String> componentTypes) {
     blocksArea.populateComponentTypes(COMPONENT_DATABASE.getComponentsJSONString());
     blocksArea.verifyAllBlocks();
+    // Blockly won't fire the events that would mark the workspace as dirty until later, so
+    // we do this here to immediately allow a save due to the removal of an extension.
+    Ode.getInstance().getEditorManager().scheduleAutoSave(this);
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/events/EventHelper.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/events/EventHelper.java
@@ -30,14 +30,14 @@ public final class EventHelper {
         event.type == 'click' || event.type == 'finished_loading') {
       // Blockly selected events are transient
       return true;
+    } else if (event.type == 'viewport_change') {
+      // Blockly viewport change events are transient
+      return true;
     } else if (event.type == 'ui' || event['isUiEvent']) {
       // Blockly ui events are transient if they are selection changes, clicks, opening of mutator
       // and warning bubbles.
       return event.element == 'selected' || event.element == 'click' ||
         event.element == 'mutatorOpen' || event.element == 'warningOpen';
-    } else if (event.type == 'viewport_change') {
-      // Blockly viewport change events are transient
-      return true;
     }
     return false;
   }-*/;

--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -1099,6 +1099,12 @@ Blockly.BlocklyEditor['create'] = function(container, formName, readOnly, rtl) {
   workspace.addChangeListener(function(e) {
     if (e.type == Blockly.Events.BLOCK_MOVE && e.newParentId !== e.oldParentId) {
       const block = workspace.getBlockById(e.blockId);
+      if (!block) {
+        // This seems to be the case when the block has been deleted since it is first moved from
+        // its parent then removed from the workspace, but both events will be run back to back
+        // after the deletion has already happened.
+        return;
+      }
       block.getDescendants().forEach(function(block) {
         if (block.type === 'lexical_variable_get' || block.type === 'lexical_variable_set') {
           // If the block is a lexical variable, then we need to rebuild the options for the field


### PR DESCRIPTION
Change-Id: Ifafabe97ae1ab0258a5a4c187f2af6ca2245e90f

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes an issue where component deletion would remove blocks but not trigger a save. It turns out because the move event is processed after the deletion actually happens, the block was undefined and prevented our change listener logic from completing.

Fixes #3351 