### PR TITLE
Add labels to the ChatBot helper blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -339,6 +339,7 @@ Blockly.Blocks['helpers_providermodel'] = {
 
     this.setOutput(true, utils.YailTypeToBlocklyType('text', utils.OUTPUT));
     this.appendDummyInput('INPUT')
+      .appendField(Blockly.Msg.LANG_CHATBOTMODEL_TITLE);
 
     this.addField();
   },
@@ -461,6 +462,7 @@ Blockly.Blocks['helpers_provider'] = {
 
     this.setOutput(true, utils.YailTypeToBlocklyType('text', utils.OUTPUT));
     this.appendDummyInput('INPUT')
+      .appendField(Blockly.Msg.LANG_CHATBOTPROVIDER_TITLE);
 
     this.addField();
   },

--- a/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
+++ b/appinventor/blocklyeditor/src/msg/ai_blockly/messages.json
@@ -806,6 +806,8 @@
 	"Blockly.Msg.LANG_SCREENS_TITLE": "Screen Name: ",
 	"Blockly.Msg.LANG_NO_ASSETS": "No available assets",
 	"Blockly.Msg.LANG_NO_PROVIDERMODEL": "No known models",
+	"Blockly.Msg.LANG_CHATBOTPROVIDER_TITLE": "ChatBot Provider",
+	"Blockly.Msg.LANG_CHATBOTMODEL_TITLE": "ChatBot Model",
 	"Blockly.Msg.SHOW_WARNINGS": "Show Warnings",
 	"Blockly.Msg.HIDE_WARNINGS": "Hide Warnings",
 	"Blockly.Msg.MISSING_SOCKETS_WARNINGS": "You should fill all of the sockets with blocks",


### PR DESCRIPTION
Change-Id: Ib66ffea150cbbd17e5821e6f9b1f4fb35d392352

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR adds labels to the ChatBot related helper blocks. The only way currently to tell the blocks apart is to parse the content of the dropdown and see if it contains a colon. Adding the labels makes determining the type of the block in screenshots a bit less effort.