### PR TITLE
Fix Issue #2696: Chunk large results in WebRTC for Do It

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -345,6 +345,7 @@ Blockly.ReplMgr.putYail = (function() {
     var sentMacros = false;
     var webrtcdata;
     var seennonce = {};
+    var chunksBuffer = {};
     var fixchrome89 = function(desc) {
         var sdp = desc.sdp;
         sdp = sdp.replace("a=extmap-allow-mixed\r\n", "")
@@ -527,9 +528,34 @@ Blockly.ReplMgr.putYail = (function() {
                 console.log('webrtc data connection open!');
                 webrtcdata.onmessage = function(ev) {
                     console.log("webrtc(onmessage): " + ev.data);
-                    var json = goog.json.parse(ev.data);
-                    if (json.status == 'OK') {
-                        context.processRetvals(json.values);
+                    var data = JSON.parse(ev.data);
+                    if (data.wrtc_chunk) {
+                        var id = data.id;
+                        if (!chunksBuffer[id]) {
+                            chunksBuffer[id] = new Array(data.n);
+                        }
+                        chunksBuffer[id][data.i] = data.data;
+                        // Check if we have all chunks
+                        var complete = true;
+                        for (var chunk_i = 0; chunk_i < data.n; chunk_i++) {
+                            if (chunksBuffer[id][chunk_i] === undefined) {
+                                complete = false;
+                                break;
+                            }
+                        }
+                        if (complete) {
+                            var fullData = chunksBuffer[id].join('');
+                            delete chunksBuffer[id];
+                            var json = JSON.parse(fullData);
+                            if (json.status == 'OK') {
+                                context.processRetvals(json.values);
+                            }
+                        }
+                    } else {
+                        var json = JSON.parse(ev.data);
+                        if (json.status == 'OK') {
+                            context.processRetvals(json.values);
+                        }
                     }
                 };
                 // Ready to actually exchange data

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/WebRTCNativeMgr.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/WebRTCNativeMgr.java
@@ -464,6 +464,10 @@ public class WebRTCNativeMgr {
   }
 
   public void send(String output) {
+    if (output.length() > 10000) {
+      sendChunked(output);
+      return;
+    }
     try {
       if (dataChannel == null) {
         Log.w(LOG_TAG, "No Data Channel in Send");
@@ -476,5 +480,37 @@ public class WebRTCNativeMgr {
       Log.e(LOG_TAG, "While encoding data to send to companion", e);
     }
   }
+
+  private void sendChunked(String output) {
+    int chunkSize = 8000;
+    int len = output.length();
+    int chunks = (len + chunkSize - 1) / chunkSize;
+    String id = String.valueOf(random.nextInt(1000000));
+
+    for (int i = 0; i < chunks; i++) {
+      int start = i * chunkSize;
+      int end = Math.min(len, start + chunkSize);
+      String substr = output.substring(start, end);
+
+      try {
+        JSONObject envelope = new JSONObject();
+        envelope.put("wrtc_chunk", true);
+        envelope.put("id", id);
+        envelope.put("i", i);
+        envelope.put("n", chunks);
+        envelope.put("data", substr);
+
+        String msg = envelope.toString();
+        ByteBuffer bbuffer = ByteBuffer.wrap(msg.getBytes("UTF-8"));
+        Buffer buffer = new Buffer(bbuffer, false);
+        dataChannel.send(buffer);
+      } catch (JSONException e) {
+        Log.e(LOG_TAG, "Error building chunk", e);
+      } catch (UnsupportedEncodingException e) {
+        Log.e(LOG_TAG, "Encoding error", e);
+      }
+    }
+  }
+
 
 }


### PR DESCRIPTION

This PR implements chunking for large "Do It" results sent over WebRTC to prevent connection termination (Issue #2696). 

**Changes:**
- `WebRTCNativeMgr.java` (Android): Added `sendChunked` method to split messages larger than 10KB into 8KB chunks.
- `replmgr.js` (Blockly): Updated `onmessage` handling to reassemble `wrtc_chunk` messages.

**Verification:**
- Verified with a local test script that split chunks are correctly reassembled.
