### PR TITLE
Fix Notifier not working on iOS 13+

### DIFF
--- a/appinventor/components-ios/src/Notifier.swift
+++ b/appinventor/components-ios/src/Notifier.swift
@@ -118,6 +118,25 @@ private extension String {
   }
 }
 
+/**
+ * Gets the main window for the application, if any.
+ *
+ * - Returns: a UIWindow object representing the main window, or nil if the app scene isn't available
+ */
+func getMainWindow() -> UIWindow? {
+  if #available(iOS 13.0, *) {
+    for scene in UIApplication.shared.connectedScenes {
+      guard let delegate = scene.delegate as? SceneDelegate else {
+        continue
+      }
+      return delegate.window
+    }
+  } else {
+    return UIApplication.shared.keyWindow
+  }
+  return nil
+}
+
 fileprivate class CustomAlertView: UIView {
   private var background = UIView()
   private var dialog = UIView()
@@ -192,7 +211,7 @@ fileprivate class CustomAlertView: UIView {
   func show(animated: Bool, callback: ((Bool) -> Void)? = nil){
     self.background.alpha = 0
     self.dialog.isHidden = true
-    if let parent =  UIApplication.shared.delegate?.window??.rootViewController?.view {
+    if let parent = getMainWindow()?.rootViewController?.view {
       parent.addSubview(self)
       if let handler = callback {
         handler(true)
@@ -378,7 +397,7 @@ open class Notifier: NonvisibleComponent {
   }
 
   @objc open func ShowChooseDialog(_ message: String, _ title: String, _ button1text: String, _ button2text: String, _ cancelable: Bool) {
-      let newAlert = CustomAlertView(title: title, message: message) // Create the new alert
+    let newAlert = CustomAlertView(title: title, message: message) // Create the new alert
     newAlert.alertType = .Choose
 
       // Configure buttons


### PR DESCRIPTION
Change-Id: Iaa491196d79567723f0037ee4a5b780c71aefc1b

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes an [issue raised in the community](https://community.appinventor.mit.edu/t/issue-with-the-notifier-component-ios/157224?u=ewpatton) regarding notifier dialogs not appearing on newer builds of iOS. The issue is down to the interaction between the logic of UIScenes and the older way of interacting with windows in the UIApplication. This caused a code path to yield nil rather than a UIWindow, and so notifiers would not be displayed.