### PR TITLE
Implement missing iOS chart extend functions

### DIFF
--- a/appinventor/components-ios/src/AxisChartView.swift
+++ b/appinventor/components-ios/src/AxisChartView.swift
@@ -67,11 +67,25 @@ open class AxisChartView : ChartView {
     }
   }
 
+  public func getXBounds() -> [Double] {
+    let minBound: Double = chart?.xAxis.axisMinimum ?? 0.0
+    let maxBound: Double = chart?.xAxis.axisMaximum ?? 0.0
+    let bounds: [Double] = [minBound, maxBound]
+    return bounds
+  }
+  
   public func setXBounds (minimum: Double, maximum: Double) {
     chart?.xAxis.axisMinimum = minimum
     chart?.xAxis.axisMaximum = maximum
   }
 
+  public func getYBounds() -> [Double] {
+    let minBound: Double = (chart as? BarLineChartViewBase)?.leftAxis.axisMinimum ?? 0.0
+    let maxBound: Double = (chart as? BarLineChartViewBase)?.leftAxis.axisMaximum ?? 0.0
+    let bounds: [Double] = [minBound, maxBound]
+    return bounds
+  }
+  
   public func setYBounds (minimum: Double, maximum: Double) {
     (chart as? BarLineChartViewBase)?.leftAxis.axisMinimum = minimum
     (chart as? BarLineChartViewBase)?.leftAxis.axisMaximum = maximum

--- a/appinventor/components-ios/src/Chart.swift
+++ b/appinventor/components-ios/src/Chart.swift
@@ -249,6 +249,34 @@ import DGCharts
       }
     }
   }
+  
+  @objc open func ExtendDomainToInclude(_ x: Double) {
+    if let chartView = (_chartView as AnyObject) as? AxisChartView {
+      let bounds: [Double] = chartView.getXBounds();
+      if x < bounds[0] {
+        chartView.setXBounds(minimum: x, maximum: bounds[1])
+      } else if x > bounds[1] {
+        chartView.setXBounds(minimum: bounds[0], maximum: x)
+      } else {
+        return
+      }
+      chartView.refresh()
+    }
+  }
+  
+  @objc open func ExtendRangeToInclude(_ y: Double) {
+    if let chartView = (_chartView as AnyObject) as? AxisChartView {
+      let bounds: [Double] = chartView.getYBounds()
+      if y < bounds[0] {
+        chartView.setYBounds(minimum: y, maximum: bounds[1])
+      } else if y > bounds[1] {
+        chartView.setYBounds(minimum: bounds[0], maximum: y)
+      } else {
+        return
+      }
+      chartView.refresh()
+    }
+  }
 
   // MARK: Chart events
 

--- a/appinventor/components-ios/src/Chart.swift
+++ b/appinventor/components-ios/src/Chart.swift
@@ -251,31 +251,33 @@ import DGCharts
   }
   
   @objc open func ExtendDomainToInclude(_ x: Double) {
-    if let chartView = (_chartView as AnyObject) as? AxisChartView {
-      let bounds: [Double] = chartView.getXBounds();
-      if x < bounds[0] {
-        chartView.setXBounds(minimum: x, maximum: bounds[1])
-      } else if x > bounds[1] {
-        chartView.setXBounds(minimum: bounds[0], maximum: x)
-      } else {
-        return
-      }
-      chartView.refresh()
+    guard let chartView = _chartView as? AxisChartView else {
+      return
     }
+    let bounds: [Double] = chartView.getXBounds();
+    if x < bounds[0] {
+      chartView.setXBounds(minimum: x, maximum: bounds[1])
+    } else if x > bounds[1] {
+      chartView.setXBounds(minimum: bounds[0], maximum: x)
+    } else {
+      return
+    }
+    chartView.refresh()
   }
   
   @objc open func ExtendRangeToInclude(_ y: Double) {
-    if let chartView = (_chartView as AnyObject) as? AxisChartView {
-      let bounds: [Double] = chartView.getYBounds()
-      if y < bounds[0] {
-        chartView.setYBounds(minimum: y, maximum: bounds[1])
-      } else if y > bounds[1] {
-        chartView.setYBounds(minimum: bounds[0], maximum: y)
-      } else {
-        return
-      }
-      chartView.refresh()
+    guard let chartView = _chartView as? AxisChartView else {
+      return
     }
+    let bounds: [Double] = chartView.getYBounds()
+    if y < bounds[0] {
+      chartView.setYBounds(minimum: y, maximum: bounds[1])
+    } else if y > bounds[1] {
+      chartView.setYBounds(minimum: bounds[0], maximum: y)
+    } else {
+      return
+    }
+    chartView.refresh()
   }
 
   // MARK: Chart events


### PR DESCRIPTION
For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Implements the missing ExtendDomain and ExtendRange functions for the iOS Charts component

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3541 


