### PR TITLE
A11y: Adding lang attribute to main page and alt text to images and icons

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TopPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopPanel.java
@@ -107,6 +107,7 @@ public class TopPanel extends Composite {
       try {
         Image wpr = Image.wrap(logo);
         wpr.addClickHandler(new WindowOpenClickHandler(logoUrl));
+        logo.setAttribute("alt", "MIT App Inventor");
       } catch (AssertionError e) {
         LOG.warning("assertion error in getting Image from logo url");
       }

--- a/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
@@ -171,7 +171,9 @@ public final class BlockSelectorBox extends Box {
     }
     rootItem = new TreeItem(new HTML("<span>" + MESSAGES.builtinBlocksLabel() + "</span>"));
     for (final BlocksCategory category : getSubsetDrawerNames(language, form)) {
-      TreeItem itemNode = new TreeItem(new HTML("<span>" + new Image(category.getImage()) +
+      Image categoryImage = new Image(category.getImage());
+      categoryImage.setAltText(category.getName() + " blocks");
+      TreeItem itemNode = new TreeItem(new HTML("<span>" + categoryImage +
           category.getName() + "</span>"));
       SourceStructureExplorerItem sourceItem = new BlockSelectorItem() {
         @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -168,12 +168,12 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       topInvisible.addFocusHandler(new FocusHandler() {
         @Override
         public void onFocus(FocusEvent event) {
-          okButton.setFocus(true); 
+          okButton.setFocus(true);
         }
       });
       bottomInvisible.addFocusHandler(new FocusHandler() {
         public void onFocus(FocusEvent event) {
-          newNameTextBox.setFocus(true); 
+          newNameTextBox.setFocus(true);
         }
       });
 
@@ -350,6 +350,9 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     this.editor = editor;
     this.type = type;
     this.iconImage = iconImage;
+    if (iconImage != null) {
+      iconImage.getElement().setAttribute("alt", "component icon");
+    }
     this.handlers = new HandlerManager(this);
     COMPONENT_DATABASE = editor.getComponentDatabase();
     componentDefinition = COMPONENT_DATABASE.getComponentDefinition(type);
@@ -891,7 +894,8 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     // Note: We create a ClippedImagePrototype because we need something that can be
     // used to get HTML for the iconImage. AbstractImagePrototype requires
     // an ImageResource, which we don't necessarily have.
-    TreeItem itemNode = new TreeItem(
+
+    final TreeItem itemNode = new TreeItem(
         new HTML("<span>" + iconImage.getElement().getString() + SafeHtmlUtils.htmlEscapeAllowEntities(getName()) + "</span>")) {
       @Override
       protected Focusable getFocusable() {
@@ -899,6 +903,21 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       }
     };
     itemNode.setUserObject(sourceStructureExplorerItem);
+
+    // Set alt text on the icon image for accessibility
+    // Use Scheduler to defer until DOM is attached
+    final String altText = getName() + " " + getVisibleTypeName();
+    com.google.gwt.core.client.Scheduler.get().scheduleDeferred(new com.google.gwt.core.client.Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        com.google.gwt.dom.client.Element element = itemNode.getElement();
+        com.google.gwt.dom.client.NodeList<com.google.gwt.dom.client.Element> imgs = element.getElementsByTagName("img");
+        if (imgs.getLength() > 0) {
+          imgs.getItem(0).setAttribute("alt", altText);
+        }
+      }
+    });
+
     return itemNode;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -182,6 +182,7 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
      */
     PhoneBar() {
       Image phoneBarImage = new Image(images.phonebar());
+      phoneBarImage.setAltText("Android status bar");
       bar = new DockPanel();
       bar.setHorizontalAlignment(HorizontalPanel.ALIGN_RIGHT);
       bar.add(phoneBarImage, DockPanel.EAST);
@@ -193,6 +194,7 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
 
     PhoneBar(String color) {
       Image phoneBarAndroidMaterial = new Image(images.phonebarAndroidMaterial());
+      phoneBarAndroidMaterial.setAltText("Android status bar");
 
       bar = new DockPanel();
       bar.setHorizontalAlignment(HorizontalPanel.ALIGN_RIGHT);
@@ -207,9 +209,13 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
     PhoneBar(boolean blackIcons, int size, String color) {
       // icons for iPhone
       blackIconsLeft = new Image(images.phonebariPhoneLeftBlack());
+      blackIconsLeft.setAltText("iOS status bar left");
       blackIconsRight = new Image(images.phonebariPhoneRightBlack());
+      blackIconsRight.setAltText("iOS status bar right");
       whiteIconsLeft = new Image(images.phonebariPhoneLeftWhite());
+      whiteIconsLeft.setAltText("iOS status bar left");
       whiteIconsRight = new Image(images.phonebariPhoneRightWhite());
+      whiteIconsRight.setAltText("iOS status bar right");
 
       phoneBarLeftPanel = new HorizontalPanel();
       phoneBarLeftPanel.setStylePrimaryName("ode-SimpleMockFormLeft");
@@ -218,9 +224,13 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
 
       //icons for iPad
       iPadWhiteIconsLeft = new Image(images.phonebariPadLeftWhite());
+      iPadWhiteIconsLeft.setAltText("iOS status bar left");
       iPadWhiteIconsRight = new Image(images.phonebariPadRightWhite());
+      iPadWhiteIconsRight.setAltText("iOS status bar right");
       iPadBlackIconsLeft = new Image(images.phonebariPadLeftBlack());
+      iPadBlackIconsLeft.setAltText("iOS status bar left");
       iPadBlackIconsRight = new Image(images.phonebariPadRightBlack());
+      iPadBlackIconsRight.setAltText("iOS status bar right");
 
       iPadPhoneBarLeftPanel = new HorizontalPanel();
       iPadPhoneBarLeftPanel.setStylePrimaryName("ode-SimpleMockFormLeftIPad");

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPaletteItemWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPaletteItemWidget.java
@@ -27,6 +27,11 @@ public abstract class AbstractPaletteItemWidget extends Image {
     AbstractImagePrototype.create(image).applyTo(this);
     this.addStyleName("ode-SimplePaletteItem-button");
 
+    String altText = getAltText();
+    if (altText != null && !altText.isEmpty()) {
+      getElement().setAttribute("alt", altText);
+    }
+
     addClickHandler(new ClickHandler() {
       @Override
       public void onClick(ClickEvent event) {
@@ -52,4 +57,11 @@ public abstract class AbstractPaletteItemWidget extends Image {
    * Handles when the user clicks (or taps) on the button.
    */
   protected abstract void handleClick();
+
+  /**
+   * Returns the alternative text for this button's image (for screen readers).
+   *
+   * @return The alt text string for this button
+   */
+  public abstract String getAltText();
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/BaseComponentFactory.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/BaseComponentFactory.java
@@ -247,19 +247,21 @@ public class BaseComponentFactory implements ComponentFactory {
   }
 
   private Image getImageFromPath(String iconPath, String packageName) {
+    Image image;
     if (iconPath.startsWith("aiwebres/") && packageName != null) {
       // icon for extension
-      Image image = new Image(StorageUtil.getFileUrl(editor.getProjectId(),
+      image = new Image(StorageUtil.getFileUrl(editor.getProjectId(),
           "assets/external_comps/" + packageName + "/" + iconPath));
       image.setWidth("16px");
       image.setHeight("16px");
-      return image;
-    }
-    if (bundledImages.containsKey(iconPath)) {
-      return new Image(bundledImages.get(iconPath));
+    } else if (bundledImages.containsKey(iconPath)) {
+      image = new Image(bundledImages.get(iconPath));
     } else {
-      return new Image(iconPath);
+      image = new Image(iconPath);
     }
+    // Set alt text for accessibility - will be updated with component name later
+    image.setAltText("component icon");
+    return image;
   }
 
   private String getLicenseUrlFromPath(String licensePath, String packageName) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentHelpWidget.java
@@ -127,7 +127,7 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
             lastClosureTime = System.currentTimeMillis();
           }
         });
-      
+
       showRelativeTo(ComponentHelpWidget.this);
     }
   }
@@ -144,5 +144,10 @@ public final class ComponentHelpWidget extends AbstractPaletteItemWidget {
         MINIMUM_MS_BETWEEN_SHOWS) {
       new ComponentHelpPopup();
     }
+  }
+
+  @Override
+  public String getAltText() {
+    return scd.getName() + " help";
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentRemoveWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/ComponentRemoveWidget.java
@@ -41,4 +41,9 @@ public class ComponentRemoveWidget extends AbstractPaletteItemWidget {
       }
     }
   }
+
+  @Override
+  public String getAltText() {
+    return "Remove " + name + " component";
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePaletteItem.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePaletteItem.java
@@ -14,6 +14,7 @@ import com.google.appinventor.client.editor.simple.components.MockComponentsUtil
 import com.google.appinventor.client.editor.simple.components.MockContainer;
 import com.google.appinventor.client.editor.simple.components.MockForm;
 import com.google.appinventor.client.editor.simple.components.MockVisibleComponent;
+import com.google.appinventor.client.utils.ImageAccessibility;
 import com.google.appinventor.client.widgets.dnd.DragSourcePanel;
 import com.google.appinventor.client.widgets.dnd.DragSourceSupport;
 import com.google.appinventor.client.widgets.dnd.DropTarget;
@@ -61,6 +62,8 @@ public class SimplePaletteItem extends DragSourcePanel {
 
     Image image = new Image(scd.getImage().getUrl());
     image.setStylePrimaryName("ode-SimplePaletteItem-icon");
+    String altText = ComponentTranslationTable.getComponentName(scd.getName()) + " component";
+    ImageAccessibility.setAltText(image, altText);
     panel.add(image);
     panel.setCellHorizontalAlignment(image, HorizontalPanel.ALIGN_LEFT);
     panel.setCellWidth(image, "30px");

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/ImageAccessibility.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/ImageAccessibility.java
@@ -1,0 +1,60 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 Massachusetts Institute of Technology. All Rights Reserved.
+
+/* This is the package-info.java file for com.google.appinventor.client.utils.
+ *
+ * @author jos@josdesign.nl (Jos Hirth)
+ */
+
+package com.google.appinventor.client.utils;
+
+import com.google.gwt.user.client.ui.Image;
+
+/**
+ * Utility methods for making images accessible.
+ *
+ * <p>This class provides helper methods to add accessibility attributes to GWT Image widgets.
+ * GWT's Image widget doesn't automatically set alt attributes, so these utilities make it
+ * easier to ensure all images have proper alternative text for screen readers.</p>
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * Image image = new Image("icon.png");
+ * ImageAccessibility.setAltText(image, "Component icon");
+ * }</pre>
+ */
+public class ImageAccessibility {
+
+  /**
+   * Sets the alt text for an image using DOM manipulation.
+   * This is the proper way to add alt attributes to GWT Image widgets.
+   *
+   * <p>Screen readers will read this text aloud when the image is encountered,
+   * allowing visually impaired users to understand what the image represents.</p>
+   *
+   * @param image The GWT Image widget
+   * @param altText The alternative text description
+   */
+  public static void setAltText(Image image, String altText) {
+    if (image != null && altText != null) {
+      image.getElement().setAttribute("alt", altText);
+    }
+  }
+
+  /**
+   * Marks an image as decorative (empty alt text and role="presentation").
+   * Use this for images that are purely decorative and provide no information.
+   *
+   * <p>Decorative images should have empty alt text, which tells screen readers
+   * to skip over them entirely. This prevents unnecessary clutter in the
+   * accessibility tree.</p>
+   *
+   * @param image The GWT Image widget
+   */
+  public static void setDecorative(Image image) {
+    if (image != null) {
+      image.getElement().setAttribute("alt", "");
+      image.getElement().setAttribute("role", "presentation");
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyHelpWidget.java
@@ -77,6 +77,11 @@ public final class PropertyHelpWidget extends Image {
       imageResource = images.help();
     }
     AbstractImagePrototype.create(imageResource).applyTo(this);
+
+    // Add alt text for accessibility - helps screen readers describe the help button
+    String altText = ComponentTranslationTable.getPropertyName(prop.getName()) + " help";
+    getElement().setAttribute("alt", altText);
+
     addClickListener(new ClickListener() {
         @Override
         public void onClick(Widget sender) {

--- a/appinventor/appengine/war/index.jsp
+++ b/appinventor/appengine/war/index.jsp
@@ -45,7 +45,7 @@
 <!-- Copyright 2007-2009 Google Inc. All Rights Reserved. -->
 <!-- Copyright 2011-2025 Massachusetts Institute of Technology. All Rights Reserved. -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=10">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

There are two main changes in this PR that directly affect an accessibility test such as lighthouse: First by adding a default lang attribute the score improves, and by adding alt text to all images and icons, the score improves again. Alt texts are managed directly through setter methods but in some cases, such as images in the source tree structure, they have to be deferred from creation to actual attachment to the DOM.

The score might vary depending on the test and if other A11y PRs have been merged or not, but this PR alone should result in an increase of around x points, from a current score of 77 (prod server) to 82 when loading a simple project (the project itself might also affect the score).

*Testing guidelines*
Run a lighthouse report from dev tools (chrome, brave, etc). I have been running with mode: Navigation, Desktop version, and just the accessibility check.