### PR TITLE
Add CheckedColor and UncheckedColor properties to CheckBox (#3635)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -914,6 +914,11 @@ public final class YoungAndroidFormUpgrader {
       // Properties related to this component have now been upgraded to version 2.
       srcCompVersion = 2;
     }
+    if (srcCompVersion < 3) {
+      // CheckedColor and UncheckedColor properties were added in version 3.
+      // No automatic upgrade needed - new properties will use default values.
+      srcCompVersion = 3;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1880,7 +1880,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "CheckBox": {
 
     // AI2: The Value property was renamed to Checked.
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // CheckedColor and UncheckedColor properties added
+    3: "noUpgrade"
 
   }, // End CheckBox upgraders
 

--- a/appinventor/components-ios/src/Checkbox.swift
+++ b/appinventor/components-ios/src/Checkbox.swift
@@ -75,6 +75,8 @@ public class CheckBoxView: UIView {
   fileprivate var _checked: CAShapeLayer!
   fileprivate var _unchecked: CAShapeLayer!
   fileprivate var _layersLoaded = false
+  fileprivate var _checkedColor: CGColor = CHECKBOX_CHECKED_COLOR
+  fileprivate var _uncheckedColor: CGColor = UIColor.black.withAlphaComponent(138.0/255.0).cgColor
 
   public init() {
     super.init(frame: .zero)
@@ -165,15 +167,9 @@ public class CheckBoxView: UIView {
           layer.fillColor = UIColor.black.withAlphaComponent(38.0/255.0).cgColor
         }
       } else if Checked {
-        layer.fillColor = CHECKBOX_CHECKED_COLOR
+        layer.fillColor = _checkedColor
       } else {
-        if #available(iOS 11.0, *) {
-          layer.fillColor = UIColor(named: "CheckBoxEnabled", in: Bundle(for: CheckBox.self),
-                                    compatibleWith: _button.traitCollection)?.cgColor
-        } else {
-          // Fallback on earlier versions
-          layer.fillColor = UIColor.black.withAlphaComponent(138.0/255.0).cgColor
-        }
+        layer.fillColor = _uncheckedColor
       }
       setNeedsDisplay()
     }
