### PR TITLE
A11y work to add ARIA roles to tree nav and form controls

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaVisibleComponentsPanel.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaVisibleComponentsPanel.ui.xml
@@ -11,13 +11,13 @@
     <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
     <g:VerticalPanel styleName="ode-SimpleFormDesigner">
         <g:VerticalPanel ui:field="phoneScreen" stylePrimaryName="ode-SimpleFormDesigner">
-          <g:CheckBox ui:field="HiddenComponentsCheckbox" text="{messages.showHiddenComponentsCheckbox}" />
-            <g:ListBox ui:field="listboxPhoneTablet">
+          <g:CheckBox ui:field="HiddenComponentsCheckbox" text="{messages.showHiddenComponentsCheckbox}" title="{messages.showHiddenComponentsCheckbox}" />
+            <g:ListBox ui:field="listboxPhoneTablet" title="{messages.previewDeviceSize}">
                 <g:item value="320, 505"><ui:text from="{messages.previewPhoneSize}" /> (320 x 505)</g:item>
                 <g:item value="480, 675"><ui:text from="{messages.previewTabletSize}" /> (480 x 675)</g:item>
                 <g:item value="768, 1024"><ui:text from="{messages.previewMonitorSize}" /> (768 x 1024)</g:item>
             </g:ListBox>
