### PR TITLE
Make Component Name visible to Java code

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -94,6 +94,8 @@
   (let* ((container :: SimpleContainer (lookup-in-current-form-environment container-name))
          (existing-component (lookup-in-current-form-environment component-name))
          (component-to-add (make component-type container)))
+    ;; Set the component name field
+    (*:setComponentName component-to-add component-name)
     (add-to-current-form-environment component-name component-to-add)
     (add-init-thunk component-name
      (lambda ()
@@ -574,6 +576,8 @@
                          ;;  (format #f "making component: ~A of type: ~A with container: ~A (container-name: ~A)"
                          ;;          component-name component-type component-container (car component-info)))
                          (let ((component-object (make component-type component-container)))
+                           ;; Set the component name field
+                           (*:setComponentName component-object component-name)
                            ;; Construct the component and assign it to its corresponding field
                            (set! (field (this) component-name) component-object)
                            ;; Add the mapping from component name -> component object to the

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
@@ -1458,6 +1458,7 @@ public class YailEvalTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         return null;
       }
+
       @Override
       public void setComponentName(final String componentName) {}
     };

--- a/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
+++ b/appinventor/buildserver/tests/com/google/appinventor/buildserver/YailEvalTest.java
@@ -1458,6 +1458,8 @@ public class YailEvalTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         return null;
       }
+      @Override
+      public void setComponentName(final String componentName) {}
     };
     scheme.define(sym, fakeComponent);
     String code = readTestCode("testComponentsAsDictKeys");

