### PR TITLE
build: add AAPT2 command/env logging (debug JPEG icon issue)

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunAapt2.java
@@ -60,6 +60,13 @@ public class RunAapt2 implements AndroidTask {
     aapt2CommandLine.add("-o");
     aapt2CommandLine.add(resourcesZip.getAbsolutePath());
     aapt2CommandLine.add("--no-crunch");
+    context.getReporter().log(
+    "AAPT2 COMPILE CMD: " +
+    aapt2Tool + " compile --dir " +
+    context.getPaths().getMergedResDir().getAbsolutePath() +
+    " -o " + resourcesZip.getAbsolutePath() +
+    " --no-crunch"
+);
     String[] aapt2CompileCommandLine = aapt2CommandLine.toArray(new String[0]);
 
     if (!Execution.execute(null, aapt2CompileCommandLine,
@@ -95,6 +102,12 @@ public class RunAapt2 implements AndroidTask {
     aapt2CommandLine.add("--no-auto-version");
     aapt2CommandLine.add("--no-version-transitions");
     aapt2CommandLine.add("--no-resource-deduping");
+    context.getReporter().log("resources.zip exists: " + resourcesZip.exists());
+context.getReporter().log("assetsDir: " + context.getPaths().getAssetsDir().getAbsolutePath());
+context.getReporter().log("manifest: " + context.getPaths().getManifest().getAbsolutePath());
+context.getReporter().log("android.jar: " + context.getResources().getAndroidRuntime());
+context.getReporter().log("AAPT2 CMD: " + String.join(" ", aapt2CommandLine));
+
     String[] aapt2LinkCommandLine = aapt2CommandLine.toArray(new String[0]);
 
     if (!Execution.execute(null, aapt2LinkCommandLine,


### PR DESCRIPTION
Temporary logging to print AAPT2 compile/link commands and key paths (android.jar, assets, manifest) so we can diagnose why JPEG app icons fail on CI.

This PR does NOT change behavior—only adds logs.
<img width="5" height="3" alt="icon" src="https://github.com/user-attachments/assets/a0512d39-92fe-4993-a473-a6ee076c3de5" />

Use this icon.jpg as the App Icon (JPEG) to reproduce.

