### PR TITLE
Fix font path not resetting when custom font is removed from assets (…

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidFontTypefaceChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidFontTypefaceChoicePropertyEditor.java
@@ -239,7 +239,7 @@ public final class YoungAndroidFontTypefaceChoicePropertyEditor extends Addition
       if (node.getName().equals(currentValue)) {
         // Our asset was removed.
         choices.selectValue(MESSAGES.defaultFontTypeface());
-        property.setValue(MESSAGES.defaultFontTypeface());
+        property.setValue("0"); // Go back to the normal font (which is called "0") to make sure everything keeps working!
       }
       
       // Remove the asset from the list.


### PR DESCRIPTION
General items:

 I have updated the relevant documentation files under docs/

 My code follows the:
 [Google Java style guide](https://google.github.io/styleguide/javaguide.html)
 (for .java files)
 [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html)
 (for .js files)
 ant tests passes on my machine

<!-- This section pertains to changes to the components module that affect the code running on the Android device. -->

If your code changes how something works on the device (i.e., it affects the companion):
 I branched from ucr
 My pull request has ucr as the base
Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):
 I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
 I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
 I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!-- This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs. -->

For all other changes:
 I branched from master
 My pull request has master as the base
What does this PR accomplish?
Description

This PR fixes an issue where removing a custom font from Assets does not fully reset the font configuration in components.
Although the Designer updates the font name to default, the internal asset path to the deleted font remains stored. This causes the Companion app and compiled APK to throw a missing font error at runtime.

The fix ensures that when a custom font is removed:
The font name is reset to default
The stored asset path is cleared
Components correctly fall back to the built-in default font
This prevents runtime crashes and removes the need for users to manually reselect the default font.

Fixes #3058