### PR TITLE
Add configurable AndroidMinSdk project property with UI dropdown and …

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -1368,12 +1368,12 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
     } else if (propertyName.equals(PROPERTY_NAME_BUILD_NUMBER)) {
       setBuildNumber(newValue);
     } else if (propertyName.equals(PROPERTY_NAME_ANDROID_MIN_SDK)) {
-        if (editor.isScreen1()) {
-            editor.getProjectEditor().changeProjectSettingsProperty(
-                SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-                SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
-                newValue);
-      } 
+      if (editor.isScreen1()) {
+        editor.getProjectEditor().changeProjectSettingsProperty(
+            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+            SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
+            newValue);
+      }
     } else if (
         propertyName.equals(PROPERTY_NAME_NSBTALWAYSUSAGEDESCRIPTION)
         || propertyName.equals(PROPERTY_NAME_NSBTPERIPHERALUSAGEDESCRIPTION)

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -355,6 +355,7 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
   private static final String PROPERTY_NAME_ICON = "Icon";
   private static final String PROPERTY_NAME_VCODE = "VersionCode";
   private static final String PROPERTY_NAME_VNAME = "VersionName";
+  private static final String PROPERTY_NAME_ANDROID_MIN_SDK = "AndroidMinSdk";
   private static final String PROPERTY_NAME_ANAME = "AppName";
   private static final String PROPERTY_NAME_SIZING = "Sizing"; // Don't show except on screen1
   private static final String PROPERTY_NAME_TITLEVISIBLE = "TitleVisible";
@@ -1120,7 +1121,8 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
 
   @Override
   protected boolean isPropertyforYail(String propertyName) {
-    if (IOS_PERMISSION_PROPERTIES.contains(propertyName)) {
+    if (IOS_PERMISSION_PROPERTIES.contains(propertyName)
+        || propertyName.equals(PROPERTY_NAME_ANDROID_MIN_SDK)) {
       // These are project-level properties, not per form.
       return false;
     }
@@ -1365,6 +1367,13 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_BUILD_NUMBER)) {
       setBuildNumber(newValue);
+    } else if (propertyName.equals(PROPERTY_NAME_ANDROID_MIN_SDK)) {
+        if (editor.isScreen1()) {
+            editor.getProjectEditor().changeProjectSettingsProperty(
+                SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+                SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
+                newValue);
+      } 
     } else if (
         propertyName.equals(PROPERTY_NAME_NSBTALWAYSUSAGEDESCRIPTION)
         || propertyName.equals(PROPERTY_NAME_NSBTPERIPHERALUSAGEDESCRIPTION)
@@ -1423,6 +1432,10 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
           editor.getProjectEditor().getProjectSettingsProperty(
             SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
             SettingsConstants.YOUNG_ANDROID_SETTINGS_TUTORIAL_URL));
+      properties.changePropertyValue(SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
+          editor.getProjectEditor().getProjectSettingsProperty(
+            SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+            SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK));
       properties.changePropertyValue(SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET,
           editor.getProjectEditor().getProjectSettingsProperty(
             SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMinSdkPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMinSdkPropertyEditor.java
@@ -1,3 +1,8 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 package com.google.appinventor.client.editor.youngandroid.properties;
 
 import com.google.appinventor.client.widgets.properties.ChoicePropertyEditor;
@@ -5,18 +10,20 @@ import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.YaVersion;
 
 public class YoungAndroidMinSdkPropertyEditor extends ChoicePropertyEditor {
-    public YoungAndroidMinSdkPropertyEditor() {
-        super(buildChoices());
-    }
-    private static Choice[] buildChoices() {
-        int min = ComponentConstants.APP_INVENTOR_MIN_SDK;
-        int max = YaVersion.TARGET_SDK_VERSION;
 
-        Choice[] choices = new Choice[max - min + 1];
+  public YoungAndroidMinSdkPropertyEditor() {
+    super(buildChoices());
+  }
 
-        for (int i = min; i <= max; i++) {
-            choices[i - min] = new Choice(String.valueOf(i), String.valueOf(i));
-        }
-        return choices;
+  private static Choice[] buildChoices() {
+    int min = ComponentConstants.APP_INVENTOR_MIN_SDK;
+    int max = YaVersion.TARGET_SDK_VERSION;
+
+    Choice[] choices = new Choice[max - min + 1];
+
+    for (int i = min; i <= max; i++) {
+      choices[i - min] = new Choice(String.valueOf(i), String.valueOf(i));
     }
+    return choices;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMinSdkPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidMinSdkPropertyEditor.java
@@ -1,0 +1,22 @@
+package com.google.appinventor.client.editor.youngandroid.properties;
+
+import com.google.appinventor.client.widgets.properties.ChoicePropertyEditor;
+import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.YaVersion;
+
+public class YoungAndroidMinSdkPropertyEditor extends ChoicePropertyEditor {
+    public YoungAndroidMinSdkPropertyEditor() {
+        super(buildChoices());
+    }
+    private static Choice[] buildChoices() {
+        int min = ComponentConstants.APP_INVENTOR_MIN_SDK;
+        int max = YaVersion.TARGET_SDK_VERSION;
+
+        Choice[] choices = new Choice[max - min + 1];
+
+        for (int i = min; i <= max; i++) {
+            choices[i - min] = new Choice(String.valueOf(i), String.valueOf(i));
+        }
+        return choices;
+    }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.java
@@ -9,7 +9,6 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.appinventor.client.editor.simple.components.i18n.ComponentTranslationTable;
 
-import com.google.appinventor.shared.settings.SettingsConstants;
 import com.google.appinventor.client.editor.simple.components.MockForm;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
 import com.google.appinventor.client.widgets.properties.EditableProperties;
@@ -170,69 +169,31 @@ public class ProjectPropertiesDialogBox {
     List<EditableProperty> properties = categoryToProperties.get(category);
 
     for (EditableProperty property : properties) {
-
-      // container for displaying one editable property
+      // container for displaing one editable property
       FlowPanel propertyContainer = new FlowPanel();
       propertyContainer.setStyleName("ode-propertyDialogPropertyContainer");
 
-      // name
-      Label name = new Label(
-          ComponentTranslationTable.getPropertyName(property.getName()));
+      // name of the EditableProperty
+      Label name = new Label(ComponentTranslationTable.getPropertyName(property.getName()));
       name.setStyleName("ode-propertyDialogPropertyTitle");
 
-      // description
-      HTML description = new HTML(
-          ComponentTranslationTable.getPropertyDescription(property.getDescription()));
+      // Description of the property
+      HTML description = new HTML(ComponentTranslationTable.getPropertyDescription(property.getDescription()));
       description.setStyleName("ode-propertyDialogPropertyDescription");
 
+      // editor of the editor
+      PropertyEditor editor = property.getEditor();
+      editor.setStyleName("ode-propertyDialogPropertyEditor");
+
+      // add to the container
       propertyContainer.add(name);
       propertyContainer.add(description);
+      propertyContainer.add(editor);
 
-      // SPECIAL HANDLING FOR AndroidMinSdk
-      if (property.getName().equals(
-          SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK)) {
-
-        ListBox minSdkDropdown = new ListBox();
-        minSdkDropdown.setStyleName("ode-propertyDialogPropertyEditor");
-
-        String[] options = {"14","16","19","21","23","26","29","33"};
-
-        for (String opt : options) {
-          minSdkDropdown.addItem(opt);
-        }
-
-        // set current value safely
-        int index = java.util.Arrays.asList(options)
-            .indexOf(property.getValue());
-
-        if (index >= 0) {
-          minSdkDropdown.setSelectedIndex(index);
-        }
-
-        minSdkDropdown.addChangeHandler(e -> {
-          String selected = minSdkDropdown.getSelectedValue();
-
-          // 1️ Update UI property
-          property.setValue(selected);
-
-          // 2️ Update actual project settings
-          projectEditor.changeProjectSettingsProperty(
-              SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
-              SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
-              selected);
-        });
-        propertyContainer.add(minSdkDropdown);
-      } else {
-
-        // default editor
-        PropertyEditor editor = property.getEditor();
-        editor.setStyleName("ode-propertyDialogPropertyEditor");
-        propertyContainer.add(editor);
-      }
-
+      // add to the main container
       propertiesContainer.add(propertyContainer);
-    }
-
+    }  
+    
     return propertiesContainer;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/dialogs/ProjectPropertiesDialogBox.java
@@ -9,6 +9,7 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.appinventor.client.editor.simple.components.i18n.ComponentTranslationTable;
 
+import com.google.appinventor.shared.settings.SettingsConstants;
 import com.google.appinventor.client.editor.simple.components.MockForm;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
 import com.google.appinventor.client.widgets.properties.EditableProperties;
@@ -169,31 +170,69 @@ public class ProjectPropertiesDialogBox {
     List<EditableProperty> properties = categoryToProperties.get(category);
 
     for (EditableProperty property : properties) {
-      // container for displaing one editable property
+
+      // container for displaying one editable property
       FlowPanel propertyContainer = new FlowPanel();
       propertyContainer.setStyleName("ode-propertyDialogPropertyContainer");
 
-      // name of the EditableProperty
-      Label name = new Label(ComponentTranslationTable.getPropertyName(property.getName()));
+      // name
+      Label name = new Label(
+          ComponentTranslationTable.getPropertyName(property.getName()));
       name.setStyleName("ode-propertyDialogPropertyTitle");
 
-      // Description of the property
-      HTML description = new HTML(ComponentTranslationTable.getPropertyDescription(property.getDescription()));
+      // description
+      HTML description = new HTML(
+          ComponentTranslationTable.getPropertyDescription(property.getDescription()));
       description.setStyleName("ode-propertyDialogPropertyDescription");
 
-      // editor of the editor
-      PropertyEditor editor = property.getEditor();
-      editor.setStyleName("ode-propertyDialogPropertyEditor");
-
-      // add to the container
       propertyContainer.add(name);
       propertyContainer.add(description);
-      propertyContainer.add(editor);
 
-      // add to the main container
+      // SPECIAL HANDLING FOR AndroidMinSdk
+      if (property.getName().equals(
+          SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK)) {
+
+        ListBox minSdkDropdown = new ListBox();
+        minSdkDropdown.setStyleName("ode-propertyDialogPropertyEditor");
+
+        String[] options = {"14","16","19","21","23","26","29","33"};
+
+        for (String opt : options) {
+          minSdkDropdown.addItem(opt);
+        }
+
+        // set current value safely
+        int index = java.util.Arrays.asList(options)
+            .indexOf(property.getValue());
+
+        if (index >= 0) {
+          minSdkDropdown.setSelectedIndex(index);
+        }
+
+        minSdkDropdown.addChangeHandler(e -> {
+          String selected = minSdkDropdown.getSelectedValue();
+
+          // 1️ Update UI property
+          property.setValue(selected);
+
+          // 2️ Update actual project settings
+          projectEditor.changeProjectSettingsProperty(
+              SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
+              SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
+              selected);
+        });
+        propertyContainer.add(minSdkDropdown);
+      } else {
+
+        // default editor
+        PropertyEditor editor = property.getEditor();
+        editor.setStyleName("ode-propertyDialogPropertyEditor");
+        propertyContainer.add(editor);
+      }
+
       propertiesContainer.add(propertyContainer);
-    }  
-    
+    }
+
     return propertiesContainer;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
@@ -8,6 +8,7 @@ package com.google.appinventor.client.settings.project;
 
 import static com.google.appinventor.components.common.YaVersion.YOUNG_ANDROID_VERSION;
 
+import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.settings.Settings;
 import com.google.appinventor.client.widgets.properties.EditableProperty;
@@ -42,7 +43,8 @@ public final class YoungAndroidSettings extends Settings {
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE, "1",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,
-        SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK, "14",
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK,
+        String.valueOf(ComponentConstants.APP_INVENTOR_MIN_SDK),
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME, "1.0",

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
@@ -8,10 +8,10 @@ package com.google.appinventor.client.settings.project;
 
 import static com.google.appinventor.components.common.YaVersion.YOUNG_ANDROID_VERSION;
 
-import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.settings.Settings;
 import com.google.appinventor.client.widgets.properties.EditableProperty;
+import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.shared.settings.SettingsConstants;
 
 /**

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
@@ -42,6 +42,9 @@ public final class YoungAndroidSettings extends Settings {
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE, "1",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK, "14",
+        EditableProperty.TYPE_INVISIBLE));
+    addProperty(new EditableProperty(this,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME, "1.0",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
@@ -11,7 +11,6 @@ import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.PopupPanel;
-import com.google.gwt.user.client.ui.ScrollPanel;
 
 /**
  * Context menu widget implementation.

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
@@ -32,7 +32,7 @@ public final class ContextMenu {
     popupPanel.setGlassStyleName("none"); //No style is passed (the default grays out the window)
     menuBar = new MenuBar(true);
     menuBar.setStylePrimaryName("ode-ContextMenu");
-    menuBar.getElement().getStyle().setProperty("maxHeight", "250px");
+    menuBar.getElement().getStyle().setProperty("maxHeight", "80%");
     menuBar.getElement().getStyle().setProperty("overflowY", "auto");
     popupPanel.add(menuBar);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
@@ -11,6 +11,7 @@ import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.ScrollPanel;
 
 /**
  * Context menu widget implementation.
@@ -32,6 +33,8 @@ public final class ContextMenu {
     popupPanel.setGlassStyleName("none"); //No style is passed (the default grays out the window)
     menuBar = new MenuBar(true);
     menuBar.setStylePrimaryName("ode-ContextMenu");
+    menuBar.getElement().getStyle().setProperty("maxHeight", "250px");
+    menuBar.getElement().getStyle().setProperty("overflowY", "auto");
     popupPanel.add(menuBar);
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1251,6 +1251,11 @@ public final class YoungAndroidFormUpgrader {
       }
       srcCompVersion = 31;
     }
+    if (srcCompVersion < 32) {
+      // The AndroidMinSdk property was added.
+      // No migration required. Default value will be applied automatically.
+      srcCompVersion = 32;
+    }
 
     return srcCompVersion;
   }

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidSettingsBuilder.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidSettingsBuilder.java
@@ -33,6 +33,7 @@ import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_AND
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_TUTORIAL_URL;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE;
+import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME;
 
 import com.google.appinventor.shared.settings.Settings;
@@ -48,7 +49,8 @@ public class YoungAndroidSettingsBuilder {
   private String projectName = "";
   private String qualifiedFormName = "";
   private String icon = "";
-  private String versionCode = "1";
+  private String versionCode = "1"; 
+  private String androidMinSdk = "14";
   private String versionName = "1.0";
   private String usesLocation = "false";
   private String appName = "";
@@ -87,6 +89,8 @@ public class YoungAndroidSettingsBuilder {
         YOUNG_ANDROID_SETTINGS_ICON));
     versionCode = Strings.nullToEmpty(settings.getSetting(PROJECT_YOUNG_ANDROID_SETTINGS,
         YOUNG_ANDROID_SETTINGS_VERSION_CODE));
+    androidMinSdk = Strings.nullToEmpty(settings.getSetting(PROJECT_YOUNG_ANDROID_SETTINGS,
+        YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK));
     versionName = Strings.nullToEmpty(settings.getSetting(PROJECT_YOUNG_ANDROID_SETTINGS,
         YOUNG_ANDROID_SETTINGS_VERSION_NAME));
     usesLocation = Strings.nullToEmpty(settings.getSetting(PROJECT_YOUNG_ANDROID_SETTINGS,
@@ -291,6 +295,7 @@ public class YoungAndroidSettingsBuilder {
     JSONObject object = new JSONObject();
     object.put(YOUNG_ANDROID_SETTINGS_ICON, icon);
     object.put(YOUNG_ANDROID_SETTINGS_VERSION_CODE, versionCode);
+    object.put(YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK, androidMinSdk);
     object.put(YOUNG_ANDROID_SETTINGS_VERSION_NAME, versionName);
     object.put(YOUNG_ANDROID_SETTINGS_USES_LOCATION, usesLocation);
     object.put(YOUNG_ANDROID_SETTINGS_APP_NAME, appName);
@@ -335,6 +340,7 @@ public class YoungAndroidSettingsBuilder {
     result.put("build", "../build");
     addPropertyIfSet(result, "icon", icon);
     addPropertyIfSet(result, "versioncode", versionCode);
+    addPropertyIfSet(result, "androidminsdk", androidMinSdk);
     addPropertyIfSet(result, "versionname", versionName);
     addPropertyIfSet(result, "useslocation", usesLocation);
     addPropertyIfSet(result, "sizing", sizing);
@@ -391,6 +397,7 @@ public class YoungAndroidSettingsBuilder {
       result &= other.qualifiedFormName.equals(qualifiedFormName);
       result &= other.icon.equals(icon);
       result &= other.versionCode.equals(versionCode);
+      result &= other.androidMinSdk.equals(androidMinSdk);
       result &= other.versionName.equals(versionName);
       result &= other.usesLocation.equals(usesLocation);
       result &= other.sizing.equals(sizing);

--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidSettingsBuilder.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidSettingsBuilder.java
@@ -10,6 +10,7 @@ import static com.google.appinventor.common.constants.YoungAndroidStructureConst
 import static com.google.appinventor.shared.settings.SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_ACCENT_COLOR;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_ACTIONBAR;
+import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_AIVERSIONING;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_APP_NAME;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET;
@@ -33,7 +34,6 @@ import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_AND
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_TUTORIAL_URL;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_USES_LOCATION;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_CODE;
-import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK;
 import static com.google.appinventor.shared.settings.SettingsConstants.YOUNG_ANDROID_SETTINGS_VERSION_NAME;
 
 import com.google.appinventor.shared.settings.Settings;
@@ -50,7 +50,7 @@ public class YoungAndroidSettingsBuilder {
   private String qualifiedFormName = "";
   private String icon = "";
   private String versionCode = "1"; 
-  private String androidMinSdk = "14";
+  private String androidMinSdk;
   private String versionName = "1.0";
   private String usesLocation = "false";
   private String appName = "";
@@ -210,6 +210,12 @@ public class YoungAndroidSettingsBuilder {
     this.versionName = versionName;
     return this;
   }
+
+  public YoungAndroidSettingsBuilder setAndroidMinSdk(String androidMinSdk) {
+    this.androidMinSdk = androidMinSdk;
+    return this;
+  }
+
 
   public YoungAndroidSettingsBuilder setUsesLocation(String usesLocation) {
     this.usesLocation = usesLocation;

--- a/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
@@ -53,6 +53,7 @@ public class SettingsConstants {
   public static final String YOUNG_ANDROID_SETTINGS_SCREEN_CHECKBOX_STATE_MAP = "ScreenCheckboxStateMap";
   public static final String YOUNG_ANDROID_SETTINGS_PHONE_TABLET = "PhoneTablet";
   public static final String YOUNG_ANDROID_SETTINGS_VERSION_CODE = "VersionCode";
+  public static final String YOUNG_ANDROID_SETTINGS_ANDROID_MIN_SDK = "AndroidMinSdk";
   public static final String YOUNG_ANDROID_SETTINGS_VERSION_NAME = "VersionName";
   public static final String YOUNG_ANDROID_SETTINGS_USES_LOCATION = "UsesLocation";
   public static final String YOUNG_ANDROID_SETTINGS_SIZING = "Sizing";

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -3087,7 +3087,12 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // For FORM_COMPONENT_VERSION 31:
     // - The default theme was changed in the designer. No block changes required.
-    31: "noUpgrade"
+    31: "noUpgrade",
+
+    // For FORM_COMPONENT_VERSION 32:
+    // - Added AndroidMinSdk designer property.
+    // No blocks need to be changed.
+    32: "noUpgrade"
 
   }, // End Screen
 

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -143,7 +143,17 @@ public class CreateManifest implements AndroidTask {
         out.write("  </queries>\n");
       }
 
-      int minSdk = AndroidBuildUtils.computeMinSdk(context);
+      int computedMinSdk = AndroidBuildUtils.computeMinSdk(context);
+      // Get user-selected min SDK from project
+      String userMinSdkStr = context.getProject().getMinSdk();
+      int userMinSdk;
+      try {
+        userMinSdk = Integer.parseInt(userMinSdkStr);
+      } catch (NumberFormatException e) {
+        userMinSdk = computedMinSdk;
+      }
+      // Final minSdk should never be lower than required by components
+      int minSdk = Math.max(userMinSdk, computedMinSdk);
       context.getReporter().log("Min SDK " + minSdk);
 
       // make permissions unique by putting them in one set

--- a/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
@@ -448,4 +448,9 @@ public class PropertyTypeConstants {
    * @see com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidChartLabelValueTypeChoicePropertyEditor
    */
   public static final String PROPERTY_TYPE_CHART_VALUE_TYPE = "chart_value_type";
+
+  /**
+   * Dynamic Android minimum SDK selector.
+   */
+  public static final String PROPERTY_TYPE_ANDROID_MIN_SDK = "android_min_sdk";
 }

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1068,7 +1068,9 @@ public class YaVersion {
   // - Add DefaultFileScope designer property.
   // For FORM_COMPONENT_VERSION 31:
   // - The default theme was changed to Device Default.
-  public static final int FORM_COMPONENT_VERSION = 31;
+  // For FORM_COMPONENT_VERSION 32:
+  // - Added the AndroidMinSdk designer property.
+  public static final int FORM_COMPONENT_VERSION = 32;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:
   // - The Fusiontables API was migrated from SQL to V1

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -2223,6 +2223,32 @@ public class Form extends AppInventorCompatActivity
     // project properties file
   }
 
+  /**
+   * The minimum Android API level required to install this app. The build system may automatically raise this value if selected components require a higher APIlevel.   
+   */
+  @DesignerProperty(
+      editorType = PropertyTypeConstants.PROPERTY_TYPE_CHOICES,
+      defaultValue = "14",
+      editorArgs = {
+            "14",
+            "16",
+            "19",
+            "21",
+            "23",
+            "26",
+            "29",
+            "33",
+      })
+  @SimpleProperty(
+      userVisible = false,
+      description = "The minimum Android SDK required to install the app. " +
+                    "The system may automatically increase this value if components " +
+                    "require a higher SDK.",
+      category = PropertyCategory.GENERAL)
+  public void AndroidMinSdk(String value) {
+    // Stored automatically in project properties
+  }
+
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_SUBSET_JSON,
     defaultValue = "")
   @SimpleProperty(userVisible = false,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -2226,29 +2226,17 @@ public class Form extends AppInventorCompatActivity
   /**
    * The minimum Android API level required to install this app. The build system may automatically raise this value if selected components require a higher APIlevel.   
    */
-  @DesignerProperty(
-      editorType = PropertyTypeConstants.PROPERTY_TYPE_CHOICES,
-      defaultValue = "14",
-      editorArgs = {
-            "14",
-            "16",
-            "19",
-            "21",
-            "23",
-            "26",
-            "29",
-            "33",
-      })
-  @SimpleProperty(
-      userVisible = false,
-      description = "The minimum Android SDK required to install the app. " +
-                    "The system may automatically increase this value if components " +
-                    "require a higher SDK.",
-      category = PropertyCategory.GENERAL)
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ANDROID_MIN_SDK, 
+    defaultValue = "" + ComponentConstants.APP_INVENTOR_MIN_SDK)
+  @SimpleProperty(userVisible = false, 
+    description = "The minimum Android SDK required to install the app. " +
+        "The system may automatically increase this value if components " +
+        "require a higher SDK.", 
+    category = PropertyCategory.GENERAL)
   public void AndroidMinSdk(String value) {
     // Stored automatically in project properties
   }
-
+  
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_SUBSET_JSON,
     defaultValue = "")
   @SimpleProperty(userVisible = false,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -2232,7 +2232,7 @@ public class Form extends AppInventorCompatActivity
     description = "The minimum Android SDK required to install the app. " +
         "The system may automatically increase this value if components " +
         "require a higher SDK.", 
-    category = PropertyCategory.GENERAL)
+    category = PropertyCategory.PUBLISHING)
   public void AndroidMinSdk(String value) {
     // Stored automatically in project properties
   }

--- a/appinventor/docs/html/reference/components/userinterface.html
+++ b/appinventor/docs/html/reference/components/userinterface.html
@@ -1101,6 +1101,8 @@ Valid values for the month field are 1-12 and 1-31 for the day field.</dd>
   <dd>A number that encodes how the contents of the arrangement are aligned vertically. The choices
  are: <code class="highlighter-rouge">1</code> (aligned at the top), <code class="highlighter-rouge">2</code> (vertically centered), <code class="highlighter-rouge">3</code> (aligned at the bottom). Vertical
  alignment has no effect if the screen is scrollable.</dd>
+  <dt id="Screen.AndroidMinSdk" class="text wo do"><em>AndroidMinSdk</em></dt>
+  <dd>The minimum Android API level required to install this app. The build system may automatically raise this value if selected components require a higher APIlevel.</dd>
   <dt id="Screen.AppName" class="text wo do"><em>AppName</em></dt>
   <dd>This is the display name of the installed application in the phone. If the <code class="highlighter-rouge">AppName</code> is blank,
  it will be set to the name of the project when the project is built.</dd>

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -1245,6 +1245,9 @@ Top-level component containing all other components in the program.
  are: `1` (aligned at the top), `2` (vertically centered), `3` (aligned at the bottom). Vertical
  alignment has no effect if the screen is scrollable.
 
+{:id="Screen.AndroidMinSdk" .text .wo .do} *AndroidMinSdk*
+: The minimum Android API level required to install this app. The build system may automatically raise this value if selected components require a higher APIlevel.
+
 {:id="Screen.AppName" .text .wo .do} *AppName*
 : This is the display name of the installed application in the phone. If the `AppName` is blank,
  it will be set to the name of the project when the project is built.


### PR DESCRIPTION
…build integration

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [X] I branched from `ucr`
- [X] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [X] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [X] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

What does this PR accomplish?

Description:
This PR introduces a configurable AndroidMinSdk project-level designer property.

The selected value is:
- Stored in project settings
- Persisted in project.properties
- Applied during AndroidManifest.xml generation

The final minSdkVersion is computed as:
              `max(userSelectedMinSdk, componentRequiredMinSdk)`

This guarantees:
- Users cannot set a value lower than required by components
- Backward compatibility is preserved
- Existing projects remain unaffected

Changes include:
- Added AndroidMinSdk to `SettingsConstants`
- Integrated into `YoungAndroidSettings` and `YoungAndroidSettingsBuilder`
- Added dropdown UI in Project Properties
- Updated `CreateManifest` to respect user selection safely
- Bumped `FORM_COMPONENT_VERSION to 32`
- Updated `YoungAndroidFormUpgrader`
- Default value remains `ComponentConstants.APP_INVENTOR_MIN_SDK`
- Build system may automatically raise the value if required by components

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3761 .
