### PR TITLE
Implement Undo/Redo Functionality In Designer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1175,6 +1175,14 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Checkbox controlling whether to display invisible components in the designer.")
   String showHiddenComponentsCheckbox();
 
+  @DefaultMessage("Undo")
+  @Description("Tooltip for the undo button in the designer viewer header.")
+  String undoButton();
+
+  @DefaultMessage("Redo")
+  @Description("Tooltip for the redo button in the designer viewer header.")
+  String redoButton();
+
   @DefaultMessage("Display components with visible property set to FALSE")
   @Description("Alternate phrasing of showHiddenComponentsCheckbox.")
   String showInvisiblePropertyComponents();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
@@ -399,6 +399,11 @@ public abstract class BlocksEditor<S extends SourceNode, T extends DesignerEdito
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed in BlocksEditor before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
     if (permanentlyDeleted) {
       removeComponent(component.getType(), component.getName(), component.getUuid());

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerChangeListener.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerChangeListener.java
@@ -33,6 +33,17 @@ public interface DesignerChangeListener {
       String propertyName, String propertyValue);
 
   /**
+   * Invoked just before a component is removed from its container.
+   * At this point, the component is still in the container's children list
+   * and all properties are still intact.
+   *
+   * @param component  the component about to be removed
+   * @param permanentlyDeleted true if the component is being permanently
+   *        deleted, false if it is being moved to another container
+   */
+  void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted);
+
+  /**
    * Invoked when a component is removed.
    *
    * @param component  the component that was removed

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -323,6 +323,11 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed in DesignerEditor before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
     if (loadComplete) {
       if (permanentlyDeleted) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerRootComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerRootComponent.java
@@ -120,6 +120,8 @@ public interface DesignerRootComponent {
 
   void fireComponentRenamed(MockComponent component, String oldName);
 
+  void fireBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted);
+
   void fireComponentRemoved(MockComponent component, boolean permanentlyDeleted);
 
   void select(NativeEvent event);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockButtonBase.java
@@ -386,6 +386,11 @@ abstract class MockButtonBase extends MockVisibleComponent implements DesignerCh
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -260,6 +260,8 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
    *        to another container
    */
   public void removeComponent(MockComponent component, boolean permanentlyDeleted) {
+    // Notify listeners before the component is removed (while it is still in the children list)
+    getRoot().fireBeforeComponentRemoved(component, permanentlyDeleted);
 
     // Remove the component from the list of child components
     children.remove(component);
@@ -275,6 +277,14 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
     }
 
     getRoot().fireComponentRemoved(component, permanentlyDeleted);
+  }
+
+  /**
+   * Returns the index of the given child component in the children list,
+   * or -1 if not found.
+   */
+  public int getChildIndex(MockComponent child) {
+    return children.indexOf(child);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockDesignerRoot.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockDesignerRoot.java
@@ -154,6 +154,16 @@ public abstract class MockDesignerRoot extends MockContainer implements Designer
   }
 
   /**
+   * Triggers a before-component-removed event to be sent to the listeners.
+   * Called before the component is removed from its container's children list.
+   */
+  public void fireBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    for (DesignerChangeListener listener : changeListeners) {
+      listener.onBeforeComponentRemoved(component, permanentlyDeleted);
+    }
+  }
+
+  /**
    * Triggers a component removed event to be sent to the listener on the listener list.
    */
   public void fireComponentRemoved(MockComponent component, boolean permanentlyDeleted) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockLabel.java
@@ -197,6 +197,11 @@ public final class MockLabel extends MockVisibleComponent implements DesignerCha
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockPasswordTextBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockPasswordTextBox.java
@@ -218,6 +218,11 @@ public final class MockPasswordTextBox extends MockWrapper implements DesignerCh
     }
   }
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockTextBoxBase.java
@@ -256,6 +256,11 @@ abstract class MockTextBoxBase extends MockWrapper implements DesignerChangeList
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockToggleBase.java
@@ -192,6 +192,11 @@ abstract class MockToggleBase<T extends Widget> extends MockWrapper implements D
   }
 
   @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
