### PR TITLE
TopToolbar: fix menu ID mismatch and comment typos

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -157,14 +157,14 @@ public class TopToolbar extends Composite {
     }
     buildDropDown.removeUnneededSeparators();
 
- if (!Ode.getUserAutoloadProject()) {
-  settingsDropDown.setItemHtmlById(WIDGET_NAME_AUTOLOAD, MESSAGES.enableAutoload());
-  settingsDropDown.setCommandById(WIDGET_NAME_AUTOLOAD, new EnableAutoloadAction());
-}
-if (!Ode.getUserDyslexicFont()) {
-  settingsDropDown.setItemHtmlById(WIDGET_NAME_DYSLEXIC_FONT, MESSAGES.enableOpenDyslexic());
-  settingsDropDown.setCommandById(WIDGET_NAME_DYSLEXIC_FONT, new SetFontDyslexicAction());
-}
+    if (!Ode.getUserAutoloadProject()) {
+      settingsDropDown.setItemHtmlById(WIDGET_NAME_AUTOLOAD, MESSAGES.enableAutoload());
+      settingsDropDown.setCommandById(WIDGET_NAME_AUTOLOAD, new EnableAutoloadAction());
+    }
+    if (!Ode.getUserDyslexicFont()) {
+      settingsDropDown.setItemHtmlById(WIDGET_NAME_DYSLEXIC_FONT, MESSAGES.enableOpenDyslexic());
+      settingsDropDown.setCommandById(WIDGET_NAME_DYSLEXIC_FONT, new SetFontDyslexicAction());
+    }
 
     if (!Ode.getInstance().getUser().getIsAdmin()) {
       adminDropDown.removeFromParent();


### PR DESCRIPTION
This PR updates the WIDGET_NAME_AUTOLOAD constant to "AutoloadLastProject" to match the UiBinder ID used in the Settings menu.
It replaces string literals with constants for better consistency and corrects minor comment typos (“Wi-Fi”, “already”).

Tested:

Verified that the “Autoload Last Project” option still appears under Settings.

No functional regressions observed.