### PR TITLE
feat(ios): Add visible border to TextBox by default

### DIFF
--- a/appinventor/components-ios/src/TextBox.swift
+++ b/appinventor/components-ios/src/TextBox.swift
@@ -34,6 +34,14 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     _field.delegate = self
     setupView()
     
+    // Add visible border to both single-line and multi-line text boxes
+    _field.layer.borderWidth = 1.0
+    _field.layer.borderColor = UIColor.lightGray.cgColor
+    _field.layer.cornerRadius = 4.0
+    _view.layer.borderWidth = 1.0
+    _view.layer.borderColor = UIColor.lightGray.cgColor
+    _view.layer.cornerRadius = 4.0
+    
     // We are single line by default
     makeSingleLine()
     textColor = UIColor.black


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

---

**What does this PR accomplish?**

*Description*

This PR adds a visible light gray border by default to all iOS TextBoxes in App Inventor.  
Previously, TextBoxes on iOS had no border, making it difficult for users (especially beginners) to identify them as input fields.  
With this change, both single-line and multi-line TextBoxes will have a clear border, improving usability and visual clarity.

---

Fixes/Resolves

Resolves # (fill in the issue number if there is one)

---

How was this tested?

- Ran the iOS Companion app and verified that all TextBoxes now have a visible border by default.

---