### PR TITLE
Texting Component: Use a notification channel and Ask for Post Notifications Permission

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -134,7 +134,8 @@ import org.json.JSONObject;
   "screen) and, moreso, even if the app is not running, so long as it's " +
   "installed on the phone. If the phone receives a text message when the " +
   "app is not in the foreground, the phone will show a notification in " +
-  "the notification bar.  Selecting the notification will bring up the " +
+  "the notification bar. (User should have granted the POST_NOTIFICATIONS " +
+  "permission). Selecting the notification will bring up the " +
   "app.  As an app developer, you'll probably want to give your users the " +
   "ability to control ReceivingEnabled so that they can make the phone " +
   "ignore text messages.</p> " +

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -1297,4 +1297,3 @@ public class Texting extends AndroidNonvisibleComponent
 
 }
 
-

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/SmsBroadcastReceiver.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/SmsBroadcastReceiver.java
@@ -12,11 +12,13 @@
 package com.google.appinventor.components.runtime.util;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.telephony.PhoneNumberUtils;
 import android.telephony.SmsMessage;
 import android.util.Log;
@@ -55,6 +57,9 @@ import java.util.List;
 public class SmsBroadcastReceiver extends BroadcastReceiver {
 
   public static final String TAG = "SmsBroadcastReceiver";
+
+  private static final String CHANNEL_ID = "sms_notifications";
+  private static final String CHANNEL_NAME = "SMS Notifications";
   public static final int NOTIFICATION_ID = 8647;
 
   /**
@@ -201,6 +206,13 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
    * @param msg
    */
   private void sendNotification(Context context, String phone, String msg) {
+    NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        nm.createNotificationChannel(new NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT));
+    }
     Log.i(TAG, "sendingNotification " + phone + ":" + msg);
 
     // Get this app's name
@@ -224,8 +236,7 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
       // Create the Notification
       PendingIntent activity = PendingIntent.getActivity(context, 0, newIntent,
           PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-      NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-      Notification note = new NotificationCompat.Builder(context)
+      Notification note = new NotificationCompat.Builder(context, CHANNEL_ID)
           .setSmallIcon(android.R.drawable.sym_call_incoming)
           .setTicker(phone + " : " + msg)
           .setWhen(System.currentTimeMillis())


### PR DESCRIPTION
Ref: [Posting a notification in case app is in background does not work for Texting component](https://community.appinventor.mit.edu/t/posting-a-notification-in-case-app-is-in-background-does-not-work-for-texting-component/143479?u=kumaraswamy)

Changelog:

1. SmsBroadcastReceiver.java: Build and use a notification channel
2. Texting.java: Ask for `POST_NOTIFICATIONS` permission if `VERSION >= Tiramisu`. 
    Set broadcast receiver `exported=false`