### PR TITLE
Fix canonical project name handling in TextValidators

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -88,12 +88,12 @@ public final class TextValidators {
     if (existing != null) {
       if (existing.isInTrash()) {
         Window.alert(MESSAGES.duplicateTrashProjectNameError(canonicalName));
-      return ProjectNameStatus.DUPLICATEINTRASH;
-  }
-  if (!quietly) {
-    Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
-  }
-      return ProjectNameStatus.DUPLICATE;
+        return ProjectNameStatus.DUPLICATEINTRASH;
+      }
+        if (!quietly) {
+          Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
+        }
+        return ProjectNameStatus.DUPLICATE;
     }
     return ProjectNameStatus.SUCCESS;
   }
@@ -155,7 +155,7 @@ public final class TextValidators {
    */
   public static ProjectNameStatus checkNewFolderName(String folderName, ProjectFolder parent) {
     // Check the format of the folder name
-     if (!isValidIdentifier(folderName)) {
+    if (!isValidIdentifier(folderName)) {
       // TODO: Decide whether to use new strings
       Window.alert(MESSAGES.malformedProjectNameError());
       return ProjectNameStatus.INVALIDFORMAT;

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -12,10 +12,10 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
 import com.google.appinventor.client.explorer.folder.ProjectFolder;
-import com.google.gwt.http.client.URL;
-import com.google.gwt.user.client.Window;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.explorer.project.ProjectManager;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.user.client.Window;
 
 import java.util.Arrays;
 import java.util.List;
@@ -90,10 +90,10 @@ public final class TextValidators {
         Window.alert(MESSAGES.duplicateTrashProjectNameError(canonicalName));
         return ProjectNameStatus.DUPLICATEINTRASH;
       }
-        if (!quietly) {
-          Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
-        }
-        return ProjectNameStatus.DUPLICATE;
+      if (!quietly) {
+        Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
+      }
+      return ProjectNameStatus.DUPLICATE;
     }
     return ProjectNameStatus.SUCCESS;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -66,14 +66,14 @@ public final class TextValidators {
   public static ProjectNameStatus checkNewProjectName(String projectName, boolean quietly) {
 
     // Check the format of the project name
-     ValidationResult result = validateName(projectName);
-     String canonicalName = result.modifiedName;
-    if (!isValidIdentifier(canonicalName)) {
+    if (!isValidIdentifier(projectName)) {
       if (!quietly) {
         Window.alert(MESSAGES.malformedProjectNameError());
       }
       return ProjectNameStatus.INVALIDFORMAT;
     }
+    ValidationResult result = validateName(projectName);
+    String canonicalName = result.modifiedName;
 
     // Check for names that reserved words
     if (isReservedName(canonicalName)) {
@@ -85,10 +85,10 @@ public final class TextValidators {
     ProjectManager pm = Ode.getInstance().getProjectManager();
     Project existing = pm.getProject(canonicalName);
 
-   if (existing != null) {
-    if (existing.isInTrash()) {
-    Window.alert(MESSAGES.duplicateTrashProjectNameError(canonicalName));
-    return ProjectNameStatus.DUPLICATEINTRASH;
+    if (existing != null) {
+      if (existing.isInTrash()) {
+        Window.alert(MESSAGES.duplicateTrashProjectNameError(canonicalName));
+      return ProjectNameStatus.DUPLICATEINTRASH;
   }
   if (!quietly) {
     Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
@@ -105,12 +105,12 @@ public final class TextValidators {
   public static boolean checkNewComponentName(String componentName) {
 
     // Check that it meets the formatting requirements.
-    ValidationResult result = validateName(componentName);
-    String canonicalName = result.modifiedName; 
-    if (!TextValidators.isValidComponentIdentifier(canonicalName)) {
+    if (!TextValidators.isValidComponentIdentifier(componentName)) {
       Window.alert(MESSAGES.malformedComponentNameError());
       return false;
     }
+    ValidationResult result = validateName(componentName);
+    String canonicalName = result.modifiedName; 
 
     long projectId = Ode.getInstance().getCurrentYoungAndroidProjectId();
     if ( projectId == 0) { // Check we have a current Project
@@ -155,13 +155,13 @@ public final class TextValidators {
    */
   public static ProjectNameStatus checkNewFolderName(String folderName, ProjectFolder parent) {
     // Check the format of the folder name
-    ValidationResult result = validateName(folderName);
-    String canonicalName = result.modifiedName;
-     if (!isValidIdentifier(canonicalName)) {
+     if (!isValidIdentifier(folderName)) {
       // TODO: Decide whether to use new strings
       Window.alert(MESSAGES.malformedProjectNameError());
       return ProjectNameStatus.INVALIDFORMAT;
     }
+    ValidationResult result = validateName(folderName);
+    String canonicalName = result.modifiedName;
 
     // Check for names that reserved words
     if (isReservedName(canonicalName)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -14,6 +14,8 @@ import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
 import com.google.appinventor.client.explorer.folder.ProjectFolder;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Window;
+import com.google.appinventor.client.explorer.project.Project;
+import com.google.appinventor.client.explorer.project.ProjectManager;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +66,9 @@ public final class TextValidators {
   public static ProjectNameStatus checkNewProjectName(String projectName, boolean quietly) {
 
     // Check the format of the project name
-    if (!isValidIdentifier(projectName)) {
+     ValidationResult result = validateName(projectName);
+     String canonicalName = result.modifiedName;
+    if (!isValidIdentifier(canonicalName)) {
       if (!quietly) {
         Window.alert(MESSAGES.malformedProjectNameError());
       }
@@ -72,19 +76,23 @@ public final class TextValidators {
     }
 
     // Check for names that reserved words
-    if (isReservedName(projectName)) {
+    if (isReservedName(canonicalName)) {
       Window.alert(MESSAGES.reservedNameError());
       return ProjectNameStatus.RESERVED;
     }
 
     // Check that project does not already exist
-    if (Ode.getInstance().getProjectManager().getProject(projectName) != null) {
-      if (Ode.getInstance().getProjectManager().getProject(projectName).isInTrash()) {
-        Window.alert(MESSAGES.duplicateTrashProjectNameError(projectName));
-        return ProjectNameStatus.DUPLICATEINTRASH;
-      } else if (!quietly) {
-        Window.alert(MESSAGES.duplicateProjectNameError(projectName));
-      }
+    ProjectManager pm = Ode.getInstance().getProjectManager();
+    Project existing = pm.getProject(canonicalName);
+
+   if (existing != null) {
+    if (existing.isInTrash()) {
+    Window.alert(MESSAGES.duplicateTrashProjectNameError(canonicalName));
+    return ProjectNameStatus.DUPLICATEINTRASH;
+  }
+  if (!quietly) {
+    Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
+  }
       return ProjectNameStatus.DUPLICATE;
     }
     return ProjectNameStatus.SUCCESS;
@@ -97,7 +105,9 @@ public final class TextValidators {
   public static boolean checkNewComponentName(String componentName) {
 
     // Check that it meets the formatting requirements.
-    if (!TextValidators.isValidComponentIdentifier(componentName)) {
+    ValidationResult result = validateName(componentName);
+    String canonicalName = result.modifiedName; 
+    if (!TextValidators.isValidComponentIdentifier(canonicalName)) {
       Window.alert(MESSAGES.malformedComponentNameError());
       return false;
     }
@@ -111,20 +121,20 @@ public final class TextValidators {
 
     // Check that it's unique.
     final List<String> names = editor.getComponentInstances();
-    if (names.contains(componentName)) {
+    if (names.contains(canonicalName)) {
       Window.alert(MESSAGES.sameAsComponentInstanceNameError());
       return false;
     }
 
     // Check that it is a variable name used in the Yail code
-    if (TextValidators.isReservedName(componentName)) {
+    if (TextValidators.isReservedName(canonicalName)) {
       Window.alert(MESSAGES.reservedNameError());
       return false;
     }
 
     //Check that it is not a Component type name
     SimpleComponentDatabase COMPONENT_DATABASE = SimpleComponentDatabase.getInstance(projectId);
-    if (COMPONENT_DATABASE.isComponent(componentName)) {
+    if (COMPONENT_DATABASE.isComponent(canonicalName)) {
       Window.alert(MESSAGES.duplicateComponentNameError());
       return false;
     }
@@ -145,22 +155,24 @@ public final class TextValidators {
    */
   public static ProjectNameStatus checkNewFolderName(String folderName, ProjectFolder parent) {
     // Check the format of the folder name
-    if (!isValidIdentifier(folderName)) {
+    ValidationResult result = validateName(folderName);
+    String canonicalName = result.modifiedName;
+     if (!isValidIdentifier(canonicalName)) {
       // TODO: Decide whether to use new strings
       Window.alert(MESSAGES.malformedProjectNameError());
       return ProjectNameStatus.INVALIDFORMAT;
     }
 
     // Check for names that reserved words
-    if (isReservedName(folderName)) {
+    if (isReservedName(canonicalName)) {
       Window.alert(MESSAGES.reservedNameError());
       return ProjectNameStatus.RESERVED;
     }
 
     // Check that folder does not already exist
     for (ProjectFolder folder : parent.getChildFolders()) {
-      if (folderName.equals(folder.getName())) {
-        Window.alert(MESSAGES.duplicateProjectNameError(folderName));
+      if (canonicalName.equals(folder.getName())) {
+        Window.alert(MESSAGES.duplicateProjectNameError(canonicalName));
         return ProjectNameStatus.DUPLICATE;
       }
     }

--- a/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
@@ -63,6 +63,5 @@ public class TextValidatorsTest extends TestCase {
     ProjectNameStatus status =
     TextValidators.checkNewProjectName("  MyApp  ", false);
     assertEquals(ProjectNameStatus.DUPLICATE, status);
-}
-
+  }
 }

--- a/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/youngandroid/TextValidatorsTest.java
@@ -57,4 +57,12 @@ public class TextValidatorsTest extends TestCase {
       assertFalse(TextValidators.isReservedName(notReservedWord));
     }
   }
+
+  public void testDuplicateProjectNameWithWhitespace() {
+    TextValidators.checkNewProjectName("MyApp", false);
+    ProjectNameStatus status =
+    TextValidators.checkNewProjectName("  MyApp  ", false);
+    assertEquals(ProjectNameStatus.DUPLICATE, status);
+}
+
 }


### PR DESCRIPTION
This change fixes inconsistent handling of project names during validation.

After a project name is normalised, subsequent validation checks were still using
the original input name in some cases. This could lead to incorrect duplicate or
duplicate-in-trash detection.

Changes:
1. Validation logic now consistently uses the canonical (normalised) project name
2. Duplicate and trash checks operate on the same normalised value
3. No UI text or behavior changes outside validation logic

Testing:
- Build passes locally
- Tested via local App Engine dev server
- Verified project creation, duplicate detection, and duplicate-in-trash cases
