### PR TITLE
Remove unnecessary locking in Crypters

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/OdeAuthFilter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/OdeAuthFilter.java
@@ -374,13 +374,16 @@ public class OdeAuthFilter implements Filter {
   }
 
   private static Crypter getCrypter() throws KeyczarException {
+    if (crypter != null) {
+      return crypter;
+    }
+
     synchronized(crypterSync) {
-      if (crypter != null) {
-        return crypter;
-      } else {
+      if (crypter == null) {
         crypter = new Crypter(sessionKeyFile.get());
-        return crypter;
       }
+
+      return crypter;
     }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/GalleryToken.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/GalleryToken.java
@@ -59,13 +59,16 @@ public class GalleryToken {
 
 
   private static Crypter getCrypter() throws KeyczarException {
+    if (crypter != null) {
+      return crypter;
+    }
+
     synchronized(crypterSync) {
-      if (crypter != null) {
-        return crypter;
-      } else {
+      if (crypter == null) {
         crypter = new Crypter(galleryKeyFile.get());
-        return crypter;
       }
+
+      return crypter;
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

This PR removes an unnecessary `syncronized` call (effectively removing locking) from the `OdeAuthFilter` and `GalleryToken` classes.

The interesting change is on `OdeAuthFilter`, which was being used as the authentication filter through the following stacktrace: `getCrypter` <- `getUserInfo` <- `doFilter`. In the previous implementation, even though the `crypter` was initialized, getting a reference to it was effectively single-threaded, but it is actually just used for a singleton initialization.  
By instead adding the extra null check outside the `syncronized` block, we achieve yielding the initialized `crypter` without making this method single threaded when not needed.