### PR TITLE
URL-encode brackets in Material Symbols font path

### DIFF
--- a/appinventor/appengine/war/static/css/fonts.css
+++ b/appinventor/appengine/war/static/css/fonts.css
@@ -25,7 +25,7 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf') format('truetype');
+  src: url('../fonts/MaterialSymbolsSharp%5BFILL,GRAD,opsz,wght%5D.ttf') format('truetype');
 }
 
 .material-icons {


### PR DESCRIPTION
This fixes the local dev server failing to load the icon font, causing Material Symbols to render as text.

Jetty 12.0.31 (shipped in gcloud SDK 550.0.0) enforces strict RFC 3986 URL parsing and rejects unencoded square brackets in paths.

https://github.com/jetty/jetty.project/pull/14013