### PR TITLE
ios companion app fix for troubleshooting, minor tweaks to buttons

### DIFF
--- a/appinventor/aicompanionapp/src/Base.lproj/Main.storyboard
+++ b/appinventor/aicompanionapp/src/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="f8E-Bx-vXj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="f8E-Bx-vXj">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,69 +20,103 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Instructions.png" translatesAutoresizingMaskIntoConstraints="NO" id="fs4-4D-vvR">
+                            <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Instructions.png" translatesAutoresizingMaskIntoConstraints="NO" id="fs4-4D-vvR">
                                 <rect key="frame" x="28" y="8" width="358" height="89.333333333333329"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="fs4-4D-vvR" secondAttribute="height" multiplier="800:200" constant="1" id="gH7-ya-JMI"/>
+                                    <constraint firstAttribute="height" constant="89.333333333333329" id="Dyw-RY-P6M"/>
                                 </constraints>
                             </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Six Character Code" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gxM-wq-OQv">
-                                <rect key="frame" x="36" y="105.33333333333334" width="342" height="34"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
-                            </textField>
-                            <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vZO-ch-Rin">
-                                <rect key="frame" x="57" y="143.33333333333334" width="300" height="49"/>
+                            <button opaque="NO" tag="4" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vZO-ch-Rin">
+                                <rect key="frame" x="77" y="290" width="257" height="78"/>
                                 <state key="normal" image="connectwCode.png"/>
                             </button>
-                            <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QmI-n4-yhD">
-                                <rect key="frame" x="57" y="200.33333333333331" width="300" height="49"/>
-                                <state key="normal" image="connectwQR.png"/>
+                            <button toolTip="Click to Scan" opaque="NO" tag="5" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" changesSelectionAsPrimaryAction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QmI-n4-yhD">
+                                <rect key="frame" x="79" y="137" width="262" height="72"/>
+                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="72" id="4e7-OR-Dit"/>
+                                </constraints>
+                                <state key="normal" image="connectwQR.png" backgroundImage="Mooning">
+                                    <color key="titleShadowColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version: Unknown" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aXu-gl-0yY">
-                                <rect key="frame" x="36" y="277.66666666666669" width="342" height="20.666666666666686"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version: Unknown" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aXu-gl-0yY">
+                                <rect key="frame" x="36" y="692" width="342" height="74"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your IP Address is: " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ste-Nv-ksy">
-                                <rect key="frame" x="36" y="257.33333333333331" width="342" height="20.333333333333314"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your IP Address is: " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ste-Nv-ksy">
+                                <rect key="frame" x="36" y="672" width="342" height="40"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view tag="6" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bp2-QU-Qf6" customClass="CheckBoxView" customModule="AIComponentKit">
-                                <rect key="frame" x="87" y="306.33333333333331" width="240" height="30"/>
+                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Six Character Code" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gxM-wq-OQv">
+                                <rect key="frame" x="108" y="270" width="198" height="34"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="34" id="K50-Zh-191"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
+                            </textField>
+                            <view tag="6" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bp2-QU-Qf6" customClass="CheckBoxView" customModule="AIComponentKit">
+                                <rect key="frame" x="88" y="350.66666666666674" width="240" height="86.333333333333258"/>
                                 <accessibility key="accessibilityConfiguration" label="Use Legacy Connection">
                                     <accessibilityTraits key="traits" button="YES"/>
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="240" id="xGY-yC-SXN"/>
-                                </constraints>
                             </view>
