### PR TITLE
Handle changes in visibility in child components

### DIFF
--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -263,14 +263,12 @@ let kMinimumToastWait = 10.0
 
   open func setVisible(component: ViewComponent, to visibility: Bool) {
     let visible = isVisible(component: component)
-    if visible == visibility {
+    if visibility == visible {
       return
     }
     if visibility {
       _linearView.setVisibility(of: component.view, to: true)
-      // Replay width/height properties
-      setChildHeight(of: component, to: component._lastSetHeight)
-      setChildWidth(of: component, to: component._lastSetWidth)
+      component.onAttach()
     } else {
       _linearView.setVisibility(of: component.view, to: false)
     }

--- a/appinventor/components-ios/src/HVArrangement.swift
+++ b/appinventor/components-ios/src/HVArrangement.swift
@@ -85,6 +85,15 @@ open class HVArrangement: ViewComponent, ComponentContainer, AbstractMethodsForV
     }
   }
 
+  open override func onAttach() {
+    super.onAttach()
+    for child in _components {
+      if child.Visible {
+        child.onAttach()
+      }
+    }
+  }
+
   open func isVisible(component: ViewComponent) -> Bool {
     return _view.contains(component.view)
   }
@@ -96,9 +105,7 @@ open class HVArrangement: ViewComponent, ComponentContainer, AbstractMethodsForV
     }
     if visibility {
       _view.setVisibility(of: component.view, to: true)
-      // Replay width/height properties
-      setChildHeight(of: component, to: component._lastSetHeight)
-      setChildWidth(of: component, to: component._lastSetWidth)
+      component.onAttach()
     } else {
       _view.setVisibility(of: component.view, to: false)
     }

--- a/appinventor/components-ios/src/LinearView.swift
+++ b/appinventor/components-ios/src/LinearView.swift
@@ -401,7 +401,8 @@ public class LinearView: UIView {
     } else {
       length.constraint = view.widthAnchor.constraint(equalToConstant: length.cgFloat)
     }
-    length.constraint?.isActive = true
+    let shouldActivate = self.superview != nil
+    length.constraint?.isActive = shouldActivate
     widthConstraints[view] = length
     invalidateIntrinsicContentSize()
   }
@@ -458,7 +459,8 @@ public class LinearView: UIView {
     } else {
       length.constraint = view.heightAnchor.constraint(equalToConstant: length.cgFloat)
     }
-    length.constraint?.isActive = true
+    let shouldActivate = self.superview != nil
+    length.constraint?.isActive = shouldActivate
     heightConstraints[view] = length
     invalidateIntrinsicContentSize()
   }

--- a/appinventor/components-ios/src/TableArrangement.swift
+++ b/appinventor/components-ios/src/TableArrangement.swift
@@ -135,7 +135,7 @@ fileprivate enum ConstraintUpdate {
   // stores all the cells for the TableArrangement. Mapped from components
   private var _cells = [[TableCell]]()
   // stores all the components for the TableArrangement, including ones that are not visible
-  private var _components = [WeakRef<ViewComponent>]()
+  fileprivate var _components = [WeakRef<ViewComponent>]()
 
   // constraints for when the height and/or width are automatic, to force the parent view to take up space
   private var _emptyConstraints: [NSLayoutConstraint]!
@@ -372,6 +372,19 @@ open class TableArrangement: ViewComponent, AbstractMethodsForViewComponent, Com
     _view.add(component: component)
   }
 
+
+  open override func onAttach() {
+    super.onAttach()
+    for child in _view._components {
+      guard let child = child.value else {
+        continue
+      }
+      if child.Visible {
+        child.onAttach()
+      }
+    }
+  }
+
   public func setChildWidth(of component: ViewComponent, to width: Int32) {
     component._lastSetWidth = width
     if _initialized {
@@ -395,6 +408,12 @@ open class TableArrangement: ViewComponent, AbstractMethodsForViewComponent, Com
   }
 
   open func getChildren() -> [Component] {
-    return []
+    var children: [Component] = []
+    _view._components.forEach {
+      if let child = $0.value {
+        children.append(child)
+      }
+    }
+    return children
   }
 }

--- a/appinventor/components-ios/src/ViewComponent.swift
+++ b/appinventor/components-ios/src/ViewComponent.swift
@@ -55,11 +55,18 @@ import Foundation
         return
       }
       container.setVisible(component: self, to: visibility)
-      if attachedToWindow {
-        container.setChildWidth(of: self, to: _lastSetWidth)
-        container.setChildHeight(of: self, to: _lastSetHeight)
-      }
     }
+  }
+
+  open func onAttach() {
+    guard attachedToWindow else {
+      return
+    }
+    guard let container = _container else {
+      return
+    }
+    container.setChildWidth(of: self, to: _lastSetWidth)
+    container.setChildHeight(of: self, to: _lastSetHeight)
   }
 
   @objc open var Width: Int32 {


### PR DESCRIPTION
Change-Id: Ic75d1fddbf95e449051f1c0e06f7c30bafdb7413

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes an issue where a component using a percent width/height is contained within an arrangement, but the arrangement is invisible. In master, this causes an error saying that the constraints are illegal (due to the component's constraints referencing Form, but not being attached to the form due to the invisibility of the parent). This PR adjusts the logic of visibility and constraint activation to ensure that the constraints only get activated when the visibility is true. It also adds an onAttach function and updates the arrangements to replay sizing constraints of their children so that reattaching the components conserves their sizes.