### PR TITLE
Improve descriptions for APK build and installation status messages

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -2538,11 +2538,11 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   String apkSavedToComputer();
 
   @DefaultMessage("The APK file will be installed in the phone.")
-  @Description("")
+  @Description("Status message shown when the system is installing the generated APK directly onto the connected phone.")
   String apkInstalledToPhone();
 
   @DefaultMessage("Waiting for the barcode.")
-  @Description("")
+  @Description("Status message shown while the system is waiting for a barcode scan to complete.")
   String waitingForBarcode();
 
   @DefaultMessage("Preparing application icon")
@@ -2550,7 +2550,7 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   String preparingApplicationIcon();
 
   @DefaultMessage("Determining permissions")
-  @Description("")
+  @Description("Status message shown while the build system determines the permissions required by the project.")
   String determiningPermissions();
 
   @DefaultMessage("Generating application information")


### PR DESCRIPTION
This PR improves the clarity of developer-facing descriptions for several APK build and installation status messages in OdeMessages.java.

Changes are limited to @Description annotations only and do not affect user-facing text, logic, or behaviour.

Test confirmation:
- App Inventor runs locally using the development server
- Build and install flow verified
