### PR TITLE
Fix iOS spreadsheet authentication

### DIFF
--- a/appinventor/components-ios/src/Spreadsheet.swift
+++ b/appinventor/components-ios/src/Spreadsheet.swift
@@ -12,7 +12,6 @@ import GoogleAPIClientForREST
   private var _service = GTLRSheetsService()
   fileprivate var _columns: NSArray = []
   private let _workQueue = DispatchQueue(label: "Spreadsheet", qos: .userInitiated)
-  private var _initialized = false
   private var _spreadsheetId = ""
   // This gets changed to the name of the project by MockSpreadsheet by default
   private var _sheetIdDict: [String: Int] = [:]
@@ -43,7 +42,6 @@ import GoogleAPIClientForREST
   // MARK: Methods
   
   @objc func Initialize() {
-    _initialized = true
     authorize()
   }
   
@@ -1422,9 +1420,6 @@ import GoogleAPIClientForREST
   
   // process credentials and authorize user
   private func authorize() {
-    guard _initialized else {
-      return
-    }
     guard !CredentialsJson.isEmpty else {
       _service.authorizer = nil
       return


### PR DESCRIPTION
- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
When the iOS Spreadsheet component is initialized, it calls authenticate(), which sets the flag _initialized to true. At this point, the CredentialsJson property does not appear to have been set. When it is set, authenticate() is called again, but since the flag is set, it returns without authenticating.

As a result, calls to the Google sheet from Screen.Initialize fail as access denied.

I have removed the _initialized flag entirely, since it seems like authenticate() should run at any time the credentials property is set. I don't know what this check was intended to protect against, however. This change should have a sanity check.


Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3543  .
