### PR TITLE
A11y work to remove nested table in empty trash dialog

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -1601,39 +1601,25 @@ public class Ode implements EntryPoint {
     dialogBox.setStylePrimaryName("ode-DialogBox");
     dialogBox.setText(MESSAGES.createNoProjectsDialogText());
 
-    Grid mainGrid = new Grid(2, 2);
-    mainGrid.getCellFormatter().setAlignment(0,
-            0,
-            HasHorizontalAlignment.ALIGN_CENTER,
-            HasVerticalAlignment.ALIGN_MIDDLE);
-    mainGrid.getCellFormatter().setAlignment(0,
-            1,
-            HasHorizontalAlignment.ALIGN_CENTER,
-            HasVerticalAlignment.ALIGN_MIDDLE);
-    mainGrid.getCellFormatter().setAlignment(1,
-            1,
-            HasHorizontalAlignment.ALIGN_RIGHT,
-            HasVerticalAlignment.ALIGN_MIDDLE);
+    HorizontalPanel mainPanel = new HorizontalPanel();
+    mainPanel.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
+    mainPanel.setSpacing(10);
 
     Image dialogImage = new Image(Ode.getImageBundle().codiVert());
 
-    Grid messageGrid = new Grid(2, 1);
-    messageGrid.getCellFormatter().setAlignment(0,
-            0,
-            HasHorizontalAlignment.ALIGN_JUSTIFY,
-            HasVerticalAlignment.ALIGN_MIDDLE);
-    messageGrid.getCellFormatter().setAlignment(1,
-            0,
-            HasHorizontalAlignment.ALIGN_LEFT,
-            HasVerticalAlignment.ALIGN_MIDDLE);
-
+    VerticalPanel messagePanel = new VerticalPanel();
+    messagePanel.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_LEFT);
 
     Label messageChunk2 = new Label(MESSAGES.showEmptyTrashMessage());
-    messageGrid.setWidget(1, 0, messageChunk2);
-    mainGrid.setWidget(0, 0, dialogImage);
-    mainGrid.setWidget(0, 1, messageGrid);
+    messagePanel.add(messageChunk2);
 
-    dialogBox.setWidget(mainGrid);
+    mainPanel.add(dialogImage);
+    mainPanel.add(messagePanel);
+
+    mainPanel.setCellHorizontalAlignment(dialogImage, HasHorizontalAlignment.ALIGN_CENTER);
+    mainPanel.setCellVerticalAlignment(dialogImage, HasVerticalAlignment.ALIGN_MIDDLE);
+
+    dialogBox.setWidget(mainPanel);
     dialogBox.center();
 
     if (showDialog) {
@@ -2688,7 +2674,7 @@ public class Ode implements EntryPoint {
   public interface Resources extends ClientBundle {
 
     public static final Resources INSTANCE =  GWT.create(Resources.class);
-    
+
     @Source({
       "com/google/appinventor/client/style/classic/light.css",
       "com/google/appinventor/client/style/classic/variableColors.css"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine


<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
It removes a nested table (Grid added to a Grid) in the empty trash dialog. Nested tables are an accessibility issue.

*Testing guidelines*
The only way I've found to trigger this dialog is to have an empty trash. From projects list, change to trash, empty it if needed, then swap back from list to trash and you'll see the dialog. It looks the same as current prod.