### PR TITLE
Fix internal error from dictionaries drawer in Japanese

### DIFF
--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ja.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages_ja.json
@@ -720,7 +720,7 @@
     "Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_RECURSIVE_SET_INPUT": "ディクショナリ %2 のキー・パス %1 の値を %3 に設定します",
     "Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_RECURSIVE_LOOKUP_INPUT": "ディクショナリ%2 のキー・パス %1 で値を取得するか、または %3 が見つからなければ取得します",
     "Blockly.Msg.LANG_DICTIONARIES_DICTIONARY_LOOKUP_INPUT": "ディクショナリ%2でキー%1の値を取得する、もしくは、%3が見つかなければ",
-    "Blockly.Msg.LANG_DICTIONARIES_DELETE_PAIR_INPUT": "ディクショナリ%からキー%2のエントリを削除します",
+    "Blockly.Msg.LANG_DICTIONARIES_DELETE_PAIR_INPUT": "ディクショナリ%1からキー%2のエントリを削除します",
     "Blockly.Msg.LANG_DICTIONARIES_SET_PAIR_INPUT": "ディクショナリ%2のキー%1の値を%3に設定する",
     "Blockly.Msg.LANG_DICTIONARIES_PAIR_INPUT": "キー%1値%2",
     "Blockly.Msg.LANG_TEXT_SPLIT_TOOLTIP_SPLIT_AT_ANY": "リスト'at'に含まれているどれかのアイテムを分割点として、与えられたテキストをリストに分割し、その結果のリストを返す。\n'appleberry,banana,cherry,dogfood'を、最初の項目がカンマ、2番目の項目が'ry'の2要素リストとして、'at'で分割すると、4つの項目のリストが返される: '(applebe banana che dogfood)'。",


### PR DESCRIPTION
Change-Id: If87195557dc2019e079a52d37648ee242e0c5e09

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes an issue in the Japanese translation where the delete key from dictionary block is missing an input field. The resulting behavior is that parsing the string causes Blockly to throw an error which propagates up to the user as an internal error. I've added the missing input number to correct the error.