### PR TITLE
Add 'ui' query parameter to control UI via URL

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1380,6 +1380,12 @@ public class Ode implements EntryPoint {
    * @return true if the user has opted to use a dark theme, false otherwise
    */
   public static boolean getUserDarkThemeEnabled() {
+    String override = Window.Location.getParameter("ui");
+    if (override != null && override.contains("light")) {
+      return false;
+    } else if (override != null && override.contains("dark")) {
+      return true;
+    }
     String value = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS)
             .getPropertyValue(SettingsConstants.DARK_THEME_ENABLED);
     if (value == null) {
@@ -1416,6 +1422,12 @@ public class Ode implements EntryPoint {
    * @return true if the user has opted to use the new UI, false otherwise
    */
   public static boolean getUserNewLayout() {
+    String override = Window.Location.getParameter("ui");
+    if (override != null && override.contains("classic")) {
+      return false;
+    } else if (override != null && override.contains("neo")) {
+      return true;
+    }
     String value = userSettings.getSettings(SettingsConstants.USER_GENERAL_SETTINGS)
             .getPropertyValue(SettingsConstants.USER_NEW_LAYOUT);
     return Boolean.parseBoolean(value);
@@ -1725,7 +1737,7 @@ public class Ode implements EntryPoint {
       }
       return null;
     });
-    if (getShowUIPicker()) {
+    if (getShowUIPicker() && Ode.getUserNewLayout()) {
       TutorialPopup popup = new TutorialPopup(MESSAGES.neoWelcomeMessage(), () -> {
         setUserNewLayout(false);
         saveUserDesignSettings();

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/Urls.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/Urls.java
@@ -52,7 +52,7 @@ public final class Urls {
    * @return the new URI to redirect to
    */
   public static String makeUri(String base, boolean hasParam) {
-    String[] params = new String[] { "locale", "repo", "galleryId" };
+    String[] params = new String[] { "locale", "repo", "galleryId", "ui" };
     String separator = "?";
     if (hasParam) {
       separator = "&";

--- a/appinventor/appengine/src/com/google/appinventor/server/LoginServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/LoginServlet.java
@@ -124,6 +124,7 @@ public class LoginServlet extends HttpServlet {
     String redirect = params.get("redirect");
     String autoload = params.get("autoload");
     String newGalleryId = params.get("ng");
+    String uiPreference = params.get("ui");
 
     if (DEBUG) {
       LOG.info("locale = " + locale + " bundle: " + new Locale(locale));
@@ -178,6 +179,7 @@ public class LoginServlet extends HttpServlet {
         .add("repo", repo)
         .add("autoload", autoload)
         .add("ng", newGalleryId)
+        .add("ui", uiPreference)
         .add("galleryId", galleryId).build();
       resp.sendRedirect(uri);
       return;
@@ -190,6 +192,7 @@ public class LoginServlet extends HttpServlet {
           .add("ng", newGalleryId)
           .add("galleryId", galleryId)
           .add("autoload", autoload)
+          .add("ui", uiPreference)
           .add("redirect", redirect).build();
         resp.sendRedirect(uri);
         return;
@@ -210,6 +213,7 @@ public class LoginServlet extends HttpServlet {
               .add("ng", newGalleryId)
               .add("galleryId", galleryId)
               .add("autoload", autoload)
+              .add("ui", uiPreference)
               .add("redirect", redirect).build();
             resp.sendRedirect(uri);
             return;
@@ -338,6 +342,7 @@ public class LoginServlet extends HttpServlet {
         .add("ng", newGalleryId)
         .add("galleryId", galleryId)
         .add("autoload", autoload)
+        .add("ui", uiPreference)
         .add("redirect", redirect).build();
       resp.sendRedirect(uri);   // This should bring up App Inventor
       return;
@@ -365,6 +370,7 @@ public class LoginServlet extends HttpServlet {
     req.setAttribute("repo", repo);
     req.setAttribute("locale", locale);
     req.setAttribute("ng", newGalleryId);
+    req.setAttribute("ui", uiPreference);
     req.setAttribute("galleryId", galleryId);
     try {
       req.getRequestDispatcher("/login.jsp").forward(req, resp);
@@ -399,6 +405,7 @@ public class LoginServlet extends HttpServlet {
     String newGalleryId = params.get("ng");
     String redirect = params.get("redirect");
     String autoload = params.get("autoload");
+    String uiPreference = params.get("ui");
 
     if (locale == null) {
       locale = "en";
@@ -454,6 +461,7 @@ public class LoginServlet extends HttpServlet {
         .add("repo", repo)
         .add("autoload", autoload)
         .add("ng", newGalleryId)
+        .add("ui", uiPreference)
         .add("galleryId", galleryId).build();
       resp.sendRedirect(uri);   // Logged in, go to service
       return;
@@ -505,6 +513,7 @@ public class LoginServlet extends HttpServlet {
       .add("autoload", autoload)
       .add("repo", repo)
       .add("ng", newGalleryId)
+      .add("ui", uiPreference)
       .add("galleryId", galleryId).build();
     resp.sendRedirect(uri);
   }

--- a/appinventor/appengine/src/com/google/appinventor/server/TosServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/TosServlet.java
@@ -36,7 +36,7 @@ public class TosServlet extends OdeServlet {
   private static final Flag<String> initialRedirectionUrl =
       Flag.createFlag("initial.redirection.url", "/");
 
-  private static final String[] PARAMS = new String[] { "locale", "repo", "galleryId" };
+  private static final String[] PARAMS = new String[] { "locale", "repo", "galleryId", "ui" };
 
   @Override
   public void doPost(HttpServletRequest req, HttpServletResponse resp)

--- a/appinventor/appengine/war/login.jsp
+++ b/appinventor/appengine/war/login.jsp
@@ -12,6 +12,7 @@
    String autoload = StringEscapeUtils.escapeHtml4((String) request.getAttribute("autoload"));
    String galleryId = StringEscapeUtils.escapeHtml4((String) request.getAttribute("galleryId"));
    String newGalleryId = StringEscapeUtils.escapeHtml4(request.getParameter("ng"));
+   String uiPreference = StringEscapeUtils.escapeHtml4(request.getParameter("ui"));
    if (locale == null) {
        locale = "en";
    }
@@ -57,6 +58,10 @@ out.println("<center><font color=red><b>" + error + "</b></font></center><br/>")
    if (newGalleryId != null && !newGalleryId.equals("")) {
    %>
 <input type=hidden name=ng value="<%= newGalleryId %>">
+<% }
+   if (uiPreference != null && !uiPreference.equals("")) {
+   %>
+<input type=hidden name=ui value="<%= uiPreference %>">
 <% } %>
 <% if (redirect != null && !redirect.equals("")) {
    %>
@@ -74,6 +79,7 @@ out.println("<center><font color=red><b>" + error + "</b></font></center><br/>")
                               .add("repo", repo)
                               .add("galleryId", galleryId)
                               .add("ng", newGalleryId)
+                              .add("ui", uiPreference)
                               .add("redirect", redirect).build() %>" style="text-decoration:none;">Click Here to use your Google Account to login</a></p></center>
 <%    } %>
 <footer>
@@ -82,12 +88,14 @@ out.println("<center><font color=red><b>" + error + "</b></font></center><br/>")
                            .add("repo", repo)
                            .add("autoload", autoload)
                            .add("galleryId", galleryId)
+                           .add("ui", uiPreference)
                            .add("redirect", redirect).build() %>"  style="text-decoration:none;" >中文</a>&nbsp;
 <a href="<%= new UriBuilder("/login")
                            .add("locale", "pt")
                            .add("repo", repo)
                            .add("autoload", autoload)
                            .add("galleryId", galleryId)
+                           .add("ui", uiPreference)
                            .add("redirect", redirect).build() %>"  style="text-decoration:none;" >Português</a>&nbsp;
 <a href="<%= new UriBuilder("/login")
                    .add("locale", "en")
@@ -95,6 +103,7 @@ out.println("<center><font color=red><b>" + error + "</b></font></center><br/>")
                    .add("autoload", autoload)
                    .add("galleryId", galleryId)
                    .add("ng", newGalleryId)
+                   .add("ui", uiPreference)
                    .add("redirect", redirect).build() %>"  style="text-decoration:none;" >English</a></center>
 <p></p>
 <center>


### PR DESCRIPTION
This change adds support for a `ui` parameter in the query string to force a particular UI regardless of the user settings. Any combination of classic, neo, light, and dark can be used:

* classic: Force the classic theme, but user-defined light/dark setting
* neo: Force the classic theme, but user-defined light/dark setting
* classic-light: Force light classic theme
* classic-dark: Force dark classic theme
* neo-light: Force light neo theme
* neo-dark: Force dark neo theme

Change-Id: I4cb8fd9854bb4983806076bb5a3a33224efd18fd

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR implements a feature request from an instructor to allow the URL query parameters to control the UI selection to standardize teaching materials, etc. It may need an adjustment to the login server to pass through the new `ui` parameter.