+                            <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="OR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FR2-4R-WPz">
+                                <rect key="frame" x="34" y="217" width="342" height="45"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" tag="18" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N8z-gK-HfL">
+                                <rect key="frame" x="114" y="555" width="193" height="58"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="RVf-63-XDD"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <size key="titleShadowOffset" width="2" height="2"/>
+                                <state key="normal" image="troubleshooting.png"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.78814870119094849" green="0.78828507661819458" blue="0.78814005851745605" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="aXu-gl-0yY" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="16" id="94X-dX-RMS"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="gxM-wq-OQv" secondAttribute="trailing" constant="16" id="9MB-fn-p3n"/>
-                            <constraint firstItem="fs4-4D-vvR" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="8" id="BLo-G5-i5W"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="fs4-4D-vvR" secondAttribute="trailing" constant="8" id="Dtc-5I-bmt"/>
-                            <constraint firstItem="gxM-wq-OQv" firstAttribute="top" secondItem="fs4-4D-vvR" secondAttribute="bottom" constant="8" id="IX8-Gz-8Gd"/>
-                            <constraint firstItem="vZO-ch-Rin" firstAttribute="centerX" secondItem="8pV-NU-cQS" secondAttribute="centerX" id="NDD-Kl-xp3"/>
-                            <constraint firstItem="vZO-ch-Rin" firstAttribute="top" secondItem="gxM-wq-OQv" secondAttribute="bottom" constant="4" id="NRu-Jb-9yq"/>
-                            <constraint firstItem="fs4-4D-vvR" firstAttribute="top" secondItem="BYZ-J5-ior" secondAttribute="bottom" constant="8" id="RMt-u4-PeI"/>
-                            <constraint firstItem="aXu-gl-0yY" firstAttribute="top" secondItem="Ste-Nv-ksy" secondAttribute="bottom" id="SJA-CL-T9W"/>
-                            <constraint firstItem="QmI-n4-yhD" firstAttribute="top" secondItem="vZO-ch-Rin" secondAttribute="bottom" constant="8" id="SOw-1N-yfn"/>
-                            <constraint firstItem="QmI-n4-yhD" firstAttribute="centerX" secondItem="8pV-NU-cQS" secondAttribute="centerX" id="V6J-uB-GXA"/>
-                            <constraint firstItem="gxM-wq-OQv" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="16" id="Z08-jF-MP0"/>
-                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="top" secondItem="QmI-n4-yhD" secondAttribute="bottom" constant="8" id="avV-TV-CYc"/>
-                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="16" id="ds2-gY-ASF"/>
-                            <constraint firstItem="Bp2-QU-Qf6" firstAttribute="top" secondItem="aXu-gl-0yY" secondAttribute="bottom" constant="8" id="fbN-YU-1vd"/>
-                            <constraint firstItem="Bp2-QU-Qf6" firstAttribute="centerX" secondItem="8pV-NU-cQS" secondAttribute="centerX" id="fiy-zB-4Sg"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Ste-Nv-ksy" secondAttribute="trailing" constant="16" id="qMb-TK-qVD"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="aXu-gl-0yY" secondAttribute="trailing" constant="16" id="uiA-T0-V0i"/>
+                            <constraint firstItem="gxM-wq-OQv" firstAttribute="centerX" secondItem="fs4-4D-vvR" secondAttribute="centerX" id="1bN-MG-JNu"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="QmI-n4-yhD" secondAttribute="trailing" constant="53" id="2YH-oO-B5N"/>
+                            <constraint firstItem="QmI-n4-yhD" firstAttribute="top" secondItem="fs4-4D-vvR" secondAttribute="bottom" constant="19.666666666666671" id="63H-6A-wQf"/>
+                            <constraint firstItem="l9f-hn-Uz9" firstAttribute="top" secondItem="aXu-gl-0yY" secondAttribute="bottom" constant="8" symbolic="YES" id="7EX-Zw-gqt"/>
+                            <constraint firstItem="Bp2-QU-Qf6" firstAttribute="top" secondItem="vZO-ch-Rin" secondAttribute="bottom" constant="-1" id="7cu-2R-oUd"/>
+                            <constraint firstItem="aXu-gl-0yY" firstAttribute="top" secondItem="N8z-gK-HfL" secondAttribute="bottom" constant="79" id="C2S-eK-DWQ"/>
+                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="leading" secondItem="aXu-gl-0yY" secondAttribute="leading" id="HBN-AU-kVM"/>
+                            <constraint firstItem="FR2-4R-WPz" firstAttribute="centerX" secondItem="vZO-ch-Rin" secondAttribute="centerX" id="IUb-PM-KJj"/>
+                            <constraint firstItem="l9f-hn-Uz9" firstAttribute="top" secondItem="Ste-Nv-ksy" secondAttribute="bottom" constant="62" id="MYX-fm-y0H"/>
+                            <constraint firstItem="gxM-wq-OQv" firstAttribute="top" secondItem="FR2-4R-WPz" secondAttribute="bottom" constant="8" id="OQR-6t-eXa"/>
+                            <constraint firstItem="gxM-wq-OQv" firstAttribute="centerX" secondItem="Ste-Nv-ksy" secondAttribute="centerX" id="PGc-ea-u0J"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="vZO-ch-Rin" secondAttribute="trailing" constant="60" id="TGE-Rb-v1K"/>
+                            <constraint firstItem="FR2-4R-WPz" firstAttribute="top" secondItem="QmI-n4-yhD" secondAttribute="bottom" constant="8" symbolic="YES" id="TSM-5Y-Rjh"/>
+                            <constraint firstItem="vZO-ch-Rin" firstAttribute="trailing" secondItem="N8z-gK-HfL" secondAttribute="trailing" id="UvG-4F-8rR"/>
+                            <constraint firstItem="QmI-n4-yhD" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="59" id="V00-6m-46Q"/>
+                            <constraint firstItem="gxM-wq-OQv" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="88" id="VXf-R3-wly"/>
+                            <constraint firstItem="N8z-gK-HfL" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="67" id="XPo-LB-bzW"/>
+                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="trailing" secondItem="aXu-gl-0yY" secondAttribute="trailing" id="YD4-un-YyS"/>
+                            <constraint firstItem="Bp2-QU-Qf6" firstAttribute="top" secondItem="gxM-wq-OQv" secondAttribute="bottom" constant="63" id="d8G-I4-gCU"/>
+                            <constraint firstItem="FR2-4R-WPz" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="14" id="jP4-ZR-3zM"/>
+                            <constraint firstItem="Bp2-QU-Qf6" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="68" id="jz6-22-4Oi"/>
+                            <constraint firstItem="vZO-ch-Rin" firstAttribute="top" secondItem="FR2-4R-WPz" secondAttribute="bottom" constant="28" id="nWk-HZ-OdP"/>
+                            <constraint firstItem="fs4-4D-vvR" firstAttribute="top" secondItem="BYZ-J5-ior" secondAttribute="bottom" constant="8" symbolic="YES" id="p5B-ZA-bWE"/>
+                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="16" id="rIz-iv-gpQ"/>
+                            <constraint firstItem="fs4-4D-vvR" firstAttribute="leading" secondItem="8pV-NU-cQS" secondAttribute="leadingMargin" constant="8" id="sSD-Ix-rlt"/>
+                            <constraint firstAttribute="bottom" secondItem="Bp2-QU-Qf6" secondAttribute="bottom" constant="391" id="sdZ-Xp-sCa"/>
+                            <constraint firstItem="QmI-n4-yhD" firstAttribute="centerX" secondItem="Bp2-QU-Qf6" secondAttribute="centerX" constant="2" id="sha-Vm-Gt3"/>
+                            <constraint firstItem="fs4-4D-vvR" firstAttribute="centerX" secondItem="8pV-NU-cQS" secondAttribute="centerX" id="vNg-B8-aoZ"/>
+                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="top" secondItem="N8z-gK-HfL" secondAttribute="bottom" constant="59" id="w9u-Up-mcO"/>
+                            <constraint firstItem="QmI-n4-yhD" firstAttribute="leading" secondItem="vZO-ch-Rin" secondAttribute="leading" constant="2" id="xb7-6g-yK4"/>
+                            <constraint firstItem="Ste-Nv-ksy" firstAttribute="baseline" secondItem="aXu-gl-0yY" secondAttribute="firstBaseline" id="y0e-lv-dBH"/>
                         </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
