### PR TITLE
Optimize RoboelectricTestBase with shared Form instance

### DIFF
--- a/appinventor/components/tests/com/google/appinventor/components/runtime/RobolectricTestBase.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/RobolectricTestBase.java
@@ -15,7 +15,7 @@ import com.google.appinventor.components.runtime.shadows.ShadowEventDispatcher;
 import com.google.appinventor.components.runtime.shadows.org.osmdroid.tileprovider.util.ShadowStorageUtils;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import org.junit.Before;
-import org.junit.BeforeClass; // Added this tool to run code only once
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
     shadows = {ShadowStorageUtils.class, ShadowEventDispatcher.class, ShadowAsynchUtil.class})
 public class RobolectricTestBase {
 
-  // This variable now stays in memory for the whole test run
   private static Form sharedForm;
 
   private static class FakeForm extends Form {
@@ -63,20 +62,14 @@ public class RobolectricTestBase {
     return sharedForm;
   }
 
-  /**
-   * This method runs ONLY ONCE at the very beginning.
-   * It builds the "Fake Phone" (Form) that all tests will share.
-   */
   @BeforeClass
   public static void setUpBeforeClass() {
     if (sharedForm == null) {
       shadowOf(Looper.getMainLooper()).getScheduler().setIdleState(IdleState.PAUSED);
-      // Build the activity once
       ActivityController<FakeForm> activityController = Robolectric.buildActivity(FakeForm.class).setup();
       sharedForm = activityController.get();
       sharedForm.DefaultFileScope(FileScope.Legacy);
       
-      // Simulate layout once
       View v = sharedForm.getFrameLayout();
       v.layout(0, 0, 240, 320);
       v.measure(240, 320);
@@ -86,23 +79,30 @@ public class RobolectricTestBase {
     }
   }
 
-  /**
-   * This method runs before EVERY test.
-   * It no longer builds a phone; it just clears old messages (Light Cleaning).
-   */
   @Before
   public void setUp() {
-    ShadowEventDispatcher.clearEvents(); // Start with a clean slate
+    if (sharedForm == null) {
+      setUpBeforeClass();
+    }
+    
+    // Reset state to ensure isolation between tests
+    if (sharedForm.getFrameLayout() != null) {
+      sharedForm.getFrameLayout().removeAllViews();
+    }
+    
+    sharedForm.Title("Screen1");
+    sharedForm.BackgroundColor(Component.COLOR_WHITE);
+    sharedForm.BackgroundImage("");
+    
+    ShadowEventDispatcher.clearEvents();
+    sharedForm.ErrorOccurredEvent(sharedForm, "", 0, "");
   }
 
   public void setUpAsRepl() {
-    // Note: If a test specifically needs the REPL form, 
-    // it will still use the existing logic, but most use FakeForm.
     setUpForm(FakeReplForm.class);
   }
 
   private <T extends Form> void setUpForm(Class<T> clazz) {
-    // Keep this for specialized setup if needed
     shadowOf(Looper.getMainLooper()).getScheduler().setIdleState(IdleState.PAUSED);
     ActivityController<T> activityController = Robolectric.buildActivity(clazz).setup();
     sharedForm = activityController.get();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
**Description**
This PR implements a shared `Form` instance in `RobolectricTestBase` as suggested in issue #3387. By moving the initialization to a `@BeforeClass` block, we avoid the overhead of reconstructing the environment for every test case.

**Performance Impact (Local Benchmarks)**
* **Baseline:** 3m 9s
* **Optimized:** ~2m 18s
* **Total Savings:** ~51 seconds (~27% reduction)

**Testing**
Verified locally using `ant tests -Dskip.ios=true`. All tests passed.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3387.

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

