### PR TITLE
Fix Road map tiles not rendering due to OSM redirects

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/NativeOpenStreetMapController.java
@@ -106,6 +106,20 @@ class NativeOpenStreetMapController implements MapController, MapListener {
   /* end copied from SVG */
 
   private static final String TAG = NativeOpenStreetMapController.class.getSimpleName();
+  private static final ITileSource OSM_ROAD_TILE_SOURCE =
+    new XYTileSource(
+        "OSM-Road",
+        1,
+        20,
+        256,
+        ".png",
+        new String[] {
+            "https://a.tile.openstreetmap.org/",
+            "https://b.tile.openstreetmap.org/",
+            "https://c.tile.openstreetmap.org/"
+        },
+        "© OpenStreetMap contributors"
+  );
   private boolean caches;
   private final Form form;
   private RelativeLayout containerView;
@@ -452,28 +466,12 @@ class NativeOpenStreetMapController implements MapController, MapListener {
     return tileSource;
   }
 
-  private ITileSource getRoadTileSource() {
-  return new XYTileSource(
-      "OSM-Road",
-      1,
-      20,
-      256,
-      ".png",
-      new String[] {
-          "https://a.tile.openstreetmap.org/",
-          "https://b.tile.openstreetmap.org/",
-          "https://c.tile.openstreetmap.org/"
-      }
-    );
-  }
-
   @Override
   public void setMapTypeAbstract(MapType type) {
     tileType = type;
     switch (type) {
       case Road:
-        view.getTileProvider().clearTileCache();
-        view.setTileSource(getRoadTileSource());
+        view.setTileSource(OSM_ROAD_TILE_SOURCE);
         break;
       case Aerial:
         view.setTileSource(TileSourceFactory.USGS_SAT);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [X] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
This PR fixes an issue where the Road map type renders as a blank or grey map.

OpenStreetMap tile servers now return HTTP redirects, which are not reliably
handled by the osmdroid version used by App Inventor. As a result, Road map
tiles fail to load, especially after switching map types (Road → Aerial → Road).

The fix replaces the redirecting endpoint with explicit OpenStreetMap tile
subdomains (a/b/c.tile.openstreetmap.org) and clears the tile cache when
switching back to Road, restoring correct behavior across Companion and
compiled apps.


<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3723.