### PR TITLE
Fix wrong version number in WebViewer upgrade path

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -2040,7 +2040,7 @@ public final class YoungAndroidFormUpgrader {
 
   private static int upgradeWebViewerProperties(Map<String, JSONValue> componentProperties,
                                                 int srcCompVersion) {
-    if (srcCompVersion < 10) {
+    if (srcCompVersion < 11) {
       // The CanGoForward and CanGoBack methods were added.
       // No properties need to be modified to upgrade to version 2.
       // UsesLocation property added.


### PR DESCRIPTION
Change-Id: I842e677b365985f95dcb077c19c712d3d8136ebc

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

What does this PR accomplish?

This PR is an emergency fix for the upgrade path for WebViewer currently on `ucr`. I forgot to change the version number check in upgradeWebViewerProperties, which causes an exception to be raised. The upgrade itself is a no-op anyway so it doesn't break people's projects, but the code as implemented in ucr prevents loading older projects until this patch is applied.