### PR TITLE
Implement UsesCamera and UsesMicrophone permissions for WebViewer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -2053,7 +2053,8 @@ public final class YoungAndroidFormUpgrader {
       // PageLoaded event was added (version 8)
       // BeforePageLoad event and Stop, Reload, and ClearCookies methods added (version 9)
       // ErrorOccurred event and RunJavaScript method added (version 10)
-      srcCompVersion = 10;
+      // The UsesCamera and UsesMicrophone properties were added (version 11)
+      srcCompVersion = 11;
     }
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -3514,7 +3514,10 @@ Blockly.Versioning.AllUpgradeMaps =
     9: "noUpgrade",
 
     // AI2: Added ErrorOccurred event and RunJavaScript method
-    10: "noUpgrade"
+    10: "noUpgrade",
+
+    // AI2: Added UsesCamera and UsesMicrophone properties
+    11: "noUpgrade"
 
   }, // End WebViewer upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1639,7 +1639,10 @@ public class YaVersion {
   // For WEBVIEWER_COMPONENT_VERSION 10:
   // - Added ErrorOccurred event
   // - Added RunJavaScript method
-  public static final int WEBVIEWER_COMPONENT_VERSION = 10;
+  // Form WEBVIEWER_COMPONENT_VERSION 11:
+  // - Added the UsesCamera property
+  // - Added the UsesMicrophone property
+  public static final int WEBVIEWER_COMPONENT_VERSION = 11;
 
   // For MEDIASTORE_COMPONENT_VERSION 1:
   // - Initial Version.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -141,6 +141,10 @@ public final class WebViewer extends AndroidViewComponent {
   // Flag to mark whether we have received permission to read external storage
   private boolean havePermission = false;
 
+  private boolean usesCamera = false;
+
+  private boolean usesMicrophone = false;
+
   /**
    * Creates a new WebViewer component.
    *
@@ -469,6 +473,51 @@ public final class WebViewer extends AndroidViewComponent {
       description = "Reload the current page.")
   public void Reload() {
     webview.reload();
+  }
+
+  /**
+   * Specifies whether this `WebViewer` can access the camera.
+   *
+   * @param uses -- Whether the camera is available
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "False")
+  @SimpleProperty(userVisible = false,
+      description = "Whether or not to give the application permission to use the camera. " +
+              "This property is available only in the designer.",
+      category = PropertyCategory.BEHAVIOR)
+  @UsesPermissions({
+      Manifest.permission.CAMERA
+  })
+  public void UsesCamera(boolean uses) {
+    this.usesCamera = uses;
+  }
+
+  public boolean UsesCamera() {
+    return usesCamera;
+  }
+
+  /**
+   * Specifies whether this `WebViewer` can access the microphone.
+   *
+   * @param uses -- Whether the microphone is available
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "False")
+  @SimpleProperty(userVisible = false,
+      description = "Whether or not to give the application permission to use the microphone. " +
+          "This property is available only in the designer.",
+      category = PropertyCategory.BEHAVIOR)
+  @UsesPermissions({
+      Manifest.permission.RECORD_AUDIO,
+      Manifest.permission.MODIFY_AUDIO_SETTINGS
+  })
+  public void UsesMicrophone(boolean uses) {
+    this.usesMicrophone = uses;
+  }
+
+  public boolean UsesMicrophone() {
+    return usesMicrophone;
   }
 
   /**

--- a/appinventor/docs/html/reference/components/userinterface.html
+++ b/appinventor/docs/html/reference/components/userinterface.html
@@ -1773,9 +1773,13 @@ having dark grey components.</li>
   <dt id="WebViewer.Top" class="number"><em>Top</em></dt>
   <dd>Specifies the position of the Top edge of the component relative to an
  AbsoluteArrangement.</dd>
+  <dt id="WebViewer.UsesCamera" class="boolean wo do"><em>UsesCamera</em></dt>
+  <dd>Specifies whether this <code class="highlighter-rouge">WebViewer</code> can access the camera.</dd>
   <dt id="WebViewer.UsesLocation" class="boolean wo do"><em>UsesLocation</em></dt>
   <dd>Specifies whether or not this <code class="highlighter-rouge">WebViewer</code> can access the JavaScript
  geolocation API.</dd>
+  <dt id="WebViewer.UsesMicrophone" class="boolean wo do"><em>UsesMicrophone</em></dt>
+  <dd>Specifies whether this <code class="highlighter-rouge">WebViewer</code> can access the microphone.</dd>
   <dt id="WebViewer.Visible" class="boolean"><em>Visible</em></dt>
   <dd>Specifies whether the <code class="highlighter-rouge">WebViewer</code> should be visible on the screen.  Value is <code class="logic block highlighter-rouge">true</code>
  if the <code class="highlighter-rouge">WebViewer</code> is showing and <code class="logic block highlighter-rouge">false</code> if hidden.</dd>

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -2074,9 +2074,15 @@ Component for viewing Web pages.
 : Specifies the position of the Top edge of the component relative to an
  AbsoluteArrangement.
 
+{:id="WebViewer.UsesCamera" .boolean .wo .do} *UsesCamera*
+: Specifies whether this `WebViewer` can access the camera.
+
 {:id="WebViewer.UsesLocation" .boolean .wo .do} *UsesLocation*
 : Specifies whether or not this `WebViewer` can access the JavaScript
  geolocation API.
+
+{:id="WebViewer.UsesMicrophone" .boolean .wo .do} *UsesMicrophone*
+: Specifies whether this `WebViewer` can access the microphone.
 
 {:id="WebViewer.Visible" .boolean} *Visible*
 : Specifies whether the `WebViewer` should be visible on the screen.  Value is `true`{:.logic.block}


### PR DESCRIPTION
Change-Id: I26d98b3c5c676b82c0b4ac15d16c06b18606154f

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

What does this PR accomplish?

This PR implements two new properties for the WebViewer: UsesCamera and UsesMicrophone. This allows people to make use of web pages that access these components. The attached project (rename from .zip to .aia) loads classifier.appinventor.mit.edu and c1.appinventor.mit.edu to demonstrate how these pages can now be used (modulo their own formatting issues) in a WebViewer.

[TestWebViewerProject.aia.zip](https://github.com/user-attachments/files/21220678/TestWebViewerProject.aia.zip)
