### PR TITLE
Fix #3335: Detect and handle unavailable extensions in dragged PNGs

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -524,16 +524,15 @@ Blockly.exportBlockAsPng = function(block) {
  */
 function extractBlockTypes(xml) {
   var blockTypes = [];
-  var blocks = xml.getElementsByTagName('block');
-  for (var i = 0; i < blocks.length; i++) {
-    var mutation = blocks[i].getElementsByTagName('mutation')[0];
-    if (mutation) {
-      var componentType = mutation.getAttribute('component_type');
-      if (componentType) {
-        blockTypes.push(componentType);
-      }
+  var mutations = xml.getElementsByTagName('mutation');
+
+  for (var i = 0; i < mutations.length; i++) {
+    var componentType = mutations[i].getAttribute('component_type');
+    if (componentType) {
+      blockTypes.push(componentType);
     }
   }
+
   return blockTypes;
 }
 
@@ -545,19 +544,13 @@ function extractBlockTypes(xml) {
  */
 function validateBlockTypes(blockTypes, workspace) {
   if (!blockTypes || blockTypes.length === 0) {
-    console.warn('No block types provided for validation.');
     return [];
   }
 
   var componentDb = workspace.getComponentDatabase();
-  if (!componentDb) {
-    console.error('Component database is not available.');
-    return [];
-  }
-
   var missingExtensions = [];
   for (var i = 0; i < blockTypes.length; i++) {
-    var typeDescriptor = componentDb.getType(blockTypes[i]);
+    const typeDescriptor = componentDb.getType(blockTypes[i]);
     if (!typeDescriptor || !typeDescriptor.componentInfo || typeDescriptor.componentInfo.name !== blockTypes[i]) {
       missingExtensions.push(blockTypes[i]);
     }
@@ -580,7 +573,7 @@ function showMissingExtensionDialog(missingExtensions) {
   });
 
   if (missingExtensions.length > 0) {
-    var message = 'This image references the following blocks which require extensions that are not present in the project:\n\n';
+    var message = Blockly.Msg['REQUIRED_EXTENSIONS_MISSING'];
     message += missingExtensions.join('\n');
     alert(message);
   }
@@ -599,6 +592,8 @@ Blockly.importPngAsBlock = function(workspace, xy, png) {
       var xmlText = new TextDecoder().decode(xmlChunk.data);
       var xml = /** @type {!Element} */ (Blockly.utils.xml.textToDom(xmlText));
       if (!xml) {
+        var message = Blockly.Msg['ERROR_PARSING_XML'];
+        alert(message);
         console.error('Failed to parse XML from PNG.');
         return;
       }

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
@@ -5,6 +5,8 @@
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "This image references the following blocks which require extensions that are not present in the project:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Error: Failed to parse XML from the PNG file. Please try again.",
 	"Blockly.Msg.UNDO": "Undo",
 	"Blockly.Msg.REDO": "Redo",
 	"Blockly.Msg.CLEAN_UP": "Clean up Blocks",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ca.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ca.json
@@ -1,4 +1,6 @@
 {
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Aquesta imatge fa referència als blocs següents que requereixen extensions que no són presents al projecte:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Error: No s'ha pogut analitzar l'XML des del fitxer PNG. Torneu-ho a provar.",
     "Blockly.Msg.DUPLICATE_BLOCK": "Duplica",
     "Blockly.Msg.SHOW": "Mostra els controls de l'Espai de treball",
     "Blockly.Msg.HIDE": "Oculta els controls de l'espai de treball",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_de.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_de.json
@@ -5,6 +5,8 @@
 		"locale": "de",
 		"messagedocumentation" : "qqq"
 	},
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Dieses Bild verweist auf die folgenden Blöcke, die Erweiterungen erfordern, die im Projekt nicht vorhanden sind:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Fehler: Konnte XML aus der PNG-Datei nicht parsen. Bitte versuchen Sie es erneut.",
 	"Blockly.Msg.UNDO": "Rückgängig machen",
 	"Blockly.Msg.REDO": "Wiederherstellen",
 	"Blockly.Msg.CLEAN_UP": "Blöcke aufräumen",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_es.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_es.json
@@ -3,6 +3,8 @@
     "@metadata.lastupdated": "2019-12-17 16:55:22.863126",
     "@metadata.locale": "es",
     "@metadata.messagedocumentation": "qqq",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Esta imagen hace referencia a los siguientes bloques que requieren extensiones que no están presentes en el proyecto:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Error: No se pudo analizar el XML desde el archivo PNG. Por favor, inténtelo de nuevo.",
     "Blockly.Msg.DUPLICATE_BLOCK": "Duplicar",
     "Blockly.Msg.REMOVE_COMMENT": "Borrar Comentario",
     "Blockly.Msg.ADD_COMMENT": "Añadir Comentario",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_fr.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_fr.json
@@ -5,6 +5,8 @@
 		"locale": "fr",
 		"messagedocumentation" : "qqq"
 	},
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Cette image fait référence aux blocs suivants qui nécessitent des extensions qui ne sont pas présentes dans le projet:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Erreur : Échec de l'analyse du XML à partir du fichier PNG. Veuillez réessayer.",
 	"Blockly.Msg.ERROR_BLOCK_CANNOT_BE_IN_DEFINTION": "Ce bloc ne peut pas être dans une définition",
 	"Blockly.Msg.ERROR_DUPLICATE_EVENT_HANDLER": "Ceci est un gestionnaire d'évènement dupliqué pour ce composant.",
 	"Blockly.Msg.ERROR_SELECT_VALID_ITEM_FROM_DROPDOWN": "Sélectionner un élément valide dans le menu déroulant.",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_he.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_he.json
@@ -1,5 +1,7 @@
 {
   "LANG_CONTROLS_FOREACH_INPUT_COLLAPSED_SUFFIX": " ברשימה",
+  "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "תמונה זו מתייחסת לחסימות הבאות שדורשות הרחבות שאינן קיימות בפרויקט:\n\n",
+  "Blockly.Msg.ERROR_PARSING_XML": "שגיאה: לא ניתן לנתח את ה-XML מקובץ ה-PNG. אנא נסה שוב.",
   "COLLAPSE_ALL": "כווץ את כל הבלוקים",
   "TEXT_CHANGECASE_OPERATOR_UPPERCASE": "לאותיות גדולות (עבור טקסט באנגלית)",
   "LANG_CONTROLS_CLOSE_APPLICATION_TITLE": "סגור יישום",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hu.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hu.json
@@ -5,6 +5,8 @@
 		"locale": "hu",
 		"messagedocumentation" : "qqq"
 	},
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Ez a kép az alábbi blokkokra hivatkozik, amelyek kiterjesztéseket igényelnek, amelyek nincsenek jelen a projektben:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Hiba: Nem sikerült az XML elemzése a PNG fájlból. Kérjük, próbálja újra.",
 	"Blockly.Msg.UNDO": "Visszavonás",
 	"Blockly.Msg.REDO": "Mégis",
 	"Blockly.Msg.CLEAN_UP": "Rendrakás",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hy.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_hy.json
@@ -125,6 +125,8 @@
     "Blockly.Msg.COLLAPSE_ALL": "Խմբավորել Բլոկները",
     "Blockly.Msg.EXPORT_IMAGE": "Ներբեռնել Բլոկները որպես նկար",
     "Blockly.Msg.HELP": "Օգնություն",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Այս նկարը վերաբերում է հետևյալ բլոկներին, որոնք պահանջում են երկարություններ, որոնք չկան նախագծում:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Սխալ: Չհաջողվեց վերլուծել XML-ը PNG ֆայլից։ Խնդրում ենք փորձել կրկին։",
     "Blockly.Msg.ENABLE_BLOCK": "Ակտիվացնել Բլոկը",
     "Blockly.Msg.DISABLE_BLOCK": "Ապաակտիվացնել Բլոկը",
     "Blockly.Msg.EXPAND_BLOCK": "Ընդարձակել Բլոկը",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_it.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_it.json
@@ -17,6 +17,8 @@
 	"Blockly.Msg.COLLAPSE_BLOCK": "Riduci Blocco",
 	"Blockly.Msg.EXPAND_BLOCK": "Espandi Blocco",
 	"Blockly.Msg.DISABLE_BLOCK": "Disabilita Blocco",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Questa immagine fa riferimento ai seguenti blocchi che richiedono estensioni che non sono presenti nel progetto:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Errore: Impossibile analizzare l'XML dal file PNG. Riprova.",
 	"Blockly.Msg.ENABLE_BLOCK": "Abilita Blocco",
 	"Blockly.Msg.HELP": "Aiuto",
 	"Blockly.Msg.COLLAPSE_ALL": "Riduci blocchi",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ja.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ja.json
@@ -16,6 +16,8 @@
     "Blockly.Msg.LANG_CONTROLS_IF_MSG_IF": "もし",
     "Blockly.Msg.LANG_CONTROLS_IF_TOOLTIP_4": "最初の値が真ならば文の最初のブロックを実行します。\nそうでない時に２番目の値が真ならば文の２番目のブロックを実行します。\nいずれの値も真でなければ文の最後のブロックを実行します。",
     "Blockly.Msg.LANG_CONTROLS_IF_TOOLTIP_3": "最初の値が真ならば文の最初のブロックを実行します。\nそうでない時に２番目の値が真ならば文の２番目のブロックを実行します。",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "この画像は、プロジェクトに存在しない拡張機能を必要とする以下のブロックを参照しています:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "エラー: PNGファイルからXMLを解析できませんでした。もう一度お試しください。",
     "Blockly.Msg.LANG_CONTROLS_IF_TOOLTIP_2": "値が真ならば文の最初のブロックを実行します。\nそうでなければ文の２番目のブロックを実行します。",
     "Blockly.Msg.LANG_CONTROLS_IF_TOOLTIP_1": "値が真ならば文を実行します。",
     "Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP": "RGBでカスタム色作成。",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ko.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ko.json
@@ -16,6 +16,8 @@
 	"Blockly.Msg.EXTERNAL_INPUTS": "외부 입력값",
 	"Blockly.Msg.INLINE_INPUTS": "인라인 입력값",
 	"Blockly.Msg.HORIZONTAL_PARAMETERS": "가로로 배열하기",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "이 이미지는 프로젝트에 없는 확장을 요구하는 다음 블록들을 참조합니다:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "오류: PNG 파일에서 XML을 파싱하지 못했습니다. 다시 시도해 주세요.",
 	"Blockly.Msg.VERTICAL_PARAMETERS": "세로로 배열하기",
 	"Blockly.Msg.CONFIRM_DELETE": "삭제 확인",
 	"Blockly.Msg.DELETE_ALL_BLOCKS": "모든 %1 블록을 삭제 하시겠습니까?",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_lt.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_lt.json
@@ -18,6 +18,8 @@
 	"Blockly.Msg.HORIZONTAL_PARAMETERS": "Parametrus išdėstyti horizontaliai",
 	"Blockly.Msg.VERTICAL_PARAMETERS": "Parametrus išdėstyti vertikaliai",
 	"Blockly.Msg.CONFIRM_DELETE": "Patvirtinti pašalinimą",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Šis vaizdas nurodo šiuos blokų, kurie reikalauja plėtinių, kurie nėra projekte:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Klaida: Nepavyko išanalizuoti XML iš PNG failo. Prašome pabandyti vėl.",
 	"Blockly.Msg.DELETE_ALL_BLOCKS": "Pašalinti visus %1 blokus (-ų)?",
 	"Blockly.Msg.DELETE_BLOCK": "Pašalinti bloką",
 	"Blockly.Msg.DELETE_X_BLOCKS": "Pašalinti %1 blokus (-ų)",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_nl.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_nl.json
@@ -15,6 +15,8 @@
     "Blockly.Msg.DELETE_BLOCK": "Verwijder blok",
     "Blockly.Msg.LANG_MATH_FORMAT_AS_DECIMAL_TOOLTIP": "Geeft het nummer terug in decimale notatie\nmet een bepaald aantal getallen achter de komma.",
     "Blockly.Msg.LANG_CONTROLS_WHILEUNTIL_OPERATOR_WHILE": "terwijl",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Deze afbeelding verwijst naar de volgende blokken die extensies vereisen die niet aanwezig zijn in het project:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Fout: Het is niet gelukt om XML te parseren vanuit het PNG-bestand. Probeer het opnieuw.",
     "Blockly.Msg.LANG_COLOUR_PINK": "roze",
     "Blockly.Msg.CONNECT_TO_DO_IT": "U moet verbonden zijn met de AI Companion app of emulator om 'Doe het' te gebruiken",
     "Blockly.Msg.LANG_VARIABLES_GET_COLLAPSED_TEXT": "krijg",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pl.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pl.json
@@ -14,6 +14,8 @@
 	"Blockly.Msg.REMOVE_COMMENT": "Usuń komentarz",
 	"Blockly.Msg.ADD_COMMENT": "Dodaj komentarz",
 	"Blockly.Msg.EXTERNAL_INPUTS": "Wejścia zewnętrzne",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Ten obrazek odnosi się do następujących bloków, które wymagają rozszerzeń, które nie są obecne w projekcie:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Błąd: Nie udało się sparsować XML z pliku PNG. Proszę spróbować ponownie.",
 	"Blockly.Msg.INLINE_INPUTS": "Wejścia liniowe",
 	"Blockly.Msg.HORIZONTAL_PARAMETERS": "Rozmieść parametry w poziomie",
 	"Blockly.Msg.VERTICAL_PARAMETERS": "Rozmieść parametry w pionie",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt.json
@@ -17,6 +17,8 @@
 	"Blockly.Msg.DELETE_BLOCK": "Apagar Bloco",
 	"Blockly.Msg.LANG_MATH_FORMAT_AS_DECIMAL_TOOLTIP": "Retorna o número formatado como um decimal\ncom o número especificado de casas.",
 	"Blockly.Msg.LANG_CONTROLS_WHILEUNTIL_OPERATOR_WHILE": "enquanto",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Esta imagem faz referência aos seguintes blocos que requerem extensões que não estão presentes no projeto:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Erro: Não foi possível analisar o XML do arquivo PNG. Tente novamente.",
 	"Blockly.Msg.LANG_COLOUR_PINK": "rosa",
 	"Blockly.Msg.CONNECT_TO_DO_IT": "Conecte-se ao assistente ou ao emulador para executar",
 	"Blockly.Msg.LANG_VARIABLES_GET_COLLAPSED_TEXT": "obter",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt_BR.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_pt_BR.json
@@ -15,6 +15,7 @@
 	"Blockly.Msg.LANG_CONTROLS_GET_START_VALUE_TOOLTIP": "Retorna o valor que foi passado para esta tela quando ela foi aberta, tipicamente por outra tela em um app multi-tela. Se nenhum valor foi passado, retorna uma cadeia de texto vazia.",
 	"Blockly.Msg.LANG_LISTS_CREATE_WITH_ITEM_TITLE": "item",
 	"Blockly.Msg.DELETE_BLOCK": "Apagar Bloco",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Esta imagem faz referência aos seguintes blocos que requerem extensões que não estão presentes no projeto:\n\n",
 	"Blockly.Msg.LANG_MATH_FORMAT_AS_DECIMAL_TOOLTIP": "Retorna o número formatado como um decimal\ncom o número especificado de casas.",
 	"Blockly.Msg.LANG_CONTROLS_WHILEUNTIL_OPERATOR_WHILE": "enquanto",
 	"Blockly.Msg.LANG_COLOUR_PINK": "rosa",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ru.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ru.json
@@ -5,6 +5,8 @@
 		"locale": "ru",
 		"messagedocumentation" : "qqq"
 	},
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Это изображение ссылается на следующие блоки, которые требуют расширений, отсутствующих в проекте:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Ошибка: Не удалось разобрать XML из PNG файла. Пожалуйста, попробуйте снова.",
 	"Blockly.Msg.ERROR_BLOCK_CANNOT_BE_IN_DEFINTION": "Этот блок не может использоваться в определении",
 	"Blockly.Msg.ERROR_DUPLICATE_EVENT_HANDLER": "Это дубликат обработчика события для этого элемента.",
 	"Blockly.Msg.ERROR_SELECT_VALID_ITEM_FROM_DROPDOWN": "Выберите подходящий пункт из выпадающего меню.",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_sv.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_sv.json
@@ -8,6 +8,8 @@
 	"Blockly.Msg.LANG_LISTS_LOOKUP_IN_PAIRS_INPUT": "slå upp parvis  nyckel %1 par %2 hittadesInte %3",
 	"Blockly.Msg.VARIABLE_CATEGORY": "Variabler",
 	"Blockly.Msg.ADD_COMMENT": "Lägg till kommentar",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Den här bilden refererar till följande block som kräver tillägg som inte finns i projektet:\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "Fel: Kunde inte analysera XML från PNG-filen. Vänligen försök igen.",
 	"Blockly.Msg.EXPAND_BLOCK": "Expandera block",
 	"Blockly.Msg.LANG_CONTROLS_IF_ELSE_TITLE_ELSE": "annars",
 	"Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT": "Delar upp texten i bitar med texten 'vid' som delningspunkt och ger en lista med resultatet.  \nAtt dela upp 'one,two,three,four' vid ',' (komma) ger listan '(one two three four)'. \nAtt dela upp 'one-potato,two-potato,three-potato,four' vid '-potato' ger listan '(one two three four)'.",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_tr.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_tr.json
@@ -16,6 +16,8 @@
     "Blockly.Msg.LANG_PROCEDURES_DOTHENRETURN_COLLAPSED_TEXT": "Yap / Sonuç",
     "Blockly.Msg.LANG_LISTS_LOOKUP_IN_PAIRS_INPUT_PAIRS": "Çift",
     "Blockly.Msg.LANG_LISTS_ADD_ITEMS_INPUT": "Listeye öğe ekle %1 öğe %2",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Bu görsel, projede mevcut olmayan eklentiler gerektiren aşağıdaki bloklara atıfta bulunmaktadır:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Hata: PNG dosyasından XML parse edilemedi. Lütfen tekrar deneyin.",
     "Blockly.Msg.LANG_COMPONENT_BLOCK_METHOD_TITLE_CALL": "çağır ",
     "Blockly.Msg.LANG_TEXT_SEGMENT_INPUT_START": "Başla",
     "Blockly.Msg.LANG_TEXT_SPLIT_INPUT_AT": "-de",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_uk.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_uk.json
@@ -15,6 +15,8 @@
     "Blockly.Msg.CLEAR_DO_IT_ERROR": "Очистити помилку",
     "Blockly.Msg.DO_IT_DISCONNECTED": "Зроби це (Companion не підключено)",
     "Blockly.Msg.DO_IT_RESULT": "Результат виконання:",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "Это изображение ссылается на следующие блоки, которые требуют расширений, отсутствующих в проекте:\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "Ошибка: Не удалось разобрать XML из PNG файла. Пожалуйста, попробуйте снова.",
     "Blockly.Msg.DO_IT": "Зроби це",
     "Blockly.Msg.GENERATE_YAIL": "Згенерувати Yail",
     "Blockly.Msg.WARNING_DELETE_X_BLOCKS": "Ви впевнені, що хочете видалити всі %1 блоки?",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_CN.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_CN.json
@@ -18,6 +18,8 @@
     "Blockly.Msg.ENABLE_BLOCK": "启用代码块",
     "Blockly.Msg.HELP": "帮助",
     "Blockly.Msg.EXPORT_IMAGE": "下载工作区为图像",
+    "Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "此图像引用了以下需要在项目中存在的扩展的块：\n\n",
+    "Blockly.Msg.ERROR_PARSING_XML": "错误：无法从PNG文件解析XML。请再试一次。",
     "Blockly.Msg.COLLAPSE_ALL": "折叠所有块",
     "Blockly.Msg.EXPAND_ALL": "展开所有块",
     "Blockly.Msg.ARRANGE_H": "横向排列所有块",

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_TW.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_zh_TW.json
@@ -22,6 +22,8 @@
 	"Blockly.Msg.EXPAND_ALL": "展開所有程式方塊",
 	"Blockly.Msg.ARRANGE_H": "水平排列所有程式方塊",
 	"Blockly.Msg.ARRANGE_V": "垂直縱向排列所有程式方塊",
+	"Blockly.Msg.REQUIRED_EXTENSIONS_MISSING": "此图像引用了以下需要在项目中存在的扩展的块：\n\n",
+	"Blockly.Msg.ERROR_PARSING_XML": "错误：无法从PNG文件解析XML。请再试一次。",
 	"Blockly.Msg.ARRANGE_S": "斜向排列所有方塊",
 	"Blockly.Msg.SORT_W": "按寬度排序所有程式方塊",
 	"Blockly.Msg.SORT_H": "按高度排序所有程式方塊",


### PR DESCRIPTION
General items:

- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `master`
- [x] My pull request has `master` as the base

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

**-** To solve the issue of importing blocks from a PNG file that requires extensions not present in the project, I added the following steps:  

**1.** **Extract Block Types**: created a function extractBlockTypes to extract the block types from the XML data embedded in the PNG file.
**2.** **Validate Block Types**: created a function validateBlockTypes to check if the extracted block types are available in the component database of the workspace.
**3. Show Missing Extensions Dialog:** created a function showMissingExtensionDialog to display an alert dialog listing the missing extensions if any.
**4. Modify importPngAsBlock:** modified the importPngAsBlock function to:

- Extract block types from the XML.
- Validate the block types against the component database.
- Show an error dialog and abort the import if any required extensions are missing.

Fixes #3335


