### PR TITLE
Improve handling of onAttach

### DIFF
--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -209,6 +209,17 @@ let kMinimumToastWait = 10.0
 
   private var _dimensions = [Int:NSLayoutConstraint]()
 
+  open func onAttach() {
+    for child in _components {
+      guard let child = child as? ViewComponent else {
+        continue
+      }
+      if child.Visible {
+        child.onAttach()
+      }
+    }
+  }
+
   open func setChildWidth(of component: ViewComponent, to width: Int32) {
     if width <= kLengthPercentTag {
       _linearView.setWidth(of: component.view, to: Length(percent: width, of: _scaleFrameLayout))
@@ -382,6 +393,7 @@ let kMinimumToastWait = 10.0
         obj.perform(#selector(Initialize))
       }
     }
+    onAttach()
   }
 
   func defaultPropertyValues() {

--- a/appinventor/components-ios/src/Label.swift
+++ b/appinventor/components-ios/src/Label.swift
@@ -27,6 +27,7 @@ public final class Label: ViewComponent, AbstractMethodsForViewComponent, Access
     _view.lineBreakMode = .byWordWrapping
     _view.font = _view.font.withSize(14.0)
     _view.textColor = preferredTextColor(parent.form)
+    _view.backgroundColor = preferredBackgroundColor(parent.form)
     super.init(parent)
     super.setDelegate(self)
     parent.add(self)

--- a/appinventor/components-ios/src/ViewComponent.swift
+++ b/appinventor/components-ios/src/ViewComponent.swift
@@ -91,7 +91,7 @@ import Foundation
   }
 
   open func onAttach() {
-    guard attachedToWindow else {
+    guard Visible else {
       return
     }
     guard let container = _container else {


### PR DESCRIPTION
Change-Id: Id11663fd3698d8a1676f70df29bc94061efe8f3b

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR resolves #3703 by ensuring that the onAttach functionality in Form is triggered to update the width/height of descendants of Form during initialization.