### PR TITLE
Ignore local docs build artifacts

### DIFF
--- a/appinventor/.gitignore
+++ b/appinventor/.gitignore
@@ -70,3 +70,5 @@ fastlane/test_output
 
 iOSInjectionProject/
 AICompanionApp.xcconfig
+.bundle/
+docs/markdown/vendor/


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] Google Java style guide (for .java files)
    - [ ] Google JavaScript style guide (for .js files)
- [ ] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR adds ignore rules for local documentation build artifacts that may begenerated when working on the Jekyll/Bundler-based docs. Specifically, it ignores`.bundle/` and `docs/markdown/vendor/`, which are local, machine-specific files
and should not be committed to the repository.

No functional, UI, or runtime behavior is affected.