@@ -95,7 +129,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fAb-e3-7Fr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="544.79999999999995" y="689.5052473763119"/>
+            <point key="canvasLocation" x="543.47826086956525" y="689.0625"/>
         </scene>
         <!--Onboard View Controller-->
         <scene sceneID="0zS-WV-goK">
@@ -152,10 +186,15 @@
     </scenes>
     <resources>
         <image name="Instructions.png" width="800" height="200"/>
-        <image name="connectwCode.png" width="300" height="49"/>
-        <image name="connectwQR.png" width="300" height="49"/>
+        <image name="Mooning" width="400" height="400"/>
+        <image name="connectwCode.png" width="300" height="100"/>
+        <image name="connectwQR.png" width="300" height="100"/>
+        <image name="troubleshooting.png" width="300" height="100"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
For all other changes:

- [ x] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?
 please review #3374 here, but basically
on iOS, there are 3 screens before the final "scan/code" screen that are to inform the user of what s/he should do. However, many don't read and just click through to the scan/code screen and then don't know what to do. Also, if they Deny access to the camera or to the wifi, they will not be able to connect at all. We can help them by giving them a Need Help button and informing them what to do to remedy their situation. (rather than deleting the app and starting over) 

basic modifications: 
swap blue for green scan button, add graphic, move and resize current buttons. Remove large dark grey instruction graphic. add Need Help? button that shows ip/version info and help in popup
