### PR TITLE
Improve contrast for Download APK dialog link text

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -1073,7 +1073,11 @@ select.ode-PropertyEditor[disabled] {
 }
 
 .ode-DialogBox .dialogContent td a {
-    color: gray-800;
+    color: selected-color;
+}
+
+.ode-DialogBox .download-button span {
+  color: gray-800;
 }
 
 .ode-SimpleMockContainer {


### PR DESCRIPTION
### What this changes
Improves the text contrast of the "Download .apk now" link in the Download APK dialog.

### Why
The link text had insufficient contrast against the background, making it difficult to read and not meeting accessibility expectations.

### How
- Updated CSS to use an existing palette color with better contrast
- No color palette definitions were changed

### Testing
- Verified using browser-based testing and developer tools

Fixes #3729
