### PR TITLE
Fix #3689: reset invalid LastOpened after screen deletion

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -425,7 +425,23 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
       formName = ((YoungAndroidBlocksNode) node).getFormName();
       removeBlocksEditor(formName);
     }
-  }
+    if (formName != null) {
+      Ode.getInstance().getDesignToolbar()
+          .removeScreen(project.getProjectId(), formName);
+
+      String lastOpened = getProjectSettingsProperty(
+          SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+          SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED);
+
+      if (formName.equals(lastOpened)) {
+        setProjectSettingsProperty(
+            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+            SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED,
+            YoungAndroidSourceNode.SCREEN1_FORM_NAME);
+        saveProjectSettings();
+      }
+    }
+ }
 
   /*
    * Returns the BlocksEditor for the given form name in this project
@@ -842,10 +858,30 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
     return formName.equals(YoungAndroidSourceNode.SCREEN1_FORM_NAME);
   }
 
-  private boolean isLastOpened(String formName) {
-    String lastOpened = this.getProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+  private String getValidLastOpenedScreen() {
+    String lastOpened = getProjectSettingsProperty(
+        SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED);
-    return lastOpened.equals(formName);
+
+    if (lastOpened == null || lastOpened.isEmpty()) {
+      return YoungAndroidSourceNode.SCREEN1_FORM_NAME;
+    }
+
+    boolean exists = false;
+    for (ProjectNode source : projectRootNode.getAllSourceNodes()) {
+      if (source instanceof YoungAndroidFormNode) {
+        if (((YoungAndroidFormNode) source).getFormName().equals(lastOpened)) {
+          exists = true;
+          break;
+        }
+      }
+    }
+
+    return exists ? lastOpened : YoungAndroidSourceNode.SCREEN1_FORM_NAME;
+  }
+
+  private boolean isLastOpened(String formName) {
+    return getValidLastOpenedScreen().equals(formName);
   }
 
   private void switchToForm(String entityName, long projectId) {


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

*Description*
Repro: Open a project → open Screen2 → delete Screen2 → reload the project.
Expected: Project opens Screen1 and does not attempt to reopen the deleted screen.
Fixes #3689.

This PR prevents the project from trying to reopen a deleted screen by:
  - Removing the deleted screen from the DesignToolbar when its node is removed

  - Resetting LastOpened to Screen1 if the deleted screen was stored as LastOpened

  - Validating LastOpened on load; fall back to Screen1 if it no longer exists
