### PR TITLE
Fix folder name validation to replace invalid characters and correct error messages (#3345)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2414,6 +2414,18 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Error shown when user types invalid character into project name.")
   String invalidCharProjectNameError();
 
+  @DefaultMessage("The first character of the folder name must be a letter")
+  @Description("Error shown when user does not type letter as first character in folder name.")
+  String firstCharFolderNameError();
+
+  @DefaultMessage("Invalid character. Folder names can only contain letters, numbers, and underscores")
+  @Description("Error shown when user types invalid character into folder name.")
+  String invalidCharFolderNameError();
+
+  @DefaultMessage("Folder names cannot contain spaces")
+  @Description("Error shown when user types space into folder name.")
+  String whitespaceFolderNameError();
+
   // Used in youngandroid/YoungAndroidFormUpgrader.java
 
   @DefaultMessage("This project was created with an older version of the App Inventor " +

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.java
@@ -63,13 +63,13 @@ public final class NewFolderWizard {
     input.setValidator(new Validator() {
       @Override
       public boolean validate(String value) {
-        errorMessage = TextValidators.getErrorMessage(value);
+        errorMessage = TextValidators.getFolderErrorMessage(value);
         input.setErrorMessage(errorMessage);
         if (errorMessage.length() > 0) {
           addButton.setEnabled(false);
           return false;
         }
-        errorMessage = TextValidators.getWarningMessages(value);
+        errorMessage = TextValidators.getFolderWarningMessages(value);
         addButton.setEnabled(true);
         return true;
       }
@@ -127,15 +127,33 @@ public final class NewFolderWizard {
     addDialog.hide();
   }
 
+  /**
+   * Handles the addition of a new folder when the add button is clicked.
+   * It validates the folder name, creates the folder if valid, and displays appropriate error messages if not.
+   * @param e The click event triggered by the add button.
+   */
   @UiHandler("addButton")
   void addFolder(ClickEvent e) {
     FolderTreeItem treeItem = (FolderTreeItem) tree.getSelectedItem();
-    TextValidators.ProjectNameStatus status = TextValidators.checkNewFolderName(
-        input.getText(), treeItem.getFolder());
+    String folderName = input.getText().trim().replaceAll("( )+", " ").replace(" ", "_");
+    TextValidators.ProjectNameStatus status = TextValidators.checkNewFolderName(folderName, treeItem.getFolder());
+
     if (status == TextValidators.ProjectNameStatus.SUCCESS) {
-      manager.createFolder(input.getText(), treeItem.getFolder());
+      manager.createFolder(folderName, treeItem.getFolder());
+      addDialog.hide();
+    } else {
+      String errorMessage = TextValidators.getFolderErrorMessage(input.getText());
+      if (errorMessage.isEmpty()) {
+        errorMessage = TextValidators.getFolderWarningMessages(input.getText());
+        if (errorMessage.isEmpty()) {
+          input.setErrorMessage("There has been an unexpected error validating the folder name.");
+        } else {
+          input.setErrorMessage(errorMessage);
+        }
+      } else {
+        input.setErrorMessage(errorMessage);
+      }
     }
-    addDialog.hide();
   }
 
   @UiHandler("topInvisible")

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/RequestNewProjectNameWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/RequestNewProjectNameWizard.java
@@ -24,12 +24,15 @@ import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import java.util.logging.Logger;
 
 /**
  * Wizard for renaming projects.
  *
  */
 public class RequestNewProjectNameWizard extends Wizard {
+
+  private static final Logger LOG = Logger.getLogger(RequestNewProjectNameWizard.class.getName());
 
   private LabeledTextBox projectNameTextBox;
   private RequestProjectNewNameInterface newName;

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -254,6 +254,28 @@ public final class TextValidators {
   }
 
   /**
+   * Returns an error message if the folder name is invalid.
+   * It checks if the folder name starts with a letter and contains only letters, numbers, and underscores.
+   * @param folderName The name of the folder to validate.
+   * @return String representing the error message, empty string if no error.
+   */
+  public static String getFolderErrorMessage(String folderName) {
+    String errorMessage = "";
+    String firstCharacterLetter = "[A-Za-z].*";
+    String temp = folderName.trim().replaceAll("( )+", " ").replace(" ", "_");
+    if (temp.length() > 0) {
+      if (!temp.matches("[A-Za-z][A-Za-z0-9_]*")) {
+        if (!temp.matches(firstCharacterLetter)) {
+          errorMessage = MESSAGES.firstCharFolderNameError();
+        } else {
+          errorMessage = MESSAGES.invalidCharFolderNameError();
+        }
+      }
+    }
+    return errorMessage;
+  }
+
+  /**
    * Determines human-readable message for specific warning if there are no errors.
    * @param filename The filename (not path) of uploaded file
    * @return String representing warning message, empty string if no warning and no error
@@ -266,6 +288,24 @@ public final class TextValidators {
         String errorMessage = MESSAGES.whitespaceProjectNameError();
         filename = filename.trim().replaceAll("( )+", " ").replace(" ","_");
         warningMessage = errorMessage + ". \n '" + filename + "' will be used if continued.";
+      }
+    }
+    return warningMessage;
+  }
+
+  /**
+   * Returns a warning message if the folder name contains spaces.
+   * It suggests a modified folder name with spaces replaced by underscores.
+   * @param folderName The name of the folder to validate.
+   * @return String representing the warning message, empty string if no warning and no error.
+   */
+  public static String getFolderWarningMessages(String folderName) {
+    String warningMessage = "";
+    if (getFolderErrorMessage(folderName).length() == 0 && folderName.trim().length() > 0) {
+      if (!folderName.matches("[A-Za-z][A-Za-z0-9_]*")) {
+        String errorMessage = MESSAGES.whitespaceFolderNameError();
+        folderName = folderName.trim().replaceAll("( )+", " ").replace(" ", "_");
+        warningMessage = errorMessage + ". \n '" + folderName + "' will be used if continued.";
       }
     }
     return warningMessage;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [X] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [X] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [X] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [X] I branched from `master`
- [X] My pull request has `mster` as the base

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

1. **Enhance `TextValidators.java`**:
   - Added `getFolderErrorMessage` method to validate folder names and return appropriate error messages.
   - Added `getFolderWarningMessages` method to provide warnings for folder names containing spaces and suggest a modified name.

2. **Update Error Messages in `OdeMessages.java`**:
   - Added new error messages specific to folder names:
  
3. **Modify `NewFolderWizard.java`**:
   - Changed the validation method to use `TextValidators.getFolderErrorMessage` and `TextValidators.getFolderWarningMessages` instead of project name validators.
   - Updated the `addFolder` method to:
     - Automatically replace spaces with underscores in the folder name.
     - Use the corrected folder name for validation and creation.


Fixes #3345  

