### PR TITLE
Implement Remote Storage outside of GCP

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/actions/BarcodeAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/BarcodeAction.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2023 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -16,8 +16,8 @@ import com.google.appinventor.client.explorer.commands.ShowProgressBarCommand;
 import com.google.appinventor.client.explorer.commands.WaitForBuildResultCommand;
 import com.google.appinventor.client.explorer.commands.WarningDialogCommand;
 import com.google.appinventor.client.tracking.Tracking;
+import com.google.appinventor.shared.util.BuildOutputFiles;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
-import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
 import com.google.gwt.user.client.Command;
 
 public class BarcodeAction implements Command {
@@ -50,7 +50,7 @@ public class BarcodeAction implements Command {
   public void execute() {
     ProjectRootNode projectRootNode = Ode.getInstance().getCurrentYoungAndroidProjectRootNode();
     if (projectRootNode != null) {
-      String target = YoungAndroidProjectNode.YOUNG_ANDROID_TARGET_ANDROID;
+      String target = BuildOutputFiles.getTargetName();
       ChainableCommand cmd = new SaveAllEditorsCommand(
           new GenerateYailCommand(
               new BuildCommand(target, secondBuildserver, isAab,

--- a/appinventor/appengine/src/com/google/appinventor/server/BuildOutputServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/BuildOutputServlet.java
@@ -1,29 +1,30 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2019 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.server;
 
-import com.google.appinventor.common.utils.StringUtils;
 import com.google.appinventor.server.storage.StorageIo;
 import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.server.storage.remote.RemoteStorage;
+import com.google.appinventor.server.storage.remote.RemoteStorageInstanceHolder;
+import com.google.appinventor.shared.util.BuildOutputFiles;
 import com.google.appinventor.server.util.CacheHeaders;
 import com.google.appinventor.server.util.CacheHeadersImpl;
 import com.google.appinventor.shared.rpc.Nonce;
-import com.google.appinventor.shared.rpc.ServerLayout;
-import com.google.appinventor.shared.rpc.project.ProjectSourceZip;
 import com.google.appinventor.shared.rpc.project.RawFile;
 import com.google.appinventor.shared.storage.StorageUtil;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Date;
-import java.util.NoSuchElementException;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -68,7 +69,6 @@ public class BuildOutputServlet extends OdeServlet {
 
     RawFile downloadableFile;
 
-    String userId = null;
     String nonceValue = null;
 
     try {
@@ -95,6 +95,37 @@ public class BuildOutputServlet extends OdeServlet {
         resp.sendError(resp.SC_NOT_FOUND, "Link has timed out");
         return;
       }
+
+      final String userId = nonce.getUserId();
+      final long projectId = nonce.getProjectId();
+
+      if (RemoteStorageInstanceHolder.isRemoteConfigured()) {
+        final StorageIo storageIo = StorageIoInstanceHolder.getInstance();
+        // Given all the output files, try to find the one that matches an output extension
+        final List<String> files = storageIo.getProjectOutputFiles(userId, projectId);
+        String outputFileName = null;
+        for (String fileName : files) {
+          if (BuildOutputFiles.isOutputFile(fileName)) {
+            outputFileName = new File(fileName).getName();
+            break;
+          }
+        }
+
+        if (outputFileName == null) {
+          throw new FileNotFoundException("No target file found!");
+        }
+
+        final RemoteStorage remoteStorage = RemoteStorageInstanceHolder.getInstance();
+        // For now, we use Android always. If we eventually support iOS, we should decide here
+        //   whether we are going for Android or Apple, as well as in the BarcodeAction.
+        final String target = BuildOutputFiles.getTargetName();
+        final String objectKey = remoteStorage.getBuildOutputObjectKey(target, userId, projectId, outputFileName);
+        final String remoteUrl = remoteStorage.generateRetrieveUrl(objectKey);
+
+        resp.sendRedirect(remoteUrl);
+        return;
+      }
+
       downloadableFile = fileExporter.exportProjectOutputFile(nonce.getUserId(), nonce.getProjectId(), null);
 
     } catch (FileNotFoundException e) {

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2019 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -8,6 +8,7 @@ package com.google.appinventor.server;
 
 import com.google.appinventor.server.storage.StorageIo;
 import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.shared.util.BuildOutputFiles;
 import com.google.appinventor.shared.rpc.project.ProjectSourceZip;
 import com.google.appinventor.shared.rpc.project.RawFile;
 import com.google.appinventor.shared.storage.StorageUtil;
@@ -47,7 +48,7 @@ public final class FileExporterImpl implements FileExporter {
     // There should never be more than one .apk file.
 
     for (String fileName : files) {
-      if (fileName.endsWith(".apk") || fileName.endsWith(".aab")) {
+      if (BuildOutputFiles.isOutputFile(fileName)) {
         byte[] content = storageIo.downloadRawFile(userId, projectId, fileName);
         return new RawFile(StorageUtil.basename(fileName), content);
       }

--- a/appinventor/appengine/src/com/google/appinventor/server/ReceiveBuildServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ReceiveBuildServlet.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2019 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -82,10 +82,14 @@ public class ReceiveBuildServlet extends OdeServlet {
           String filePath = buildFileDirPath + "/" + fileName;
           LOG.info("Saving build output files: " + filePath);
           storageIo.addOutputFilesToProject(userId, projectId, filePath);
-          storageIo.uploadRawFileForce(projectId, filePath, userId, fileBytes);
-          storageIo.storeBuildStatus(userId, projectId, 0); // Reset for the next build
+          if (fileBytes.length > 0) {
+            // We only "upload" the file if it actually has something. This is because in the remote build,
+            //   we will issue an empty file back to GAE for the APK/AAB files.
+            storageIo.uploadRawFileForce(projectId, filePath, userId, fileBytes);
+          }
         }
       }
+      storageIo.storeBuildStatus(userId, projectId, 0); // Reset for the next build
     } finally {
       odeFilter.removeUser();
     }

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2017 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -33,6 +33,8 @@ import com.google.appinventor.server.project.CommonProjectService;
 import com.google.appinventor.server.project.utils.Security;
 import com.google.appinventor.server.properties.json.ServerJsonParser;
 import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.remote.RemoteStorage;
+import com.google.appinventor.server.storage.remote.RemoteStorageInstanceHolder;
 import com.google.appinventor.server.util.UriBuilder;
 import com.google.appinventor.shared.properties.json.JSONParser;
 import com.google.appinventor.shared.properties.json.JSONUtil;
@@ -516,9 +518,11 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     ProjectSourceZip zipFile = null;
     try {
       buildServerUrl = new URL(getBuildServerUrlStr(
+          target,
           user.getUserEmail(),
           userId,
           projectId,
+          projectName,
           secondBuildserver,
           outputFileDir,
           isAab));
@@ -770,9 +774,10 @@ public final class YoungAndroidProjectService extends CommonProjectService {
   // Note that this is a function rather than just a constant because we assume it will get
   // a little more complicated when we want to get the URL from an App Engine config file or
   // command line argument.
-  private String getBuildServerUrlStr(String userName, String userId,
-    long projectId, boolean secondBuildserver, String fileName, boolean isAab)
+  private String getBuildServerUrlStr(String target, String userName, String userId,
+    long projectId, String projectName, boolean secondBuildserver, String fileName, boolean isAab)
       throws EncryptionException {
+    final String extName = isAab ? "aab" : "apk";
     UriBuilder uriBuilder = new UriBuilder(
         "http://"
             + (secondBuildserver ? buildServerHost2.get() : buildServerHost.get())
@@ -782,10 +787,21 @@ public final class YoungAndroidProjectService extends CommonProjectService {
             ServerLayout.RECEIVE_BUILD_SERVLET + "/" +
             Security.encryptUserAndProjectId(userId, projectId) + "/" +
             fileName)
-        .add("ext", isAab ? "aab" : "apk");
+        .add("ext", extName);
     if (sendGitVersion.get()) {
       uriBuilder.add("gitBuildVersion", GitBuildId.getVersion());
     }
+
+    if (RemoteStorageInstanceHolder.isRemoteConfigured()) {
+      final RemoteStorage remoteStorage = RemoteStorageInstanceHolder.getInstance();
+      final String objectKey = remoteStorage.getBuildOutputObjectKey(target, userId, projectId, projectName, extName);
+      final String uploadUrl = remoteStorage.generateUploadUrl(objectKey);
+
+      // We use this parameter to indicate the buildserver to send the APK/AAB to this remote
+      //   location and not send it back here
+      uriBuilder.add("uploadUrl", uploadUrl);
+    }
+
     return uriBuilder.build();
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorage.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorage.java
@@ -1,0 +1,85 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025-2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.storage.remote;
+
+/**
+ * Interface which abstracts the remote storage access patterns.
+ * This allows AI2 to store different files, like build outputs, outside
+ *   GCP, and provide a presigned URL to download and/or access them.
+ */
+public abstract class RemoteStorage {
+  // We partition the bucket into different usage types, so specific lifecycle rules could
+  //   be applied by prefix, if required.
+  private final static String BUILD_OUTPUT_PREFIX = "build";
+  private final static String PROJECT_EXPORT_PREFIX = "export";
+
+  /**
+   * Generates a, usually, presigned URL to upload the file to the remote
+   *   storage server.
+   *
+   * @param objectKey object key in the remote storage server
+   * @return (presigned) upload URL
+   */
+  public abstract String generateUploadUrl(final String objectKey);
+
+  /**
+   * Generates an external URL to access the object. Depending on the
+   *   implementation, this may behave as a presigned URL or a "normal"
+   *   URL (if using a CDN, for example).
+   *
+   * @param objectKey object key in the remote storage server
+   * @return (presigned) get/retrieval URL
+   */
+  public abstract String generateRetrieveUrl(final String objectKey);
+
+  /**
+   * Generates a constant object key for a given specific project build output.
+   *
+   * @param target the type of target (Android)
+   * @param userId the user ID owning the project
+   * @param projectId the given project ID
+   * @param projectName the name of the project to store
+   * @param extensionName the extension name the build is on
+   * @return build/userId/projectId/target/projectName.extensionName
+   */
+  public final String getBuildOutputObjectKey(final String target, final String userId, final Long projectId,
+      final String projectName, final String extensionName) {
+    final String fileName = projectName + "." + extensionName;
+    return getBuildOutputObjectKey(target, userId, projectId, fileName);
+  }
+
+  /**
+   * Generates a constant object key for a given specific project build output.
+   *
+   * @param target the type of target (Android)
+   * @param userId the user ID owning the project
+   * @param projectId the given project ID
+   * @param fileName the file name to download
+   * @return build/userId/projectId/target/projectName.extensionName
+   */
+  public final String getBuildOutputObjectKey(final String target, final String userId, final Long projectId,
+      final String fileName) {
+    final String filePath = userId + "/" + projectId + "/" + target;
+    return BUILD_OUTPUT_PREFIX + "/" + filePath + "/" + fileName;
+  }
+
+  /**
+   * Generates a constant object key for a given specific project export.
+   *
+   * @param userId the user ID owning the project
+   * @param projectId the given project ID
+   * @param projectName the name of the project to store
+   * @return export/userId/projectId/projectName.aia
+   */
+  public final String getProjectExportObjectKey(final String userId, final Long projectId,
+      final String projectName) {
+    final String filePath = userId + "/" + projectId;
+    final String fileName = projectName + ".aia";
+
+    return PROJECT_EXPORT_PREFIX + "/" + filePath + "/" + fileName;
+  }
+
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorageInstanceHolder.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorageInstanceHolder.java
@@ -1,0 +1,53 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025-2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.storage.remote;
+
+import com.google.appinventor.server.flags.Flag;
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Holds the singleton BuildOutputRemoteStorage subclass object. We introduce this class
+ * so that we can switch out the underlying BuildOutputRemoteStorage subclass without changing
+ * the references in the code to the INSTANCE.
+ */
+public class RemoteStorageInstanceHolder {
+  private static final Flag<String> PROVIDER_NAME = Flag.createFlag("remotestorage", null);
+
+  private static RemoteStorage INSTANCE;
+
+  private RemoteStorageInstanceHolder() {} // not to be instantiated
+
+  public static RemoteStorage getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = createRemoteInstance();
+    }
+
+    return INSTANCE;
+  }
+
+  public static boolean isRemoteConfigured() {
+    return getInstance() != null;
+  }
+
+  @VisibleForTesting
+  public static void setInstance(RemoteStorage instance) {
+    INSTANCE = instance;
+  }
+
+  private static RemoteStorage createRemoteInstance() {
+    final String providerName = PROVIDER_NAME.get();
+    if (providerName == null || providerName.isBlank()) {
+      // If not configured, then use the default provider (aka none).
+      return null;
+    }
+
+    if (providerName.equals("s3")) {
+      return new RemoteStorageProviderS3();
+    }
+
+    throw new UnsupportedOperationException("Unknown remote storage provider: " + providerName);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorageProviderS3.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/storage/remote/RemoteStorageProviderS3.java
@@ -1,0 +1,167 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025-2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.storage.remote;
+
+import com.google.appinventor.server.flags.Flag;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public final class RemoteStorageProviderS3 extends RemoteStorage {
+  private static final Flag<String> ENDPOINT = Flag.createFlag("remotestorage.s3.endpoint", null);
+  private static final Flag<String> BUCKET_NAME = Flag.createFlag("remotestorage.s3.bucketname", null);
+  private static final Flag<String> BUCKET_REGION = Flag.createFlag("remotestorage.s3.bucketregion", null);
+  private static final Flag<String> ACCESS_KEY_ID = Flag.createFlag("remotestorage.s3.accesskeyid", null);
+  private static final Flag<String> SECRET_ACCESS_KEY = Flag.createFlag("remotestorage.s3.secretaccesskey", null);
+
+  // Upload URLs should be valid for 15 minutes
+  private static final int UPLOAD_EXPIRATION_SECONDS = 900;
+  // Retrieve URLs for 5 minutes
+  private static final int RETRIEVE_EXPIRATION_SECONDS = 300;
+
+  private static final String ALGORITHM = "AWS4-HMAC-SHA256";
+  private static final String SERVICE = "s3";
+  private static final String REQUEST_TYPE = "aws4_request";
+
+  private final String endpoint;
+  private final String bucketName;
+  private final String bucketRegion;
+  private final String accessKeyId;
+  private final String secretAccessKey;
+
+  public RemoteStorageProviderS3() {
+    this.endpoint = validateOptionalParameter(ENDPOINT.get());
+    this.bucketName = validateRequiredParameter(BUCKET_NAME.get(), "bucketName");
+    this.bucketRegion = validateRequiredParameter(BUCKET_REGION.get(), "bucketRegion");
+    this.accessKeyId = validateRequiredParameter(ACCESS_KEY_ID.get(), "accesskeyid");
+    this.secretAccessKey = validateRequiredParameter(SECRET_ACCESS_KEY.get(), "secretaccesskey");
+  }
+
+  private String validateRequiredParameter(final String param, final String paramName) {
+    if (param == null || param.isBlank()) {
+      throw new IllegalArgumentException("Missing required parameter: " + paramName);
+    }
+
+    return param.strip();
+  }
+
+  private String validateOptionalParameter(final String param) {
+    if (param == null || param.isBlank()) {
+      return null;
+    }
+
+    return param.strip();
+  }
+
+  @Override
+  public String generateUploadUrl(final String objectKey) {
+    return generatePresignedUrl(objectKey, "PUT", UPLOAD_EXPIRATION_SECONDS);
+  }
+
+  @Override
+  public String generateRetrieveUrl(final String objectKey) {
+    return generatePresignedUrl(objectKey, "GET", RETRIEVE_EXPIRATION_SECONDS);
+  }
+
+  // AWS Presigned URL Generation
+  private String generatePresignedUrl(final String objectKey, final String httpMethod, final int expirationSeconds) {
+    // Current time
+    long now = Instant.now().getEpochSecond();
+    String date = Instant.ofEpochSecond(now).atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    String timestamp = Instant.ofEpochSecond(now).atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"));
+
+    String endpoint = getEndpoint();
+    String credentialsScope = accessKeyId + "/" + date + "/" + bucketRegion + "/" + SERVICE + "/" + REQUEST_TYPE;
+
+    // Canonical request
+    String canonicalUri = "/" + objectKey;
+    String canonicalQueryString = "X-Amz-Algorithm=" + ALGORITHM +
+        "&X-Amz-Credential=" + urlEncode(credentialsScope) +
+        "&X-Amz-Date=" + timestamp +
+        "&X-Amz-Expires=" + expirationSeconds +
+        "&X-Amz-SignedHeaders=" + "host";
+    String canonicalHeaders = "host:" + endpoint + "\n";
+    String signedHeaders = "host";
+    String payloadHash = "UNSIGNED-PAYLOAD";
+    String canonicalRequest = httpMethod + "\n" +
+        canonicalUri + "\n" +
+        canonicalQueryString + "\n" +
+        canonicalHeaders + "\n" +
+        signedHeaders + "\n" +
+        payloadHash;
+
+    // String to sign
+    String stringToSign = ALGORITHM + "\n" +
+        timestamp + "\n" +
+        date + "/" + bucketRegion + "/" + SERVICE + "/" + REQUEST_TYPE + "\n" +
+        toHex(hash(canonicalRequest));
+
+    // Signing key
+    byte[] kSecret = ("AWS4" + secretAccessKey).getBytes();
+    byte[] kDate = hmacSha256(kSecret, date);
+    byte[] kRegion = hmacSha256(kDate, bucketRegion);
+    byte[] kService = hmacSha256(kRegion, SERVICE);
+    byte[] kSigning = hmacSha256(kService, REQUEST_TYPE);
+
+    // Signature
+    String signature = toHex(hmacSha256(kSigning, stringToSign));
+
+    // Construct URL
+    return "https://" + endpoint + "/" + objectKey +
+        "?" + canonicalQueryString +
+        "&X-Amz-Signature=" + signature;
+  }
+
+  private String getEndpoint() {
+    if (endpoint != null) {
+      return endpoint;
+    }
+
+    return bucketName + ".s3." + bucketRegion + ".amazonaws.com";
+  }
+
+  // Utility methods for hashing and URL encoding
+  private static byte[] hash(String data) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return digest.digest(data.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to compute hash", e);
+    }
+  }
+
+  private static byte[] hmacSha256(byte[] key, String data) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      SecretKeySpec secretKeySpec = new SecretKeySpec(key, "HmacSHA256");
+      mac.init(secretKeySpec);
+      return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to compute HMAC-SHA256", e);
+    }
+  }
+
+  private static String urlEncode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8)
+        .replace("+", "%20")
+        .replace("*", "%2A")
+        .replace("%7E", "~");
+  }
+
+  private static String toHex(byte[] bytes) {
+    StringBuilder result = new StringBuilder();
+    for (byte aByte : bytes) {
+      result.append(String.format("%02x", aByte));
+    }
+    return result.toString();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/shared/util/BuildOutputFiles.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/util/BuildOutputFiles.java
@@ -1,0 +1,33 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025-2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.shared.util;
+
+import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+
+public final class BuildOutputFiles {
+  private BuildOutputFiles() {
+  }
+
+  /**
+   * Returns whether the given file is an output file or not.
+   * @param fileName the file name to check
+   * @return true if it's an output file
+   */
+  public static boolean isOutputFile(final String fileName) {
+    return fileName.endsWith(".apk") || fileName.endsWith(".aab");
+  }
+
+  /**
+   * Returns the target name
+   * @return Android
+   */
+  public static String getTargetName() {
+    // This method is created for when iOS builds are available, to be able to change it to
+    //   Apple or iOS or something similar, based on an input param.
+    return YoungAndroidProjectNode.YOUNG_ANDROID_TARGET_ANDROID;
+  }
+
+}

--- a/appinventor/appengine/war/WEB-INF/appengine-web.xml
+++ b/appinventor/appengine/war/WEB-INF/appengine-web.xml
@@ -192,5 +192,15 @@
     <!-- https://example.com/something. -->
     <property name="ode.base" value="" />
 
+    <!-- Remote Storage Provider -->
+    <property name="remotestorage" value="" />
+
+    <!-- S3 Compatible Storage Configuration -->
+    <property name="remotestorage.s3.endpoint" value="" />
+    <property name="remotestorage.s3.bucketname" value="" />
+    <property name="remotestorage.s3.bucketregion" value="" />
+    <property name="remotestorage.s3.accesskeyid" value="" />
+    <property name="remotestorage.s3.secretaccesskey" value="" />
+
   </system-properties>
 </appengine-web-app>

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -48,6 +49,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
@@ -84,9 +86,9 @@ public class BuildServer {
     // of the build. The reporting is done by calling the callback URL
     // and putting the status inside a "build.status" file. This isn't
     // particularly efficient, but this is the version 0.9 implementation
-    String callbackUrlStr;
-    ProgressReporter(String callbackUrlStr) {
-      this.callbackUrlStr = callbackUrlStr;
+    URL callbackUrl;
+    ProgressReporter(URL callbackUrl) {
+      this.callbackUrl = callbackUrl;
     }
 
     public void report(int progress) {
@@ -100,7 +102,6 @@ public class BuildServer {
         zipoutput.flush();
         zipoutput.close();
         ByteArrayInputStream zipinput = new ByteArrayInputStream(output.toByteArray());
-        URL callbackUrl = new URL(callbackUrlStr);
         HttpURLConnection connection = (HttpURLConnection) callbackUrl.openConnection();
         connection.setDoOutput(true);
         connection.setRequestMethod("POST");
@@ -560,12 +561,14 @@ public class BuildServer {
     @QueryParam("callback") final String callbackUrlStr,
     @QueryParam("gitBuildVersion") final String gitBuildVersion,
     @QueryParam("ext") final String ext,
+    @QueryParam("uploadUrl") final String uploadUrlStr,
     final File inputZipFile) throws IOException {
     // Set the inputZip field so we can delete the input zip file later in
     // cleanUp.
     inputZip = inputZipFile;
     inputZip.deleteOnExit(); // In case build server is killed before cleanUp executes.
-    String requesting_host = (new URL(callbackUrlStr)).getHost();
+    final URL callbackUrl = new URL(callbackUrlStr);
+    String requesting_host = callbackUrl.getHost();
 
     //for the request for update part, the file should be empty
     if (inputZip.length() == 0L) {
@@ -621,10 +624,16 @@ public class BuildServer {
             try {
               LOG.info("START NEW BUILD " + count);
               checkMemory();
-              buildAndCreateZip(userName, inputZipFile, ext, new ProgressReporter(callbackUrlStr));
+              buildAndCreateZip(userName, inputZipFile, ext, new ProgressReporter(callbackUrl));
+
+              // Upload APK directly
+              if (uploadUrlStr != null && !uploadUrlStr.isBlank()) {
+                LOG.info("Uploading output to remote...");
+                uploadToRemoteAndTruncateOutput(uploadUrlStr, ext);
+              }
+
               // Send zip back to the callbackUrl
               LOG.info("CallbackURL: " + callbackUrlStr);
-              URL callbackUrl = new URL(callbackUrlStr);
               HttpURLConnection connection = (HttpURLConnection) callbackUrl.openConnection();
               connection.setDoOutput(true);
               connection.setRequestMethod("POST");
@@ -647,7 +656,8 @@ public class BuildServer {
               } finally {
                 bufferedOutputStream.close();
               }
-              if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {LOG.severe("Bad Response Code!: "+ connection.getResponseCode());
+              if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                LOG.severe("Bad Response Code!: "+ connection.getResponseCode());
                 // TODO(user) Maybe do some retries
               }
             } catch (Exception e) {
@@ -681,6 +691,143 @@ public class BuildServer {
     // number.
     return Response.ok().type(MediaType.TEXT_PLAIN_TYPE)
       .entity("" + 0).build();
+  }
+
+  private void uploadToRemoteAndTruncateOutput(final String uploadUrlStr, final String ext) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) new URL(uploadUrlStr).openConnection();
+    connection.setDoOutput(true);
+    connection.setRequestMethod("PUT");
+
+    if ("apk".equals(ext)) {
+      connection.addRequestProperty("Content-Type","application/vnd.android.package-archive");
+    } else if ("aab".equals(ext)) {
+      connection.addRequestProperty("Content-Type","application/vnd.android.bundle");
+    } else {
+      connection.addRequestProperty("Content-Type","application/zip");
+    }
+
+    connection.setConnectTimeout(60000);
+    connection.setReadTimeout(60000);
+    try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(connection.getOutputStream())) {
+      try (BufferedInputStream bufferedInputStream = new BufferedInputStream(new FileInputStream(outputApk))) {
+        ByteStreams.copy(bufferedInputStream, bufferedOutputStream);
+        checkMemory();
+        bufferedOutputStream.flush();
+      }
+    }
+
+    if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      LOG.severe("Failed to upload output: "+ connection.getResponseCode());
+      // If we fail to upload the output, use send it back to GAE as a fallback
+      return;
+    }
+
+    // Now we truncate the apk or aab inside
+    LOG.info("Truncating " + outputApk.getName());
+    truncateZipEntry(outputZip, outputApk.getName(), 0);
+  }
+
+  /**
+   * Truncates a specific entry within a ZIP file and updates the ZIP file in place.
+   *
+   * @param outputZip The path to the original ZIP file.
+   * @param entryToTruncateName The name of the entry within the ZIP file to truncate (e.g., "myApp.apk").
+   * @param maxSize The maximum size in bytes for the truncated entry.
+   * @throws IOException If an I/O error occurs during the process.
+   */
+  public static void truncateZipEntry(File outputZip, String entryToTruncateName, int maxSize) throws IOException {
+    LOG.info("Starting truncation process for entry: " + entryToTruncateName + " in ZIP: " + outputZip.getName());
+
+    // Create a temporary file for the new ZIP archive
+    File tempZipFile = File.createTempFile(outputZip.getName() + "_temp", ".zip");
+    LOG.info("Created temporary ZIP file: " + tempZipFile.getAbsolutePath());
+
+    ZipFile originalZipFile = null;
+    ZipOutputStream newZipOutputStream = null;
+
+    try {
+      originalZipFile = new ZipFile(outputZip);
+      newZipOutputStream = new ZipOutputStream(new FileOutputStream(tempZipFile));
+
+      Enumeration<? extends ZipEntry> entries = originalZipFile.entries();
+      boolean entryFoundAndProcessed = false;
+
+      // Iterate through all entries in the original ZIP file
+      while (entries.hasMoreElements()) {
+        ZipEntry entry = entries.nextElement();
+        String entryName = entry.getName();
+
+        // Check if this is the entry we need to truncate
+        if (entryName.equals(entryToTruncateName)) {
+          LOG.info("Found entry to truncate: " + entryName);
+          entryFoundAndProcessed = true;
+
+          // Create a new ZipEntry for the truncated content
+          // It's important to create a new ZipEntry as the original might have size/CRC info
+          ZipEntry newEntry = new ZipEntry(entryName);
+          newZipOutputStream.putNextEntry(newEntry);
+
+          try (InputStream is = originalZipFile.getInputStream(entry)) {
+            byte[] buffer = new byte[4096]; // Use a larger buffer for better performance
+            int totalRead = 0;
+            int bytesRead;
+
+            // Read from the input stream and write to the new ZIP entry, truncating as needed
+            while ((bytesRead = is.read(buffer)) != -1 && totalRead < maxSize) {
+              int toWrite = Math.min(bytesRead, maxSize - totalRead);
+              newZipOutputStream.write(buffer, 0, toWrite);
+              totalRead += toWrite;
+            }
+            LOG.info("Truncated '" + entryName + "' to " + totalRead + " bytes (max " + maxSize + " bytes).");
+          }
+          newZipOutputStream.closeEntry(); // Close the current entry in the new ZIP
+        } else {
+          // For all other entries, copy them directly to the new ZIP file
+          LOG.info("Copying entry: " + entryName);
+          newZipOutputStream.putNextEntry(new ZipEntry(entryName));
+          try (InputStream is = originalZipFile.getInputStream(entry)) {
+            byte[] buffer = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+              newZipOutputStream.write(buffer, 0, bytesRead);
+            }
+          }
+          newZipOutputStream.closeEntry(); // Close the current entry in the new ZIP
+        }
+      }
+
+      if (!entryFoundAndProcessed) {
+        LOG.info("Warning: Entry '" + entryToTruncateName + "' was not found in the original ZIP file.");
+      }
+
+    } finally {
+      // Ensure all streams and zip files are closed
+      if (newZipOutputStream != null) {
+        try {
+          newZipOutputStream.close();
+        } catch (IOException e) {
+          LOG.severe("Error closing new ZipOutputStream: " + e.getMessage());
+        }
+      }
+      if (originalZipFile != null) {
+        try {
+          originalZipFile.close();
+        } catch (IOException e) {
+          LOG.severe("Error closing original ZipFile: " + e.getMessage());
+        }
+      }
+    }
+
+    // Replace the original ZIP file with the temporary one
+    LOG.info("Replacing original ZIP file with the truncated version.");
+    if (outputZip.delete()) {
+      if (!tempZipFile.renameTo(outputZip)) {
+        throw new IOException("Failed to rename temporary ZIP file to original name: " + outputZip.getAbsolutePath());
+      }
+      LOG.info("Successfully updated ZIP file: " + outputZip.getName());
+    } else {
+      throw new IOException("Failed to delete original ZIP file: " + outputZip.getAbsolutePath());
+    }
   }
 
   private void buildAndCreateZip(String userName, File inputZipFile, String ext,

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/ProjectBuilder.java
@@ -227,12 +227,8 @@ public final class ProjectBuilder {
 
         if (success) {
           // Locate output file
-          String fileName = outputFileName;
-          if (fileName == null) {
-            fileName = project.getProjectName() + "." + ext;
-          }
           File outputFile = new File(projectRoot,
-              "build" + SEPARATOR + "deploy" + SEPARATOR + fileName);
+              "build" + SEPARATOR + "deploy" + SEPARATOR + outputFileName);
           if (!outputFile.exists()) {
             LOG.warning("Young Android build - " + outputFile + " does not exist");
           } else {


### PR DESCRIPTION
### Background

App Inventor currently uses Google Cloud Storage as the main storage solution for "large" objects, which is mainly build outputs. These large objects are built outside of Google App Engine, and sent back to get them stored in GCS. Then, GAE will proxy them to the user to download it.

This however implies quite a lot of network hops, and increases egress traffic costs: from the buildserver to GAE (if there is egress network charge), from GAE to GCS to get it stored, from GCS back to GAE when downloading it, and from GAE to the user. This last hop is the most expensive, as it charges $0.139 per GB transferred to the Internet.

With that in mind, it makes sense to allow the users to download the files directly, instead of going through GAE (which is also taking resources to load in memory that data).

### Description

This PR implements support for "Remote Storage" in App Inventor. It allows GAE to generate Presigned URLs in a 3P storage provider, and interact with files out there. It is mainly targeted to store build outputs outside of GAE, as these are the largest artifacts eating up the majority of the egress traffic.

This PR also removes the "build size" limitation. By directly letting the user download the output file from storage, we are no longer bound to GAE's request/response payload limits, so it can effectively "download" larger projects.

### Current Capabilities

* GAE has now support to configure "remote storage", which can be interacted using presigned URLs.
* Buildserver can now, optionally, receive an extra argument: `uploadUrl`. If provided, the output file (APK or AAB) gets uploaded there, instead of sent back to GAE.
    * It will still send back to GAE the ZIP file with the full structure, but the output file will be truncated to 0. This is needed to "acknowledge" the build, and make sure the target file in the remote storage can be identified.
* Implementation can be cloud-provider agnostic without any libraries: as of now, only S3 is implemented. However, this is S3-compatible and not vendor locked. Any S3 compatible storage provider can be used, as long as they support presigned URLs. Some examples are:
    * Cloud: MinIO, Blackblaze, Cloudflare R2, Hetzner
    * Self Hosted: MinIO, SeaweedFS

### Pending Items

* [ ] Allow sending exported projects (AIA) to remote storage.
* [ ] Implement GCS support, to avoid leaving Google Cloud.

### Testing

* Presigned URL generation works as intended.
* Locally built using remote storage some apps.
* Tested with both AWS S3 buckets ("native" S3), and Hetzer Object Storage buckets (S3 compatible)
