### PR TITLE
Add support for remotely debugging Junit tests

### DIFF
--- a/appinventor/build-common.xml
+++ b/appinventor/build-common.xml
@@ -16,6 +16,8 @@
 <project name="CommonDefinitions" xmlns:if="ant:if" xmlns:unless="ant:unless">
   <!-- Always build with debug set... (jis) -->
   <property name="debug" value="true"/>
+  <property name="attach" value="false"/>
+
   <description>
     Definitions common to multiple App Inventor build.xml files."
   </description>
@@ -217,6 +219,7 @@
              haltonfailure="no"
              maxmemory="2000m"
              showoutput="no">
+        <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" if:true="${attach}"/>
         <sysproperty key="gwt.args" value="-prod -gen ${local.build.dir}/gen -war ${local.build.dir}/build/war" if:true="@{aij-prod}"/>
         <sysproperty key="gwt.args" value="-devMode -logLevel WARN -war ${local.build.dir}/build/war" unless:true="@{aij-prod}"/>
         <sysproperty key="java.awt.headless" value="true"/>


### PR DESCRIPTION
Change-Id: I8766de28b1b79cb69102cd8370733ce7c463c059

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This adds a new ant flag, `attach` that can be used to instruct the JVM to pause for remote debugger connections prior to running unit tests. This can be used to debug unit tests within a particular module through IDEs like IntelliJ.

Note: I need to add some documentation on how to do this. Right now it just adds the flag.