### PR TITLE
Fix: Change adaptive icon background to transparent (#2328)

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/XmlConfig.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/XmlConfig.java
@@ -434,7 +434,7 @@ public class XmlConfig implements AndroidTask {
         Files.newOutputStream(icBackgroundFile.toPath()), StandardCharsets.UTF_8))) {
       out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
       out.write("<resources>\n");
-      out.write("<color name=\"ic_launcher_background\">#ffffff</color>\n");
+      out.write("<color name=\"ic_launcher_background\">#00ffffff</color>\n");
       out.write("</resources>\n");
     } catch (IOException e) {
       context.getReporter().error("Error writing IC launcher background file");

--- a/appinventor/docs/BUG_FIX_2328.md
+++ b/appinventor/docs/BUG_FIX_2328.md
@@ -1,0 +1,26 @@
+# Bug Fix: Adaptive Icon White Edges (#2328)
+
+## Issue
+Android apps built with App Inventor showed thin white borders or "slivers" around their adaptive icons on Android 8.0+ devices.
+
+## Root Cause
+The adaptive icon's background layer was hardcoded to solid white (`#ffffff`) in the build server configuration file `XmlConfig.java`.
+
+## Solution
+Changed the launcher background color from `#ffffff` (opaque white) to `#00ffffff` (transparent white) in the `writeLauncherBackground()` method.
+
+## Impact
+- Eliminates white edges/borders on adaptive icons
+- Preserves the adaptive icon parallax motion effect
+- No user-facing API changes
+- Affects only Android 8.0+ devices with adaptive icon support
+
+## Files Modified
+- `appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/XmlConfig.java` (Line 437)
+
+## Testing
+Manually tested by building apps and verifying that adaptive icons no longer show white edges on Android 8.0+ devices.
+
+## Related
+- Issue: #2328
+- Pull Request: #3744


### PR DESCRIPTION
General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the Google Java style guide
- [ ] `ant tests` passes on my machine - Attempted but failed due to Java 25 vs Java 11 incompatibility

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

## What does this PR accomplish?

This PR fixes the issue where generated Android apps show thin white borders or "slivers" around their adaptive icons on Android 8.0+ devices.

### The Fix:
I identified that the adaptive icon's background layer was hardcoded to solid white (`#ffffff`) in the buildserver. I have changed this to transparent (`#00ffffff`). This ensures that only the intended foreground icon is visible, eliminating the white artifacts while preserving the adaptive parallax effect.

### Files Changed:
- `buildserver/src/.../XmlConfig.java` (1 line changed)
- `docs/BUG_FIX_2328.md` (documentation added)

### Testing:
Manually tested by building apps and verifying that adaptive icons no longer show white edges on Android 8.0+ devices.

Fixes #2328
