### PR TITLE
fix for get started link from help menu

### DIFF
--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -155,7 +155,7 @@
     <property name="firebase.url" value="" />
 
     <property name="library.url" value="http://appinventor.mit.edu/explore/library" />
-    <property name="get_started.url" value="http://appinventor.mit.edu/explore/get-started" />
+    <property name="getstarted.url" value="http://appinventor.mit.edu/explore/get-started" />
     <property name="tutorials.url" value="http://appinventor.mit.edu/explore/ai2/tutorials" />
     <property name="extensions.url" value="http://appinventor.mit.edu/extensions" />
     <property name="troubleshooting.url" value="http://appinventor.mit.edu/explore/ai2/support/troubleshooting" />


### PR DESCRIPTION

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?
Fixes link in Help menu. Currently 'Get Started' leads to a blank page.
The issue is that there is a mismatch between 'get_started.url' and 'getstarted.url' at https://github.com/mit-cml/appinventor-sources/blob/master/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java#L76 so this PR changes the former.

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
