### PR TITLE
Mark workspace as invisible at initialization time

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -666,6 +666,7 @@ public class BlocklyPanel extends HTMLPanel {
       }
     }.bind(workspace));
     this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace = workspace;
+    workspace.setVisible(false);  // The workspace is invisible by default
   }-*/;
 
   /**


### PR DESCRIPTION
Change-Id: I4bb7a0c3fac298f3c959d61f1f8c0a0bb2ea5e98

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR marks the workspace as not visible when it is initialized. This fixes an issue where the multiselect plugin captures the copy key gesture and cancels the event, preventing the browser from triggering a 'copy' event listened to by the designer. Users could get around this bug by manually going to the Edit > Copy menu rather than using the keyboard shortcut. Blockly shortcuts won't trigger if the workspace is invisible.