### PR TITLE
CloudDB: add CloseConnection() to close Redis connections and stop li…

### DIFF
--- a/appinventor/components/CHANGELOG.md
+++ b/appinventor/components/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Components changes
+
+- Added CloudDB.CloseConnection() SimpleFunction to explicitly close Redis connections and stop the listener to avoid leaking connections on screen changes or when using private Redis servers with connection limits.
+
+Usage:
+
+- Call `CloseConnection()` when you are done with the CloudDB in your app (for example, when leaving a screen) to ensure connections are released.
+
+Example (blocks-like pseudocode):
+
+1. When Screen1.Hide
+    CloudDB1.CloseConnection()
+
+2. When Screen2.Initialize
+    // CloudDB will be reinitialized when needed by calling Initialize() or by accessing CloudDB.
+
+Notes:
+- CloseConnection prevents automatic listener restart by setting the component's `shutdown` flag. To restart the listener, call the component's `Initialize()` method again.
+- This change also ensures the listener's Jedis instance is explicitly closed when stopping the listener.

--- a/appinventor/components/samples/CloudDBCloseConnectionExample.txt
+++ b/appinventor/components/samples/CloudDBCloseConnectionExample.txt
@@ -1,0 +1,15 @@
+CloudDB CloseConnection example
+
+Description:
+Call CloseConnection when a screen is hidden to release Redis connections.
+
+Pseudo-blocks:
+
+Screen1.Initialize
+  // normal setup
+
+Screen1.Hide
+  call CloudDB1.CloseConnection
+
+Screen1.Show
+  // If you need CloudDB again, call Initialize on the component or let it auto-start on use.

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -84,6 +84,12 @@ The `CloudDB` component is a Non-visible component that allows you to store data
 {:id="CloudDB.ClearTag" class="method"} <i/> ClearTag(*tag*{:.text})
 : Remove the tag from CloudDB.
 
+{:id="CloudDB.CloseConnection" class="method"} <i/> CloseConnection()
+: CloseConnection explicitly closes any open connections to the Redis server
+ and stops the listener. Use this when you want to release connections to
+ a private/self-hosted Redis instance (for example to avoid hitting
+ connection limits when switching screens or when the app is done).
+
 {:id="CloudDB.CloudConnected" class="method returns boolean"} <i/> CloudConnected()
 : Returns `true`{:.logic.block} if we are on the network and will likely be able to connect to
  the `CloudDB` server.


### PR DESCRIPTION
Summary

- Adds a new public SimpleFunction CloudDB.CloseConnection() that explicitly closes any open Redis connections used by the CloudDB component and stops the subscription listener.
- Ensures the listener's subscribe Jedis is tracked and closed when the listener is stopped, preventing connection leaks that can cause “connection limit” failures on private/self-hosted Redis instances.
- Adds a short changelog and a small sample showing when to call CloseConnection().

Motivation / Background
Some users run App Inventor apps against private/self-hosted Redis servers that enforce a hard connection limit. The CloudDB component previously opened subscribe connections for the listener thread and also used a shared Jedis instance for commands. In certain app flows (screen changes, component lifecycle events) those connections could be left open or reopened without reusing existing connections, eventually exhausting the server’s connection limit and making the DB unavailable.

This PR gives app authors a way to explicitly release connections when they know the component is no longer needed (for example, on Screen.Hide), and fixes a listener leak by tracking and closing the listener Jedis.
