### PR TITLE
Fix notifier console not scrolling

### DIFF
--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3478,6 +3478,7 @@ div.dropdiv p {
 #aiConsolePanel {
   height: 100%;
   background-color: white;
+  overflow-y: scroll;
 }
 
 #aiConsolePanel .Warning {


### PR DESCRIPTION
Change-Id: Ia0e216ce42af20a324b59025067452cf7ffac2e1

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

When the Notifier log functions are used frequently, they'll overflow the console <div> in the UI. Currently, the browser will clip the messages. This changes the CSS so that the div is scrollable so users can view the remainder of the logs.