### PR TITLE
Avoid extracting component types of corrupted AIAs

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -139,7 +139,7 @@ public final class ProjectBuilder {
         File buildTmpDir = new File(projectRoot, "build/tmp");
         buildTmpDir.mkdirs();
 
-        Set<String> componentTypes = getComponentTypes(sourceFiles, project.getAssetsDirectory());
+        Set<String> componentTypes = getComponentTypes(sourceFiles, project.getAssetsDirectory(), projectRoot);
         if (isForCompanion) {
           componentTypes.addAll(getAllComponentTypes());
         }
@@ -271,13 +271,17 @@ public final class ProjectBuilder {
     return result;
   }
 
-  private static Set<String> getComponentTypes(List<String> files, File assetsDir)
+  private static Set<String> getComponentTypes(List<String> files, File assetsDir, File projectRoot)
       throws IOException, JSONException {
     Map<String, String> nameTypeMap = createNameTypeMap(assetsDir);
 
+    // Make sure to skip any .scm file not in the src/ directory, to avoid corrupted AIAs
+    //   containing extensions.
+    String sourcePrefix = new File(projectRoot, "src").getAbsolutePath() + SEPARATOR;
+
     Set<String> componentTypes = Sets.newHashSet();
     for (String f : files) {
-      if (f.endsWith(".scm")) {
+      if (f.startsWith(sourcePrefix) && f.endsWith(".scm")) {
         File scmFile = new File(f);
         String scmContent = new String(Files.toByteArray(scmFile),
             PathUtil.DEFAULT_CHARSET);


### PR DESCRIPTION
Some AIAs may contain another project in the extensions' directory. If those extensions contain any .scm, avoid parsing their components.

Basically, when reading the build information for a project, component types is determined by parsing the .scm files in the project. If the AIA is corrupted and, "by mistake", contains an exploded AIA file inside the assets/external_comps/ directory (or anywhere else), it will also read those .scm files to determine the types.  
If those .scm files contain a non existent component (an extension, for example), then a `null` entry is added to the component types. Later, when parsing extension, the `null` is moved to the external component types. And finally, the ReadBuildInfo task is going to iterate over the external component types, calls `ExecutorUtils.getExtCompDirPath` for a null type, and it throws a null pointer exception.

This PR does not prevent importing the corrupted AIAs, nor sanitizes them, but prevents failing builds without any action for the user. This way, it ensures that only .scm files in the src/ folder are parsed. And we should assume that all .scm files in that folder are legit, as they are actually read by the frontend to render the project.

See the following post for more details: https://community.kodular.io/t/compilation-error/292521/25?u=diego  
And use the following AIA against AI2 for testing purposes: https://kodular-community.s3.dualstack.eu-west-1.amazonaws.com/original/4X/7/1/8/718f6449d005a1d9b8b1935b7a90ae9b21fa9495.aia