### PR TITLE
Bump Android min SDK to 14

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
@@ -8,6 +8,7 @@ package com.google.appinventor.buildserver;
 
 import static com.google.appinventor.common.constants.YoungAndroidStructureConstants.YAIL_FILE_EXTENSION;
 
+import com.google.appinventor.components.common.ComponentConstants;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -116,7 +117,7 @@ public final class Project {
   private static final String DEFAULT_APP_NAME = "AI2 App";
   private static final String DEFAULT_VERSION_CODE = "1";
   private static final String DEFAULT_VERSION_NAME = "1.0";
-  private static final String DEFAULT_MIN_SDK = "7";
+  private static final String DEFAULT_MIN_SDK = ComponentConstants.APP_INVENTOR_MIN_SDK + "";
   private static final String DEFAULT_COLOR_PRIMARY = "#A5CF47";
   private static final String DEFAULT_COLOR_PRIMARY_DARK = "#41521C";
   private static final String DEFAULT_COLOR_ACCENT = "#00728A";

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -18,7 +18,7 @@ public class ComponentConstants {
   /**
    * App constants
    */
-  public static final int APP_INVENTOR_MIN_SDK = 7;
+  public static final int APP_INVENTOR_MIN_SDK = 14;
 
   /**
    * Layout constants.


### PR DESCRIPTION
Change-Id: Ife750b4324f76abe2b55ca9e6381491b8281f0d8

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR bumps the min SDK version for Android to 14 from 7. This requires that people have upgraded to the newer emulator packages for Windows and macOS, both linked from our website.