### PR TITLE
Remove project switch animation

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -205,9 +205,6 @@ public class Ode implements EntryPoint {
   public static final int TRASHCAN = 3;
   public static int currentView = PROJECTS;
 
-  // GWT DeckPanel animation is 350ms but we add a small buffer
-  public static final int DECKPANEL_ANIMATION_DURATION_MS = 375;
-
   /*
    * The following fields define the general layout of the UI as seen in the following diagram:
    *
@@ -251,7 +248,6 @@ public class Ode implements EntryPoint {
   private boolean tutorialVisible = false;
 
   private boolean consoleVisible = false;
-  private boolean isDeckPanelAnimating = false;
 
   // Popup that indicates that an asynchronous request is pending. It is visible
   // initially, and will be hidden automatically after the first RPC completes.
@@ -1006,18 +1002,6 @@ public class Ode implements EntryPoint {
 
     // Create tab panel for subsequent tabs
     deckPanel = new DeckPanel() {
-      @Override
-      public void showWidget(int index) {
-        if (isAnimationEnabled() && getVisibleWidget() != index) {
-          isDeckPanelAnimating = true;
-          Scheduler.get().scheduleFixedDelay(() -> {
-            isDeckPanelAnimating = false;
-            return false;
-          }, DECKPANEL_ANIMATION_DURATION_MS);
-        }
-        super.showWidget(index);
-      }
-
       @Override
       public final void onBrowserEvent(Event event) {
         switch (event.getTypeInt()) {
@@ -2516,10 +2500,6 @@ public class Ode implements EntryPoint {
 
   public boolean isConsoleVisible() {
     return consoleVisible;
-  }
-
-  public boolean isDeckPanelAnimating() {
-    return isDeckPanelAnimating;
   }
 
   public void setTutorialURL(String newURL) {

--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.ui.xml
@@ -17,7 +17,7 @@
     <ode:TopPanel ui:field="topPanel" />
     <g:FlowPanel styleName="ode-TutorialWrapper" ui:field="overDeckPanel">
       <ed:TutorialPanel ui:field="tutorialPanel" width="100%" height="100%" visible="false" />
-      <g:DeckPanel ui:field="deckPanel" animationEnabled="true" styleName="ode-DeckPanel">
+      <g:DeckPanel ui:field="deckPanel" animationEnabled="false" styleName="ode-DeckPanel">
         <g:FlowPanel width="100%" >
           <ex:ProjectToolbar width="100%" ui:field="projectToolbar" />
           <box:ProjectListBox width="100%" ui:field="projectListbox" />

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocklyPanel.java
@@ -755,9 +755,9 @@ public class BlocklyPanel extends HTMLPanel {
   /**
    * Inject the workspace into the &lt;div&gt; element with specific mode
    */
-  native void injectWorkspace(boolean isDarkMode, int animationDelayMs)/*-{
+  native void injectWorkspace(boolean isDarkMode)/*-{
     var el = this.@com.google.gwt.user.client.ui.UIObject::getElement()();
-    $wnd.AI.inject(el, this.@com.google.appinventor.client.editor.blocks.BlocklyPanel::workspace, isDarkMode, animationDelayMs);
+    $wnd.AI.inject(el, this.@com.google.appinventor.client.editor.blocks.BlocklyPanel::workspace, isDarkMode);
   }-*/;
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
@@ -627,8 +627,7 @@ public abstract class BlocksEditor<S extends SourceNode, T extends DesignerEdito
       Ode.getInstance().getStructureAndAssets().insert(BlockSelectorBox.getBlockSelectorBox(), 0);
       BlockSelectorBox.getBlockSelectorBox().setVisible(true);
       AssetListBox.getAssetListBox().setVisible(true);
-      blocksArea.injectWorkspace(Ode.getUserDarkThemeEnabled(),
-          Ode.getInstance().isDeckPanelAnimating() ? Ode.DECKPANEL_ANIMATION_DURATION_MS : 0);
+      blocksArea.injectWorkspace(Ode.getUserDarkThemeEnabled());
       hideBlocksDrawer();
     } else {
       LOG.warning("Can't get designer for blocks: " + getFileId());

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/Ode.ui.xml
@@ -18,7 +18,7 @@
     <neo:TopPanelNeo ui:field="topPanel" />
     <g:FlowPanel styleName="ode-TutorialWrapper" ui:field="overDeckPanel">
       <ed:TutorialPanel ui:field="tutorialPanel" width="100%" height="100%" visible="false" />
-      <g:DeckPanel ui:field="deckPanel" animationEnabled="true" styleName="ode-DeckPanel">
+      <g:DeckPanel ui:field="deckPanel" animationEnabled="false" styleName="ode-DeckPanel">
         <g:FlowPanel width="100%" height="100%" styleName="ode-Project-FlexColumn">
           <neo:ProjectToolbarNeo ui:field="projectToolbar" />
           <box:ProjectListBox ui:field="projectListbox" styleName="ode-Box ode-Box-projectlist" />

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/UISettingsWizard.java
@@ -9,7 +9,6 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.appinventor.client.Ode;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -81,14 +80,8 @@ public class UISettingsWizard {
   }
 
   public void show() {
-    // We add a delay here in case the DeckPanel that makes up the main App Inventor display
-    // is in the middle of animating. Unfortunately, there seems to be no way to acquire its
-    // animation state from GWT.
-    Scheduler.get().scheduleFixedDelay(() -> {
-      uiDialog.center();
-      classicRadioButton.focus();
-      return false;
-    }, Ode.getInstance().isDeckPanelAnimating() ? Ode.DECKPANEL_ANIMATION_DURATION_MS : 0);
+    uiDialog.center();
+    classicRadioButton.focus();
   }
 
   public void hide() {

--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -1152,7 +1152,7 @@ Blockly.BlocklyEditor['create'] = function(container, formName, readOnly, rtl) {
  * @param {!Element|string} container
  * @param {!Blockly.WorkspaceSvg} workspace
  */
-AI.inject = function(container, workspace, isDarkMode=false, animationDelayMs=0) {
+AI.inject = function(container, workspace, isDarkMode=false) {
   if (isDarkMode) {
     Blockly.common.getMainWorkspace().setTheme(Blockly.Themes.darkTheme);
   }
@@ -1164,20 +1164,18 @@ AI.inject = function(container, workspace, isDarkMode=false, animationDelayMs=0)
   // it was possible for workspace.injected to be false, but that is no longer the case.
   workspace.setGridSettings(gridEnabled, gridSnap);
   // Update the workspace size in case the window was resized while we were hidden
-  setTimeout(function() {
-    for (const block of workspace.blocksNeedingRendering) {
-      workspace.getWarningHandler().checkErrors(block);
-      block.render();
-    }
-    workspace.blocksNeedingRendering.splice(0);  // clear the array of pending blocks
-    workspace.resizeContents();
-    Blockly.common.svgResize(workspace);
-    if (workspace.notYetRendered) {
-      workspace.notYetRendered = false;
-      workspace.scrollCenter();
-    }
-    //AI.Blockly.navigationController.enable(workspace);
-  }, animationDelayMs);
+  for (const block of workspace.blocksNeedingRendering) {
+    workspace.getWarningHandler().checkErrors(block);
+    block.render();
+  }
+  workspace.blocksNeedingRendering.splice(0);  // clear the array of pending blocks
+  workspace.resizeContents();
+  Blockly.common.svgResize(workspace);
+  if (workspace.notYetRendered) {
+    workspace.notYetRendered = false;
+    workspace.scrollCenter();
+  }
+  //AI.Blockly.navigationController.enable(workspace);
 };
 
 // Preserve Blockly during Closure and GWT optimizations


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

This PR is based on https://github.com/mit-cml/appinventor-sources/pull/3749, so rebase after that merges and then merge this. That way if we decide we want the troublesome animation back and we can revert this and use the workarounds.