### PR TITLE
Remove unused getUserInformation RPC

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/local/LocalUserInfoService.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/local/LocalUserInfoService.java
@@ -30,11 +30,6 @@ public class LocalUserInfoService implements UserInfoServiceAsync {
   }
 
   @Override
-  public void getUserInformation(String sessionId, AsyncCallback<User> callback) {
-
-  }
-
-  @Override
   public void loadUserSettings(AsyncCallback<String> callback) {
     String settings = "{\"GeneralSettings\":{\"LastLocale\":\"en\",\"Folders\":\"\",\"AutoloadLastProject\":\"false\",\"ShowUIPicker\":\"false\",\"NewLayout\":\"true\"}}";
     callback.onSuccess(settings);

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -132,27 +132,6 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
   }
 
   /**
-   * Returns user information.
-   *
-   * (obsoleted by getSystemConfig())
-   *
-   * @return  user information record
-   */
-
-  @Override
-  public User getUserInformation(String sessionId) {
-    // This is a little evil here. We are fetching the User object
-    // *and* side effecting it by storing the sessionId
-    // A more pedagotically correct way would be to do the store
-    // in a separate RPC. But that would add another round trip.
-    User user = userInfoProvider.getUser();
-    user.setSessionId(sessionId); // Store local copy
-    // Store it in the data store
-    storageIo.setUserSessionId(userInfoProvider.getUserId(), sessionId);
-    return user;
-  }
-
-  /**
    * Retrieves the user's settings.
    *
    * @return  user's settings

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoService.java
@@ -33,15 +33,6 @@ public interface UserInfoService extends RemoteService {
   String getUserBackpack();
 
   /**
-   * Retrieves information about the current user
-   *
-   * (Obsoleted by getSystemConfig())
-   *
-   * @return  user information
-   */
-  User getUserInformation(String sessionId);
-
-  /**
    * Retrieves the user's settings.
    *
    * @return  user's settings

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/UserInfoServiceAsync.java
@@ -27,11 +27,6 @@ public interface UserInfoServiceAsync {
   void getUserBackpack(AsyncCallback<String> callback);
 
   /**
-   * @see UserInfoService#getUserInformation()
-   */
-  void getUserInformation(String sessionId, AsyncCallback<User> callback);
-
-  /**
    * @see UserInfoService#loadUserSettings()
    */
   void loadUserSettings(AsyncCallback<String> callback);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
Removes unused getUserInformation RPC. It has been unused for over a decade, see:
https://github.com/mit-cml/appinventor-sources/commit/2471bf7463be806bcd1d30edee36eb52b1a933cc
