### PR TITLE
Added visible border to iOS TextBox for better clarity in tutorials

### DIFF
--- a/appinventor/components-ios/src/TextBox.swift
+++ b/appinventor/components-ios/src/TextBox.swift
@@ -34,6 +34,17 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     _field.delegate = self
     setupView()
     
+    // Add a visible border for better visual clarity
+    _field.layer.borderColor = UIColor.systemGray.cgColor
+    _field.layer.borderWidth = 1.0
+    _field.layer.cornerRadius = 5.0
+    _field.backgroundColor = UIColor.systemGray6
+
+    _view.layer.borderColor = UIColor.systemGray.cgColor
+    _view.layer.borderWidth = 1.0
+    _view.layer.cornerRadius = 5.0
+    _view.backgroundColor = UIColor.systemGray6
+    
     // We are single line by default
     makeSingleLine()
     textColor = UIColor.black
@@ -43,7 +54,6 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
   }
   
   private func setupView() {
-    // Set up the minimum size constraint for the UITextView
     let heightConstraint = _view.heightAnchor.constraint(greaterThanOrEqualToConstant: 20)
     heightConstraint.priority = UILayoutPriority.defaultHigh
     _view.addConstraint(heightConstraint)
@@ -164,7 +174,7 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     }
     set(multiLine) {
       if _multiLine == multiLine {
-        return  // nothing to do
+        return
       }
       if multiLine {
         makeMultiLine()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/ *(Not required for this UI-only iOS change)*
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine *(Not applicable for iOS Swift files)*

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

---

### What does this PR accomplish?

**Enhancement:**
This pull request improves the visual clarity of the `TextBox` component on **iOS** devices by adding a visible border and light background color by default.

Currently, TextBoxes on iOS do not have any visible indicators unless a hint or background color is manually set, making it difficult for beginners to identify input fields.

---

### *Description*

- Added a light gray background color (`systemGray6`) to `_field` and `_view` in `TextBox.swift`.
- Added 1px border and slight corner radius to improve visibility.
- Changes affect only the iOS companion and do not alter Android behavior.

---
---
