### PR TITLE
Make Translator ApiKey take values similar to ChatBot

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTranslator.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTranslator.java
@@ -83,11 +83,16 @@ public class MockTranslator extends MockNonVisibleComponent {
     if (propertyName.equals(PROPERTY_NAME_APIKEY)) {
       EditableProperty token = properties.getProperty(PROPERTY_NAME_APIKEY);
       int tokenType = token.getType();
-      persistToken = false;
-      tokenType |= EditableProperty.TYPE_NONPERSISTED;
-      tokenType |= EditableProperty.TYPE_DOYAIL;
+      if (newValue == null || newValue.isEmpty()) {
+        tokenType |= EditableProperty.TYPE_NONPERSISTED;
+        tokenType |= EditableProperty.TYPE_DOYAIL;
+        token.setType(tokenType);
+        getTokenFromServer();
+        return;                 // Callback from getTokenFromServer finishes up
+      } else if (newValue.charAt(0) == '%') {
+        tokenType &= ~EditableProperty.TYPE_NONPERSISTED;
+      }
       token.setType(tokenType);
-      getTokenFromServer();
     }
     super.onPropertyChange(propertyName, newValue);
   }


### PR DESCRIPTION
Change-Id: Iffcca9932b90d4c04a76d2a5449ee8a1dcf11928

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

Fixes an issue we discovered where the ApiKey property cannot be changed to anything other than the value set by the App Inventor server. This prevents testing in the dev environment by copy-pasting a valid ApiKey from the Translator component on ai2. The logic is changed to match MockChatBot.