### PR TITLE
Automate PR Label Transitions to help new contributors (#3173)

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,37 @@
+# Helpful bot to manage labels!
+name: "Label Helper"
+
+# This bot runs when you open a PR or update it.
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  helper:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      # Step 1: When you open a new PR, the bot adds a label for you!
+      - name: Setup New PR
+        if: github.event.action == 'opened'
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "pull request: needs review"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+
+      # Step 2: When you send new code, the bot helps update the label!
+      - name: Reset After Push
+        if: github.event.action == 'synchronize'
+        run: |
+          # The bot looks at the labels on your PR.
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --template '{{range .labels}}{{.name}},{{end}}')
+          
+          # If it sees you need to reply, it changes it back to "needs review".
+          if [[ "$labels" == *"pull request: needs reply to review"* ]]; then
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "pull request: needs reply to review" --add-label "pull request: needs review"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This Pull Request introduces a simple GitHub Action named **"Label Helper"** to automate the management of labels on Pull Requests. 

Currently, the project uses labels like `pull request: needs review` and `pull request: needs reply to review` to track progress. However, new contributors (first-time helpers) do not have the permissions in GitHub to change these labels themselves. This means that after a new contributor fixes something based on feedback, they can't easily mark their work as "ready for review" again without a maintainer's help.

### How this helps

This bot acts as a friendly helper that has the necessary permissions to update labels for you!

1.  **Welcome Label:** When you first open a new Pull Request, the bot will automatically add the `pull request: needs review` label so maintainers know you have something new for them to see.
2.  **Automatic Reset:** If a reviewer asks for changes (adding the `pull request: needs reply to review` label), the bot watches for your updates. As soon as you push new code to your branch, the bot will automatically flip the label back to `pull request: needs review`.

### Why this is beginner-friendly

-   **No Permissions Needed:** New contributors don't need to worry about being unable to click buttons or change labels.
-   **Less Manual Work:** Maintainers don't have to keep a constant eye on comments to see if someone has pushed updates; the label tells them immediately.
-   **Clear Communication:** The labels always stay up-to-date with the actual status of the work.

### Technical Details

-   Uses `pull_request_target` to safely access the repository's labels even from forks.
-   Keeps the code very simple and easy to maintain.

Fixes #3173.