### PR TITLE
Implement peak active tasks measure for buildserver

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/BuildServer.java
@@ -336,6 +336,7 @@ public class BuildServer {
     maximumActiveBuildTasks = Math.max(maximumActiveBuildTasks, buildExecutor.getActiveTaskCount());
     variables.put("maximum-simultaneous-build-tasks-occurred", maximumActiveBuildTasks + "");
     variables.put("active-build-tasks", buildExecutor.getActiveTaskCount() + "");
+    variables.put("peak-active-build-tasks", buildExecutor.getPeakActiveTaskCount() + "");
 
     return mapToHtml(variables);
   }


### PR DESCRIPTION
Change-Id: I59f457a452c840dac6743c231f37e7fb13972588

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR adds a mechanism that tracks the peak number of active builds. The main purpose of this datum is to track whether we'll need to add another iOS build server at some point.