### PR TITLE
Implement ARIA support for modal dialogs

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/commands/CopyYoungAndroidProjectCommand.java
@@ -17,6 +17,7 @@ import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
 import com.google.appinventor.shared.rpc.project.UserProject;
 import com.google.appinventor.client.widgets.Validator;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
@@ -84,6 +85,12 @@ public final class CopyYoungAndroidProjectCommand extends ChainableCommand {
 
       String oldName = oldProjectNode.getName();
       setText(checkpoint ? MESSAGES.checkpointTitle(oldName) : MESSAGES.saveAsTitle(oldName));
+
+      // Add ARIA attributes for accessibility
+      Roles.getDialogRole().set(getElement());
+      getElement().setAttribute("aria-modal", "true");
+      getElement().setAttribute("aria-label",
+          checkpoint ? "Save Checkpoint - " + oldName : "Save Project As - " + oldName);
 
       VerticalPanel contentPanel = new VerticalPanel();
       contentPanel.setSpacing(10);

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/NoProjectDialogBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/NoProjectDialogBox.java
@@ -10,6 +10,7 @@ import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.wizards.NewProjectWizard.NewProjectCommand;
 import com.google.appinventor.client.wizards.TemplateUploadWizard;
 import com.google.appinventor.client.wizards.youngandroid.NewYoungAndroidProjectWizard;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.FocusEvent;
@@ -72,6 +73,12 @@ public class NoProjectDialogBox extends DialogBox {
     this.setAnimationEnabled(true);
     this.setAutoHideEnabled(true);
     this.setModal(false);
+
+    // Add ARIA attributes for accessibility
+    Roles.getDialogRole().set(getElement());
+    getElement().setAttribute("aria-modal", "false"); // Not truly modal (auto-hide enabled)
+    getElement().setAttribute("aria-label", "Welcome to MIT App Inventor - Get Started");
+
     noDialogNewProject.setFocus(true);
     lastDialog = this;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.ui.xml
@@ -12,9 +12,10 @@
 
   <ui:with type="com.google.appinventor.client.Images" field="res"/>
 
-  <wiz:Dialog ui:field="projectProperties" styleName="ode-DialogBox">
+  <wiz:Dialog ui:field="projectProperties" role="dialog" ariaModal="true" ariaLabel="Project Properties"
+              styleName="ode-DialogBox">
     <g:VerticalPanel>
-    <g:Button ui:field='topInvisible' styleName="FocusTrap"/>
+    <g:Button ui:field='topInvisible' styleName="FocusTrap" tabIndex="-1"/>
       <g:HorizontalPanel styleName='ode-propertyDialogContainer'>
         <g:ListBox ui:field="categoryList" styleName='ode-projectPropertyCategoryTitlePanel'></g:ListBox>
         <g:ScrollPanel styleName='ode-propertyDialogPropertiesScrollPanel'>
@@ -28,7 +29,7 @@
           >Close</ui:msg>
         </g:Button>
       </g:FlowPanel>
-    <g:Button ui:field='bottomInvisible' styleName="FocusTrap"/>
+    <g:Button ui:field='bottomInvisible' styleName="FocusTrap" tabIndex="-1"/>
     </g:VerticalPanel>
   </wiz:Dialog>
 </ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/MessageDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/MessageDialog.java
@@ -7,6 +7,8 @@ package com.google.appinventor.client.utils;
 
 import com.google.appinventor.client.widgets.boxes.Box;
 
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.ClickListener;
 import com.google.gwt.user.client.ui.DialogBox;
@@ -63,9 +65,22 @@ public class MessageDialog {
     dialogBox.setGlassEnabled(true);
     dialogBox.setAnimationEnabled(true);
     dialogBox.center();
+
+    // Add ARIA attributes for accessibility
+    Roles.getDialogRole().set(dialogBox.getElement());
+    dialogBox.getElement().setAttribute("aria-modal", "true");
+
+    // Set aria-label for title and generate ID for message description
+    dialogBox.getElement().setAttribute("aria-label", title);
+
+    // Generate unique ID for message to use with aria-describedby
+    String messageId = Document.get().createUniqueId();
+    dialogBox.getElement().setAttribute("aria-describedby", messageId);
+
     VerticalPanel DialogBoxContents = new VerticalPanel();
     HTML messageHtml = new HTML("<p>" + message + "</p>");
     messageHtml.setStyleName("DialogBox-message");
+    messageHtml.getElement().setId(messageId);
     FlowPanel holder = new FlowPanel();
     Button okButton = new Button(OK);
     okButton.addClickListener(new ClickListener() {

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/AppStoreSettingsDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/AppStoreSettingsDialog.ui.xml
@@ -9,8 +9,8 @@
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
   <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
-  <wiz:Dialog ui:field="settingsDialog" caption="{messages.settingsTabName}"
-              styleName="ode-DialogBox" width="400px">
+  <wiz:Dialog ui:field="settingsDialog" role="dialog" ariaModal="true" ariaLabel="App Store Settings"
+              caption="{messages.settingsTabName}" styleName="ode-DialogBox" width="400px">
     <g:FlowPanel>
       <g:HTML>
         Please provide your Apple ID and App Specific Password for MIT App Inventor below. These

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/Dialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/Dialog.java
@@ -6,23 +6,319 @@
 
 package com.google.appinventor.client.wizards;
 
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.FocusWidget;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.Widget;
 
-// Simple wrapper for the GWT Dialogbox that exposes the caption to UIBinder
+import java.util.Iterator;
 
+/**
+ * Accessible wrapper for the GWT DialogBox that provides ARIA support and
+ * keyboard navigation following WCAG 2.1 guidelines.
+ *
+ * This class extends DialogBox with:
+ * - ARIA attributes (role, aria-modal, aria-labelledby, aria-describedby)
+ * - Global Escape key handling to close dialogs
+ * - Focus management (auto-focus on open, restore on close)
+ * - UIBinder support for all accessibility features
+ */
 public class Dialog extends DialogBox {
 
-
   private Caption caption;
+  private String ariaRole = "dialog";  // Default role
+  private com.google.gwt.dom.client.Element triggerElement = null;  // For focus restoration
+  private boolean isModal = true;  // Track modal state
+  private Event.NativePreviewHandler keyboardHandler;
 
   public Dialog() {
     super(false, true, new CaptionImpl());
     caption = getCaption();
     setGlassEnabled(true);
     setModal(false);
+
+    // Set default ARIA role and attributes
+    Roles.getDialogRole().set(getElement());
+    getElement().setAttribute("aria-modal", "true");
+
+    // Add global Escape key handler for accessibility
+    keyboardHandler = new Event.NativePreviewHandler() {
+      @Override
+      public void onPreviewNativeEvent(Event.NativePreviewEvent event) {
+        if (event.getTypeInt() == Event.ONKEYDOWN &&
+            isShowing() &&
+            event.getNativeEvent().getKeyCode() == KeyCodes.KEY_ESCAPE) {
+          event.getNativeEvent().preventDefault();
+          event.getNativeEvent().stopPropagation();
+          handleEscapeKey();
+        }
+      }
+    };
+    Event.addNativePreviewHandler(keyboardHandler);
   }
 
+  /**
+   * Sets the caption text for this dialog.
+   *
+   * @param text The caption text to display
+   */
   public void setCaption(String text) {
     caption.setText(text);
   }
+
+  /**
+   * Sets the ARIA role for this dialog.
+   * Called by UIBinder when role="..." attribute is present.
+   *
+   * @param role The ARIA role ("dialog" or "alertdialog")
+   */
+  public void setRole(String role) {
+    this.ariaRole = role;
+    if ("dialog".equals(role)) {
+      Roles.getDialogRole().set(getElement());
+    } else if ("alertdialog".equals(role)) {
+      Roles.getAlertdialogRole().set(getElement());
+    }
+  }
+
+  /**
+   * Sets the aria-modal attribute.
+   * Called by UIBinder when ariaModal="..." attribute is present.
+   *
+   * @param modal "true" or "false"
+   */
+  public void setAriaModal(String modal) {
+    this.isModal = "true".equals(modal);
+    getElement().setAttribute("aria-modal", modal);
+  }
+
+  /**
+   * Sets the aria-labelledby attribute.
+   * Called by UIBinder when ariaLabelledby="..." attribute is present.
+   *
+   * @param id The ID of the element that labels this dialog (usually title)
+   */
+  public void setAriaLabelledby(String id) {
+    getElement().setAttribute("aria-labelledby", id);
+  }
+
+  /**
+   * Sets the aria-describedby attribute.
+   * Called by UIBinder when ariaDescribedby="..." attribute is present.
+   *
+   * @param id The ID of the element that describes this dialog
+   */
+  public void setAriaDescribedby(String id) {
+    getElement().setAttribute("aria-describedby", id);
+  }
+
+  /**
+   * Sets the aria-label attribute.
+   * Called by UIBinder when ariaLabel="..." attribute is present.
+   * Use when dialog has no visible title element.
+   *
+   * @param label The accessible label
+   */
+  public void setAriaLabel(String label) {
+    getElement().setAttribute("aria-label", label);
+  }
+
+  /**
+   * Configure ARIA attributes programmatically.
+   * Use when creating dialogs in Java code (not UIBinder).
+   *
+   * @param titleText The dialog title text (can be null)
+   */
+  public void configureAria(String titleText) {
+    setRole("dialog");
+    setAriaModal("true");
+
+    // If caption exists, link it with aria-labelledby
+    if (getCaption() != null) {
+      String titleId = Document.get().createUniqueId();
+      getCaption().asWidget().getElement().setId(titleId);
+      setAriaLabelledby(titleId);
+    } else if (titleText != null) {
+      setAriaLabel(titleText);
+    }
+  }
+
+  /**
+   * Shows this dialog with proper focus management.
+   * Stores the currently focused element and moves focus to the first
+   * focusable element within the dialog.
+   */
+  @Override
+  public void show() {
+    // Store current focus for restoration
+    com.google.gwt.dom.client.Element activeElement = getFocusedElement();
+    if (activeElement != null) {
+      triggerElement = activeElement;
+    }
+
+    super.show();
+
+    // Move focus to first focusable element in dialog (with a small delay to avoid
+    // conflicts with explicit focus management in subclasses)
+    com.google.gwt.core.client.Scheduler.get().scheduleDeferred(new com.google.gwt.core.client.Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        // Only auto-focus if nothing else has claimed focus
+        com.google.gwt.dom.client.Element currentFocus = getFocusedElement();
+        if (currentFocus == null || !getElement().isOrHasChild(currentFocus)) {
+          focusFirstElement();
+        }
+      }
+    });
+  }
+
+  /**
+   * Hides this dialog and restores focus to the trigger element.
+   */
+  @Override
+  public void hide() {
+    super.hide();
+
+    // Restore focus to trigger element (with a small delay to ensure dialog is fully hidden)
+    final com.google.gwt.dom.client.Element elementToFocus = triggerElement;
+    triggerElement = null;
+
+    if (elementToFocus != null) {
+      com.google.gwt.core.client.Scheduler.get().scheduleDeferred(new com.google.gwt.core.client.Scheduler.ScheduledCommand() {
+        @Override
+        public void execute() {
+          try {
+            // Only restore focus if the element is still in the document and visible
+            if (isElementValid(elementToFocus)) {
+              elementToFocus.focus();
+            }
+          } catch (Exception e) {
+            // Ignore focus restoration errors - element might be gone
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Check if an element is still valid for focus restoration.
+   */
+  private native boolean isElementValid(com.google.gwt.dom.client.Element element) /*-{
+    return element != null &&
+           $doc.body.contains(element) &&
+           element.offsetParent != null;
+  }-*/;
+
+  /**
+   * Handle Escape key press.
+   * Subclasses can override to customize behavior (e.g., prevent closing).
+   */
+  protected void handleEscapeKey() {
+    hide();
+  }
+
+  /**
+   * Focus the first focusable element in the dialog.
+   */
+  private void focusFirstElement() {
+    Widget firstFocusable = findFirstFocusableWidget(this);
+    if (firstFocusable instanceof FocusWidget) {
+      ((FocusWidget) firstFocusable).setFocus(true);
+    } else if (firstFocusable != null) {
+      firstFocusable.getElement().focus();
+    }
+  }
+
+  /**
+   * Find first focusable widget in a widget tree.
+   * Searches recursively through the widget hierarchy.
+   *
+   * @param widget The root widget to search from
+   * @return The first focusable widget found, or null if none found
+   */
+  private Widget findFirstFocusableWidget(Widget widget) {
+    // Check if current widget is focusable
+    if (isFocusable(widget)) {
+      return widget;
+    }
+
+    // If widget is a container, search its children
+    if (widget instanceof HasWidgets) {
+      Iterator<Widget> iterator = ((HasWidgets) widget).iterator();
+      while (iterator.hasNext()) {
+        Widget child = iterator.next();
+        Widget focusable = findFirstFocusableWidget(child);
+        if (focusable != null) {
+          return focusable;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if a widget is focusable.
+   *
+   * @param widget The widget to check
+   * @return true if the widget can receive focus
+   */
+  private boolean isFocusable(Widget widget) {
+    if (widget == null) {
+      return false;
+    }
+
+    // Skip focus trap buttons - they're for Tab key containment, not initial focus
+    com.google.gwt.dom.client.Element element = widget.getElement();
+    if (element != null) {
+      String className = element.getClassName();
+      if (className != null && className.contains("FocusTrap")) {
+        return false;
+      }
+
+      // Skip elements with tabindex="-1"
+      int tabIndex = element.getTabIndex();
+      if (tabIndex < 0) {
+        return false;
+      }
+    }
+
+    // Check if it's a FocusWidget (Button, TextBox, etc.)
+    if (widget instanceof FocusWidget) {
+      FocusWidget focusWidget = (FocusWidget) widget;
+      return focusWidget.isEnabled();
+    }
+
+    // Check if the element has a positive tabindex
+    if (element != null) {
+      int tabIndex = element.getTabIndex();
+      if (tabIndex >= 0) {
+        return true;
+      }
+
+      // Check for naturally focusable elements
+      String tagName = element.getTagName().toLowerCase();
+      if ("a".equals(tagName) || "button".equals(tagName) ||
+          "input".equals(tagName) || "select".equals(tagName) ||
+          "textarea".equals(tagName)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get currently focused element from DOM using JSNI.
+   *
+   * @return The currently focused element, or null if none
+   */
+  private native com.google.gwt.dom.client.Element getFocusedElement() /*-{
+    return $doc.activeElement;
+  }-*/;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/ErrorDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/ErrorDialog.ui.xml
@@ -8,8 +8,8 @@
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
   <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
-  <wiz:Dialog ui:field="dialog" styleName="ode-DialogBox" animationEnabled="true"
-              width="350px" height="150px">
+  <wiz:Dialog ui:field="dialog" role="alertdialog" ariaModal="true" ariaLabel="Error"
+              styleName="ode-DialogBox" animationEnabled="true" width="350px" height="150px">
     <g:FlowPanel>
       <g:HTML ui:field="errorMessage" />
       <g:FlowPanel styleName="buttonRow" >

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadErrorDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/FileUploadErrorDialog.ui.xml
@@ -10,8 +10,8 @@
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
   <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
-  <wiz:Dialog ui:field="uploadError" styleName="ode-DialogBox" animationEnabled="true"
-              width="350px" height="150px">
+  <wiz:Dialog ui:field="uploadError" role="alertdialog" ariaModal="true" ariaLabel="Upload Error"
+              styleName="ode-DialogBox" animationEnabled="true" width="350px" height="150px">
     <g:FlowPanel>
       <g:HTML ui:field="errorMessage" />
       <g:FlowPanel styleName="buttonRow" >

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.ui.xml
@@ -8,10 +8,10 @@
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
   <ui:with field="messages" type="com.google.appinventor.client.OdeMessages"/>
-  <wiz:Dialog ui:field="uiDialog" caption="{messages.uiSettings}"
-              styleName="ode-DialogBox ode-UserSettingsDialog">
+  <wiz:Dialog ui:field="uiDialog" role="dialog" ariaModal="true" ariaLabel="User Interface Settings"
+              caption="{messages.uiSettings}" styleName="ode-DialogBox ode-UserSettingsDialog">
     <g:FlowPanel>
-      <g:Button ui:field='topInvisible' styleName="FocusTrap"/>
+      <g:Button ui:field='topInvisible' styleName="FocusTrap" tabIndex="-1"/>
       <g:FlowPanel styleName="ode-DialogRow">
         <g:Label text="{messages.selectStyle}" />
       </g:FlowPanel>
@@ -54,7 +54,7 @@
         <g:Button ui:field="cancelButton" text='{messages.cancelButton}' styleName="ode-ProjectListButton"/>
         <g:Button ui:field="applyButton" text='{messages.okButton}' styleName="ode-ProjectListButton"/>
       </g:FlowPanel>
-      <g:Button ui:field='bottomInvisible' styleName="FocusTrap" />
+      <g:Button ui:field='bottomInvisible' styleName="FocusTrap" tabIndex="-1" />
     </g:FlowPanel>
   </wiz:Dialog>
 </ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/Wizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/Wizard.java
@@ -7,6 +7,9 @@
 package com.google.appinventor.client.wizards;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
@@ -84,6 +87,29 @@ public abstract class Wizard extends DialogBox {
 
     setStylePrimaryName("ode-DialogBox");
     setText(title);
+
+    // Add ARIA role for dialog accessibility
+    Roles.getDialogRole().set(getElement());
+    if (modal) {
+      getElement().setAttribute("aria-modal", "true");
+    }
+
+    // Set aria-label for accessibility (using title since caption element is not easily accessible)
+    getElement().setAttribute("aria-label", title);
+
+    // Add global Escape key handler for accessibility
+    Event.addNativePreviewHandler(new Event.NativePreviewHandler() {
+      @Override
+      public void onPreviewNativeEvent(Event.NativePreviewEvent event) {
+        if (event.getTypeInt() == Event.ONKEYDOWN &&
+            isShowing() &&
+            event.getNativeEvent().getKeyCode() == KeyCodes.KEY_ESCAPE) {
+          event.getNativeEvent().preventDefault();
+          event.getNativeEvent().stopPropagation();
+          handleCancelClick();
+        }
+      }
+    });
 
     ClickListener buttonListener = new ClickListener() {
       @Override
@@ -316,6 +342,12 @@ public abstract class Wizard extends DialogBox {
 
     // Show page
     pageDeck.showWidget(currentPageIndex);
+
+    // Announce page change to screen readers for multi-page wizards
+    if (pageDeck.getWidgetCount() > 1) {
+      String pageAnnouncement = "Page " + (currentPageIndex + 1) + " of " + pageDeck.getWidgetCount();
+      getElement().setAttribute("aria-label", pageAnnouncement);
+    }
 
     // Because pages are embedded in scroll panels it is important to set the size of the page to
     // the current height of the content panel


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Implement ARIA support for modal dialogs following WCAG 2.1 guidelines.

**Changes:**
  - Enhanced Dialog.java with ARIA setters, global Escape key handling,
    and deferred focus management to avoid race conditions
  - Enhanced Wizard.java with ARIA support and page announcements for
    multi-step dialogs
  - Added ARIA attributes to 5 UIBinder dialog templates
  - Added programmatic ARIA to MessageDialog, NoProjectDialogBox, and
    CopyYoungAndroidProjectCommand (these do not use UIBinder)

**Features:**
  - role="dialog" or role="alertdialog" on all dialogs
  - aria-modal="true" for modal dialogs
  - aria-label for accessible dialog titles
  - Global Escape key closes dialogs from any focused element
  - Auto-focus first interactive element on open (skips FocusTrap buttons)
  - Restore focus to trigger element on close
  - Multi-page wizard announces "Page X of Y" for screen readers



*Testing guidelines:*

This change does not reflect in the lighthouse score (dialogs do not appear on load) but it can be seen by selecting a dialog such as `Settings --> User Interface Settings` and then running the following code in the console and comparing the output in production and with the changes. Prod will likely just show undefined.

```javascript
  document.querySelectorAll('[role="dialog"], [role="alertdialog"]').forEach(dialog => {
    console.log({
      "tag": dialog.tagName,
      "role": dialog.getAttribute('role'),
      "ariaModal": dialog.getAttribute('aria-modal'),
      "ariaLabel": dialog.getAttribute('aria-label'),
      "visible": dialog.offsetParent !== null
    });
  });
```
