### PR TITLE
Place Web downloads into a non-temp path

### DIFF
--- a/appinventor/components-ios/src/FileUtil.swift
+++ b/appinventor/components-ios/src/FileUtil.swift
@@ -9,6 +9,7 @@ private let FILENAME_PREFIX: String = "app_inventor_"
 private let DIRECTORY_RECORDINGS: String = "Recordings"
 private let ANDROID_TO_IOS_RECORDING_EXTENSION: String = "aac"
 private let DIRECTORY_PICTURES: String = "Pictures"
+private let DIRECTORY_DOWNLOADS: String = "Downloads"
 
 open class FileUtil {
   
@@ -24,7 +25,11 @@ open class FileUtil {
   public static func getPictureFile(_ fileExtension: String) throws -> String {
     return try getFile(DIRECTORY_PICTURES, fileExtension)
   }
-  
+
+  public static func getDownloadFile(_ fileExtension: String) throws -> String {
+    return try getFile(DIRECTORY_DOWNLOADS, fileExtension)
+  }
+
   public static func transformFileExtension(_ fileName: String, toExtension fileExtension: String) -> String {
     let originalName: NSString = NSString(string: fileName)
     let pathPrefix: NSString = NSString(string: originalName.deletingPathExtension)

--- a/appinventor/components-ios/src/Web.swift
+++ b/appinventor/components-ios/src/Web.swift
@@ -246,11 +246,17 @@ open class Web: NonvisibleComponent {
   fileprivate func saveResponseContent(_ response: URLResponse, _ fileName: String, _ responseType: String, _ data: Data?) -> String {
     let filename = (fileName.isEmpty) ? response.suggestedFilename : fileName
 
-    let fileManager = FileManager.default
-    let path = NSTemporaryDirectory() + filename!
-    fileManager.createFile(atPath: path, contents: data, attributes: nil)
+    let fileExtension = (filename ?? "download.tmp").split(separator: ".").last ?? ""
 
-    return path
+    let fileManager = FileManager.default
+    if let path = try? FileUtil.getDownloadFile(String(fileExtension)) {
+      fileManager.createFile(atPath: path, contents: data, attributes: nil)
+      return path
+    } else {
+      let path = NSTemporaryDirectory() + (filename ?? "download.tmp")
+      fileManager.createFile(atPath: path, contents: data)
+      return path
+    }
   }
 
   fileprivate func openSession(_ webProps: CapturedProperties, _ httpVerb: String) -> URLSession {


### PR DESCRIPTION
Change-Id: I645b77c729ecbfdac6cf11a895498a068b606000

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR updates the Web component behavior on iOS to be similar to that on Android. On iOS we make use of the native tempdir features, but these files often get cleaned up within a few hours. On Android the files are saved in a location where they will persist indefinitely. This is particularly important because utility functions like File.CopyFile haven't been ported to the iOS version yet, so there is no way to escape the temporary nature of the downloaded files.