### PR TITLE
Position 'read only' message to not occlude top panel buttons in Neo

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -430,7 +430,7 @@ they get cut off in Windows.
     background-color: background-color;
     background-image: unset;
   }
-  
+
   /*.ode-Logo {
     margin: 0 0 4px 4px;
     -webkit-filter: drop-shadow(0px 0px 1px #222);
@@ -482,6 +482,7 @@ they get cut off in Windows.
     padding-top: 5px;
     font-size: unset;
     padding-right: unset;
+    align-items: center;
   }
   
   .right-spacer {
@@ -520,6 +521,9 @@ they get cut off in Windows.
   
   .ode-TopPanelWarningLabel {
     color: #FF0000;
+    text-align: left;
+    margin-left: 200px;
+    font-size: large;
   }
   
   .ode-TopPanelLabel {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
Using the neo theme, the read only message shows on top of the top panel buttons. See images below.

Ideally the text should be part of the grid, but YA.css sets the message as `absolute` and the height for the logo is also hardcoded in TopPanelNeo.ui.xml as 37px, which makes the logo a bit over 166px in width, so the 200px in this PR is safe to use (at least for the logo).

Before:
<img width="815" alt="readOnlyBefore" src="https://github.com/user-attachments/assets/9581fb64-8ab6-4517-84d5-390288a1e7dc" />

After:
<img width="815" alt="readOnlyAfter" src="https://github.com/user-attachments/assets/b8a93df8-0678-4721-b6a5-ceadc2b76c78" />