+  @Override
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
@@ -155,6 +155,8 @@ public class DesignToolbar extends Toolbar {
   @UiField protected ToolbarItem switchToDesign;
   @UiField protected ToolbarItem switchToBlocks;
   @UiField protected ToolbarItem sendToGalleryItem;
+  @UiField protected ToolbarItem undoItem;
+  @UiField protected ToolbarItem redoItem;
 
   /**
    * Initializes and assembles all commands into buttons in the toolbar.
@@ -400,6 +402,21 @@ public class DesignToolbar extends Toolbar {
     boolean notOnScreen1 = getCurrentProject() != null
         && !"Screen1".equals(getCurrentProject().currentScreen);
     setButtonEnabled(WIDGET_NAME_REMOVEFORM, notOnScreen1);
+
+    // Hide undo/redo buttons in blocks view, show in designer view
+    setVisibleItem(undoItem, !blocks);
+    setVisibleItem(redoItem, !blocks);
+  }
+
+  /**
+   * Updates the enabled state of the undo and redo toolbar buttons.
+   *
+   * @param canUndo true if undo is available
+   * @param canRedo true if redo is available
+   */
+  public void updateUndoRedoButtons(boolean canUndo, boolean canRedo) {
+    setButtonEnabled(undoItem.getName(), canUndo);
+    setButtonEnabled(redoItem.getName(), canRedo);
   }
 
   public void toggleView() {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.ui.xml
@@ -36,6 +36,14 @@
                     align="center">
       <ya:ProjectPropertiesAction />
     </ai:ToolbarItem>
+    <ai:ToolbarItem name="Undo" caption="{messages.undoButton}" ui:field="undoItem"
+                    align="center" enabled="false">
+      <ya:UndoAction />
+    </ai:ToolbarItem>
+    <ai:ToolbarItem name="Redo" caption="{messages.redoButton}" ui:field="redoItem"
+                    align="center" enabled="false">
+      <ya:RedoAction />
+    </ai:ToolbarItem>
     <ai:ToolbarItem name="Gallery" caption="{messages.publishToGalleryButton}"
        ui:field="sendToGalleryItem" align="center">
       <actions:SendToGalleryAction />

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -139,6 +139,9 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     super.onShow();
     // Replace the old singleton call with the new panel method
     visibleComponentsPanel.show(root);
+    // Refresh undo/redo button state to match this screen's undo manager
+    Ode.getInstance().getDesignToolbar().updateUndoRedoButtons(
+        undoManager.canUndo(), undoManager.canRedo());
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -551,6 +551,7 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
       switch (event.getNativeKeyCode()) {
         case KeyCodes.KEY_Z:
           event.preventDefault();
+          event.stopPropagation();
           if (event.isShiftKeyDown()) {
             if (undoManager.canRedo()) {
               undoManager.redo();
@@ -563,6 +564,7 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
           return;
         case KeyCodes.KEY_Y:
           event.preventDefault();
+          event.stopPropagation();
           if (undoManager.canRedo()) {
             undoManager.redo();
           }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -14,11 +14,14 @@ import com.google.appinventor.client.editor.ProjectEditor;
 import com.google.appinventor.client.editor.designer.DesignerEditor;
 import com.google.appinventor.client.editor.simple.ComponentNotFoundException;
 import com.google.appinventor.client.editor.simple.SimpleComponentDatabase;
+import com.google.appinventor.client.editor.blocks.BlocksEditor;
 import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.simple.components.MockContainer;
 import com.google.appinventor.client.editor.simple.components.MockForm;
 import com.google.appinventor.client.editor.simple.palette.AbstractPalettePanel;
 import com.google.appinventor.client.editor.simple.palette.DropTargetProvider;
 import com.google.appinventor.client.editor.youngandroid.palette.YoungAndroidPalettePanel;
+import com.google.appinventor.client.editor.youngandroid.undo.DesignerUndoManager;
 import com.google.appinventor.client.properties.json.ClientJsonParser;
 import com.google.appinventor.client.properties.json.ClientJsonString;
 import com.google.appinventor.client.widgets.dnd.DropTarget;
@@ -83,6 +86,8 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
    * A mapping of component UUIDs to mock components in the designer view.
    */
   private final Map<String, MockComponent> componentsDb = new HashMap<>();
+
+  private final DesignerUndoManager undoManager = new DesignerUndoManager(this);
 
   private static final int OLD_PROJECT_YAV = 150; // Projects older then this have no authURL
 
@@ -155,6 +160,8 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
   @Override
   public void onClose() {
     root.removeDesignerChangeListener(this);
+    root.removeDesignerChangeListener(undoManager);
+    undoManager.clear();
     // Note: our partner YaBlocksEditor will remove itself as a DesignerChangeListener, even
     // though we added it.
   }
@@ -181,6 +188,11 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     if (isLoadComplete() && component.isPropertyPersisted(propertyName)) {
       updatePhone();          // Push changes to the phone if it is connected
     }
+  }
+
+  @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed in YaFormEditor before component removal.
   }
 
   // other public methods
@@ -344,6 +356,16 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     // of in the blocks editor so that we don't risk it missing any updates.
     root.addDesignerChangeListener(((YaProjectEditor) projectEditor)
         .getBlocksFileEditor(root.getName()));
+
+    // Register the undo manager as a change listener and initialize tracking.
+    root.addDesignerChangeListener(undoManager);
+    undoManager.initializePropertyTracking();
+    undoManager.setStateListener(new DesignerUndoManager.UndoRedoStateListener() {
+        @Override
+        public void onUndoRedoStateChanged(boolean canUndo, boolean canRedo) {
+            Ode.getInstance().getDesignToolbar().updateUndoRedoButtons(canUndo, canRedo);
+        }
+    });
   }
 
   /**
@@ -522,7 +544,29 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     if (!isActiveEditor()) {
       return;  // Not the active editor
     }
-    if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.shouldSuppressShortcuts()
+    if (event.isControlKeyDown() || event.isMetaKeyDown()) {
+      switch (event.getNativeKeyCode()) {
+        case KeyCodes.KEY_Z:
+          event.preventDefault();
+          if (event.isShiftKeyDown()) {
+            if (undoManager.canRedo()) {
+              undoManager.redo();
+            }
+          } else {
+            if (undoManager.canUndo()) {
+              undoManager.undo();
+            }
+          }
+          return;
+        case KeyCodes.KEY_Y:
+          event.preventDefault();
+          if (undoManager.canRedo()) {
+            undoManager.redo();
+          }
+          return;
+      }
+    }
+    if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.isTextboxFocused()
         && !(event.isControlKeyDown() || event.isMetaKeyDown())) {
       getVisibleComponentsPanel().focusCheckbox();
     } else {
@@ -530,4 +574,160 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     }
   }
 
+  // --- Undo/Redo support ---
+
+  /**
+   * Returns the undo manager for this form editor.
+   */
+  public DesignerUndoManager getUndoManager() {
+    return undoManager;
+  }
+
+  /**
+   * Finds a component by its UUID across all components in this form.
+   *
+   * @param uuid the component UUID to search for
+   * @return the MockComponent with the given UUID, or null if not found
+   */
+  public MockComponent getComponentByUuid(String uuid) {
+    if (uuid == null) {
+      return null;
+    }
+    // Check the form itself
+    if (uuid.equals(root.getUuid())) {
+      return root;
+    }
+    Map<String, MockComponent> components = getComponents();
+    for (MockComponent component : components.values()) {
+      if (uuid.equals(component.getUuid())) {
+        return component;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Encodes a single component (and its children) as a JSON string.
+   * Used by undo commands to capture component state before deletion.
+   *
+   * @param component the component to encode
+   * @return JSON string representation of the component subtree
+   */
+  public String encodeComponentAsJson(MockComponent component) {
+    StringBuilder sb = new StringBuilder();
+    encodeComponentProperties(component, sb, false);
+    return sb.toString();
+  }
+
+  /**
+   * Recreates a component (and its children) from a JSON string and adds it
+   * to the given container at the specified index. Used by undo/redo commands.
+   *
+   * @param json the JSON representation of the component subtree
+   * @param parent the container to add the component to
+   * @param index the index within the container's children list (-1 for end)
+   * @return the recreated MockComponent, or null on failure
+   */
+  public MockComponent recreateComponentFromJson(String json, MockContainer parent, int index) {
+    try {
+      JSONObject propertiesObject = JSON_PARSER.parse(json).asObject();
+      MockComponent component = createMockComponentForUndo(propertiesObject, parent, index);
+      if (isLoadComplete()) {
+        onStructureChange();
+      }
+      return component;
+    } catch (Exception e) {
+      LOG.severe("Failed to recreate component from JSON: " + e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Removes a component and its subtree for undo purposes.
+   * Cleans up blocks editor registration, non-visible panel, and container.
+   *
+   * @param component the component to remove
+   */
+  public void removeComponentForUndo(MockComponent component) {
+    // Remove from blocks editor
+    BlocksEditor<?, ?> blockEditor = getBlocksEditor();
+    removeComponentFromBlocksEditor(component, blockEditor);
+
+    // Select the form before removal
+    root.setSelectedComponent(root, null);
+
+    // Remove from container
+    MockContainer container = component.getContainer();
+    if (container != null) {
+      container.removeComponent(component, true);
+    }
+
+    // Clean up the component
+    component.onRemoved();
+    component.getProperties().removePropertyChangeListener(component);
+    component.getProperties().clear();
+  }
+
+  /**
+   * Recursively removes a component and its children from the blocks editor.
+   */
+  private void removeComponentFromBlocksEditor(MockComponent component, BlocksEditor<?, ?> blockEditor) {
+    // Remove children first (for containers)
+    for (MockComponent child : new ArrayList<MockComponent>(component.getChildren())) {
+      removeComponentFromBlocksEditor(child, blockEditor);
+    }
+    blockEditor.removeComponent(component.getType(), component.getName(), component.getUuid());
+  }
+
+  /*
+   * Parses the JSON properties and creates the component structure at a specific index.
+   * This overload is used by the undo system to insert at a specific position.
+   */
+  private MockComponent createMockComponentForUndo(JSONObject propertiesObject, MockContainer parent, int index) {
+    Map<String, JSONValue> properties = propertiesObject.getProperties();
+
+    // Component name and type
+    String componentType = properties.get("$Type").asString().getString();
+
+    // Instantiate a mock component for the visual designer
+    MockComponent mockComponent = palettePanel.createMockComponent(componentType,
+        componentDatabase.getComponentType(componentType));
+
+    // Add the component to its parent container at the specified index
+    if (index >= 0 && index <= parent.getChildren().size()) {
+      parent.addComponent(mockComponent, index);
+    } else {
+      parent.addComponent(mockComponent);
+    }
+    if (!mockComponent.isVisibleComponent()) {
+      nonVisibleComponentsPanel.addComponent(mockComponent);
+    }
+
+    // Set the name of the component
+    String componentName = properties.get("$Name").asString().getString();
+    mockComponent.changeProperty("Name", componentName);
+
+    // Set component properties
+    for (String name : properties.keySet()) {
+      if (name.charAt(0) != '$') {
+        mockComponent.changeProperty(name, properties.get(name).asString().getString());
+      }
+    }
+
+    // Add component type to the blocks editor
+    BlocksEditor<?, ?> blockEditor = getBlocksEditor();
+    if (blockEditor != null) {
+      blockEditor.addComponent(mockComponent.getType(), mockComponent.getName(),
+          mockComponent.getUuid());
+    }
+
+    // Add nested components
+    if (properties.containsKey("$Components")) {
+      for (JSONValue nestedComponent : properties.get("$Components").asArray().getElements()) {
+        createMockComponentForUndo(nestedComponent.asObject(), (MockContainer) mockComponent, -1);
+      }
+    }
+
+    return mockComponent;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/RedoAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/RedoAction.java
@@ -1,0 +1,24 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.actions;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.FileEditor;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+import com.google.gwt.user.client.Command;
+
+public class RedoAction implements Command {
+  @Override
+  public void execute() {
+    FileEditor currentEditor = Ode.getInstance().getCurrentFileEditor();
+    if (currentEditor instanceof YaFormEditor) {
+      YaFormEditor editor = (YaFormEditor) currentEditor;
+      if (editor.getUndoManager().canRedo()) {
+        editor.getUndoManager().redo();
+      }
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/UndoAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/UndoAction.java
@@ -1,0 +1,24 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.actions;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.FileEditor;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+import com.google.gwt.user.client.Command;
+
+public class UndoAction implements Command {
+  @Override
+  public void execute() {
+    FileEditor currentEditor = Ode.getInstance().getCurrentFileEditor();
+    if (currentEditor instanceof YaFormEditor) {
+      YaFormEditor editor = (YaFormEditor) currentEditor;
+      if (editor.getUndoManager().canUndo()) {
+        editor.getUndoManager().undo();
+      }
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidComponentSelectorPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidComponentSelectorPropertyEditor.java
@@ -182,6 +182,10 @@ public final class YoungAndroidComponentSelectorPropertyEditor
       String propertyName, String propertyValue) {
   }
 
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    // No action needed before component removal.
+  }
+
   public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
     if (permanentlyDeleted) {
       if (componentTypes == null || componentTypes.contains(component.getType())) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/AddComponentCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/AddComponentCommand.java
@@ -1,0 +1,68 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.simple.components.MockContainer;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+
+/**
+ * Command that represents adding a component to the form.
+ * Undo removes the component; redo recreates it from the stored JSON.
+ */
+public class AddComponentCommand implements DesignerCommand {
+
+  private final YaFormEditor formEditor;
+  private final String componentJson;
+  private final String containerUuid;
+  private final int childIndex;
+  private final String componentUuid;
+  private final boolean isNonVisible;
+
+  public AddComponentCommand(YaFormEditor formEditor, String componentJson,
+      String containerUuid, int childIndex, String componentUuid, boolean isNonVisible) {
+    this.formEditor = formEditor;
+    this.componentJson = componentJson;
+    this.containerUuid = containerUuid;
+    this.childIndex = childIndex;
+    this.componentUuid = componentUuid;
+    this.isNonVisible = isNonVisible;
+  }
+
+  @Override
+  public void execute() {
+    // Redo: recreate the component from stored JSON
+    MockContainer container = getContainer();
+    if (container != null) {
+      formEditor.recreateComponentFromJson(componentJson, container, childIndex);
+    }
+  }
+
+  @Override
+  public void undo() {
+    // Undo: remove the component
+    MockComponent component = formEditor.getComponentByUuid(componentUuid);
+    if (component != null) {
+      formEditor.removeComponentForUndo(component);
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "Add component";
+  }
+
+  private MockContainer getContainer() {
+    if (containerUuid == null) {
+      return formEditor.getForm();
+    }
+    MockComponent comp = formEditor.getComponentByUuid(containerUuid);
+    if (comp instanceof MockContainer) {
+      return (MockContainer) comp;
+    }
+    return formEditor.getForm();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DeleteComponentCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DeleteComponentCommand.java
@@ -1,0 +1,76 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.simple.components.MockContainer;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+
+/**
+ * Command that represents deleting a component from the form.
+ * Undo recreates the component from the stored JSON; redo deletes it again.
+ */
+public class DeleteComponentCommand implements DesignerCommand {
+
+  private final YaFormEditor formEditor;
+  private final String componentJson;
+  private final String containerUuid;
+  private final int childIndex;
+  private final boolean isVisible;
+
+  /** UUID extracted from the JSON for redo (finding the recreated component). */
+  private String componentUuid;
+
+  public DeleteComponentCommand(YaFormEditor formEditor, String componentJson,
+      String containerUuid, int childIndex, boolean isVisible) {
+    this.formEditor = formEditor;
+    this.componentJson = componentJson;
+    this.containerUuid = containerUuid;
+    this.childIndex = childIndex;
+    this.isVisible = isVisible;
+  }
+
+  @Override
+  public void execute() {
+    // Redo: delete the component again
+    if (componentUuid != null) {
+      MockComponent component = formEditor.getComponentByUuid(componentUuid);
+      if (component != null) {
+        formEditor.removeComponentForUndo(component);
+      }
+    }
+  }
+
+  @Override
+  public void undo() {
+    // Undo: recreate the component from stored JSON
+    MockContainer container = getContainer();
+    if (container != null) {
+      MockComponent recreated = formEditor.recreateComponentFromJson(
+          componentJson, container, childIndex);
+      if (recreated != null) {
+        componentUuid = recreated.getUuid();
+        recreated.select(null);
+      }
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "Delete component";
+  }
+
+  private MockContainer getContainer() {
+    if (containerUuid == null) {
+      return formEditor.getForm();
+    }
+    MockComponent comp = formEditor.getComponentByUuid(containerUuid);
+    if (comp instanceof MockContainer) {
+      return (MockContainer) comp;
+    }
+    return formEditor.getForm();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DesignerCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DesignerCommand.java
@@ -1,0 +1,35 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+/**
+ * Interface for undoable commands in the Designer panel.
+ *
+ * <p>Each command encapsulates a user action that can be undone and redone.
+ * Commands are stored on the undo/redo stacks managed by {@link DesignerUndoManager}.
+ */
+public interface DesignerCommand {
+
+  /**
+   * Executes (or re-executes) this command.
+   * Called when the command is first performed or when it is redone.
+   */
+  void execute();
+
+  /**
+   * Reverses this command.
+   * Called when the user triggers an undo operation.
+   */
+  void undo();
+
+  /**
+   * Returns a human-readable description of this command,
+   * e.g. "Change Button1.Text" or "Delete Label1".
+   *
+   * @return description string
+   */
+  String getDescription();
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DesignerUndoManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/DesignerUndoManager.java
@@ -1,0 +1,452 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.designer.DesignerChangeListener;
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.simple.components.MockContainer;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+import com.google.appinventor.client.widgets.properties.EditableProperty;
+import com.google.gwt.user.client.Timer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Manages undo and redo stacks for the Designer panel.
+ *
+ * <p>Implements {@link DesignerChangeListener} to automatically record undoable
+ * commands as the user modifies the form in the visual designer.
+ *
+ * <p>One instance exists per {@link YaFormEditor} (i.e., per screen).
+ */
+public class DesignerUndoManager implements DesignerChangeListener {
+  private static final Logger LOG = Logger.getLogger(DesignerUndoManager.class.getName());
+
+  private static final int MAX_UNDO_SIZE = 100;
+  private static final int MAX_REDO_SIZE = 50;
+  private static final int PROPERTY_CHANGE_DEBOUNCE_MS = 500;
+
+  private final YaFormEditor formEditor;
+
+  private final List<DesignerCommand> undoStack = new ArrayList<DesignerCommand>();
+  private final List<DesignerCommand> redoStack = new ArrayList<DesignerCommand>();
+
+  /**
+   * When true, form change events are ignored (not recorded as commands).
+   * Set during undo/redo execution to prevent recursive recording.
+   */
+  private boolean suppressRecording = false;
+
+  // --- Property change debouncing ---
+
+  /** Pending property change command, awaiting debounce timer. */
+  private PropertyChangeCommand pendingPropertyCommand = null;
+  private Timer propertyChangeTimer = null;
+
+  /**
+   * Tracks the last-known property values for all components, keyed by
+   * "componentUuid:propertyName". Used to determine the old value when
+   * a property change event fires (since the value has already changed).
+   */
+  private final Map<String, String> lastKnownPropertyValues = new HashMap<String, String>();
+
+  // --- Move detection ---
+
+  /** Temporary state for detecting component moves (remove with permanentlyDeleted=false). */
+  private PendingMoveInfo pendingMove = null;
+
+  // --- Before-remove capture ---
+
+  /** Captures container/index info before a component is removed from the children list. */
+  private BeforeRemoveInfo beforeRemoveInfo = null;
+
+  /** Callback to update toolbar button states. */
+  private UndoRedoStateListener stateListener;
+
+  /**
+   * Creates a new DesignerUndoManager for the given form editor.
+   */
+  public DesignerUndoManager(YaFormEditor formEditor) {
+    this.formEditor = formEditor;
+  }
+
+  // --- Public API ---
+
+  /**
+   * Initializes the property value tracking map with the current state of all components.
+   * Should be called once after the form is fully loaded.
+   */
+  public void initializePropertyTracking() {
+    lastKnownPropertyValues.clear();
+    Map<String, MockComponent> components = formEditor.getComponents();
+    for (MockComponent component : components.values()) {
+      trackComponentProperties(component);
+    }
+  }
+
+  /**
+   * Performs an undo operation. Pops the top command from the undo stack,
+   * pushes it to the redo stack, and calls its undo() method.
+   */
+  public void undo() {
+    flushPendingPropertyCommand();
+    if (undoStack.isEmpty()) {
+      return;
+    }
+    DesignerCommand command = undoStack.remove(undoStack.size() - 1);
+    if (redoStack.size() >= MAX_REDO_SIZE) {
+      redoStack.remove(0);
+    }
+    redoStack.add(command);
+
+    suppressRecording = true;
+    try {
+      command.undo();
+    } finally {
+      suppressRecording = false;
+    }
+
+    Ode.getInstance().getEditorManager().scheduleAutoSave(formEditor);
+    notifyStateListener();
+    LOG.info("Undo: " + command.getDescription());
+  }
+
+  /**
+   * Performs a redo operation. Pops the top command from the redo stack,
+   * pushes it to the undo stack, and calls its execute() method.
+   */
+  public void redo() {
+    flushPendingPropertyCommand();
+    if (redoStack.isEmpty()) {
+      return;
+    }
+    DesignerCommand command = redoStack.remove(redoStack.size() - 1);
+    if (undoStack.size() >= MAX_UNDO_SIZE) {
+      undoStack.remove(0);
+    }
+    undoStack.add(command);
+
+    suppressRecording = true;
+    try {
+      command.execute();
+    } finally {
+      suppressRecording = false;
+    }
+
+    Ode.getInstance().getEditorManager().scheduleAutoSave(formEditor);
+    notifyStateListener();
+    LOG.info("Redo: " + command.getDescription());
+  }
+
+  public boolean canUndo() {
+    return !undoStack.isEmpty() || pendingPropertyCommand != null;
+  }
+
+  public boolean canRedo() {
+    return !redoStack.isEmpty();
+  }
+
+  /**
+   * Clears both undo and redo stacks and resets all internal state.
+   */
+  public void clear() {
+    undoStack.clear();
+    redoStack.clear();
+    pendingPropertyCommand = null;
+    if (propertyChangeTimer != null) {
+      propertyChangeTimer.cancel();
+      propertyChangeTimer = null;
+    }
+    pendingMove = null;
+    beforeRemoveInfo = null;
+    lastKnownPropertyValues.clear();
+    notifyStateListener();
+  }
+
+  /**
+   * Returns the form editor associated with this undo manager.
+   */
+  public YaFormEditor getFormEditor() {
+    return formEditor;
+  }
+
+  /**
+   * Sets a listener to be notified when the undo/redo state changes
+   * (e.g. to enable/disable toolbar buttons).
+   */
+  public void setStateListener(UndoRedoStateListener listener) {
+    this.stateListener = listener;
+  }
+
+  /**
+   * Returns whether recording is currently suppressed (during undo/redo execution).
+   */
+  public boolean isSuppressed() {
+    return suppressRecording;
+  }
+
+  // --- DesignerChangeListener implementation ---
+
+  @Override
+  public void onComponentPropertyChanged(MockComponent component,
+      String propertyName, String propertyValue) {
+    if (suppressRecording) {
+      return;
+    }
+    if (!component.isPropertyPersisted(propertyName)) {
+      return;
+    }
+
+    String key = component.getUuid() + ":" + propertyName;
+    String oldValue = lastKnownPropertyValues.get(key);
+    if (oldValue == null) {
+      oldValue = propertyValue; // fallback if not tracked
+    }
+
+    // Update tracking
+    lastKnownPropertyValues.put(key, propertyValue);
+
+    // If there's already a pending command for the same component+property, coalesce
+    if (pendingPropertyCommand != null
+        && pendingPropertyCommand.getComponentUuid().equals(component.getUuid())
+        && pendingPropertyCommand.getPropertyName().equals(propertyName)) {
+      pendingPropertyCommand.setNewValue(propertyValue);
+      restartPropertyTimer();
+      return;
+    }
+
+    // Flush any existing pending command for a different property
+    flushPendingPropertyCommand();
+
+    // Create new pending command
+    pendingPropertyCommand = new PropertyChangeCommand(
+        formEditor, component.getUuid(), component.getName(),
+        propertyName, oldValue, propertyValue);
+    restartPropertyTimer();
+  }
+
+  @Override
+  public void onBeforeComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    if (suppressRecording) {
+      return;
+    }
+    // Capture the container and index BEFORE the component is removed from the children list
+    MockContainer container = component.getContainer();
+    if (container != null) {
+      int index = container.getChildIndex(component);
+      beforeRemoveInfo = new BeforeRemoveInfo(
+          container.getUuid(), index, component.isVisibleComponent());
+    }
+  }
+
+  @Override
+  public void onComponentRemoved(MockComponent component, boolean permanentlyDeleted) {
+    if (suppressRecording) {
+      return;
+    }
+
+    if (!permanentlyDeleted) {
+      // This is the first half of a move operation.
+      // Store the source info and wait for onComponentAdded.
+      if (beforeRemoveInfo != null) {
+        pendingMove = new PendingMoveInfo(
+            component.getUuid(),
+            beforeRemoveInfo.containerUuid,
+            beforeRemoveInfo.childIndex);
+        beforeRemoveInfo = null;
+      }
+      return;
+    }
+
+    // Permanent deletion: capture the component's full state.
+    flushPendingPropertyCommand();
+
+    String componentJson = formEditor.encodeComponentAsJson(component);
+    String containerUuid = beforeRemoveInfo != null ? beforeRemoveInfo.containerUuid : null;
+    int childIndex = beforeRemoveInfo != null ? beforeRemoveInfo.childIndex : -1;
+    boolean isVisible = beforeRemoveInfo != null ? beforeRemoveInfo.isVisible : component.isVisibleComponent();
+    beforeRemoveInfo = null;
+
+    DeleteComponentCommand command = new DeleteComponentCommand(
+        formEditor, componentJson, containerUuid, childIndex, isVisible);
+    pushUndoCommand(command);
+
+    // Remove tracked property values for deleted component
+    removeComponentPropertyTracking(component);
+  }
+
+  @Override
+  public void onComponentAdded(MockComponent component) {
+    if (suppressRecording) {
+      // Even when suppressed, update property tracking for new components
+      trackComponentProperties(component);
+      return;
+    }
+
+    // Check if this is the second half of a move operation
+    if (pendingMove != null && pendingMove.componentUuid.equals(component.getUuid())) {
+      flushPendingPropertyCommand();
+
+      MockContainer newContainer = component.getContainer();
+      String dstContainerUuid = newContainer != null ? newContainer.getUuid() : null;
+      int dstIndex = newContainer != null ? newContainer.getChildIndex(component) : -1;
+
+      MoveComponentCommand command = new MoveComponentCommand(
+          formEditor, component.getUuid(),
+          pendingMove.srcContainerUuid, pendingMove.srcChildIndex,
+          dstContainerUuid, dstIndex);
+      pendingMove = null;
+      pushUndoCommand(command);
+      return;
+    }
+    pendingMove = null;
+
+    // Regular add (from palette, paste, duplicate)
+    flushPendingPropertyCommand();
+
+    MockContainer container = component.getContainer();
+    String containerUuid = container != null ? container.getUuid() : null;
+    int childIndex = container != null ? container.getChildIndex(component) : -1;
+    String componentJson = formEditor.encodeComponentAsJson(component);
+
+    AddComponentCommand command = new AddComponentCommand(
+        formEditor, componentJson, containerUuid, childIndex,
+        component.getUuid(), !component.isVisibleComponent());
+    pushUndoCommand(command);
+
+    // Track properties for the new component
+    trackComponentProperties(component);
+  }
+
+  @Override
+  public void onComponentRenamed(MockComponent component, String oldName) {
+    if (suppressRecording) {
+      return;
+    }
+    flushPendingPropertyCommand();
+
+    RenameComponentCommand command = new RenameComponentCommand(
+        formEditor, component.getUuid(), oldName, component.getName());
+    pushUndoCommand(command);
+  }
+
+  @Override
+  public void onComponentSelectionChange(MockComponent component, boolean selected) {
+    // Selection changes are not undoable.
+  }
+
+  // --- Internal helpers ---
+
+  private void pushUndoCommand(DesignerCommand command) {
+    if (undoStack.size() >= MAX_UNDO_SIZE) {
+      undoStack.remove(0);
+    }
+    undoStack.add(command);
+    redoStack.clear();
+    notifyStateListener();
+    LOG.info("Recorded: " + command.getDescription());
+  }
+
+  private void flushPendingPropertyCommand() {
+    if (propertyChangeTimer != null) {
+      propertyChangeTimer.cancel();
+      propertyChangeTimer = null;
+    }
+    if (pendingPropertyCommand != null) {
+      // Only push if the value actually changed
+      if (!pendingPropertyCommand.getOldValue().equals(pendingPropertyCommand.getNewValue())) {
+        if (undoStack.size() >= MAX_UNDO_SIZE) {
+          undoStack.remove(0);
+        }
+        undoStack.add(pendingPropertyCommand);
+        redoStack.clear();
+        LOG.info("Recorded (flushed): " + pendingPropertyCommand.getDescription());
+      }
+      pendingPropertyCommand = null;
+      notifyStateListener();
+    }
+  }
+
+  private void restartPropertyTimer() {
+    if (propertyChangeTimer != null) {
+      propertyChangeTimer.cancel();
+    }
+    propertyChangeTimer = new Timer() {
+      @Override
+      public void run() {
+        flushPendingPropertyCommand();
+      }
+    };
+    propertyChangeTimer.schedule(PROPERTY_CHANGE_DEBOUNCE_MS);
+  }
+
+  private void trackComponentProperties(MockComponent component) {
+    String uuid = component.getUuid();
+    for (EditableProperty property : component.getProperties()) {
+      if (component.isPropertyPersisted(property.getName())) {
+        String key = uuid + ":" + property.getName();
+        lastKnownPropertyValues.put(key, property.getValue());
+      }
+    }
+  }
+
+  private void removeComponentPropertyTracking(MockComponent component) {
+    String uuid = component.getUuid();
+    List<String> keysToRemove = new ArrayList<String>();
+    for (String key : lastKnownPropertyValues.keySet()) {
+      if (key.startsWith(uuid + ":")) {
+        keysToRemove.add(key);
+      }
+    }
+    for (String key : keysToRemove) {
+      lastKnownPropertyValues.remove(key);
+    }
+  }
+
+  private void notifyStateListener() {
+    if (stateListener != null) {
+      stateListener.onUndoRedoStateChanged(canUndo(), canRedo());
+    }
+  }
+
+  // --- Inner data classes ---
+
+  private static class PendingMoveInfo {
+    final String componentUuid;
+    final String srcContainerUuid;
+    final int srcChildIndex;
+
+    PendingMoveInfo(String componentUuid, String srcContainerUuid, int srcChildIndex) {
+      this.componentUuid = componentUuid;
+      this.srcContainerUuid = srcContainerUuid;
+      this.srcChildIndex = srcChildIndex;
+    }
+  }
+
+  private static class BeforeRemoveInfo {
+    final String containerUuid;
+    final int childIndex;
+    final boolean isVisible;
+
+    BeforeRemoveInfo(String containerUuid, int childIndex, boolean isVisible) {
+      this.containerUuid = containerUuid;
+      this.childIndex = childIndex;
+      this.isVisible = isVisible;
+    }
+  }
+
+  /**
+   * Listener interface for undo/redo state changes (to update UI buttons).
+   */
+  public interface UndoRedoStateListener {
+    void onUndoRedoStateChanged(boolean canUndo, boolean canRedo);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/MoveComponentCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/MoveComponentCommand.java
@@ -1,0 +1,81 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.simple.components.MockContainer;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+
+/**
+ * Command that represents moving a component from one container to another.
+ */
+public class MoveComponentCommand implements DesignerCommand {
+
+  private final YaFormEditor formEditor;
+  private final String componentUuid;
+  private final String srcContainerUuid;
+  private final int srcChildIndex;
+  private final String dstContainerUuid;
+  private final int dstChildIndex;
+
+  public MoveComponentCommand(YaFormEditor formEditor, String componentUuid,
+      String srcContainerUuid, int srcChildIndex,
+      String dstContainerUuid, int dstChildIndex) {
+    this.formEditor = formEditor;
+    this.componentUuid = componentUuid;
+    this.srcContainerUuid = srcContainerUuid;
+    this.srcChildIndex = srcChildIndex;
+    this.dstContainerUuid = dstContainerUuid;
+    this.dstChildIndex = dstChildIndex;
+  }
+
+  @Override
+  public void execute() {
+    // Redo: move from source to destination
+    moveComponent(srcContainerUuid, dstContainerUuid, dstChildIndex);
+  }
+
+  @Override
+  public void undo() {
+    // Undo: move from destination back to source
+    moveComponent(dstContainerUuid, srcContainerUuid, srcChildIndex);
+  }
+
+  private void moveComponent(String fromContainerUuid, String toContainerUuid, int toIndex) {
+    MockComponent component = formEditor.getComponentByUuid(componentUuid);
+    if (component == null) {
+      return;
+    }
+    MockContainer fromContainer = resolveContainer(fromContainerUuid);
+    MockContainer toContainer = resolveContainer(toContainerUuid);
+    if (fromContainer == null || toContainer == null) {
+      return;
+    }
+    fromContainer.removeComponent(component, false);
+    if (toIndex >= 0 && toIndex <= toContainer.getChildren().size()) {
+      toContainer.addComponent(component, toIndex);
+    } else {
+      toContainer.addComponent(component);
+    }
+    component.select(null);
+  }
+
+  private MockContainer resolveContainer(String containerUuid) {
+    if (containerUuid == null) {
+      return formEditor.getForm();
+    }
+    MockComponent comp = formEditor.getComponentByUuid(containerUuid);
+    if (comp instanceof MockContainer) {
+      return (MockContainer) comp;
+    }
+    return formEditor.getForm();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Move component";
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/PropertyChangeCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/PropertyChangeCommand.java
@@ -1,0 +1,73 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+
+/**
+ * Command that represents a property value change on a component.
+ */
+public class PropertyChangeCommand implements DesignerCommand {
+
+  private final YaFormEditor formEditor;
+  private final String componentUuid;
+  private final String componentName;
+  private final String propertyName;
+  private final String oldValue;
+  private String newValue;
+
+  public PropertyChangeCommand(YaFormEditor formEditor, String componentUuid,
+      String componentName, String propertyName, String oldValue, String newValue) {
+    this.formEditor = formEditor;
+    this.componentUuid = componentUuid;
+    this.componentName = componentName;
+    this.propertyName = propertyName;
+    this.oldValue = oldValue;
+    this.newValue = newValue;
+  }
+
+  @Override
+  public void execute() {
+    MockComponent component = formEditor.getComponentByUuid(componentUuid);
+    if (component != null) {
+      component.changeProperty(propertyName, newValue);
+    }
+  }
+
+  @Override
+  public void undo() {
+    MockComponent component = formEditor.getComponentByUuid(componentUuid);
+    if (component != null) {
+      component.changeProperty(propertyName, oldValue);
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "Change " + componentName + "." + propertyName;
+  }
+
+  public String getComponentUuid() {
+    return componentUuid;
+  }
+
+  public String getPropertyName() {
+    return propertyName;
+  }
+
+  public String getOldValue() {
+    return oldValue;
+  }
+
+  public String getNewValue() {
+    return newValue;
+  }
+
+  public void setNewValue(String newValue) {
+    this.newValue = newValue;
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/RenameComponentCommand.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/undo/RenameComponentCommand.java
@@ -1,0 +1,53 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.undo;
+
+import com.google.appinventor.client.editor.simple.components.MockComponent;
+import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
+
+/**
+ * Command that represents renaming a component.
+ */
+public class RenameComponentCommand implements DesignerCommand {
+
+  private final YaFormEditor formEditor;
+  private final String componentUuid;
+  private final String oldName;
+  private final String newName;
+
+  public RenameComponentCommand(YaFormEditor formEditor, String componentUuid,
+      String oldName, String newName) {
+    this.formEditor = formEditor;
+    this.componentUuid = componentUuid;
+    this.oldName = oldName;
+    this.newName = newName;
+  }
+
+  @Override
+  public void execute() {
+    // Redo: rename to newName
+    rename(newName, oldName);
+  }
+
+  @Override
+  public void undo() {
+    // Undo: rename back to oldName
+    rename(oldName, newName);
+  }
+
+  private void rename(String toName, String fromName) {
+    MockComponent component = formEditor.getComponentByUuid(componentUuid);
+    if (component != null) {
+      component.changeProperty(MockComponent.PROPERTY_NAME_NAME, toName);
+      component.getRoot().fireComponentRenamed(component, fromName);
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "Rename " + oldName + " to " + newName;
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.java
@@ -28,6 +28,8 @@ public class DesignToolbarNeo extends DesignToolbar {
   @UiField protected ToolbarItem sendToGalleryItem;
   @UiField protected Boolean isAvailable;
   @UiField protected ToolbarItem backArrow;
+  @UiField protected ToolbarItem undoItem;
+  @UiField protected ToolbarItem redoItem;
 
   @Override
   public void bindUI() {
@@ -44,5 +46,7 @@ public class DesignToolbarNeo extends DesignToolbar {
     super.sendToGalleryItem = sendToGalleryItem;
     super.isAvailable = isAvailable;
     super.backArrow = backArrow;
+    super.undoItem = undoItem;
+    super.redoItem = redoItem;
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
@@ -43,6 +43,14 @@
         tooltip="{messages.projectPropertiesText}" align="center" styleName="ode-ProjectListButton inline left-spacer">
       <ya:ProjectPropertiesAction />
     </ai:ToolbarItem>
+    <ai:ToolbarItem name="Undo" icon="undo" ui:field="undoItem"
+        tooltip="{messages.undoButton}" align="center" styleName="ode-ProjectListButton inline" enabled="false">
+      <ya:UndoAction />
+    </ai:ToolbarItem>
+    <ai:ToolbarItem name="Redo" icon="redo" ui:field="redoItem"
+        tooltip="{messages.redoButton}" align="center" styleName="ode-ProjectListButton inline" enabled="false">
+      <ya:RedoAction />
+    </ai:ToolbarItem>
 
     <ai:ToolbarItem name="Gallery" icon="public" tooltip="{messages.publishToGalleryButton}"
                     ui:field="sendToGalleryItem" align="center"  styleName="ode-ProjectListButton inline">

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
@@ -44,11 +44,11 @@
       <ya:ProjectPropertiesAction />
     </ai:ToolbarItem>
     <ai:ToolbarItem name="Undo" icon="undo" ui:field="undoItem"
-        tooltip="{messages.undoButton}" align="center" styleName="ode-ProjectListButton inline" enabled="false">
+        tooltip="{messages.undoButton}" align="center" styleName="ode-ProjectListButton inline left-spacer bleft" enabled="false">
       <ya:UndoAction />
     </ai:ToolbarItem>
     <ai:ToolbarItem name="Redo" icon="redo" ui:field="redoItem"
-        tooltip="{messages.redoButton}" align="center" styleName="ode-ProjectListButton inline" enabled="false">
+        tooltip="{messages.redoButton}" align="center" styleName="ode-ProjectListButton inline bright" enabled="false">
       <ya:RedoAction />
     </ai:ToolbarItem>
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

Adds Undo/Redo functionality to the Designer. It implements a diff-based stack, rather than full screen snapshots.

## Functionality Details

* Stacks are limited to 100 edits backwards ("undo") and 50 edits forwards ("redo").
* Stacks are per-screen: switching screens maintains the old stack. So, navigating back to the previous screen allows to "restore" the history.
* When a component is deleted either by Ctrl+Z or Delete button directly, this is propagated to blocks editor to delete all those blocks. Blocks editor now has that in their own Undo stack, so it's possible to restore as well there (see the last demo video). As of now, restoring a component from Undo/Redo Designer doesn't restore the blocks, but I think this is the intended behaviour to make the Designer be able to "create" blocks automatically...
* There's a small bug/feature: in the Table Arrangement, there are 3 actions happening when a component is moved: move component, and x2 set property in the arrangement. These 2 correspond go the row/columns. In the demo, you'll notice that I need to Ctrl+Z 3 times to actually undo that action.

## Demo Recordings

### Classic Theme Demo

https://github.com/user-attachments/assets/cbcb5950-51e9-409f-be13-bcbe42bc758c

### New Theme Demo

https://github.com/user-attachments/assets/10a312ae-a6ca-4ec7-bf0e-eb2e18836d92

### Layouts Demo

https://github.com/user-attachments/assets/139f8159-1911-4d91-ab32-8c70a93061eb

### Components' Blocks Destroy/Restore Demo

https://github.com/user-attachments/assets/252a33e6-7c3c-41f2-be34-491ff1d9eef2
