### PR TITLE
Fix Header Alignment on AdminUserList Page

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/AdminUserList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/AdminUserList.java
@@ -93,7 +93,7 @@ public class AdminUserList extends Composite {
 
     // Initialize UI
     table = new Grid(1, 4); // The table initially contains just the header row.
-    table.addStyleName("ode-ProjectTable");
+    table.addStyleName("ode-AdminUserListTable");
     table.setWidth("100%");
     table.setCellSpacing(0);
     nameSortIndicator = new Label("");
@@ -144,30 +144,30 @@ public class AdminUserList extends Composite {
    *
    */
   private void setHeaderRow() {
-    table.getRowFormatter().setStyleName(0, "ode-ProjectHeaderRow");
+    table.getRowFormatter().setStyleName(0, "ode-AdminUserListHeaderRow");
 
     HorizontalPanel emailHeader = new HorizontalPanel();
     final Label emailHeaderLabel = new Label("User Email");
-    emailHeaderLabel.addStyleName("ode-ProjectHeaderLabel");
+    emailHeaderLabel.addStyleName("ode-AdminUserListLabel");
     emailHeader.add(emailHeaderLabel);
     emailHeader.add(nameSortIndicator);
     table.setWidget(0, 0, emailHeader);
 
     HorizontalPanel uidHeader = new HorizontalPanel();
     final Label uidHeaderLabel = new Label("UID");
-    uidHeaderLabel.addStyleName("ode-ProjectHeaderLabel");
+    uidHeaderLabel.addStyleName("ode-AdminUserListLabel");
     uidHeader.add(uidHeaderLabel);
     table.setWidget(0, 1, uidHeader);
 
     HorizontalPanel adminHeader = new HorizontalPanel();
     final Label adminHeaderLabel = new Label("isAdmin?");
-    adminHeaderLabel.addStyleName("ode-ProjectHeaderLabel");
+    adminHeaderLabel.addStyleName("ode-AdminUserListLabel");
     adminHeader.add(adminHeaderLabel);
     table.setWidget(0, 2, adminHeader);
 
     HorizontalPanel visitedHeader = new HorizontalPanel();
     final Label visitedLabel = new Label("Visited");
-    visitedLabel.addStyleName("ode-ProjectHeaderLabel");
+    visitedLabel.addStyleName("ode-AdminUserListLabel");
     visitedHeader.add(visitedLabel);
     visitedHeader.add(visitedSortIndicator);
     table.setWidget(0, 3, visitedHeader);
@@ -230,7 +230,7 @@ public class AdminUserList extends Composite {
 
     private UserWidgets(final AdminUser user) {
       nameLabel = new Label(user.getEmail());
-      nameLabel.addStyleName("ode-ProjectNameLabel");
+      nameLabel.addStyleName("ode-AdminUserListNameLabel");
       uidLabel = new Label(user.getId());
       Date visited = user.getVisited();
       if (visited == null) {

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -431,6 +431,56 @@ div.StatusPanel {
 }
 
 /*
+* AdminUserList css
+*/
+
+.ode-AdminUserListNameLabel {
+  font-weight: bold;
+  font-size: small;
+  color: #555;
+  cursor: pointer;
+  vertical-align: top;
+  text-align: left;
+  flex-grow: 1;
+  min-width: 100px;
+}
+
+.ode-AdminUserListTable {
+  padding: 0;
+  margin: 0;
+  border: 1px;
+  overflow: auto;
+  border-radius: 4px;
+  height: auto;
+  width: 100%;
+}
+
+.ode-AdminUserListHeaderRow {
+  background: url(../images/toolbarBG.png) repeat;
+  align-items: center;
+  grid-gap: 10px;
+
+  border: 1px;
+  border-bottom: 1px solid #bbccff;
+  position: relative;
+  flex-direction: row;
+  width: 100%;
+}
+
+.ode-AdminUserListLabel {
+  text-indent: initial;
+  color: black;
+  font-size: 11px;
+  font-weight: bold;
+  cursor: pointer;
+  text-align: left;
+  padding-right: 10px;
+  display: inline-flex;
+
+  align-items: center;
+}
+
+/*
  * ComponentList
  */
 .ode-ComponentNameLabel {


### PR DESCRIPTION
When I originally built the AdminUserList page I was lazy and re-used the CSS for the ProjectList. However when the new UI binder code was introduced, the ProjectList CSS was updated, which broke the AdminUserList page, which was not converted.

This change just gives the AdminUserList page its own CSS which works properly.

Change-Id: Ic4f035b2f0ec2b2174810293a03cf604f9cccbc8

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Fixes the AdminUserList page headers.

