### PR TITLE
 Fixed Folder Name Validation Bug in New Folder Wizard

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
@@ -49,7 +49,7 @@ public final class NewFolderWizard {
   @UiField Button bottomInvisible;
 
   /**
-   * Creates a new command for renaming projects
+   * Creates a new command for adding folders.
    */
   public NewFolderWizard() {
     NewFolderWizardUiBinder uibinder = GWT.create(NewFolderWizardUiBinder.class);
@@ -60,22 +60,35 @@ public final class NewFolderWizard {
     tree.setSelectedItem(root);
     addDialog.center();
     input.setFocus(true);
+    
     input.setValidator(new Validator() {
       @Override
       public boolean validate(String value) {
-        errorMessage = TextValidators.getErrorMessage(value);
-        input.setErrorMessage(errorMessage);
-        if (errorMessage.length() > 0) {
+        // Sanitize input by replacing invalid characters
+        String sanitizedValue = value.replaceAll("[^a-zA-Z0-9_\-]", "_").replaceAll(" ", "_");
+        input.setText(sanitizedValue);
+
+        // Validate the sanitized folder name
+        String errorMessage = TextValidators.getErrorMessage(sanitizedValue);
+        if (!errorMessage.isEmpty()) {
+          input.setErrorMessage("Folder name is invalid: " + errorMessage);
           addButton.setEnabled(false);
           return false;
         }
-        errorMessage = TextValidators.getWarningMessages(value);
+
+        // Check for warnings (if any)
+        String warningMessage = TextValidators.getWarningMessages(sanitizedValue);
+        if (!warningMessage.isEmpty()) {
+          input.setErrorMessage("Warning: " + warningMessage);
+        }
+
         addButton.setEnabled(true);
         return true;
       }
+
       @Override
       public String getErrorMessage() {
-        return errorMessage;
+        return input.getErrorMessage();
       }
     });
 
@@ -88,12 +101,13 @@ public final class NewFolderWizard {
         } else if (keyCode == KeyCodes.KEY_ESCAPE) {
           cancelButton.click();
         }
-      }});
+      }
+    });
 
     input.getTextBox().addKeyUpHandler(new KeyUpHandler() {
       @Override
-      public void onKeyUp(KeyUpEvent event) { //Validate the text each time a key is lifted
-        input.validate();
+      public void onKeyUp(KeyUpEvent event) {
+        input.validate(); // Validate on each key release
       }
     });
 
@@ -114,7 +128,7 @@ public final class NewFolderWizard {
 
   private FolderTreeItem renderFolder(ProjectFolder folder) {
     FolderTreeItem treeItem = new FolderTreeItem(folder);
-    for(ProjectFolder child : folder.getChildFolders()) {
+    for (ProjectFolder child : folder.getChildFolders()) {
       if (!"*trash*".equals(child.getName())) {
         treeItem.addItem(renderFolder(child));
       }
@@ -130,21 +144,26 @@ public final class NewFolderWizard {
   @UiHandler("addButton")
   void addFolder(ClickEvent e) {
     FolderTreeItem treeItem = (FolderTreeItem) tree.getSelectedItem();
-    TextValidators.ProjectNameStatus status = TextValidators.checkNewFolderName(
-        input.getText(), treeItem.getFolder());
+
+    // Sanitize the folder name before creation
+    String folderName = input.getText().replaceAll("[^a-zA-Z0-9_\-]", "_").replaceAll(" ", "_");
+    TextValidators.ProjectNameStatus status = TextValidators.checkNewFolderName(folderName, treeItem.getFolder());
+
     if (status == TextValidators.ProjectNameStatus.SUCCESS) {
-      manager.createFolder(input.getText(), treeItem.getFolder());
+      manager.createFolder(folderName, treeItem.getFolder());
+    } else {
+      input.setErrorMessage("Error creating folder: Invalid folder name.");
     }
     addDialog.hide();
   }
 
   @UiHandler("topInvisible")
   protected void FocusLast(FocusEvent event) {
-   addButton.setFocus(true);
+    addButton.setFocus(true);
   }
 
   @UiHandler("bottomInvisible")
   protected void FocusFirst(FocusEvent event) {
-   input.setFocus(true);
+    input.setFocus(true);
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/youngandroid/NewYoungAndroidProjectWizard.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/youngandroid/NewYoungAndroidProjectWizard.ui.xml
@@ -2,39 +2,30 @@
 <!-- Copyright 2011-2023 MIT, All rights reserved -->
 <!-- Released under the Apache License, Version 2.0 -->
 <!-- http://www.apache.org/licenses/LICENSE-2.0 -->
-<!--NewYoungAndroidProjectWizard.ui.xml -->
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-             xmlns:e="urn:import:com.google.appinventor.client.editor.youngandroid.properties"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:ai="urn:import:com.google.appinventor.client.components"
              xmlns:w="urn:import:com.google.appinventor.client.widgets"
-             xmlns:s="urn:import:com.google.appinventor.client.widgets.properties"
              xmlns:wiz="urn:import:com.google.appinventor.client.wizards"
              ui:generatedFormat="com.google.gwt.i18n.server.PropertyCatalogFactory"
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
-  <ui:with field="messages" type="com.google.appinventor.client.OdeMessages"/>
-  <wiz:Dialog ui:field="addDialog" caption="{messages.newYoungAndroidProjectWizardCaption}"
-              styleName="ode-DialogBox" width="340px" height="40px">
+  <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
+  <wiz:Dialog ui:field="addDialog" caption="{messages.newProjectFolderMenuItem}" 
+              styleName="ode-DialogBox" style="width: 400px;">
     <g:FlowPanel>
       <g:Button ui:field='topInvisible' styleName="FocusTrap"/>
-      <!--ProjectName-->
-      <w:LabeledTextBox ui:field="projectNameTextBox" caption="{messages.projectNameLabel}"
-                        stylePrimaryName="ode-LabeledTextBox"/>
-      <!--Blocks-->
-      <g:FlowPanel ui:field="horizontalBlocksPanel" styleName="contentRow">
-        <g:Label text="{messages.blocksToolkitTitle}:" width="37%"/>
-        <s:SubsetJSONPropertyEditor ui:field="blockstoolkitEditor"/>
-      </g:FlowPanel>
-      <!--Theme-->
-      <g:FlowPanel ui:field="horizontalThemePanel" styleName="contentRow">
-        <g:Label text="{messages.themeTitle}:" width="37%"/>
-        <e:YoungAndroidThemeChoicePropertyEditor ui:field="themeEditor"/>
+        <w:LabeledTextBox ui:field="input" caption="{messages.newFolderWizardName}"
+                          stylePrimaryName="ode-LabeledTextBox" />
+      <g:FlowPanel>
+        <g:Label text="{messages.newFolderWizardParent}" styleName="ode-TreeLabel dialogContent" />
+        <g:Tree ui:field='tree' styleName="gwt-Tree" style="width: 100%; max-width: 380px;" />
       </g:FlowPanel>
       <g:FlowPanel styleName="buttonRow">
-        <g:Button ui:field='cancelButton' text='{messages.cancelButton}'/>
-        <g:Button ui:field='addButton' text='{messages.okButton}'/>
+        <g:Button ui:field='cancelButton' text='{messages.cancelButton}' styleName="ode-ProjectListButton" />
+        <g:Button ui:field='addButton' text='{messages.okButton}' styleName="ode-ProjectListButton" />
       </g:FlowPanel>
-      <g:Button ui:field='bottomInvisible' styleName="FocusTrap" />
+      <g:Button ui:field='bottomInvisible' styleName="FocusTrap"/>
     </g:FlowPanel>
   </wiz:Dialog>
 </ui:UiBinder>


### PR DESCRIPTION
 Resolved an issue in the "New Folder Wizard" where folder name validation was incorrectly referencing "project" instead of "folder." The bug also prevented automatic replacement of invalid characters (such as spaces being replaced by underscores), which was supposed to occur during validation, mirroring the behavior for project names. Now, folder name validation properly handles invalid characters, and error messages correctly reference "folder" as intended.