### PR TITLE
Change TEXTING_REQUEST_CODE to fit 16-bit limit

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -181,9 +181,12 @@ public class Texting extends AndroidNonvisibleComponent
   public static final String TAG = "Texting Component";
 
   /**
-   * Magic number "TEXT" used to report when a text message has been sent.
+   * Magic number "TX" used to report when a text message has been sent.
+   * Changed from 0x54455854 ("TEXT") to 0x5458 ("TX") to fit within Android's
+   * 16-bit request code limit (0-65535). The original value caused
+   * "can only use lower 16 bits for request code" runtime error.
    */
-  public static final int TEXTING_REQUEST_CODE = 0x54455854;
+  public static final int TEXTING_REQUEST_CODE = 0x5458;
 
   public static final String SMS_RECEIVED = "android.provider.Telephony.SMS_RECEIVED";
   public static final String GV_SMS_RECEIVED = "com.google.android.apps.googlevoice.SMS_RECEIVED";


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Updated the texting request code to fit within Android's 16-bit limit, changing it from 'TEXT' to 'TX'.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes https://community.kodular.io/t/while-using-texting-component-runtime-error-can-only-use-lower-16-bits-for-request-code/145085?u=diego

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
