### PR TITLE
Fix project properties when lastOpened is blank

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -845,6 +845,9 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   private boolean isLastOpened(String formName) {
     String lastOpened = this.getProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED);
+    if (lastOpened.isEmpty()) { // This happens sometimes when a screen is deleted
+      lastOpened = "Screen1";   // Haven't found the cause, so this is a workaround
+    }
     return lastOpened.equals(formName);
   }
 


### PR DESCRIPTION
Under some circumstances, as of now unknown, the lastOpened field of a project properties can be set to the empty string when a screen is deleted.

This commit offers a work around setting lastOpened to Screen1 when it is found to be the empty string.

Change-Id: I9af97423b6e9a6afac32fba907a255d85f7fe210

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .
