### PR TITLE
Fix hanging builds due to malformed keystores

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/DexExecTask.java
@@ -234,8 +234,8 @@ public class DexExecTask {
         String[] dxCommandLine = new String[commandLineList.size()];
         commandLineList.toArray(dxCommandLine);
 
-        boolean dxSuccess = Execution.execute(null, dxCommandLine, System.out, System.err);
-        return dxSuccess;
+        return Execution.execute(null, dxCommandLine, System.out, System.err,
+            Execution.Timeout.LONG);
 
     }
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import java.util.zip.ZipFile;
 
+import com.google.appinventor.buildserver.util.Execution;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -115,6 +116,12 @@ public final class Main {
       LOG.severe("Problem opening inout zip file: " + commandLineOptions.inputZipFile.getName());
       System.exit(1);
     }
+
+    if (commandLineOptions.isForCompanion) {
+      // If we are building for the Companion, disable timeouts
+      Execution.disableTimeouts();
+    }
+
     Result result = projectBuilder.build(commandLineOptions.userName,
                                          zip,
                                          commandLineOptions.outputDir,

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Main.java
@@ -6,6 +6,7 @@
 
 package com.google.appinventor.buildserver;
 
+import com.google.appinventor.buildserver.util.Execution;
 import com.google.appinventor.buildserver.stats.NullStatReporter;
 import com.google.appinventor.buildserver.tasks.android.AndroidBuildFactory;
 
@@ -14,7 +15,6 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import java.util.zip.ZipFile;
 
-import com.google.appinventor.buildserver.util.Execution;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -406,7 +406,8 @@ public final class ProjectBuilder {
         "-keypass", "android"
     };
 
-    if (Execution.execute(null, keytoolCommandline, System.out, System.err)) {
+    if (Execution.execute(null, keytoolCommandline, System.out, System.err,
+        Execution.Timeout.SHORT)) {
       if (keyStoreFile.length() > 0) {
         return keyStoreFile.getAbsolutePath();
       }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -207,7 +207,12 @@ public final class ProjectBuilder {
 
         boolean success;
         try {
-          success = executor.get(MAX_BUILD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+          if (isForCompanion) {
+            // If we are building for companion, very likely in CI, don't limit the build time...
+            success = executor.get();
+          } else {
+            success = executor.get(MAX_BUILD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+          }
         } catch (TimeoutException e) {
           LOG.severe("Build has timed out");
           context.getReporter().error("Build has timed out");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/GenerateClasses.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/GenerateClasses.java
@@ -180,7 +180,7 @@ public class GenerateClasses implements AndroidTask {
       boolean kawaSuccess;
       synchronized (context.getResources().getSyncKawaOrDx()) {
         kawaSuccess = Execution.execute(null, kawaCommandLine,
-            System.out, new PrintStream(kawaOutputStream));
+            System.out, new PrintStream(kawaOutputStream), Execution.Timeout.MEDIUM);
       }
       if (!kawaSuccess) {
         context.getReporter().error("Kawa compile has failed.", true);

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt.java
@@ -73,7 +73,7 @@ public class RunAapt implements AndroidTask {
     // Using System.err and System.out on purpose. Don't want to pollute build messages with
     // tools output
     if (!Execution.execute(null, aaptPackageCommandLine,
-        System.out, System.err)) {
+        System.out, System.err, Execution.Timeout.MEDIUM)) {
       return TaskResult.generateError("Error running AAPT");
     }
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
@@ -62,7 +62,7 @@ public class RunAapt2 implements AndroidTask {
     String[] aapt2CompileCommandLine = aapt2CommandLine.toArray(new String[0]);
 
     if (!Execution.execute(null, aapt2CompileCommandLine,
-        System.out, System.err)) {
+        System.out, System.err, Execution.Timeout.MEDIUM)) {
       context.getReporter().error("Could not execute AAPT2 compile step");
       return false;
     }
@@ -97,7 +97,7 @@ public class RunAapt2 implements AndroidTask {
     String[] aapt2LinkCommandLine = aapt2CommandLine.toArray(new String[0]);
 
     if (!Execution.execute(null, aapt2LinkCommandLine,
-        System.out, System.err)) {
+        System.out, System.err, Execution.Timeout.MEDIUM)) {
       context.getReporter().error("Could not execute AAPT2 link step");
       return false;
     }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
@@ -39,7 +39,9 @@ public class RunApkSigner implements AndroidTask {
 
     if (!Execution.execute(null, apksignerCommandLine,
         System.out, System.err)) {
-      TaskResult.generateError("Error while running ZipAligned tool");
+      context.getReporter().warn("We could not sign your app. In case you are using a custom keystore, please make " +
+        "sure its password is set to 'android', and the key is set to 'androidkey'.");
+      return TaskResult.generateError("Error while running ApkSigner tool");
     }
 
     return TaskResult.generateSuccess();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
@@ -33,6 +33,7 @@ public class RunApkSigner implements AndroidTask {
         "-ks", context.getKeystoreFilePath(),
         "-ks-key-alias", "AndroidKey",
         "-ks-pass", "pass:android",
+        // "-key-pass", "pass:android",
         context.getPaths().getDeployFile().getAbsolutePath()
     };
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
@@ -33,7 +33,6 @@ public class RunApkSigner implements AndroidTask {
         "-ks", context.getKeystoreFilePath(),
         "-ks-key-alias", "AndroidKey",
         "-ks-pass", "pass:android",
-        // "-key-pass", "pass:android",
         context.getPaths().getDeployFile().getAbsolutePath()
     };
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunApkSigner.java
@@ -38,7 +38,7 @@ public class RunApkSigner implements AndroidTask {
     };
 
     if (!Execution.execute(null, apksignerCommandLine,
-        System.out, System.err)) {
+        System.out, System.err, Execution.Timeout.SHORT)) {
       context.getReporter().warn("We could not sign your app. In case you are using a custom keystore, please make " +
         "sure its password is set to 'android', and the key is set to 'androidkey'.");
       return TaskResult.generateError("Error while running ApkSigner tool");

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
@@ -237,7 +237,7 @@ public class RunBundletool implements AndroidTask {
     String[] bundletoolBuildCommandLine = bundletoolCommandLine.toArray(new String[0]);
 
     return Execution.execute(null, bundletoolBuildCommandLine,
-        System.out, System.err);
+        System.out, System.err, Execution.Timeout.LONG);
   }
 
   private boolean jarsigner(CompilerContext<AndroidPaths> context) {
@@ -265,6 +265,6 @@ public class RunBundletool implements AndroidTask {
     String[] jarsignerSignCommandLine = jarsignerCommandLine.toArray(new String[0]);
 
     return Execution.execute(null, jarsignerSignCommandLine,
-        System.out, System.err);
+        System.out, System.err, Execution.Timeout.SHORT);
   }
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
@@ -100,6 +100,8 @@ public class RunBundletool implements AndroidTask {
 
     context.getReporter().info("Signing bundle");
     if (!jarsigner(context)) {
+      context.getReporter().warn("We could not sign your app. In case you are using a custom keystore, please make " +
+        "sure its password is set to 'android', and the key is set to 'androidkey'.");
       return TaskResult.generateError("Could not sign bundle");
     }
     return TaskResult.generateSuccess();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
@@ -258,8 +258,6 @@ public class RunBundletool implements AndroidTask {
     jarsignerCommandLine.add(context.getKeystoreFilePath());
     jarsignerCommandLine.add("-storepass");
     jarsignerCommandLine.add("android");
-    // jarsignerCommandLine.add("-keypass");
-    // jarsignerCommandLine.add("android");
     jarsignerCommandLine.add(context.getPaths().getDeployFile().getAbsolutePath());
     jarsignerCommandLine.add("AndroidKey");
     String[] jarsignerSignCommandLine = jarsignerCommandLine.toArray(new String[0]);

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunBundletool.java
@@ -256,6 +256,8 @@ public class RunBundletool implements AndroidTask {
     jarsignerCommandLine.add(context.getKeystoreFilePath());
     jarsignerCommandLine.add("-storepass");
     jarsignerCommandLine.add("android");
+    // jarsignerCommandLine.add("-keypass");
+    // jarsignerCommandLine.add("android");
     jarsignerCommandLine.add(context.getPaths().getDeployFile().getAbsolutePath());
     jarsignerCommandLine.add("AndroidKey");
     String[] jarsignerSignCommandLine = jarsignerCommandLine.toArray(new String[0]);

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunD8.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunD8.java
@@ -216,7 +216,7 @@ public class RunD8 extends DexTask implements AndroidTask {
     arguments.add("@" + javaArgsFile.getAbsolutePath());
     synchronized (context.getResources().getSyncKawaOrDx()) {
       boolean result = Execution.execute(context.getPaths().getTmpDir(),
-          arguments.toArray(new String[0]), System.out, System.err);
+          arguments.toArray(new String[0]), System.out, System.err, Execution.Timeout.LONG);
       if (!result) {
         return false;
       }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
@@ -34,7 +34,7 @@ public class RunZipAlign implements AndroidTask {
     };
 
     if (!Execution.execute(null, zipAlignCommandLine,
-        System.out, System.err)) {
+        System.out, System.err, Execution.Timeout.SHORT)) {
       return TaskResult.generateError("Error while running ZipAlign tool");
     }
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunZipAlign.java
@@ -35,12 +35,12 @@ public class RunZipAlign implements AndroidTask {
 
     if (!Execution.execute(null, zipAlignCommandLine,
         System.out, System.err)) {
-      TaskResult.generateError("Error while running ZipAlign tool");
+      return TaskResult.generateError("Error while running ZipAlign tool");
     }
 
     if (!ExecutorUtils.copyFile(zipAlignedApk.getAbsolutePath(),
         context.getPaths().getDeployFile().getAbsolutePath())) {
-      TaskResult.generateError("Error while copying ZipAlign'ed APK");
+      return TaskResult.generateError("Error while copying ZipAlign'ed APK");
     }
 
     return TaskResult.generateSuccess();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
@@ -30,6 +30,8 @@ public final class Execution {
   private static final Logger LOG = Logger.getLogger(Execution.class.getName());
   private static final Joiner joiner = Joiner.on(" ");
 
+  private static boolean DISABLE_TIMEOUTS = false;
+
   public enum Timeout {
     SHORT(5), // 5 seconds
     MEDIUM(30), // 30 seconds
@@ -44,6 +46,10 @@ public final class Execution {
     public int getSeconds() {
       return seconds;
     }
+  }
+
+  public static void disableTimeouts() {
+    DISABLE_TIMEOUTS = true;
   }
 
   /*
@@ -103,6 +109,10 @@ public final class Execution {
       process.getOutputStream().close();
       new RedirectStreamHandler(new PrintWriter(out, true), process.getInputStream());
       new RedirectStreamHandler(new PrintWriter(err, true), process.getErrorStream());
+
+      if (timeoutSeconds <= 0 || DISABLE_TIMEOUTS) {
+        return process.waitFor() == 0;
+      }
 
       if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
         process.destroyForcibly();

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/Execution.java
@@ -107,8 +107,11 @@ public final class Execution {
     		command[i] = command[i].replace("\"", "\\\"");
     	}
     }
+
     try {
       Process process = Runtime.getRuntime().exec(command, null, workingDir);
+      // Prevent any interactive shell from waiting for input
+      process.getOutputStream().close();
       new RedirectStreamHandler(new PrintWriter(out, true), process.getInputStream());
       new RedirectStreamHandler(new PrintWriter(err, true), process.getErrorStream());
       return process.waitFor() == 0;
@@ -132,8 +135,11 @@ public final class Execution {
       StringBuffer err) throws IOException {
     LOG.log(Level.INFO, "____Executing " + joiner.join(command));
     Process process = Runtime.getRuntime().exec(command, null, workingDir);
+    // Prevent any interactive shell from waiting for input
+    process.getOutputStream().close();
     Thread outThread = new RedirectStreamToStringBuffer(out, process.getInputStream());
     Thread errThread = new RedirectStreamToStringBuffer(err, process.getErrorStream());
+
     try {
       process.waitFor();
       outThread.join();


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

*Description*

* Prevents a potential Denial Of Service when using customized keystores; see below.
* Prevents any subprocess from requesting stdin, and hanging around without exiting.
* Ensures all subprocesses will terminate within 5 minutes.

App Inventor uses keystores to sign apps, more specifically `apksigner` for APKs and `jarsigner` for AABs. AI2 relies on the keystores on having a password as `android` in order to decrypt and read the private key inside them. However, apparently there is a two-level password in keystores: one to unlock the container, and another one to unlock the `androidkey` which AI2 uses.  
Some keystores do have the container password as `android`, but the actual key as something else (probably generated using Android Studio or just changing the password of the AI2 one). This causes `apksigner` and `jarsigner` to change to interactive mode, and prompts for a password. As such, the process keeps running indefinitely, and never halts. It doesn't even complain, because the first layer password is correct, but prompts for the second one. As such, AI2 thinks that `apksigner` / `jarsigner` is still running, although they are waiting for some input from stdin, and never kills them. And finally, as a result, this build process consumes "one build slot", and if it gets filled up, no new builds are allowed. And in case of unlimited builds, this might lead to the buildserver running out of space, as the temporary resources for each build request would never get cleaned up.

The actual documentation states that there is one extra parameter to prevent this behaviour:

```text
--key-pass            Password with which the private key is protected.
                      The following formats are supported:
                          pass:<password> password provided inline
                          env:<name>      password provided in the named
                                          environment variable
                          file:<file>     password provided in the named
                                          file, as a single line
                          stdin           password provided on standard input,
                                          as a single line
                      If --key-pass is not specified for a KeyStore key, this
                      tool will attempt to load the key using the KeyStore
                      password and, if that fails, will prompt for key password
                      and attempt to load the key using that password.
                      If --key-pass is not specified for a private key file key,
                      this tool will prompt for key password only if a password
                      is required.
                      When the same file (including standard input) is used for
                      providing multiple passwords, the passwords are read from
                      the file one line at a time. Passwords are read in the
                      order in which signers are specified and, within each
                      signer, KeyStore password is read before the key password
                      is read.
```

Note it says "it will prompt for key password if using the same password as the keystore fails". When preparing a fix for the DoS, it was considered to introduce those flags into `apksigner` and `jarsigner`. However, as of now, anyone using a keystore with `android` as password and no password for the actual key works as intended; introducing those parameters may break that behaviour and invalidate their own keystores. Considering that, it seemed like a safer non-breaking change approach was to just completely disable stdin.

The preconditions for the DoS to apply are:
* Buildservers must be limiting number of builds based on maximum number of concurrent ones.
* Keystores must use a password other than `android` for the `androidkey.`
* _Unless this is some version-specific behaviour, `apksigner` and `jarsigner` must yield to IO in case of incorrect password._
