### PR TITLE
Fix TimePicker crash on Android 14 with Classic theme

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
@@ -19,8 +19,9 @@ import com.google.appinventor.components.runtime.util.ErrorMessages;
 
 import android.app.Dialog;
 import android.app.TimePickerDialog;
-import android.text.format.DateFormat;
+import android.os.Build;
 import android.os.Handler;
+import android.text.format.DateFormat;
 
 import java.util.Calendar;
 
@@ -65,8 +66,16 @@ public class TimePicker extends ButtonBase {
     final Calendar c = Calendar.getInstance();
     hour = c.get(Calendar.HOUR_OF_DAY);
     minute = c.get(Calendar.MINUTE);
+
+    // On newer Android phones (like Android 14), we need to use a special style
+    // so the time picker does not crash!
+    int themeId = 0;
+    if (Build.VERSION.SDK_INT >= 34 /* UPSIDE_DOWN_CAKE */) {
+      themeId = android.R.style.Theme_Material_Dialog;
+    }
+
     time = new TimePickerDialog(this.container.$context(),
-        timePickerListener, hour, minute, DateFormat.is24HourFormat(this.container.$context()));
+        themeId, timePickerListener, hour, minute, DateFormat.is24HourFormat(this.container.$context()));
 
     instant = Dates.TimeInstant(hour, minute);
     androidUIHandler = new Handler();


### PR DESCRIPTION
## Description
Fixes #3175 - TimePicker crashes on Android 14 when using Classic theme

This PR resolves a crash that occurs when users interact with the TimePicker component on Android 14 devices. The crash is caused by a bug in Android's framework code (`TimePickerSpinnerDelegate`) when using the Classic theme.

## Changes Made
- Modified `TimePicker.java` to detect Android 14+ (API 34) and use Material theme instead of Classic theme
- Added `android.os.Build` import for version detection
- Maintains backward compatibility - older Android versions continue using Classic theme

## Testing
- ✅ All 70+ component tests passed locally
- ⚠️ Manual testing on Android 14 device recommended before merge

## Impact
- **Fixes**: TimePicker crash on Android 14
- **Maintains**: Full backward compatibility with Android 10-13
- **Changes**: Visual appearance on Android 14+ only (Material theme instead of spinner)

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are minimal and focused
- [x] All automated tests pass
- [x] Commit message follows conventions
- [ ] Tested on Android 14 device (manual testing recommended)
- [ ] Tested on Android 10-13 devices (regression testing)