### PR TITLE
Fix expired service overlay for Neo

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/ExpiredServiceOverlay.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/ExpiredServiceOverlay.ui.xml
@@ -19,6 +19,8 @@
       font-weight: bold;
       color: darkred;
       text-align: center;
+      z-index: 100000;
+      opacity: 0.7;
     }
   </ui:style>
 


### PR DESCRIPTION
Change-Id: Ibb7b06e2c33a4cbb5e7abbe2d88a8b42756c0f11

General items:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

The warning message about expired App Inventor services does not appear in the Neo UI due to a low z-index. This PR bumps the z-index up and also adjusts the opacity slightly so it's still prominent but not intrusive.