### PR TITLE
Dismiss iOS keyboard on taps outside of text boxes

### DIFF
--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -56,6 +56,7 @@ let kMinimumToastWait = 10.0
   private var _bigDefaultText = false
   private var _highContrast = false
   private var _backGesture: UIGestureRecognizer? = nil
+  private var _tapGesture: UITapGestureRecognizer? = nil
 
   /**
    * Returns whether the current theme selected by the user is Dark or not.
@@ -184,6 +185,9 @@ let kMinimumToastWait = 10.0
   open override func viewDidLoad() {
     super.viewDidLoad()
     view.accessibilityIdentifier = String(describing: type(of: self))
+    _tapGesture = UITapGestureRecognizer(target: self, action: #selector(HideKeyboard))
+    _tapGesture?.cancelsTouchesInView = false
+    view.addGestureRecognizer(_tapGesture!)
   }
 
   open func add(_ component: NonvisibleComponent) {


### PR DESCRIPTION
Change-Id: Ieffd1088afbf4be22cda7f3cdf152d3bd894c354

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This is an alternative approach to dismissing the keyboard when the background is tapped in the iOS companion compared the one proposed as part of #3595.