-          <g:ListBox ui:field="listboxPhonePreview">
+          <g:ListBox ui:field="listboxPhonePreview" title="{messages.previewOperatingSystem}">
             <g:item value="0"><ui:text from="{messages.previewAndroid5Devices}"/></g:item>
             <g:item value="1"><ui:text from="{messages.previewAndroid4Devices}"/></g:item>
             <g:item value="2"><ui:text from="{messages.previewIOS}"/></g:item>

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -26,6 +26,7 @@ import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.OpenEvent;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.aria.client.Roles;
 
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -82,6 +83,7 @@ public class SourceStructureExplorer extends Composite {
     tree = new EventCaptureTree(Ode.getImageBundle());
     tree.setAnimationEnabled(true);
     tree.setScrollOnSelectEnabled(false);
+    Roles.getTreeRole().set(tree.getElement());
     tree.addCloseHandler(new CloseHandler<TreeItem>() {
       @Override
       public void onClose(CloseEvent<TreeItem> event) {

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/YaVisibleComponentsPanelNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/YaVisibleComponentsPanelNeo.ui.xml
@@ -13,19 +13,19 @@
     <g:VerticalPanel ui:field="phoneScreen" stylePrimaryName="ode-SimpleFormDesigner"  horizontalAlignment="ALIGN_CENTER">
       <g:FlowPanel  stylePrimaryName="ode-SimpleFormDesignerToolbar">
         <ai:Icon ui:field="size_icon" icon="aspect_ratio" tooltip="{messages.previewDeviceSize}" />
-        <g:ListBox ui:field="listboxPhoneTablet">
+        <g:ListBox ui:field="listboxPhoneTablet" title="{messages.previewDeviceSize}">
           <g:item value="320, 650"><ui:text from="{messages.previewPhone}" /> (320 x 650)</g:item>
           <g:item value="480, 675"><ui:text from="{messages.previewTablet}" /> (480 x 675)</g:item>
           <g:item value="768, 1024"><ui:text from="{messages.previewMonitor}" /> (768 x 1024)</g:item>
         </g:ListBox>
         <ai:Icon ui:field="os_icon" icon="smartphone" tooltip="{messages.previewOperatingSystem}" />
-        <g:ListBox ui:field="listboxPhonePreview">
+        <g:ListBox ui:field="listboxPhonePreview" title="{messages.previewOperatingSystem}">
           <g:item value="0"><ui:text from="{messages.previewAndroidMaterial}" /></g:item>
           <g:item value="1"><ui:text from="{messages.previewAndroidHolo}" /></g:item>
           <g:item value="2"><ui:text from="{messages.previewIOS13}" /></g:item>
         </g:ListBox>
         <ai:Icon icon="visibility_off" tooltip="{messages.showInvisiblePropertyComponents}"/>
-        <g:CheckBox ui:field="HiddenComponentsCheckbox" />
+        <g:CheckBox ui:field="HiddenComponentsCheckbox" text="{messages.showHiddenComponentsCheckbox}" title="{messages.showHiddenComponentsCheckbox}" />
       </g:FlowPanel>
     </g:VerticalPanel>
   </g:VerticalPanel>

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/AdditionalChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/AdditionalChoicePropertyEditor.java
@@ -187,4 +187,11 @@ public abstract class AdditionalChoicePropertyEditor extends PropertyEditor {
       updateValue();
     }
   }
+
+  @Override
+  public void setAriaLabelledBy(String labelId) {
+    if (labelId != null && !labelId.isEmpty()) {
+      summary.getElement().setAttribute("aria-labelledby", labelId);
+    }
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/BooleanPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/BooleanPropertyEditor.java
@@ -51,6 +51,15 @@ public class BooleanPropertyEditor extends PropertyEditor implements ValueChange
     }
   }
 
+  @Override
+  public void setAriaLabelledBy(String labelId) {
+    if (labelId != null && !labelId.isEmpty()) {
+      // GWT CheckBox renders as <input type="checkbox"> inside the wrapper
+      // We need to set aria-labelledby on the input element
+      checkbox.getElement().getFirstChildElement().setAttribute("aria-labelledby", labelId);
+    }
+  }
+
   // ValueChangeHandler implementation
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/ChoicePropertyEditor.java
@@ -237,4 +237,11 @@ public class ChoicePropertyEditor extends PropertyEditor {
     dropDownButton.setVisible(visible);
   }
 
+  @Override
+  public void setAriaLabelledBy(String labelId) {
+    if (labelId != null && !labelId.isEmpty()) {
+      dropDownButton.getElement().setAttribute("aria-labelledby", labelId);
+    }
+  }
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
@@ -114,6 +114,9 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
       HorizontalPanel header = new HorizontalPanel();
       Label label = new Label(property.getCaption());
       label.setStyleName("ode-PropertyLabel");
+      // Generate unique ID for the label to enable aria-labelledby association
+      String labelId = "prop-label-" + property.getName() + "-" + System.currentTimeMillis();
+      label.getElement().setId(labelId);
       header.add(label);
       header.setStyleName("ode-PropertyHeader");
       if ( hasValidDescription(property) ) {
@@ -128,6 +131,8 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
       if (!editor.getStyleName().contains("PropertyEditor")) {
         editor.setStyleName("ode-PropertyEditor");
       }
+      // Set aria-labelledby on the form control to associate it with the label
+      editor.setAriaLabelledBy(labelId);
       parent.add(editor);
       parent.setWidth("100%");
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertyEditor.java
@@ -93,4 +93,15 @@ public abstract class PropertyEditor extends Composite {
   public boolean isMultipleValues() {
     return multiple;
   }
+
+  /**
+   * Sets the aria-labelledby attribute on the form control element.
+   * Default implementation does nothing. Subclasses should override to set the attribute
+   * on their specific form control element (input, textarea, checkbox, etc.).
+   *
+   * @param labelId the ID of the label element that describes this form control
+   */
+  public void setAriaLabelledBy(String labelId) {
+    // Default implementation does nothing
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/TextPropertyEditorBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/TextPropertyEditorBase.java
@@ -122,6 +122,13 @@ public class TextPropertyEditorBase extends PropertyEditor {
     textEdit.setText(property.getValue());
   }
 
+  @Override
+  public void setAriaLabelledBy(String labelId) {
+    if (labelId != null && !labelId.isEmpty()) {
+      textEdit.getElement().setAttribute("aria-labelledby", labelId);
+    }
+  }
+
   private void handleKeyPress(char keyCode) {
     if (keyCode == KeyCodes.KEY_ENTER || keyCode == KeyCodes.KEY_TAB) {
       // Pressing <tab>, <enter> or <return> will surrender focus.

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.ui.xml
@@ -48,7 +48,7 @@
     </g:FlowPanel>
     <g:FlowPanel styleName="ode-DialogRow">
       <g:Label text="{messages.selectTheme}" />
-      <g:ListBox multipleSelect="false" ui:field="themeSelector" />
+      <g:ListBox multipleSelect="false" ui:field="themeSelector" title="{messages.selectTheme}" />
     </g:FlowPanel>
       <g:FlowPanel styleName="buttonRow">
         <g:Button ui:field="cancelButton" text='{messages.cancelButton}' styleName="ode-ProjectListButton"/>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

A11y ARIA work for tree navigation and form controls. This PR has a direct effect on lighthouse score when run on project load page. In some cases we use aria-labelledby instead of a direct label because of the way GWT renders the controls.

*Testing guidelines*
Running a lighthouse report (navigation mode, desktop and just accessibility category) should produce an increased score when loading a project (depending on the project, other A11y PRs) of at least 5 points (in my testing it goes from 77 to 82 with a simple project with 1 button and two labels).