### PR TITLE
Make GVoice permissions conditional on GoogleVoiceEnabled

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -161,8 +161,6 @@ import org.json.JSONObject;
 
 @SimpleObject
 @UsesPermissions(permissionNames =
-  "com.google.android.apps.googlevoice.permission.RECEIVE_SMS, " +
-  "com.google.android.apps.googlevoice.permission.SEND_SMS, " +
   "android.permission.ACCOUNT_MANAGER, android.permission.MANAGE_ACCOUNTS, " +
   "android.permission.GET_ACCOUNTS, android.permission.USE_CREDENTIALS, " +
   "android.permission.POST_NOTIFICATIONS")
@@ -523,6 +521,10 @@ public class Texting extends AndroidNonvisibleComponent
                   @ActionElement(name = "com.google.android.apps.googlevoice.SMS_RECEIVED")
               })
           })
+  })
+  @UsesPermissions({
+    "com.google.android.apps.googlevoice.permission.RECEIVE_SMS",
+    "com.google.android.apps.googlevoice.permission.SEND_SMS"
   })
   public void GoogleVoiceEnabled(boolean enabled) {
     if (SdkLevel.getLevel() >= SdkLevel.LEVEL_ECLAIR) {


### PR DESCRIPTION
Change-Id: I91d3cb50f08bf9365669fc8c2fdc622393bb4bdb

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR moves the Google Voice permissions from being applied generally to the Texting component to being conditional on the user enabling the GoogleVoiceEnabled property. This removes the permissions from compiled apps that do not use Google Voice.