### PR TITLE
Fix default map tiles not appearing in iOS

### DIFF
--- a/appinventor/components-ios/src/Map.swift
+++ b/appinventor/components-ios/src/Map.swift
@@ -78,7 +78,7 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
   private var _boundsChangeReady: Bool = false
   private var _terrainOverlay: MKTileOverlay?
   private var _customUrlOverlay: MKTileOverlay?
-  private var _customURL = ""
+  private var _customURL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
   private var _activeOverlay: MapOverlayShape? = nil
   private var _lastPoint: CLLocationCoordinate2D? = nil
   private var _activeMarker: Marker? = nil
@@ -383,7 +383,7 @@ open class Map: ViewComponent, MKMapViewDelegate, UIGestureRecognizerDelegate, M
         return _customURL
       }
       set(newUrl) {
-        guard let newUrl = newUrl, newUrl != CustomUrl else {
+        guard let newUrl = newUrl, newUrl != _customURL else {
             return
         }
         _customURL = newUrl


### PR DESCRIPTION
Change-Id: I846ebb4e1d4b225c318570bf26af41423044ea1c

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes an issue where the default map tile provided gets removed, preventing Maps on iOS from not working correctly.