### PR TITLE
Make iOS report extension support during rendezvous

### DIFF
--- a/appinventor/aicompanionapp/src/ViewController.swift
+++ b/appinventor/aicompanionapp/src/ViewController.swift
@@ -246,6 +246,18 @@ public class ViewController: UINavigationController, UITextFieldDelegate {
       "os": form.Platform,
       "aid": phoneStatus.InstallationId(),
       "r2": "true",
+      "extensions": """
+      [
+      \"edu.mit.appinventor.ble\",
+      \"com.bbc.microbit.profile\",
+      \"edu.mit.appinventor.ai.personalimageclassifier\",
+      \"edu.mit.appinventor.ai.personalaudioclassifier\",
+      \"edu.mit.appinventor.ai.posenet\",
+      \"edu.mit.appinventor.ai.facemesh\",
+      \"edu.mit.appinventor.ai.teachablemachine\",
+      \"fun.microblocks.microblocks\"
+      ]
+      """,
       "useproxy": phoneStatus.UseProxy ? "true" : "false"
     ].map({ (key: String, value: String) -> String in
       return "\(key)=\(value)"

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -1517,6 +1517,10 @@ Blockly.ReplMgr.getFromRendezvous = function() {
                 rs.versionurl = 'http://' + json.ipaddr + ':8001/_getversion';
                 rs.baseurl = 'http://' + json.ipaddr + ':8001/';
                 rs.android = !(new RegExp('^i(pad)?os$').test((json.os || 'Android').toLowerCase()));
+                if (!rs.android && json.extensions) {
+                    // Newer iOS versions will report the extensions that they support
+                    top.ALLOWED_IOS_EXTENSIONS = JSON.parse(json.extensions);
+                }
                 if (!(rs.android) && Blockly.ReplMgr.hasDisallowedIosExtensions()) {
                     rs.dialog.hide();
                     top.ReplState.state = Blockly.ReplMgr.rsState.IDLE;


### PR DESCRIPTION
Change-Id: I73f89407964b25f6c35664a04c657b6f00572154

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR changes how extension support is enabled on iOS.

Currently, there is an AllowedIosExtensions object in the data store that includes a JSON serialized array of supported packages. However, this requires the server to know what the iOS companion can support.

With this change, the iOS companion will send an "extensions" field in the rendezvous payload, which will be used for checking extension support against the project extensions.

This means that the server no longer needs to be configured to know about iOS extensions and can be removed at a later point.