### PR TITLE
Add defensive guards to Safari focus implementation

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplSafari.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplSafari.java
@@ -14,8 +14,14 @@ import com.google.gwt.dom.client.Element;
 public class FocusImplSafari extends com.google.gwt.user.client.ui.impl.FocusImplSafari {
   @Override
   public native void focus(Element elem)/*-{
+  if (!elem || !elem.focus) {
+    return;
+    }
     $wnd.setTimeout(function() {
+    try {
       elem.focus({'preventScroll': true});
+    } catch (e) {
+    }
     }, 0);
   }-*/;
 }


### PR DESCRIPTION
This PR adds defensive checks to the Safari-specific focus implementation to prevent JavaScript runtime errors in edge cases.

Specifically, it:
1. Guards against null or unsupported elements before calling focus
2. Wraps the focus call in a try/catch to avoid crashes when elements are detached or focus is disallowed
3. Preserves existing behaviour for valid focus calls (preventScroll and timing unchanged)

This is a Safari/iOS-specific safety improvement with no API or functional behaviour changes in normal cases.
