### PR TITLE
Fix crash on bad credentials in Spreadsheet

### DIFF
--- a/appinventor/components-ios/src/ErrorMessages.swift
+++ b/appinventor/components-ios/src/ErrorMessages.swift
@@ -138,6 +138,9 @@ import Foundation
   // ImageBot Errors
   case ERROR_IMAGEBOT_ERROR = 4300
 
+  // Spreadsheet Errors
+  case ERROR_SPREADSHEET_ERROR = 4401
+
   // ListView Errors
   case ERROR_LISTVIEW_INDEX_OUT_OF_BOUNDS = 4601
 
@@ -392,6 +395,9 @@ import Foundation
     // ImageBot Errors
     case .ERROR_IMAGEBOT_ERROR:
       return "Error from the ImageBot code: %d %s"
+
+    case .ERROR_SPREADSHEET_ERROR:
+      return "Error in Spreadsheet: %s"
 
     // ListView Errors
     case .ERROR_LISTVIEW_INDEX_OUT_OF_BOUNDS:

--- a/appinventor/components-ios/src/ServiceAccountAuthorizer.swift
+++ b/appinventor/components-ios/src/ServiceAccountAuthorizer.swift
@@ -12,8 +12,11 @@ import GTMSessionFetcher
   var request: NSMutableURLRequest? = nil
   var canceled = false
 
-  public init(serviceAccountConfig: Data, scopes: [String]) {
-    self.tokenProvider = ServiceAccountTokenProvider(credentialsData: serviceAccountConfig, scopes: scopes)!
+  public init?(serviceAccountConfig: Data, scopes: [String]) {
+    guard let tokenProvider = ServiceAccountTokenProvider(credentialsData: serviceAccountConfig, scopes: scopes) else {
+      return nil
+    }
+    self.tokenProvider = tokenProvider
     super.init()
     self.userEmail = self.tokenProvider.credentials.ClientEmail
   }

--- a/appinventor/components-ios/src/Spreadsheet.swift
+++ b/appinventor/components-ios/src/Spreadsheet.swift
@@ -1102,7 +1102,9 @@ import GoogleAPIClientForREST
   // Description: Triggered whenever an API call encounters an error. Details about the error are in `errorMessage`
   @objc func ErrorOccurred(_ errorMessage: String) {
     DispatchQueue.main.async {
-      EventDispatcher.dispatchEvent(of: self, called: "ErrorOccurred", arguments: errorMessage as AnyObject)
+      if (!EventDispatcher.dispatchEvent(of: self, called: "ErrorOccurred", arguments: errorMessage as AnyObject)) {
+        self._form?.dispatchErrorOccurredEvent(self, "ErrorOccurred", ErrorMessage.ERROR_SPREADSHEET_ERROR, errorMessage)
+      }
     }
   }
   
@@ -1430,6 +1432,10 @@ import GoogleAPIClientForREST
       _service.authorizer = ServiceAccountAuthorizer(serviceAccountConfig: credentials, scopes: [
         kGTLRAuthScopeSheetsSpreadsheets,
       ])
+      guard _service.authorizer != nil else {
+        self.ErrorOccurred("Authorization failed due to bad credential.")
+        return
+      }
     } catch {
       self.ErrorOccurred("\(error)")
       return


### PR DESCRIPTION
Change-Id: Idfbc67a86bb35449d2c20dd205c5d8c0163aef0a

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes a crash that can occur when the Spreadsheet component receives a file for the CredentialsJson property that is malformed. A malformed file results in force unwrapping a nil object. I changed the init function in question to be fallible and then if it returns nil we report an error to the user. This also fixes a mismatch in the Android and iOS behaviors where the lack of the ErrorOccurred event block for the spreadsheet would propagate to the form (Android) but not on iOS.