### PR TITLE
Make Neo the default first-time UIPicker is opened

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/settings/user/GeneralSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/user/GeneralSettings.java
@@ -37,7 +37,7 @@ public final class GeneralSettings extends Settings {
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this, SettingsConstants.DARK_THEME_ENABLED, "false",
         EditableProperty.TYPE_INVISIBLE));
-    addProperty(new EditableProperty(this, SettingsConstants.USER_NEW_LAYOUT, "false",
+    addProperty(new EditableProperty(this, SettingsConstants.USER_NEW_LAYOUT, "true",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this, SettingsConstants.USER_AUTOLOAD_PROJECT, "true",
         EditableProperty.TYPE_INVISIBLE));

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.java
@@ -45,14 +45,7 @@ public class UISettingsWizard {
    * Creates a new YoungAndroid project wizard.
    */
   public UISettingsWizard() {
-    bindUI();
-    userThemePreference = Ode.getUserDarkThemeEnabled();
-    userLayoutPreference = Ode.getUserNewLayout();
-    if (userLayoutPreference) {
-      modernRadioButton.setChecked(true);
-    } else {
-      classicRadioButton.setChecked(true);
-    }
+    this(false);
 //    if (userThemePreference){
 //      darkModeRadioButton.setValue(true);
 //    }else{
@@ -61,10 +54,17 @@ public class UISettingsWizard {
   }
 
   public UISettingsWizard(boolean intro) {
-    this();
+    bindUI();
+    firstUIChoice = intro;
+    userThemePreference = Ode.getUserDarkThemeEnabled();
+    userLayoutPreference = Ode.getUserNewLayout();
+    if (intro || userLayoutPreference) {
+      modernRadioButton.setChecked(true);
+    } else {
+      classicRadioButton.setChecked(true);
+    }
     introText.setVisible(intro);
     cancelButton.setVisible(!intro);
-    firstUIChoice = intro;
   }
 
   public void bindUI() {


### PR DESCRIPTION

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

This PR changes the UI Picker wizard to default to Neo when it is shown to the user for the first time. Previously, it defaulted to Classic.