### PR TITLE
Fixed iOS 13 version for Date and TimePicker making screen appear in …

### DIFF
--- a/appinventor/components-ios/src/DatePicker.swift
+++ b/appinventor/components-ios/src/DatePicker.swift
@@ -28,11 +28,10 @@ open class DatePicker: Picker, DateTimePickerDelegate {
     
     super.init(parent)
     super.setDelegate(self)
-
+    
     guard let form = parent.form else {
       return
     }
-    
     _viewController = getDateTimePickerController(self, screen: form, isDatePicker: true, isPhone: _isPhone)
     _viewController?.pickerView.setValue(preferredTextColor(form), forKeyPath: "textColor")
     _viewController?.setDateTime(calendar)

--- a/appinventor/components-ios/src/DateTimePickerBase.swift
+++ b/appinventor/components-ios/src/DateTimePickerBase.swift
@@ -26,6 +26,14 @@ class DateTimePickerPadController: PickerPadController, DateTimePickerController
     _delegate = delegate
     _isDatePicker = isDatePicker
     super.init()
+    if #available(iOS 14.0, *) {
+      _pickerView.preferredDatePickerStyle = .inline
+      if UITraitCollection.current.userInterfaceStyle == .dark {
+        _pickerView.backgroundColor = .black
+      } else {
+        _pickerView.backgroundColor = .white
+      }
+    }
     _pickerView.datePickerMode = isDatePicker ? .date: .time
   }
 
@@ -35,7 +43,15 @@ class DateTimePickerPadController: PickerPadController, DateTimePickerController
   }
 
   override func setupViews() {
-    _setDateTimeButton.backgroundColor = .clear
+    if #available(iOS 13.0, *){
+      if UITraitCollection.current.userInterfaceStyle == .dark {
+        _setDateTimeButton.backgroundColor = .black
+      } else {
+        _setDateTimeButton.backgroundColor = .white
+      }
+    } else {
+      _setDateTimeButton.backgroundColor = .clear
+    }
     _setDateTimeButton.setTitle("Set \(_isDatePicker ? "Date": "Time")", for: .normal)
     _setDateTimeButton.setTitleColor(view.tintColor, for: .normal)
     _setDateTimeButton.addTarget(self, action: #selector(dateTimeSet), for: .touchUpInside)
@@ -56,6 +72,7 @@ class DateTimePickerPadController: PickerPadController, DateTimePickerController
     _setDateTimeButton.topAnchor.constraint(equalTo: _pickerView.bottomAnchor, constant: 0).isActive = true
 
     view.bottomAnchor.constraint(equalTo: _setDateTimeButton.bottomAnchor, constant: 20).isActive = true
+    view.backgroundColor = _setDateTimeButton.backgroundColor
     self.preferredContentSize = CGSize(width: _pickerView.frame.width, height: 300)
   }
 
@@ -93,6 +110,9 @@ class DateTimePickerPhoneController: PickerPhoneController, DateTimePickerContro
   public init(_ delegate: DateTimePickerDelegate, screen form: Form, isDatePicker: Bool) {
     _delegate = delegate
     super.init(contentView: _pickerView, screen: form)
+    if #available(iOS 14.0, *) {
+      _pickerView.preferredDatePickerStyle = .inline
+    }
     _pickerView.datePickerMode = isDatePicker ? .date: .time
   }
 
@@ -127,9 +147,14 @@ class DateTimePickerPhoneController: PickerPhoneController, DateTimePickerContro
 }
 
 func getDateTimePickerController(_ delegate: DateTimePickerDelegate, screen form: Form, isDatePicker: Bool, isPhone: Bool) -> DateTimePickerController {
-  if isPhone {
-    return DateTimePickerPhoneController(delegate, screen: form, isDatePicker: isDatePicker)
-  } else {
+  if #available(iOS 13.4, *){
     return DateTimePickerPadController(delegate, isDatePicker: isDatePicker)
+  } else {
+    if isPhone {
+      return DateTimePickerPhoneController(delegate, screen: form, isDatePicker: isDatePicker)
+    } else {
+      return DateTimePickerPadController(delegate, isDatePicker: isDatePicker)
+    }
   }
+  
 }


### PR DESCRIPTION
…one click instead of two

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
