### PR TITLE
File Cache API

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -292,9 +292,11 @@ public class Form extends AppInventorCompatActivity
   // FragmentActivity is added in future.
   public static final int MAX_PERMISSION_NONCE = 100000;
 
-  public FileCache fileCache;
+  private FileCache fileCache;
 
-
+  public FileCache getFileCache() {
+    return fileCache;
+  }
 
   public static class PercentStorageRecord {
     public enum Dim {
@@ -335,7 +337,7 @@ public class Form extends AppInventorCompatActivity
     super.onCreate(icicle);
 
     if (fileCache == null) {
-      this.fileCache = new FileCache(new java.io.File(this.getCacheDir(), "file_cache"));
+      this.fileCache = new FileCache(this);
     }
 
     // This version is for production apps. See {@link ReplForm#onCreate} for the REPL version,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [X] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [X] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

### Description

This PR introduces a **File Cache API** that lets components and extensions download, cache, and reuse large external assets (e.g., ML model files, language libraries) directly on the device. Removing the need to bundle them in the APK and allowing for offline use after the initial fetch.

### Highlights
| Feature | Details |
|---------|---------|
| **Utility class** | `com.google.appinventor.components.runtime.util.FileCache` |
| **Lifecycle** | A single `FileCache` instance is attached to the `Form` (`form.fileCache`) to avoid collisions with other cache uses. |
| **registerFile(path, url)** | Asynchronously downloads the asset at *url* into *cacheDir/path* (no-op if already cached). Returns `CompletableFuture<Void>` so callers can await completion or launch multiple downloads in parallel without blocking the UI. |
| **getFile(path)** | Returns `CompletableFuture<File>` that resolves once the asset is present, transparently waiting if the file is still downloading. |
| **resetCache()** | Clears the cache sub-directory. Use if widespread corruption is detected (e.g., interrupted downloads while offline). |
| **Implementation notes** | Leverages `FileUtil.downloadUrlToFile`; avoids I/O on the main thread and keeps downloads independent. |

### Typical usage
```java
// Cache a model the first time the app launches
this.form.fileCache.registerFile("models/myModel.tflite",
    "https://example.com/models/myModel.tflite");

// Later, retrieve and use the cached file
File model = this.form.fileCache.getFile("models/myModel.tflite").get()
```
   
This mechanism allows for features such as Teachable LLM and similar tools that rely on assets too large to ship inside an extension, while preserving users’ ability to run the app offline after the initial download. 

<!-- If this fixes a known issue, please note it here (otherwise, delete) --> <!-- If this resolves an enhancement/feature request issue, please note it here (otherwise, delete) -->

### Resolves [#3533](https://github.com/mit-cml/appinventor-sources/issues/3533)