### PR TITLE
Use 25 year expiry for Android keystore compatibility

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/ios/CertificateRequestGenerator.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ios/CertificateRequestGenerator.java
@@ -65,7 +65,7 @@ public class CertificateRequestGenerator {
       Date start = new Date(now);
       Calendar calendar = Calendar.getInstance();
       calendar.setTime(start);
-      calendar.add(Calendar.YEAR, 1);
+      calendar.add(Calendar.YEAR, 25);
       Date end = calendar.getTime();
       ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate());
       JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(name, timestamp, start, end, name, keyPair.getPublic());


### PR DESCRIPTION
Change-Id: I7bf84b6d9b551a14e08a4ad009e845d62ddd319d

Note that I haven't tested this with Apple yet, but it is intended to fix [this issue report](https://community.appinventor.mit.edu/t/wrong-key-same-app/159581/4).