### PR TITLE
Conditionally ask for READ_MEDIA permissions if declared

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/FileOperation.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/FileOperation.java
@@ -287,9 +287,15 @@ public abstract class FileOperation implements Runnable, PermissionResultHandler
           && file.getScope() == FileScope.Shared && accessMode == FileAccessMode.READ) {
         // READ_EXTERNAL_STORAGE was migrated into finer-grained permissions in SDK 33
         neededPermissions.remove(READ_EXTERNAL_STORAGE);
-        neededPermissions.add(READ_MEDIA_AUDIO);
-        neededPermissions.add(READ_MEDIA_IMAGES);
-        neededPermissions.add(READ_MEDIA_VIDEO);
+        if (form.doesAppDeclarePermission(READ_MEDIA_AUDIO)) {
+          neededPermissions.add(READ_MEDIA_AUDIO);
+        }
+        if (form.doesAppDeclarePermission(READ_MEDIA_IMAGES)) {
+          neededPermissions.add(READ_MEDIA_IMAGES);
+        }
+        if (form.doesAppDeclarePermission(READ_MEDIA_VIDEO)) {
+          neededPermissions.add(READ_MEDIA_VIDEO);
+        }
       }
       return this;
     }


### PR DESCRIPTION
Change-Id: I77f1487c242ffd7a67df2605e6590291a9fb6b0e

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR fixes an issue where file operations may still ask for READ_MEDIA permissions even if the app doesn't declare them (due to removal of those perms in a previous commit). This change conditionally adds the READ_MEDIA permissions if the app actually has them declared, otherwise it does nothing. In apps without these permissions, a read may fail if the permission is needed, in which case the user will need to add the corresponding permission block to their app (but this would have already been true of ucr since the app didn't have the requisite permission in any case), and only affects apps on Tiramisu or higher.