### PR TITLE
Match iOS errors in LocationSensor to Android behavior

### DIFF
--- a/appinventor/components-ios/src/LocationSensor.swift
+++ b/appinventor/components-ios/src/LocationSensor.swift
@@ -217,7 +217,7 @@ open class LocationSensor: NonvisibleComponent, CLLocationManagerDelegate, Lifec
         print("Error geocoding address: \(error.localizedDescription)")
         // Note in theory we could have a single error here, but the Android version will produce an error for each dimension.
         self._form?.dispatchErrorOccurredEvent(self, "LatitudeFromAddress", ErrorMessage.ERROR_LOCATION_SENSOR_LATITUDE_NOT_FOUND, address)
-        self._form?.dispatchErrorOccurredEvent(self, "LongitudeFromAddress", ErrorMessage.ERROR_LOCATION_SENSOR_LATITUDE_NOT_FOUND, address)
+        self._form?.dispatchErrorOccurredEvent(self, "LongitudeFromAddress", ErrorMessage.ERROR_LOCATION_SENSOR_LONGITUDE_NOT_FOUND, address)
         // Trigger the GotLocation event with default/fallback values
         self.GotLocationFromAddress(address, LocationSensor.UNKNOWN_VALUE, LocationSensor.UNKNOWN_VALUE)
         return


### PR DESCRIPTION
Change-Id: I0c894834f796447d5105315408ead03ab77b52c2

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes an incosistency reported on the community where the Android version reports a location sensor error via the ErrorOccurred event when it cannot geocode an address and the iOS version doesn't. Because of the way the Geocode method is implemented, two errors are actually raised (one for latitude and one for longitude). I chose to keep this behavior on iOS even though it may be more appropriate to just report a single error.