### PR TITLE
Clarify non-null contract for identifier validators

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/TextValidators.java
@@ -8,6 +8,7 @@ package com.google.appinventor.client.youngandroid;
 
 import com.google.appinventor.client.Ode;
 import static com.google.appinventor.client.Ode.MESSAGES;
+import java.util.Objects;
 
 import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
@@ -173,10 +174,12 @@ public final class TextValidators {
    * (unaccented English) letters, digits, or underscores.
    *
    * @param text the proposed identifier
+   * @throws NullPointerException if text is null
    * @return {@code true} if the argument is a legal identifier, {@code false}
    *         otherwise
    */
   public static boolean isValidIdentifier(String text) {
+    Objects.requireNonNull(text, "Identifier must not be null");
     return text.matches("^[a-zA-Z]\\w*$");
   }
 
@@ -196,10 +199,12 @@ public final class TextValidators {
    * Blockly.LexicalVariable.checkIdentifier for the regex reference
    *
    * @param text the proposed identifier
+   * @throws NullPointerException if text is null
    * @return {@code true} if the argument is a legal identifier, {@code false}
    *         otherwise
    */
   public static boolean isValidComponentIdentifier(String text) {
+     Objects.requireNonNull(text,"Component Identifier must not be null");
     return text.matches("^[" + ID_DISALLOWED_STARTCHARS + "][" + ID_DISALLOWED_CHARS + "]*$");
   }
 
@@ -210,10 +215,12 @@ public final class TextValidators {
    * - all characters must be 7-bit printable ASCII
    * - none of { '/' '\\' ':' }
    * @param filename The filename (not path) of uploaded file
+   * @throws NullPointerException if filename is null
    * @return {@code true} if the argument is a legal filename, {@code false}
    *         otherwise
    */
   public static boolean isValidCharFilename(String filename){
+     Objects.requireNonNull(filename,"Filename must not be null");
     return !filename.contains("'") && filename.equals(URL.encodePathSegment(filename));
   }
 
@@ -225,10 +232,12 @@ public final class TextValidators {
    * where kMaxAssetFileName is defined to be 100.
    * (A legal name, therefore, has length <= kMaxAssetFileNames)
    * @param filename The filename (not path) of uploaded file
+   *  @throws NullPointerException if filename is null
    * @return {@code true} if the length of the argument is legal, {@code false}
    *         otherwise
    */
   public static boolean isValidLengthFilename(String filename){
+     Objects.requireNonNull(filename,"Filename must not be null");
     return !(filename.length() > MAX_FILENAME_SIZE || filename.length() < MIN_FILENAME_SIZE);
   }
 


### PR DESCRIPTION
### Summary

This PR makes the non-null contract of identifier validation methods explicit by enforcing it with ⁠ Objects.requireNonNull ⁠ and documenting the behavior via Javadoc.

### Background / Motivation

The identifier validators in ⁠ TextValidators ⁠ assume non-null inputs and are used to validate syntax, not to sanitize or recover from programming errors. Previously, adding silent null handling (e.g., returning ⁠ false ⁠ for ⁠ null ⁠) unintentionally changed this contract and could mask upstream bugs.

As discussed in earlier review feedback, failing silently in these cases is undesirable.

### What this PR does

•⁠  ⁠Enforces the existing non-null contract explicitly using ⁠ Objects.requireNonNull ⁠
•⁠  ⁠Documents the contract in Javadoc (⁠ @param ⁠ and ⁠ @throws ⁠)
•⁠  ⁠Preserves all existing validation semantics for non-null inputs
•⁠  ⁠Avoids introducing silent failure or behavioral changes

### Scenario

If a ⁠ null ⁠ value reaches an identifier validator, this indicates a programming error upstream rather than an invalid user input. By failing fast with a clear exception, the issue becomes immediately visible and debuggable instead of being silently converted into a validation failure.

### What this PR does NOT do

•⁠  ⁠Does not treat ⁠ null ⁠ as a valid or expected input
•⁠  ⁠Does not change validation rules or accepted identifiers
•⁠  ⁠Does not introduce new error handling paths or logging

### Notes

This PR follows up on the discussion in #3721 and addresses the feedback about avoiding silent failure by making the non-null contract explicit.