### PR TITLE
Fix NPE on some Android 16 devices

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/QUtil.java
@@ -140,7 +140,14 @@ public class QUtil {
     }
     if ((!legacy && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) || forcePrivate) {
       // Q no longer allows using getExternalStorageDirectory()
-      return context.getExternalFilesDir(null);
+      File externalStorage = context.getExternalFilesDir(null);
+      if (externalStorage == null) {
+        // This can happen if the external storage is not currently mounted, but we need some
+        // place to put assets, etc. Fall back to internal storage in this case.
+        return context.getFilesDir();
+      } else {
+        return externalStorage;
+      }
     } else {
       return Environment.getExternalStorageDirectory();
     }


### PR DESCRIPTION
Change-Id: Id7fcc397b62ac45dd75d26db5a5ed67779cefbc3

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

What does this PR accomplish?

This PR addresses an issue where context.getExternalFilesDir(String) returns null in some cases. If null is returned, we assume external storage is not available and switch to using the private storage directory instead. The issue was originally [reported on the community](https://community.appinventor.mit.edu/t/companion-crash-android-16-pixel-7/158185) where the companion app was unable to even start due to the exception being thrown on app startup.