@@ -356,6 +352,26 @@ public class CheckBox: ViewComponent, AbstractMethodsForViewComponent, Accessibl
     }
     set(color) {
       _view._text.textColor = argbToColor(color)
+    }
+  }
+
+  @objc open var CheckedColor: Int32 {
+    get {
+      return colorToArgb(UIColor(cgColor: _view._checkedColor))
+    }
+    set(color) {
+      _view._checkedColor = argbToColor(color).cgColor
+      _view.updateColor()
+    }
+  }
+
+  @objc open var UncheckedColor: Int32 {
+    get {
+      return colorToArgb(UIColor(cgColor: _view._uncheckedColor))
+    }
+    set(color) {
+      _view._uncheckedColor = argbToColor(color).cgColor
+      _view.updateColor()
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -919,7 +919,9 @@ public class YaVersion {
 
   // For CHECKBOX_COMPONENT_VERSION 2:
   // - The Value property was renamed to Checked.
-  public static final int CHECKBOX_COMPONENT_VERSION = 2;
+  // For CHECKBOX_COMPONENT_VERSION 3:
+  // - Added CheckedColor and UncheckedColor properties for customization.
+  public static final int CHECKBOX_COMPONENT_VERSION = 3;
 
   // For CIRCLE_COMPONENT_VERSION 1:
   // - Initial implementation of Circle for Maps

--- a/appinventor/components/src/com/google/appinventor/components/runtime/CheckBox.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/CheckBox.java
@@ -6,6 +6,8 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.content.res.ColorStateList;
+import androidx.core.widget.CompoundButtonCompat;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -33,6 +35,12 @@ import com.google.appinventor.components.common.YaVersion;
 @SimpleObject
 public final class CheckBox extends ToggleBase<android.widget.CheckBox> {
 
+  // Backing for box color when checked
+  private int checkedColor;
+
+  // Backing for box color when unchecked
+  private int uncheckedColor;
+
   /**
    * Creates a new CheckBox component.
    *
@@ -42,7 +50,20 @@ public final class CheckBox extends ToggleBase<android.widget.CheckBox> {
     super(container);
     view = new android.widget.CheckBox(container.$context());
     Checked(false);
+    CheckedColor(Component.COLOR_GREEN);
+    UncheckedColor(Component.COLOR_LTGRAY);
     initToggle();
+  }
+
+  private ColorStateList createCheckBoxColors(int checked_color, int unchecked_color) {
+    return new ColorStateList(new int[][]{
+            new int[]{android.R.attr.state_checked},
+            new int[]{}
+            },
+            new int[]{
+                    checked_color,
+                    unchecked_color
+            });
   }
 
   /**
@@ -68,6 +89,56 @@ public final class CheckBox extends ToggleBase<android.widget.CheckBox> {
   @SimpleProperty
   public void Checked(boolean value) {
     view.setChecked(value);
+    view.invalidate();
+  }
+
+  /**
+   * Returns the checkbox's color when checked.
+   *
+   * @return  checkbox RGB color with alpha
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+      description = "Color of the checkbox when checked.")
+  public int CheckedColor() {
+    return checkedColor;
+  }
+
+  /**
+   * Specifies the checkbox's color when checked.
+   *
+   * @param argb  checkbox RGB color with alpha
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
+      defaultValue = Component.DEFAULT_VALUE_COLOR_GREEN)
+  @SimpleProperty
+  public void CheckedColor(int argb) {
+    checkedColor = argb;
+    CompoundButtonCompat.setButtonTintList(view, createCheckBoxColors(argb, uncheckedColor));
+    view.invalidate();
+  }
+
+  /**
+   * Returns the checkbox's color when unchecked.
+   *
+   * @return  checkbox RGB color with alpha
+   */
+  @SimpleProperty(category = PropertyCategory.APPEARANCE,
+      description = "Color of the checkbox when unchecked.")
+  public int UncheckedColor() {
+    return uncheckedColor;
+  }
+
+  /**
+   * Specifies the checkbox's color when unchecked.
+   *
+   * @param argb  checkbox RGB color with alpha
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_COLOR,
+      defaultValue = Component.DEFAULT_VALUE_COLOR_LTGRAY)
+  @SimpleProperty
+  public void UncheckedColor(int argb) {
+    uncheckedColor = argb;
+    CompoundButtonCompat.setButtonTintList(view, createCheckBoxColors(checkedColor, argb));
     view.invalidate();
   }
 

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/CheckboxTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/CheckboxTest.java
@@ -55,4 +55,46 @@ public class CheckboxTest extends ToggleTestBase {
     assertTrue(aCheckbox.Checked());
   }
 
+  @Test
+  public void testCheckboxCheckedColorDefault() {
+    // Default checked color should be green
+    assertEquals(Component.COLOR_GREEN, aCheckbox.CheckedColor());
+  }
+
+  @Test
+  public void testCheckboxUncheckedColorDefault() {
+    // Default unchecked color should be light gray
+    assertEquals(Component.COLOR_LTGRAY, aCheckbox.UncheckedColor());
+  }
+
+  @Test
+  public void testCheckboxCheckedColorCustom() {
+    // Test setting custom checked color
+    aCheckbox.CheckedColor(Component.COLOR_BLUE);
+    assertEquals(Component.COLOR_BLUE, aCheckbox.CheckedColor());
+    
+    aCheckbox.CheckedColor(Component.COLOR_RED);
+    assertEquals(Component.COLOR_RED, aCheckbox.CheckedColor());
+  }
+
+  @Test
+  public void testCheckboxUncheckedColorCustom() {
+    // Test setting custom unchecked color
+    aCheckbox.UncheckedColor(Component.COLOR_YELLOW);
+    assertEquals(Component.COLOR_YELLOW, aCheckbox.UncheckedColor());
+    
+    aCheckbox.UncheckedColor(Component.COLOR_CYAN);
+    assertEquals(Component.COLOR_CYAN, aCheckbox.UncheckedColor());
+  }
+
+  @Test
+  public void testCheckboxBothColorsCustom() {
+    // Test setting both colors together
+    aCheckbox.CheckedColor(Component.COLOR_MAGENTA);
+    aCheckbox.UncheckedColor(Component.COLOR_ORANGE);
+    
+    assertEquals(Component.COLOR_MAGENTA, aCheckbox.CheckedColor());
+    assertEquals(Component.COLOR_ORANGE, aCheckbox.UncheckedColor());
+  }
+
 }


### PR DESCRIPTION
## Summary
Resolves #3635

This PR adds color customization properties to the CheckBox component, bringing it in line with the Switch component's customization capabilities. Users can now set custom colors for both checked and unchecked states.

## Changes Made

### Android Implementation
- Added `CheckedColor` and `UncheckedColor` properties to `CheckBox.java`
- Implemented color customization using `ColorStateList` and `CompoundButtonCompat`
- Added necessary imports: `ColorStateList` and `CompoundButtonCompat`
- Created `createCheckBoxColors()` helper method for state-based coloring

### iOS Implementation  
- Added matching `CheckedColor` and `UncheckedColor` properties to `Checkbox.swift`
- Updated `CheckBoxView` to store custom colors
- Modified `updateColor()` method to use stored colors instead of hardcoded values

### Version Management
- Updated `CHECKBOX_COMPONENT_VERSION` from 2 to 3 in `YaVersion.java`
- Added upgrade logic in `YoungAndroidFormUpgrader.java`
- Updated `versioning.js` for blocks editor compatibility

## Default Colors
- **CheckedColor**: Green (`Component.COLOR_GREEN`)
- **UncheckedColor**: Light Gray (`Component.COLOR_LTGRAY`)

## Technical Details

**Pattern Used:** Followed the Switch component's implementation pattern for consistency

**Android API:** Uses `CompoundButtonCompat.setButtonTintList()` for backward compatibility

**iOS API:** Uses `CAShapeLayer.fillColor` with custom CGColor values

## Testing Checklist
- [x] Code changes implemented for Android
- [x] Code changes implemented for iOS  
- [x] Version number incremented
- [x] Upgrade logic added
- [x] Blocks editor versioning updated
- [ ] Built and tested on local development server
- [ ] Tested on Android emulator
- [ ] Tested on iOS simulator

## Example Usage

**Blocks:**
```
Set CheckBox1.CheckedColor to: Blue
Set CheckBox1.UncheckedColor to: Red
```

**Result:** CheckBox will be blue when checked, red when unchecked

## Files Modified
- `appinventor/components/src/com/google/appinventor/components/runtime/CheckBox.java`
- `appinventor/components-ios/src/Checkbox.swift`
- `appinventor/components/src/com/google/appinventor/components/common/YaVersion.java`
- `appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java`
- `appinventor/blocklyeditor/src/versioning.js`

## Screenshots
_Will add screenshots after building and testing on local server_

## Rationale
As noted in #3635, the Switch component has extensive color customization options, but CheckBox does not. Users want similar control over CheckBox appearance to match their app's design. This change provides parity between the two similar components and enhances the platform's customization capabilities.

## Cross-Platform Consistency
✅ Both Android and iOS implementations included
✅ Same property names and behavior on both platforms
✅ Default colors match existing Switch component patterns