### PR TITLE
Redirect to the login page directly from index.jsp

### DIFF
--- a/appinventor/appengine/war/index.jsp
+++ b/appinventor/appengine/war/index.jsp
@@ -1,22 +1,27 @@
 <%@page import="com.google.appinventor.server.Server,com.google.appinventor.common.version.AppInventorFeatures,msg.i18n" %>
 <%@page import="com.google.appinventor.server.flags.Flag" %>
+<%@page import="com.google.appinventor.server.OdeAuthFilter" %>
 <%
-   if (request.getScheme().equals("http") && Server.isProductionServer()
-       && AppInventorFeatures.enableHttpRedirect()) {
-        String qs = request.getQueryString();
-        String host = request.getServerName();
-        if (qs != null) {
-           String redirect = "https://" + host + "/?" + qs;
-           response.sendRedirect(redirect);
-        } else {
-           String redirect = "https://" + host;
-           response.sendRedirect(redirect);
-        }
-     return;
-   }
-   if (AppInventorFeatures.enableHttpRedirect()) {
-       response.setHeader("Strict-Transport-Security", "max-age=3600");
-   }
+  if (request.getScheme().equals("http") && Server.isProductionServer()
+      && AppInventorFeatures.enableHttpRedirect()) {
+       String qs = request.getQueryString();
+       String host = request.getServerName();
+       if (qs != null) {
+          String redirect = "https://" + host + "/?" + qs;
+          response.sendRedirect(redirect);
+       } else {
+          String redirect = "https://" + host;
+          response.sendRedirect(redirect);
+       }
+    return;
+  }
+  if (AppInventorFeatures.enableHttpRedirect()) {
+      response.setHeader("Strict-Transport-Security", "max-age=3600");
+  }
+  if (OdeAuthFilter.getUserInfo(request) == null) {
+      response.sendRedirect("/login");
+      return;
+  }
   String cachePostfix = "@blocklyeditor_isRelease@".equals("true") ? "cache" : "nocache";
   String locale = request.getParameter("locale");
   if (locale == null || locale.isEmpty()) {


### PR DESCRIPTION
When the index page was a straight HTML page, we would load it. It would then load Ode, which is not small! Ode would then check if you are logged in and if not redirect you to the login page. The login page would then redirect you back to the index page once you are logged in. This would now load Ode a second time which would again check if you are logged in. This time you would be logged in and project loading etc. would continue.

The index page is now a jsp, so we can execute code in it. This change causes index.jsp to do the login check and if you are not logged in, it redirects you immediately to the login page rather then loading Ode.

Ode still does the login check, but it should now always be true. I have intentionally left that check in place. It isn't expensive and we may have situations where having the check there makes sense.

Change-Id: I6c7f220a32d2734f1ce3242a01a0b2bcf45fd596

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
