### PR TITLE
Rename NetworkUtils to MAINetworkUtils to resolve naming conflict

### DIFF
--- a/appinventor/aicompanionapp/src/ViewController.swift
+++ b/appinventor/aicompanionapp/src/ViewController.swift
@@ -195,7 +195,7 @@ public class ViewController: UINavigationController, UITextFieldDelegate {
       legacyCheckbox = form.view.viewWithTag(6) as? CheckBoxView
       libraryButton = form.view.viewWithTag(7) as! UIButton?
       legacyCheckbox.Text = "Use Legacy Connection"
-      let ipaddr: String! = NetworkUtils.getIPAddress()
+      let ipaddr: String! = MAINetworkUtils.getIPAddress()
       let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] ?? "unknown"
       let build = Bundle.main.infoDictionary?["CFBundleVersion"] ?? "?"
       ipAddrLabel?.text = "IP Address: \(ipaddr!)"
@@ -293,7 +293,7 @@ public class ViewController: UINavigationController, UITextFieldDelegate {
     var request = URLRequest(url: url!)
     let values = [
       "key": code,
-      "ipaddr": NetworkUtils.getIPAddress(),
+      "ipaddr": MAINetworkUtils.getIPAddress(),
       "port": "9987",
       "webrtc": phoneStatus.WebRTC ? "true" : "false",
       "version": phoneStatus.GetVersionName(),

--- a/appinventor/components-ios/src/NetworkUtils.h
+++ b/appinventor/components-ios/src/NetworkUtils.h
@@ -5,7 +5,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NetworkUtils : NSObject
+@interface MAINetworkUtils : NSObject
 
 + (NSString * _Nonnull) getIPAddress;
 

--- a/appinventor/components-ios/src/NetworkUtils.m
+++ b/appinventor/components-ios/src/NetworkUtils.m
@@ -7,7 +7,7 @@
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 
-@implementation NetworkUtils
+@implementation MAINetworkUtils
 
 + (NSString *)getIPAddress {
   

--- a/appinventor/components-ios/src/PhoneStatus.swift
+++ b/appinventor/components-ios/src/PhoneStatus.swift
@@ -12,11 +12,11 @@ open class PhoneStatus : NonvisibleComponent {
 
   // MARK: PhoneStatus Methods
   @objc open class func GetWifiIpAddress() -> String {
-    return NetworkUtils.getIPAddress()
+    return MAINetworkUtils.getIPAddress()
   }
 
   @objc open class func isConnected() -> Bool {
-    return NetworkUtils.getIPAddress() != "error"
+    return MAINetworkUtils.getIPAddress() != "error"
   }
 
   @objc open func setHmacSeedReturnCode(_ seed: String) -> String {


### PR DESCRIPTION
Change-Id: Ib2a1403d3b78b192127b53e5bf15d0484dce3d5a

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

When running the iOS companion in debug mode, we get a warning about the class name NetworkUtils being defined in both an internal Apple framework and App Inventor. This PR renames NetworkUtils to MAINetworkUtils to prevent the naming collision. As far as I know the name collision hasn't triggered any crashes, but this is a better safe than sorry change.