### PR TITLE
Make Blockly 10 build on Windows

### DIFF
--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -125,29 +125,29 @@
                 description="For now, compiling the Blockly editor means cat-ing its javascript together with the relevant javascript in the Blockly library"
                 depends="init,CheckBlocklyCompile"
                 unless="BlocklyCompile.uptodate">
-		<java failonerror="true" fork="true" jar="${lib.dir}/closure-compiler/closure-compiler-v20211201.jar">
+		<java failonerror="true" fork="true" jar="${lib.dir}/closure-compiler/closure-compiler-v20211201.jar" dir="${appinventor.dir}">
 			<arg line="--compilation_level ${compilation_level}"/>
 			<arg line="--language_in ECMASCRIPT_NEXT"/>
 			<arg line="--language_out ECMASCRIPT_NEXT"/>
-			<arg line="--js_output_file ${public.build.dir}/blockly-all.js"/>
-			<arg line="${blockly.src.dir}/blockly_compressed.js"/>
-			<arg line="${blockly.plugin.dir}/block-lexical-variables-core-2.0.6.min.js"/>
-			<arg line="src/blocks/utilities.js"/>
-			<arg line="src/mixins/dynamic_connections.js"/>
-			<arg line="src/mixins/mixins.js"/>
-			<arg line="src/**.js"/>
-			<arg line="${lib.dir}/closure-library/closure/goog/**.js"/>
-			<arg line="!${lib.dir}/closure-library/closure/goog/**_test.js"/>
-			<arg line="!${lib.dir}/closure-library/closure/goog/testing/**.js"/>
-			<arg line="!${lib.dir}/closure-library/closure/goog/**tests.js"/>
-			<arg line="!${lib.dir}/closure-library/closure/goog/**_perf.js"/>
+			<arg line="--js_output_file"/>
+			<arg file="${public.build.dir}/blockly-all.js"/>
 			<arg line="--entry_point=goog:AI.Blockly.BlocklyEditor"/>
 			<arg line="--charset UTF-8"/>
-			<arg line="--create_source_map ${public.build.dir}/blockly-all.js.map"/>
+			<arg line="--create_source_map"/>
+			<arg file="${public.build.dir}/blockly-all.js.map"/>
 			<arg line="--source_map_location_mapping src|/ode/static/js"/>
-			<arg line="--source_map_input ${blockly.src.dir}/blockly_compressed.js|${blockly.src.dir}/blockly_compressed.js.map"/>
+			<arg line="--source_map_input"/>
+			<arg value="${blockly.src.dir}/blockly_compressed.js|${blockly.src.dir}/blockly_compressed.js.map"/>
 			<arg line="--output_wrapper='%output%&#10;//# sourceMappingURL=/static/js/blockly-all.js.map'" if:true="${release}"/>
 			<arg line="--dependency_mode=PRUNE_LEGACY"/>
+			<arg value="--js='${blockly.src.dir}/blockly_compressed.js'"/>
+			<arg value="--js='${blockly.plugin.dir}/block-lexical-variables-core-2.0.6.min.js'"/>
+			<arg value="--js='blocklyeditor/src/**.js'"/>
+			<arg value="--js='${lib.dir}/closure-library/closure/goog/**.js'"/>
+			<arg value="--js='!${lib.dir}/closure-library/closure/goog/**_test.js'"/>
+			<arg value="--js='!${lib.dir}/closure-library/closure/goog/testing/**.js'"/>
+			<arg value="--js='!${lib.dir}/closure-library/closure/goog/**tests.js'"/>
+			<arg value="--js='!${lib.dir}/closure-library/closure/goog/**_perf.js'"/>
 		</java>
 	</target>
 


### PR DESCRIPTION
Change-Id: I62e6d77408642fc381fec5fa485cc93b696a25ec

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes a regression in the build system for blocklyeditor that prevents it from compiling on Windows. Apparently, the glob expansion used by Closure Compiler is different on Windows than Unix systems (e.g., macOS) so the rules didn't actually include the various Google Closure Library dependencies needed to correctly build App Inventor on Windows.