### PR TITLE
Add information numberOfArguments and variadic properties to SCMProcedure

### DIFF
--- a/appinventor/schemekit/src/SCMProcedure.h
+++ b/appinventor/schemekit/src/SCMProcedure.h
@@ -16,6 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithProcedure:(pic_value)procedure interpreter:(SCMInterpreter *)interpreter;
 - (nullable id<SCMValue>)invoke;
 - (nullable id<SCMValue>)invokeWithArguments:(NSArray<id> * _Nonnull)arguments;
+- (NSInteger)numberOfArguments;
+- (BOOL)variadic;
+
+@property(readonly) NSInteger numberOfArguments;
+@property(readonly) BOOL variadic;
 
 @end
 

--- a/appinventor/schemekit/src/SCMProcedure.m
+++ b/appinventor/schemekit/src/SCMProcedure.m
@@ -4,6 +4,9 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 #import "SCMProcedure.h"
+#import "picrin.h"
+#include "picrin/private/object.h"
+#include "picrin/private/vm.h"
 #import "SCMInterpreter-Private.h"
 
 @interface SCMProcedure () {
@@ -88,6 +91,22 @@
 
 - (id<SCMValue>)invokeWithArguments:(NSArray<id> *)arguments {
   return [interpreter_ apply:self.value to:arguments];
+}
+
+- (NSInteger)numberOfArguments {
+  if (pic_type(interpreter_.state, value_) == PIC_TYPE_IREP) {
+    struct proc *proc = pic_proc_ptr(interpreter_.state, value_);
+    return (NSInteger) proc->u.i.irep->argc - 1;
+  }
+  return 0;
+}
+
+- (BOOL)variadic {
+  if (pic_type(interpreter_.state, value_) == PIC_TYPE_IREP) {
+    struct proc *proc = pic_proc_ptr(interpreter_.state, value_);
+    return proc->u.i.irep->varg;
+  }
+  return NO;
 }
 
 @end

--- a/appinventor/schemekit/tests/SCMProcedureTests.m
+++ b/appinventor/schemekit/tests/SCMProcedureTests.m
@@ -40,4 +40,22 @@
   XCTAssertEqual(4, result.intValue);
 }
 
+- (void)testNumArgs {
+  [interpreter evalForm:@"(yail:invoke *test-environment* 'setObject:forKey: (lambda (x y) (+ x y)) \"proc3\")"];
+  XCTAssertNil(interpreter.exception);
+  SCMProcedure *proc = (SCMProcedure *) env[@"proc3"];
+  XCTAssertNotNil(proc);
+  XCTAssertEqual(2, proc.numberOfArguments);
+  XCTAssertFalse(proc.variadic);
+}
+
+- (void)testVariadic {
+  [interpreter evalForm:@"(yail:invoke *test-environment* 'setObject:forKey: (lambda (x y . z) #f) \"proc4\")"];
+  XCTAssertNil(interpreter.exception);
+  SCMProcedure *proc = (SCMProcedure *) env[@"proc4"];
+  XCTAssertNotNil(proc);
+  XCTAssertEqual(2, proc.numberOfArguments);
+  XCTAssertTrue([proc variadic]);
+}
+
 @end


### PR DESCRIPTION
Change-Id: I106f9a25619b3545081b834dbd50c215a8a41a8a

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Adds properties to the SCMProcedure object in SchemeKit to support certain blocks in the anonymous procedures feature.