### PR TITLE
Avoid unpacking assets & jni libraries in the AAR package dir.

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibrary.java
@@ -241,6 +241,10 @@ public class AARLibrary {
       Enumeration<? extends ZipEntry> i = zip.entries();
       while (i.hasMoreElements()) {
         ZipEntry entry = i.nextElement();
+        if (entry.getName().startsWith(ASSET_DIR) || entry.getName().startsWith(JNI_DIR)) {
+          // These are not needed here as we're already merging jni & assets (AttachAarLibs.java:104:122).
+          continue;
+        }
         File target = new File(basedir, entry.getName());
         if (entry.isDirectory() && !target.exists() && !target.mkdirs()) {
           throw new IOException("Unable to create directory " + path.getAbsolutePath());


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

*Avoid unpacking assets & jni libraries in the AAR package dir. These are not necessary here.*

Fixes # .

Resolves # .
