### PR TITLE
Fix error crash in iOS BluetoothLE

### DIFF
--- a/appinventor/components-ios/src/BluetoothLE.swift
+++ b/appinventor/components-ios/src/BluetoothLE.swift
@@ -993,7 +993,7 @@ func bleStringToUuid(_ uuidString: String) -> CBUUID? {
       // Success! Nothing to do
       return
     }
-    _form?.dispatchErrorOccurredEvent(self, "RegisterForValues", .ERROR_EXTENSION_ERROR, ERROR_OPERATION_NOT_SUPPORTED, error.localizedDescription)
+    _form?.dispatchErrorOccurredEvent(self, "RegisterForValues", .ERROR_EXTENSION_ERROR, ERROR_OPERATION_NOT_SUPPORTED, self, error.localizedDescription)
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {

--- a/appinventor/components-ios/src/String+Format.swift
+++ b/appinventor/components-ios/src/String+Format.swift
@@ -12,9 +12,15 @@ extension String {
       formatted += f[..<next!]
       switch f[f.index(next!, offsetBy: 1)] {
       case "s":
+        if i >= messageArgs.count {
+          break
+        }
         formatted += String(describing: messageArgs[i])
         i += 1
       case "d", "f":
+        if i >= messageArgs.count {
+          break
+        }
         formatted += (messageArgs[i] as! NSNumber).stringValue
         i += 1
       case "%":

--- a/appinventor/components-ios/tests/FormTests.swift
+++ b/appinventor/components-ios/tests/FormTests.swift
@@ -17,4 +17,24 @@ class FormTests: AppInventorTestCase {
     form.dispatchErrorOccurredEvent(form, "Test", Int32(ErrorMessage.ERROR_IOS_INSTALLING_URLS_NOT_SUPPORTED.rawValue))
     verify()
   }
+
+  func testDispatchErrorEvent() {
+    let ble = BluetoothLE(form)
+    expectToReceiveEvent(on: form, named: "ErrorOccurred") { arguments in
+      XCTAssertEqual(ble, arguments[0] as? BluetoothLE)
+      XCTAssertEqual("RegisterForValues", arguments[1] as! String)
+    }
+    form.dispatchErrorOccurredEvent(ble, "RegisterForValues", .ERROR_EXTENSION_ERROR, 9012, ble, "Test error")
+    verify()
+  }
+
+  func testDispatchMalformedErrorMessage() {
+    let ble = BluetoothLE(form)
+    expectToReceiveEvent(on: form, named: "ErrorOccurred") { arguments in
+      XCTAssertEqual(ble, arguments[0] as? BluetoothLE)
+      XCTAssertEqual("RegisterForValues", arguments[1] as! String)
+    }
+    form.dispatchErrorOccurredEvent(ble, "RegisterForValues", .ERROR_EXTENSION_ERROR, 9012, "Test error")
+    verify()
+  }
 }


### PR DESCRIPTION
Change-Id: I8d6e32515ce3ae1cdbbe66bcf6af0c27a18465df

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This fixes a crash in the iOS companion where an error during BLE notification reported by the OS triggers an index out of bounds array in the App Inventor error handling. I haven't been able to trigger the error on device, but did write a test to trigger it and then patched String+Format.swift to address the crash.