### PR TITLE
Implement a ListSheets/GotSheetList feature for the Spreadsheet component

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1770,6 +1770,10 @@ public final class YoungAndroidFormUpgrader {
       // added an add sheet block and a delete sheet block
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // added a get sheet names block
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -3178,8 +3178,10 @@ Blockly.Versioning.AllUpgradeMaps =
       Blockly.Versioning.changeEventParameterName("Spreadsheet", "GotColumnData", "colDataList", "columnData")
     ],
 
-    3: "noUpgrade"
-    
+    3: "noUpgrade",
+
+    // The ListSheets and GotSheetList blocks were added.
+    4: "noUpgrade"
   },
 
   "TableArrangement": {

--- a/appinventor/components-ios/src/Spreadsheet.swift
+++ b/appinventor/components-ios/src/Spreadsheet.swift
@@ -1085,6 +1085,40 @@ import GoogleAPIClientForREST
       }
     }
   }
+
+  @objc func ListSheets() {
+    if SpreadsheetID.isEmpty {
+      ErrorOccurred("ListSheets: " + "SpreadsheetID is empty.")
+      return
+    }
+    // wrap the API call in an Async Utility
+    _workQueue.async {
+      let query = GTLRSheetsQuery_SpreadsheetsGet.query(withSpreadsheetId: self.SpreadsheetID)
+      self._service.executeQuery(query) { (ticket:GTLRServiceTicket, result:Any?, error:Error?) in
+        if let error = error {
+          self.ErrorOccurred("\(error)")
+        } else {
+          let spreadsheet = result as? GTLRSheets_Spreadsheet
+          let sheets = spreadsheet?.sheets as? [GTLRSheets_Sheet] ?? []
+          var sheetNames: Array<String> = []
+          for sheet in sheets {
+            guard let sheetName = sheet.properties?.title, let sheetId = sheet.properties?.sheetId else {
+              continue
+            }
+            sheetNames.append(sheet.properties?.title ?? "")
+            self._sheetIdDict[sheetName] = sheetId.intValue
+          }
+          self.GotSheetList(YailList(array: sheetNames))
+        }
+      }
+    }
+  }
+
+  @objc func GotSheetList(_ sheetList: YailList<AnyObject>) {
+    DispatchQueue.main.async {
+      EventDispatcher.dispatchEvent(of: self, called: "GotSheetList", arguments: sheetList as AnyObject)
+    }
+  }
   
   // Description = Reads the *entire* Google Sheet document and triggers the GotSheetData callback event.
   @objc func ReadSheet(_ sheetName: String) {

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1433,14 +1433,14 @@ public class YaVersion {
   // - The FinishedAddCol event was renamed to FinishedAddColumn
   // - The RemoveCol method was renamed to RemoveColumn
   // - The FinishedRemoveCol event was renamed to FinishedRemoveColumn
-
   // For SPREADSHEET_COMPONENT_VERSION 3:
   // - Added the AddSheet block
   // - Added the FinishedAddSheet event
   // - Added the DeleteSheet block
   // - Added the FinishedDeleteSheet event
-
-  public static final int SPREADSHEET_COMPONENT_VERSION = 3;
+  // For SPREADSHEET_COMPONNET_VERSION 4:
+  // - The ListSheets and GotSheetList blocks were added.
+  public static final int SPREADSHEET_COMPONENT_VERSION = 4;
 
   // For SWITCH_COMPONENT_VERSION 1
   //  - Initial Version

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
@@ -29,6 +29,7 @@ import com.google.api.services.sheets.v4.model.DeleteDimensionRequest;
 import com.google.api.services.sheets.v4.model.DeleteSheetRequest;
 import com.google.api.services.sheets.v4.model.DimensionRange;
 import com.google.api.services.sheets.v4.model.Request;
+import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
@@ -797,6 +798,53 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       + "values on the table have been updated.")
   public void FinishedDeleteSheet(final String sheetName) {
     EventDispatcher.dispatchEvent(this, "FinishedDeleteSheet", sheetName);
+  }
+
+  @SimpleFunction(
+    description="Lists the names of all sheets in the spreadsheet. Triggers the " +
+      "GotSheetList callback event with a list of sheet names.")
+  public void ListSheets() {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
+      ErrorOccurred("ListSheets: " + "SpreadsheetID is empty.");
+      return;
+    }
+    // Run the API call asynchronously
+    AsynchUtil.runAsynchronously(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          Sheets sheetsService = getSheetsService();
+          com.google.api.services.sheets.v4.model.Spreadsheet spreadsheet = sheetsService.spreadsheets().get(spreadsheetID).execute();
+          List<String> sheetNames = new ArrayList<>();
+          for (Sheet sheet : spreadsheet.getSheets()) {
+            sheetNames.add(sheet.getProperties().getTitle());
+            sheetIdMap.put(sheet.getProperties().getTitle(), sheet.getProperties().getSheetId());
+          }
+          final YailList sheetNamesList = YailList.makeList(sheetNames);
+          activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              GotSheetList(sheetNamesList);
+            }
+          });
+        } catch (final Exception e) {
+          activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              Log.e(LOG_TAG, "Error occurred in ListSheets", e);
+              ErrorOccurred("ListSheets: " + e.getMessage());
+            }
+          });
+
+        }
+      }
+    });
+  }
+
+  @SimpleEvent(description = "The callback event for the ListSheets block, called once the "
+      + "list of sheets has been retrieved.")
+  public void GotSheetList(final YailList sheetNames) {
+    EventDispatcher.dispatchEvent(this, "GotSheetList", sheetNames);
   }
 
   /**

--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -463,6 +463,8 @@ as <code class="highlighter-rouge">Pictures</code>.</li>
   <dt id="Spreadsheet.GotSheetData">GotSheetData(<em class="list">sheetData</em>)</dt>
   <dd>The callback event for the <a href="#Spreadsheet.ReadSheet"><code class="highlighter-rouge">ReadSheet</code></a> block. The <code class="highlighter-rouge">sheetData</code> is a
  list of rows.</dd>
+  <dt id="Spreadsheet.GotSheetList">GotSheetList(<em class="list">sheetNames</em>)</dt>
+  <dd>The callback event for the ListSheets block, called once the list of sheets has been retrieved.</dd>
 </dl>
 
 <h3 id="Spreadsheet-Methods">Methods</h3>
@@ -493,6 +495,8 @@ as <code class="highlighter-rouge">Pictures</code>.</li>
   <dd>Converts the integer representation of rows and columns for the corners of
  the range to A1-Notation used in Google Sheets. For example, selecting the
  range from row 1, col 2 to row 3, col 4 corresponds to the string “B1:D3”.</dd>
+  <dt id="Spreadsheet.ListSheets" class="method"><i></i> ListSheets()</dt>
+  <dd>Lists the names of all sheets in the spreadsheet. Triggers the GotSheetList callback event with a list of sheet names.</dd>
   <dt id="Spreadsheet.ReadCell" class="method"><i></i> ReadCell(<em class="text">sheetName</em>,<em class="text">cellReference</em>)</dt>
   <dd>On the page with the provided sheetName, reads the cell at the given
  cellReference and triggers the <a href="#Spreadsheet.GotCellData"><code class="highlighter-rouge">GotCellData</code></a> callback event. The

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -398,6 +398,9 @@ Spreadsheet is a non-visible component for storing and receiving data from
 : The callback event for the [`ReadSheet`](#Spreadsheet.ReadSheet) block. The `sheetData` is a
  list of rows.
 
+{:id="Spreadsheet.GotSheetList"} GotSheetList(*sheetNames*{:.list})
+: The callback event for the ListSheets block, called once the list of sheets has been retrieved.
+
 ### Methods  {#Spreadsheet-Methods}
 
 {:.methods}
@@ -433,6 +436,9 @@ Spreadsheet is a non-visible component for storing and receiving data from
 : Converts the integer representation of rows and columns for the corners of
  the range to A1-Notation used in Google Sheets. For example, selecting the
  range from row 1, col 2 to row 3, col 4 corresponds to the string "B1:D3".
+
+{:id="Spreadsheet.ListSheets" class="method"} <i/> ListSheets()
+: Lists the names of all sheets in the spreadsheet. Triggers the GotSheetList callback event with a list of sheet names.
 
 {:id="Spreadsheet.ReadCell" class="method"} <i/> ReadCell(*sheetName*{:.text},*cellReference*{:.text})
 : On the page with the provided sheetName, reads the cell at the given


### PR DESCRIPTION
Change-Id: If0db7a94394586aa1f24b972d7eea1a3728a84bf

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

What does this PR accomplish?

This PR implements a method/event pair to query a Spreadsheet for the list of sheet names. Unfortunately, due to the design of the Google Sheets API, this can only be done if the sheet is authenticated (i.e., a credential must be present).