### PR TITLE
Remove READ_MEDIA_VIDEO and READ_MEDIA_IMAGES for Play Store builds

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -134,7 +134,7 @@ public class CreateManifest implements AndroidTask {
         permissions.add("android.permission.READ_EXTERNAL_STORAGE");
         permissions.add("android.permission.WRITE_EXTERNAL_STORAGE");
       }
-      if (context.isForCompanion() || context.usesSharedFileAccess()) {
+      if (context.isForCompanion()) {
         permissions.add("android.permission.READ_MEDIA_AUDIO");
         permissions.add("android.permission.READ_MEDIA_IMAGES");
         permissions.add("android.permission.READ_MEDIA_VIDEO");


### PR DESCRIPTION
Google Play Store policy may require us to remove these permissions. So far we haven't received any reports in the console that we need to, but in case the companion gets flagged in review we can have this in our back pocket.