### PR TITLE
Clean out constraints holding strong references in iOS

### DIFF
--- a/appinventor/components-ios/src/LinearView.swift
+++ b/appinventor/components-ios/src/LinearView.swift
@@ -289,6 +289,8 @@ public class LinearView: UIView {
     _innerHeadZero.isActive = false
     _innerTailZero.isActive = false
 
+    widthConstraints.removeAll()
+    heightConstraints.removeAll()
     updatePositioningConstraints()
     updatePriorities()
   }


### PR DESCRIPTION
Change-Id: I14308694d9d2f66a0770f10e28323dd5833091a0

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes a memory leak that is seen in the AR kit support (and likely affects many other UI components). The LinearView that represents the Form's vertical arrangement never cleared the constraints dictionaries, which hold strong references to the corresponding views. Memory heavy views like Maps, Charts, and AR view could quickly consume user memory and lead to app crashes.