### PR TITLE
Make iOS Web.PostFile actually post the file

### DIFF
--- a/appinventor/components-ios/src/Web.swift
+++ b/appinventor/components-ios/src/Web.swift
@@ -176,7 +176,17 @@ open class Web: NonvisibleComponent {
       request.httpBody = postData
     } else if let postFile = postFile {
       request.httpMethod = httpVerb
-      request.httpBody = Data(base64Encoded: postFile)
+      do {
+        if postFile.starts(with: "file:"), let fileUrl = URL(string: postFile) {
+          request.httpBody = try Data(contentsOf: fileUrl)
+        } else if postFile.starts(with: "/"), let fileUrl = URL(string: "file:" + postFile) {
+          request.httpBody = try Data(contentsOf: fileUrl)
+        } else if let filePath = Application.current?.assetManager.pathForExistingFileAsset(postFile) {
+          request.httpBody = try Data(contentsOf: URL(fileURLWithPath: filePath))
+        }
+      } catch {
+        _form?.dispatchErrorOccurredEvent(self, httpVerb, ErrorMessage.ERROR_WEB_UNKNOWN_ERROR, "\(error)")
+      }
     }
     if webProps.timeout > 0 {
       request.timeoutInterval = Double(webProps.timeout) / 1000.0


### PR DESCRIPTION
Change-Id: Ia4d5b1790a6d85e096cf1548006d295f9fa7005e

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Fixes #3603

Test Script: [server.py](https://github.com/user-attachments/files/22373513/server.py)
Test AIA: [PostTest.aia.zip](https://github.com/user-attachments/files/22373509/PostTest.aia.zip)

Note you will have to change the IP address in the Web.URL designer property of the test AIA to point to the machine running the server.py script.

Posting the image will write it to a file called temp.png, and you can visually verify that the Canvas gets posted correctly.