### PR TITLE
Add support for android.minSdk project property

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/Project.java
@@ -105,6 +105,7 @@ public final class Project {
   private static final String USESLOCATIONTAG = "useslocation";
   private static final String ANAMETAG = "aname";
   private static final String ANDROID_MIN_SDK_TAG = "androidminsdk";
+  private static final String ANDROID_MIN_SDK_DOT_TAG = "android.minSdk";
   private static final String ACTIONBAR_TAG = "actionbar";
   private static final String COLOR_THEMETAG = "theme";
   private static final String COLOR_PRIMARYTAG = "color.primary";
@@ -306,8 +307,32 @@ public final class Project {
    * @return  the minimum Android sdk
    */
   public String getMinSdk() {
-    return properties.getProperty(ANDROID_MIN_SDK_TAG, DEFAULT_MIN_SDK);
+    // Prefer the new property name if present
+    String minSdk = properties.getProperty(ANDROID_MIN_SDK_DOT_TAG);
+
+    // Fall back to legacy property name
+    if (minSdk == null) {
+      minSdk = properties.getProperty(ANDROID_MIN_SDK_TAG);
+    }
+
+    // Final fallback to default
+    if (minSdk == null) {
+      LOG.info("Using default App Inventor minSdkVersion = " + DEFAULT_MIN_SDK);
+      return DEFAULT_MIN_SDK;
+    }
+
+    // Validate value
+    try {
+      int parsed = Integer.parseInt(minSdk.trim());
+      LOG.info("Using project-defined minSdkVersion = " + parsed);
+      return String.valueOf(parsed);
+    } catch (NumberFormatException e) {
+      LOG.warning(
+          "Invalid minSdkVersion '" + minSdk + "', falling back to default = " + DEFAULT_MIN_SDK);
+      return DEFAULT_MIN_SDK;
+    }
   }
+
 
   /**
    * Returns whether the ActionBar should be enabled in the project.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
This PR adds support for an optional android.minSdk project property that allows advanced users to override the minimum Android SDK version used during builds.

The default App Inventor behavior remains unchanged, and the legacy androidminsdk property is still supported for backward compatibility. Invalid values fall back to the default minimum SDK.


<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3761 .
