### PR TITLE
Project caching status dialog

### DIFF
--- a/appinventor/components-ios/src/AssetFetcher.swift
+++ b/appinventor/components-ios/src/AssetFetcher.swift
@@ -40,24 +40,33 @@ class AssetLoadError: Error {
       guard let rootView = window.rootViewController else {
         return
       }
-      let alertView = UIAlertController(title: "Saving", message: nil, preferredStyle: .alert)
-      alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-      rootView.present(alertView, animated: true) {
-        alertView.message = "Downloading and saving your project..."
+      let alert = UIAlertController(title: "Saving", message: "Downloading and saving your project...", preferredStyle: .alert)
+      let spinner = UIActivityIndicatorView(style: .gray)
+      spinner.translatesAutoresizingMaskIntoConstraints = false;
+      alert.view.addSubview(spinner)
+      NSLayoutConstraint.activate([
+        spinner.bottomAnchor.constraint(equalTo: alert.view.bottomAnchor, constant: -10),
+        spinner.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
+        alert.view.heightAnchor.constraint(equalToConstant: 100)
+      ])
+      rootView.present(alert, animated: true) {
+        spinner.startAnimating()
       }
       let projectUrl = uri + "/ode/download/project-cached/" + projectId;
       getProject(projectUrl: projectUrl, cookieValue: cookieValue, projectName: projectName, depth: 0) { success, error in
         if success {
           DispatchQueue.main.async {
             let center = CGPoint(x: window.frame.size.width / 2.0, y: window.frame.size.height / 2.0)
-            alertView.dismiss(animated: true)
+            spinner.stopAnimating()
+            alert.dismiss(animated: true)
             window.makeToast("Head to your Library to open your downloaded app.", point: center,
                              title: "Project successfully downloaded!", image: nil, completion: nil)
           }
         } else if let error = error {
           DispatchQueue.main.async {
             let center = CGPoint(x: window.frame.size.width / 2.0, y: window.frame.size.height / 2.0)
-            alertView.dismiss(animated: true)
+            spinner.stopAnimating()
+            alert.dismiss(animated: true)
             window.makeToast("Unable to download project with error \(error)", point: center,
                              title: nil, image: nil, completion: nil)
           }


### PR DESCRIPTION
For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

Adds a status dialog to the project caching feature on iOS. This is to help users know something is happening while they download a large project that could take several seconds. Currently, there is no response to the user until the project download is complete.