### PR TITLE
Split Android/iOS companion and built apps for bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,10 @@ Please check off the part of the system that is affected by the bug.
 - [ ] Designer
 - [ ] Blocks editor
 - [ ] Projects Explorer
-- [ ] Companion
-- [ ] Compiled apps
+- [ ] Android Companion
+- [ ] iOS Companion
+- [ ] Android Compiled APK/AAB
+- [ ] iOS Compiled IPA
 - [ ] Buildserver
 - [ ] Debugging
 - [ ] Other... (please describe)


### PR DESCRIPTION
Change-Id: If43ee7eb8eab4ce5e1f786e5dff83a850fb0f729

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR updates our bug report template to split the Android and iOS features into separate items to allow for better refinement of bug reports.