### PR TITLE
Added @UsesFeatures annotation

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/context/ComponentInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/context/ComponentInfo.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2024 MIT, All rights reserved
+// Copyright 2021-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -37,6 +37,7 @@ public class ComponentInfo {
   private final ConcurrentMap<String, Set<String>> servicesNeeded;
   private final ConcurrentMap<String, Set<String>> contentProvidersNeeded;
   private final ConcurrentMap<String, Set<String>> xmlsNeeded;
+  private final ConcurrentMap<String, Set<String>> featuresNeeded;
 
   private Set<String> uniqueLibsNeeded;
   private AARLibraries explodedAarLibs;
@@ -60,6 +61,7 @@ public class ComponentInfo {
     servicesNeeded = new ConcurrentHashMap<>();
     contentProvidersNeeded = new ConcurrentHashMap<>();
     xmlsNeeded = new ConcurrentHashMap<>();
+    featuresNeeded = new ConcurrentHashMap<>();
 
     uniqueLibsNeeded = Sets.newHashSet();
   }
@@ -141,6 +143,10 @@ public class ComponentInfo {
     return xmlsNeeded;
   }
 
+  public ConcurrentMap<String, Set<String>> getFeaturesNeeded() {
+    return featuresNeeded;
+  }
+
   @Override
   public String toString() {
     return "JsonInfo{"
@@ -154,6 +160,7 @@ public class ComponentInfo {
         + ", componentBroadcastReceiver=" + componentBroadcastReceiver
         + ", uniqueLibsNeeded=" + uniqueLibsNeeded
         + ", xmlsNeeded=" + xmlsNeeded
+        + ", featuresNeeded=" + featuresNeeded
         + '}';
   }
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2023 MIT, All rights reserved
+// Copyright 2021-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -27,6 +27,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -105,6 +106,17 @@ public class CreateManifest implements AndroidTask {
         } else {
           // We actually require wifi
           out.write("  <uses-feature android:name=\"android.hardware.wifi\" />\n");
+        }
+      }
+
+      final Map<String, Set<String>> featuresNeeded = context.getComponentInfo().getFeaturesNeeded();
+      if (!featuresNeeded.isEmpty()) {
+        final Set<String> uniqueFeatures = new HashSet<>();
+        for (Map.Entry<String, Set<String>> componentSubElSetPair : featuresNeeded.entrySet()) {
+          uniqueFeatures.addAll(componentSubElSetPair.getValue());
+        }
+        for (String feature : uniqueFeatures) {
+          out.write(feature);
         }
       }
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2024 MIT, All rights reserved
+// Copyright 2021-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -70,7 +70,8 @@ public class LoadComponentInfo implements CommonTask {
         || !this.generatePermissions()
         || !this.generateQueries()
         || !this.generateServices()
-        || !this.generateXmls()) {
+        || !this.generateXmls()
+        || !this.generateFeatures()) {
       return TaskResult.generateError("Could not extract info from the app");
     }
 
@@ -273,6 +274,28 @@ public class LoadComponentInfo implements CommonTask {
     }
 
     context.getReporter().log("Component xmls needed, n = " + n);
+    return true;
+  }
+
+  /**
+   * Generate a set of conditionally included uses-features needed by this project.
+   */
+  private boolean generateFeatures() {
+    try {
+      loadJsonInfo(context.getComponentInfo().getFeaturesNeeded(),
+              ComponentDescriptorConstants.FEATURES_TARGET);
+    } catch (IOException | JSONException e) {
+      // This is fatal.
+      context.getReporter().error("There was an error in the Features stage", true);
+      return false;
+    }
+
+    int n = 0;
+    for (String type : context.getComponentInfo().getFeaturesNeeded().keySet()) {
+      n += context.getComponentInfo().getFeaturesNeeded().get(type).size();
+    }
+
+    context.getReporter().log("Component features needed, n = " + n);
     return true;
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/annotations/UsesFeatures.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/UsesFeatures.java
@@ -1,0 +1,30 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations;
+
+import com.google.appinventor.components.annotations.androidmanifest.FeatureElement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares hardware or software features that is used by a component.
+ *
+ * @author https://github.com/jewelshkjony (Jewel Shikder Jony)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface UsesFeatures {
+
+    /**
+     * The values of the features (as an array)
+     *
+     * @return the array of elements data
+     */
+    FeatureElement[] features();
+}

--- a/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/FeatureElement.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/FeatureElement.java
@@ -1,0 +1,54 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations.androidmanifest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to describe an <uses-feature> element required by a component
+ * so that it can be added to AndroidManifest.xml.
+ *
+ * @author https://github.com/jewelshkjony (Jewel Shikder Jony)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FeatureElement {
+
+    /**
+     * Specifies a single hardware or software feature used by the application as a descriptor string.
+     * Valid attribute values are listed in the
+     * <a href="https://developer.android.com/guide/topics/manifest/uses-feature-element#hw-features">Hardware features</a>
+     * and <a href="https://developer.android.com/guide/topics/manifest/uses-feature-element#sw-features">Software features</a> sections.
+     * These attribute values are case-sensitive.
+     *
+     * @return the name of the element
+     */
+    String name();
+
+    /**
+     * Boolean value that indicates whether the application requires the featureContents of the xml file.
+     * Declaring true for a feature indicates that the application can't function,
+     * or isn't designed to function, when the specified feature isn't present on the device.
+     * Declaring false for a feature indicates that the application uses the feature if present on the device,
+     * but that it is designed to function without the specified feature if necessary.
+     *
+     * @return Returns true if required otherwise false
+     */
+    boolean required() default true;
+
+    /**
+     * The OpenGL ES version required by the application. The higher 16 bits represent the major
+     * number and the lower 16 bits represent the minor number. For example, to specify OpenGL
+     * ES version 2.0, you set the value as "0x00020000", or to specify OpenGL ES 3.2,
+     * you set the value as "0x00030002".
+     *
+     * @return the glEs version
+     */
+    int glEsVersion() default -1;
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2011-2024 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -33,6 +33,7 @@ public final class ComponentDescriptorConstants {
   public static final String ANDROIDMINSDK_TARGET = "androidMinSdk";
   public static final String CONDITIONALS_TARGET = "conditionals";
   public static final String XMLS_TARGET = "xmls";
+  public static final String FEATURES_TARGET = "features";
 
   // TODO(Will): Remove the following target once the deprecated
   //             @SimpleBroadcastReceiver annotation is removed. It should

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2024 MIT, All rights reserved
+// Copyright 2011-2025 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -89,6 +89,7 @@ public final class ComponentListGenerator extends ComponentProcessor {
     appendComponentInfo(json, ComponentDescriptorConstants.CONTENT_PROVIDERS_TARGET,
         component.contentProviders);
     appendComponentInfo(json, ComponentDescriptorConstants.XMLS_TARGET, component.xmls);
+    appendComponentInfo(json, ComponentDescriptorConstants.FEATURES_TARGET, component.features);
     appendConditionalComponentInfo(component, json);
     // TODO(Will): Remove the following call once the deprecated
     //             @SimpleBroadcastReceiver annotation is removed. It should


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Added the ability to declare <[uses-features](https://developer.android.com/guide/topics/manifest/uses-feature-element)> element in AndroidManifest.xml.

Example usage # .

```
@UsesFeatures(features = {
  @FeatureElement(name = "android.hardware.bluetooth", required = false),
  @FeatureElement(name = "android.hardware.wifi", required = true),
  @FeatureElement(name = "android.hardware.camera", required = false)
})
```

Resolves # .
