### PR TITLE
Update link for Google Sheets API setup instructions

### DIFF
--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -395,7 +395,7 @@ as <code class="highlighter-rouge">Pictures</code>.</li>
 
 <p>Instructions on how to create the Service Account, as well as where to find
  other relevant information for using the Google Sheets Component, can be
- found <a href="/reference/other/googlesheets-api-setup.html">here</a>.</p>
+ found <a href="https://docs.google.com/document/d/10PcV0WGgtedebzxn1H1tu58BP1cSFOIVSUGPwVQ_rsQ/edit?tab=t.0#heading=h.xval8usla33g">here</a>.</p>
 
 <p>Row and column numbers are 1-indexed.</p>
 


### PR DESCRIPTION
Replaced Google Sheets Service Account setup instructions link with updated Google Docs instructions. 
Documentation change only.