### PR TITLE
Implement an unobtrusive popup to notify people of UI switching

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5788,4 +5788,8 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @DefaultMessage("Time")
   @Description("Set x-axis label values Type as Time")
   String labelTime();
+
+  @DefaultMessage("Welcome to App Inventor Neo! If you are looking for the classic App Inventor look, you can switch in the User Interface Settings, or <a href=\"\">click here</a>.")
+  @Description("Message shown in the info popup when the user first opens the Neo UI.")
+  String neoWelcomeMessage();
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/TutorialPopup.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/TutorialPopup.java
@@ -1,0 +1,47 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.widgets;
+
+import com.google.gwt.dom.client.Element;
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+/**
+ * A class that displays a tutorial popup positioned below a given element with a small arrow
+ * pointing up to the element.
+ */
+@JsType(isNative = true, name = "Popup", namespace = JsPackage.GLOBAL)
+public class TutorialPopup {
+  /**
+   * The callback, if any, to be invoked when the popup is clicked.
+   */
+  @JsFunction
+  public interface Callback {
+    void onClick();
+  }
+
+  /**
+   * Creates a new tutorial popup.
+   *
+   * @param text the text to display in the popup
+   * @param callback the callback to invoke when the popup is clicked, or null if no action is desired
+   */
+  public TutorialPopup(String text, Callback callback) {
+  }
+
+  /**
+   * Show the tutorial popup.
+   *
+   * @param el the element to position the popup below
+   */
+  public native void show(Element el);
+
+  /**
+   * Hides the tutorial popup.
+   */
+  public native void hide();
+}

--- a/appinventor/appengine/war/index.jsp
+++ b/appinventor/appengine/war/index.jsp
@@ -98,6 +98,7 @@
         }, 2000);
       })();
     </script>
+    <script src="static/js/tutorial.js"></script>
     <script type="text/javascript" src="static/closure-library/closure/goog/base.js"></script>
     <script type="text/javascript" src="<%= odeBase %>ode/aiblockly-@blocklyeditor_BlocklyChecksum@.js"></script>
     <script type="text/javascript" src="static/js/scroll-options-5.0.11.min.js"></script>

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3451,3 +3451,34 @@ div.dropdiv p {
     flex-direction: column;
   }
 }
+
+.popup {
+  background-color: transparent;
+  position: absolute;
+}
+
+.popup .popup-triangle {
+  position: absolute;
+  top: -8px;
+  left: calc(50% - 8px);
+  height: 0;
+  width: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #128BA8;
+  border-top: 0 solid transparent;
+}
+
+.popup .popup-content {
+  background-color: #128BA8;
+  color: #fff;
+  padding: 8px 16px;
+  max-width: 300px;
+  text-align: justify;
+  border-radius: 8px;
+}
+
+.popup a {
+  color: #fff;
+  text-decoration: underline;
+}

--- a/appinventor/appengine/war/static/js/tutorial.js
+++ b/appinventor/appengine/war/static/js/tutorial.js
@@ -1,0 +1,67 @@
+// -*- mode: javascript; js-indent-level: 2; -*-
+// Copyright © 2025 Massachusetts Institute of Technology
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+'use strict';
+
+class Popup {
+  constructor(text, cb) {
+    this.text = text;
+    this.cb = cb;
+    this.popup = document.createElement('div');
+    this.popup.className = 'popup';
+    let triangle = document.createElement('div');
+    triangle.className = 'popup-triangle';
+    this.popup.appendChild(triangle);
+    this.content = document.createElement('div');
+    this.content.className = 'popup-content';
+    this.content.innerHTML = text;
+    this.popup.appendChild(this.content);
+  }
+
+  show(el) {
+    let link = this.content.querySelector('a');
+    if (link) {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.hide();
+        if (this.cb) {
+          this.cb();
+        }
+      });
+    }
+    this.popup.style.display = 'block';
+    const rect = el.getBoundingClientRect();
+    this.popup.style.left = (rect.left + rect.width / 2 - 150) + 'px';
+    this.popup.style.top = (rect.bottom + 8) + 'px';
+    document.body.appendChild(this.popup);
+    this.hideCallback = function(e) {
+      let target = e.target;
+      while (target) {
+        if (target === this.popup) {
+          return;
+        }
+        target = target.parentElement;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      this.hide();
+    }.bind(this);
+    document.body.addEventListener('click', this.hideCallback, true);
+  }
+
+  hide() {
+    this.popup.style.display = 'none';
+    if (this.popup.parentNode) {
+      this.popup.parentNode.removeChild(this.popup);
+    }
+    if (this.hideCallback) {
+      document.body.removeEventListener('click', this.hideCallback, true);
+      this.hideCallback = null;
+    }
+  }
+}
+
+window.Popup = Popup;


### PR DESCRIPTION
Change-Id: Ibd790ead0d74042367025d8bb1724255c5519aee

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR introduces a popup bubble that can be positioned relative to another element on the screen. It transitions from showing the UI picker from being on the critical path to using the popup to notify people that the UI can be switched in the settings. If the user clicks "Click here" they will revert to the classic UI. Otherwise, they won't be interrupted by a modal dialog.