### PR TITLE
Harmonize first responder among different TextBoxBase implementations

### DIFF
--- a/appinventor/components-ios/src/EmailPicker.swift
+++ b/appinventor/components-ios/src/EmailPicker.swift
@@ -124,6 +124,10 @@ class EmailPickerAdapter: NSObject, AbstractMethodsForTextBox, UITextFieldDelega
       _field.selectedTextRange = _field.textRange(from: offset, to: offset)
     }
   }
+
+  var responder: UIResponder {
+    _field
+  }
 }
 
 protocol EmailPickerProtocol: UITextFieldDelegate, UITableViewDataSource, UITableViewDelegate {

--- a/appinventor/components-ios/src/PasswordTextBox.swift
+++ b/appinventor/components-ios/src/PasswordTextBox.swift
@@ -155,6 +155,10 @@ class PasswordTextBoxAdapter: NSObject, AbstractMethodsForTextBox, UITextFieldDe
       _field.selectedTextRange = _field.textRange(from: offset, to: offset)
     }
   }
+
+  var responder: UIResponder {
+    _field
+  }
 }
 
 open class PasswordTextBox: TextBoxBase {

--- a/appinventor/components-ios/src/TextBox.swift
+++ b/appinventor/components-ios/src/TextBox.swift
@@ -41,7 +41,11 @@ class TextBoxAdapter: NSObject, TextBoxDelegate {
     // we want to be able to force unwrap
     text = ""
   }
-  
+
+  public var responder: UIResponder {
+    _multiLine ? _view : _field
+  }
+
   private func setupView() {
     // Set up the minimum size constraint for the UITextView
     let heightConstraint = _view.heightAnchor.constraint(greaterThanOrEqualToConstant: 20)
@@ -325,10 +329,5 @@ open class TextBox: TextBoxBase {
     set(multiLine) {
       _adapter.multiLine = multiLine
     }
-  }
-
-  // MARK: TextBox Methods
-  @objc public func HideKeyboard() {
-    _adapter._view.resignFirstResponder()
   }
 }

--- a/appinventor/components-ios/src/TextBoxBase.swift
+++ b/appinventor/components-ios/src/TextBoxBase.swift
@@ -14,6 +14,7 @@ public protocol AbstractMethodsForTextBox: AbstractMethodsForViewComponent {
   var placeholderColor: Int32 { get set }
   var text: String? { get set }
   var readOnly: Bool { get set }
+  var responder: UIResponder { get }
   func textFieldDidBeginEditing(_ textField: UITextField)
   func textFieldDidEndEditing(_ textfield: UITextField)
   func setTextbase(_ base: TextBoxBase)
@@ -308,9 +309,13 @@ open class TextBoxBase: ViewComponent, UITextViewDelegate, AccessibleComponent {
   }
 
   @objc open func RequestFocus() {
-    _delegate?.view.becomeFirstResponder()
+    _delegate.responder.becomeFirstResponder()
   }
-  
+
+  @objc open func HideKeyboard() {
+    _delegate.responder.resignFirstResponder()
+  }
+
   // MARK: TextboxBase Events
   @objc open func GotFocus() {
     EventDispatcher.dispatchEvent(of: self, called: "GotFocus")


### PR DESCRIPTION
Change-Id: Ia253e8dfa1d3247a855ab23d01401cd001bd7439

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes #3523. In particular, it makes sense that all of the focus management can be in the TextBoxBase class and then the subclass adapters simply have to report what view to route the first responder messages to. Note that technically PasswordTextBox and EmailPicker do not provide the HideKeyboard method, but if we ever provide that block then iOS will support it automatically.