### PR TITLE
Refactor and fix issues in designer copy/paste in Chrome

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -820,7 +820,7 @@ public final class YaBlocksEditor extends FileEditor
       $wnd.Blockly.Events.setGroup(true);
     }
     blocks.forEach(function(blockXml) {
-      var dom = $wnd.Blockly.Xml.textToDom(blockXml);
+      var dom = $wnd.Blockly.utils.xml.textToDom(blockXml);
       var mutations = dom.getElementsByTagName('mutation');
       for (var i = 0; i < mutations.length; i++) {
         var mutation = mutations[i];
@@ -863,7 +863,7 @@ public final class YaBlocksEditor extends FileEditor
               // Check for blocks in snap range to any of its connections.
               var connections = block.getConnections_(false);
               for (var i = 0, connection; connection = connections[i]; i++) {
-                var neighbour = connection.closest($wnd.Blockly.SNAP_RADIUS,
+                var neighbour = connection.closest($wnd.Blockly.config.snapRadius,
                   new $wnd.goog.math.Coordinate(blockX, blockY));
                 if (neighbour.connection) {
                   collide = true;
@@ -873,21 +873,21 @@ public final class YaBlocksEditor extends FileEditor
             }
             if (collide) {
               if (workspace.RTL) {
-                blockX -= $wnd.Blockly.SNAP_RADIUS;
+                blockX -= $wnd.Blockly.config.snapRadius;
               } else {
-                blockX += $wnd.Blockly.SNAP_RADIUS;
+                blockX += $wnd.Blockly.config.snapRadius;
               }
-              blockY += $wnd.Blockly.SNAP_RADIUS * 2;
+              blockY += $wnd.Blockly.config.snapRadius * 2;
             }
           } while (collide);
           block.moveBy(blockX, blockY);
         }
         if (workspace.rendered) {
           block.initSvg();
-          workspace.requestRender(block);
+          block.queueRender();
         }
       } catch(e) {
-        console.log(e);
+        console.error(e);
       }
     });
     if ($wnd.Blockly.Events.isEnabled()) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -951,7 +951,10 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
     RootPanel.get().addDomHandler(new KeyDownHandler() {
       @Override
       public void onKeyDown(KeyDownEvent event) {
-        if (event.isAltKeyDown() && isActiveEditor()) {
+        if (!isActiveEditor()) {
+          return;  // Not the active editor
+        }
+        if (event.isAltKeyDown()) {
           List<MockComponent> allComponents = new ArrayList<>(getComponents().values());
           MockComponent selectedComponent = form.getLastSelectedComponent();
           int index = form.getChildren().indexOf(selectedComponent);
@@ -1017,13 +1020,14 @@ public final class YaFormEditor extends SimpleEditor implements FormChangeListen
                 break;
             }
           }
-        } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.isTextboxFocused() && isActiveEditor()) {
+        } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.isTextboxFocused()) {
           SourceStructureBox.getSourceStructureBox().getSourceStructureExplorer().getTree().setFocus(true);
-        } else if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.isTextboxFocused() && isActiveEditor() && !event.isControlKeyDown()) {
+        } else if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.isTextboxFocused()
+            && !(event.isControlKeyDown() || event.isMetaKeyDown())) {
           getVisibleComponentsPanel().focusCheckbox();
-        } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.isTextboxFocused() && isActiveEditor()) {
+        } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.isTextboxFocused()) {
           PropertiesBox.getPropertiesBox().getElement().getElementsByTagName("a").getItem(0).focus();
-        } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.isTextboxFocused() && isActiveEditor()) {
+        } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.isTextboxFocused()) {
           AssetListBox.getAssetListBox().getAssetList().getTree().setFocus(true);
         }
       }


### PR DESCRIPTION
Change-Id: I1eed43294d5f6674ace2ba10281eba8740fa081f

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Fixes copy and paste in Chrome on macOS. The previous fix only considered the Ctrl key, but on macOS the Command key is mapped to meta. I also refactored the onKeyDown handler to factor out the common check of `isActiveEditor()`.

There were also some issues in pasting of blocks associated with the copied components caused by the Blockly update. 