--- a/appinventor/components/src/com/google/appinventor/components/runtime/AndroidNonvisibleComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AndroidNonvisibleComponent.java
@@ -17,6 +17,7 @@ import com.google.appinventor.components.annotations.SimpleObject;
 public abstract class AndroidNonvisibleComponent implements Component {
 
   protected final Form form;
+  protected String componentName;
 
   /**
    * Creates a new AndroidNonvisibleComponent.
@@ -32,5 +33,10 @@ public abstract class AndroidNonvisibleComponent implements Component {
   @Override
   public HandlesEventDispatching getDispatchDelegate() {
     return form;
+  }
+
+  @Override
+  public void setComponentName(final String componentName) {
+    this.componentName = componentName;
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
@@ -21,6 +21,10 @@ public interface Component {
    */
   public HandlesEventDispatching getDispatchDelegate();
 
+  // We add here a method to avoid having Scheme runtime errors of the method
+  //   not being defined, and instead have build errors.
+  void setComponentName(final String componentName);
+
   /*
    * Components asset directory.
    */

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Component.java
@@ -21,8 +21,12 @@ public interface Component {
    */
   public HandlesEventDispatching getDispatchDelegate();
 
-  // We add here a method to avoid having Scheme runtime errors of the method
-  //   not being defined, and instead have build errors.
+  /**
+   * Sets the component name from Scheme runtime.
+   * @param componentName component name
+   */
+  // We add the method here to force a build error in case a component did not
+  //   implement it, rather than receiving runtime errors.
   void setComponentName(final String componentName);
 
   /*

--- a/appinventor/components/src/com/google/appinventor/components/runtime/DataCollection.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/DataCollection.java
@@ -42,6 +42,8 @@ public abstract class DataCollection<C extends ComponentContainer, M extends Dat
   protected final C container;
   protected M dataModel;
 
+  protected String componentName;
+
   /**
    * Used to queue & execute asynchronous tasks while ensuring
    * order of method execution (ExecutorService should be a Single Thread runner)
@@ -105,6 +107,11 @@ public abstract class DataCollection<C extends ComponentContainer, M extends Dat
     dataFileColumns = Arrays.asList("", "");
     sheetsColumns = Arrays.asList("", "");
     webColumns = Arrays.asList("", ""); // Construct default webColumns list with 2 entries
+  }
+
+  @Override
+  public void setComponentName(String componentName) {
+    this.componentName = componentName;
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -166,6 +166,7 @@ public class Form extends AppInventorCompatActivity
   protected final Handler androidUIHandler = new Handler();
 
   protected String formName;
+  protected String componentName;
 
   private boolean screenInitialized;
 
@@ -3003,5 +3004,11 @@ public class Form extends AppInventorCompatActivity
     } else {
       return FileUtil.openFile(this, path);
     }
+  }
+
+  @Override
+  public void setComponentName(String componentName) {
+    // Note this here will have the same value as formName, but formName is specific to only Forms
+    this.componentName = componentName;
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/MapFeatureBase.java
@@ -30,6 +30,8 @@ import org.osmdroid.util.GeoPoint;
 
 @SimpleObject
 public abstract class MapFeatureBase implements MapFeature, HasStroke {
+  protected String componentName;
+
   protected MapFeatureContainer container = null;
   protected Map map = null;
   private boolean visible = true;
@@ -105,6 +107,11 @@ public abstract class MapFeatureBase implements MapFeature, HasStroke {
     StrokeWidth(1);
     Title("");
     Visible(true);
+  }
+
+  @Override
+  public void setComponentName(String componentName) {
+    this.componentName = componentName;
   }
 
   public void setMap(MapFactory.MapFeatureContainer container) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Trendline.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Trendline.java
@@ -79,6 +79,8 @@ public class Trendline implements ChartComponent, DataSourceChangeListener {
         }
       };
 
+  protected String componentName;
+
   private final DashPathEffect dashed;
   private final DashPathEffect dotted;
   private final Chart container;
@@ -112,6 +114,11 @@ public class Trendline implements ChartComponent, DataSourceChangeListener {
     container.addDataComponent(this);
     dashed = new DashPathEffect(new float[]{10f * density, 10f * density}, 0f);
     dotted = new DashPathEffect(new float[]{2f * density, 10f * density}, 0f);
+  }
+
+  @Override
+  public void setComponentName(String componentName) {
+    this.componentName = componentName;
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VisibleComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VisibleComponent.java
@@ -18,6 +18,8 @@ import com.google.appinventor.components.annotations.SimpleProperty;
  */
 @SimpleObject
 public abstract class VisibleComponent implements Component {
+  protected String componentName;
+
   protected VisibleComponent() {
   }
 
@@ -80,4 +82,9 @@ public abstract class VisibleComponent implements Component {
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE)
   public abstract void HeightPercent(int hPercent);
+
+  @Override
+  public void setComponentName(final String componentName) {
+    this.componentName = componentName;
+  }
 }

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/util/PropertyUtilTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/util/PropertyUtilTest.java
@@ -39,6 +39,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -69,6 +72,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -110,6 +116,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -152,6 +161,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -180,6 +192,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -209,6 +224,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -233,6 +251,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -262,6 +283,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -293,6 +317,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -330,6 +357,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -364,6 +394,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -492,6 +525,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
 
     TestClass sourceObj = new TestClass();
@@ -553,6 +589,9 @@ public class PropertyUtilTest extends TestCase {
       public HandlesEventDispatching getDispatchDelegate() {
         throw new UnsupportedOperationException();
       }
+
+      @Override
+      public void setComponentName(final String componentName) {}
     }
     @SimpleObject
     class TestClass extends SuperTestClass {


### PR DESCRIPTION
Component Names were only visible to Scheme runtime. Now a componentName protected variable is available, which can be useful for better debugging and logging, either by internal components or extension developers.

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

### What does this PR accomplish?

**Description**

This PR aims to provide visibility to Java runtime to be aware of each "component name". It is achieved by creating a new `setComponentName` method, called by Scheme runtime after initializing each component.  
The main goal is to allow for better debugging and tracing, as now Java runtimes can "customize" the logs or capture the specific component name, allowing to pin-point exactly which component caused trouble whenever it crashes inside a screen. This feature is mainly focused on extension developers or advanced debugging with logcat, as it should be used within the logs.

Also, this change is backwards compatible with existing extensions. I was originally implementing as part of the constructors, but then realized it was going to break existing components and extensions unless updated. By using the method, it guarantees breaking at build time rather than runtime Scheme.  
Also, it is compatible for extension developers without having them to update existing extensions. As they extend `AndroidNonVisibleComponent`, this already implements the `setComponentName` method. For extension developers to use this new field, they do have to update AI2 to the this commit, and then consume the `protected componentName` field.

**Testing**

I tested locally by adding a `Log.i` statement inside the `setComponentName`, and log the actual component name. Worked like a charm.