### PR TITLE
Improve error handling in iOS Web component

### DIFF
--- a/appinventor/components-ios/src/ErrorMessages.swift
+++ b/appinventor/components-ios/src/ErrorMessages.swift
@@ -59,6 +59,7 @@ import Foundation
   case ERROR_WEB_XML_TEXT_DECODE_FAILED = 1115
   case ERROR_WEB_REQUEST_TIMED_OUT = 1117
   case ERROR_WEB_JSON_TEXT_ENCODE_FAILED = 1118
+  case ERROR_WEB_UNKNOWN_ERROR = 1119
 
   // Camcorder Errors
   case ERROR_CAMCORDER_NO_CLIP_RETURNED = 1201
@@ -262,6 +263,8 @@ import Foundation
       return "Took longer than timeout period to receive data from the URL: %s"
     case .ERROR_WEB_JSON_TEXT_ENCODE_FAILED:
       return "Unable to encode as JSON the object %@"
+    case .ERROR_WEB_UNKNOWN_ERROR:
+      return "Unknown Web error: %s"
 
     // Camcorder Errors
     case .ERROR_CAMCORDER_NO_CLIP_RETURNED:

--- a/appinventor/components-ios/src/Web.swift
+++ b/appinventor/components-ios/src/Web.swift
@@ -178,6 +178,9 @@ open class Web: NonvisibleComponent {
       request.httpMethod = httpVerb
       request.httpBody = Data(base64Encoded: postFile)
     }
+    if webProps.timeout > 0 {
+      request.timeoutInterval = Double(webProps.timeout) / 1000.0
+    }
     request.allHTTPHeaderFields = webProps.requestHeaders.mapValues({ (items) -> String in
       return items.joined(separator: ", ")
     })
@@ -213,11 +216,16 @@ open class Web: NonvisibleComponent {
         }
       } else if let error = error {
         NSLog("Got error during URL fetch: \(error.localizedDescription)")
-        if (error as NSError).code == URLError.timedOut.rawValue {
+        let errorCode = (error as NSError).code
+        if errorCode == URLError.timedOut.rawValue || errorCode == URLError.cannotConnectToHost.rawValue || errorCode == URLError.notConnectedToInternet.rawValue {
           DispatchQueue.main.async {
             self.TimedOut(webProps.urlString as NSString)
             self._form?.dispatchErrorOccurredEvent(self, httpVerb,
                 ErrorMessage.ERROR_WEB_REQUEST_TIMED_OUT.code, webProps.urlString)
+          }
+        } else {
+          DispatchQueue.main.async {
+            self._form?.dispatchErrorOccurredEvent(self, httpVerb, ErrorMessage.ERROR_WEB_UNKNOWN_ERROR, error.localizedDescription)
           }
         }
       }


### PR DESCRIPTION
Change-Id: I28437c483ed09800193b2c2471af3d97a4b31ddd

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes an issue where most Web related errors on iOS are eaten by the error handler. We only ever checked specifically for a Timeout error and then dropped the others. I mapped a few additional error conditions that might reasonably be considered timeouts to that particular handler and all other errors will now go to ErrorOccurred rather than silently disappearing.