### PR TITLE
Break up component translation map into smaller methods

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
@@ -547,7 +547,14 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
     sb.append("  }\n");
     sb.append("  public static HashMap<String, String> map() {\n");
     sb.append("    HashMap<String, String> map = new HashMap<String, String>();\n");
+    sb.append("    mapComponents(map);\n");
+    sb.append("    mapOptionLists(map);\n");
+    sb.append("    mapDescriptions(map);\n");
+    sb.append("    mapCategories(map);\n");
+    sb.append("    return map;\n");
+    sb.append("  }\n");
 
+    sb.append("  private static void mapComponents(Map<String, String> map) {\n");
     // Components are already sorted.
     Set<String> categories = new TreeSet<>();
     Set<String> properties = new TreeSet<>();
@@ -558,10 +565,16 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
       outputComponent(component, properties, methods, events, sb);
       categories.add(component.getCategory());
     }
+    sb.append("  }\n");
+
+    sb.append("  private static void mapOptionLists(Map<String, String> map) {\n");
     for (Map.Entry<String, OptionList> entry : optionLists.entrySet()) {
       OptionList optionList = entry.getValue();
       outputOptionList(optionList, sb);
     }
+    sb.append("  }\n");
+
+    sb.append("  private static void mapDescriptions(Map<String, String> map) {\n");
     sb.append("\n\n    /* Descriptions */\n\n");
     for (String key : tooltipProperties.keySet()) {
       sb.append("    map.put(\"PROPDESC-");
@@ -584,6 +597,9 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
       sb.append(key);
       sb.append("());\n");
     }
+    sb.append("  }\n");
+
+    sb.append("  private static void mapCategories(Map<String, String> map) {\n");
     sb.append("\n\n    /* Categories */\n\n");
     for (String category : categories) {
       outputCategory(category, sb);
@@ -591,7 +607,6 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
     outputPropertyCategory("Appearance", sb);
     outputPropertyCategory("Behavior", sb);
     outputPropertyCategory("Unspecified", sb);
-    sb.append("  return map;\n");
     sb.append("  }\n");
     sb.append("}\n");
     FileObject src = createOutputFileObject(OUTPUT_FILE_NAME);


### PR DESCRIPTION
Change-Id: Ib8cb70ff48ea34bd7cdc3991f90d1c91394cd37d

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine
- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR breaks up the `map()` function in the generated ComponentTranslations file into smaller functions. Java methods are limited in length to 65535 bytes in the class file, and in some downstream projects that add more components, the `map` function grows too large and the compiler complains.

I have a theory of how we can replace our current technique of doing codegen to manage translations but that's a larger change that this proposed patch.