### PR TITLE
Add CopyToClipboard block to Sharing component (Android & iOS)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -205,6 +205,17 @@ public final class YoungAndroidFormUpgrader {
       }
     }
   }
+  
+  private static int upgradeSharingProperties(Map<String, JSONValue> componentProperties,
+    int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Version 2:
+      // Added CopyToClipboard method.
+      // No properties need to be modified.
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
 
   private static void upgradeComponentProperties(Map<String, JSONValue> componentProperties,
       String componentType, int srcCompVersion, final int sysCompVersion) {
@@ -437,6 +448,8 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradeEv3UltrasonicSensorProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("NxtDirectCommands")) {
         srcCompVersion = upgradeNxtDirectCommandsProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("Sharing")) {
+        srcCompVersion = upgradeSharingProperties(componentProperties, srcCompVersion);
       }
 
       if (srcCompVersion < sysCompVersion) {

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -368,6 +368,9 @@ public final class YoungAndroidFormUpgrader {
       } else if (componentType.equals("Regression")) {
         srcCompVersion = upgradePlayerProperties(componentProperties, srcCompVersion);
 
+      } else if (componentType.equals("Sharing")) {
+        srcCompVersion = upgradeSharingProperties(componentProperties, srcCompVersion);
+        
       } else if (componentType.equals("Sound")) {
         srcCompVersion = upgradeSoundProperties(componentProperties, srcCompVersion);
 
@@ -448,8 +451,6 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradeEv3UltrasonicSensorProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("NxtDirectCommands")) {
         srcCompVersion = upgradeNxtDirectCommandsProperties(componentProperties, srcCompVersion);
-      } else if (componentType.equals("Sharing")) {
-        srcCompVersion = upgradeSharingProperties(componentProperties, srcCompVersion);
       }
 
       if (srcCompVersion < sysCompVersion) {

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -3094,7 +3094,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "Sharing": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+
+    // Added CopyToClipboard method
+    2: "noUpgrade"
 
   }, // End Sharing upgraders
 

--- a/appinventor/components-ios/src/Sharing.swift
+++ b/appinventor/components-ios/src/Sharing.swift
@@ -26,6 +26,11 @@ open class Sharing: NonvisibleComponent {
   @objc open func ShareMessage(_ message: String) {
     showActivityPicker([message])
   }
+  
+  // MARK: Clipboard Methods
+  @objc open func CopyToClipboard(_ text: String) {
+    UIPasteboard.general.string = text
+  }
 
 
   @objc open func ShareFile(_ file: String) {

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1390,7 +1390,7 @@ public class YaVersion {
   // - The CalculateLineOfBestFitValue second argument was changed from String to LOBFValues
   public static final int REGRESSION_COMPONENT_VERSION = 2;
 
-  public static final int SHARING_COMPONENT_VERSION = 1;
+  public static final int SHARING_COMPONENT_VERSION = 2;
 
   // For SLIDER_COMPONENT_VERSION 1:
   // - Initial version.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
@@ -5,14 +5,14 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 package com.google.appinventor.components.runtime;
 
-import java.io.File;
-
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.webkit.MimeTypeMap;
+
+import java.io.File;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.SimpleFunction;
@@ -98,8 +98,8 @@ public class Sharing extends AndroidNonvisibleComponent {
 
     if (clipboard != null) {
       String label = form.getApplication().getApplicationInfo()
-       .loadLabel(form.getApplication().getPackageManager())
-       .toString();
+          .loadLabel(form.getApplication().getPackageManager())
+          .toString();
 
       ClipData clip = ClipData.newPlainText(label, text);
       clipboard.setPrimaryClip(clip);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
@@ -4,29 +4,24 @@
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-package com.google.appinventor.components.runtime;
+import java.io.File;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
-
 import android.net.Uri;
-
 import android.webkit.MimeTypeMap;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.UsesPermissions;
-
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.YaVersion;
-
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.NougatUtil;
 
-import java.io.File;
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
 
 /**
  * Sharing is a non-visible component that enables sharing files and/or messages between your app

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
@@ -3,6 +3,7 @@
 // Copyright 2011-2018 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
+package com.google.appinventor.components.runtime;
 
 import java.io.File;
 
@@ -96,7 +97,11 @@ public class Sharing extends AndroidNonvisibleComponent {
         (ClipboardManager) form.getSystemService(Context.CLIPBOARD_SERVICE);
 
     if (clipboard != null) {
-      ClipData clip = ClipData.newPlainText("App Inventor Clipboard", text);
+      String label = form.getApplication().getApplicationInfo()
+       .loadLabel(form.getApplication().getPackageManager())
+       .toString();
+
+      ClipData clip = ClipData.newPlainText(label, text);
       clipboard.setPrimaryClip(clip);
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Sharing.java
@@ -24,6 +24,9 @@ import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.NougatUtil;
 
 import java.io.File;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 
 /**
  * Sharing is a non-visible component that enables sharing files and/or messages between your app
@@ -88,6 +91,21 @@ public class Sharing extends AndroidNonvisibleComponent {
     // oversized pop up sharing window.
     this.form.startActivity(shareIntent);
   }
+
+  /**
+   * Copies the given text to the system clipboard.
+   */
+  @SimpleFunction(description = "Copies the given text to the system clipboard.")
+  public void CopyToClipboard(String text) {
+    ClipboardManager clipboard =
+        (ClipboardManager) form.getSystemService(Context.CLIPBOARD_SERVICE);
+
+    if (clipboard != null) {
+      ClipData clip = ClipData.newPlainText("App Inventor Clipboard", text);
+      clipboard.setPrimaryClip(clip);
+    }
+  }
+
 
   /**
    * Shares a file using Android' built-in sharing.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] Google Java style guide
    - [x] Google JavaScript style guide
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in YaVersion.java
- [x] I have updated the corresponding upgrader in YoungAndroidFormUpgrader.java
- [x] I have updated the corresponding entries in versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base


What does this PR accomplish?

This PR adds a new `CopyToClipboard` method to the Sharing component, allowing developers to copy text to the system clipboard without invoking the platform share sheet.

The implementation works consistently across platforms:
- Android uses `ClipboardManager` and `ClipData`
- iOS uses `UIPasteboard.general`

The change is additive and backward compatible.


<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

### Summary
This PR adds a new `CopyToClipboard` method to the Sharing component, allowing apps to copy text to the system clipboard without invoking the platform share sheet.

### Platform support
- **Android:** Uses `ClipboardManager` and `ClipData`
- **iOS:** Uses `UIPasteboard.general`

### Versioning
- Bumped `SHARING_COMPONENT_VERSION` from 1 → 2
- Updated `blocklyeditor/src/versioning.js` (no upgrade required)

### Notes
This is an additive, backward-compatible change. No existing blocks or behaviors are modified, and no SCM upgrades are required.
No `YoungAndroidFormUpgrader` changes are required since this PR only adds a new method and does not alter existing properties or block semantics.


<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3736