### PR TITLE
Improve SpreadsheetID property description with URL example

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
@@ -245,7 +245,9 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_STRING,
       defaultValue = "")
   @SimpleProperty(description = "The ID for the Google Sheets file you want to edit. You can "
-      + "find the spreadsheetID in the URL of the Google Sheets file.")
+      + "find the spreadsheetID in the URL of the Google Sheets file. Look for the part between "
+      + "'/d/' and '/edit' in the URL, e.g. in "
+      + "https://docs.google.com/spreadsheets/d/1234abcd/edit the ID is '1234abcd'.")
   public void SpreadsheetID(String spreadsheetID) {
     if (spreadsheetID.startsWith("https:")) {
       // URL: https://docs.google.com/spreadsheets/d/<id>/edit#gid=0

--- a/appinventor/docs/html/reference/components/storage.html
+++ b/appinventor/docs/html/reference/components/storage.html
@@ -407,7 +407,7 @@ as <code class="highlighter-rouge">Pictures</code>.</li>
   <dt id="Spreadsheet.CredentialsJson" class="text"><em>CredentialsJson</em></dt>
   <dd>The JSON File with credentials for the Service Account</dd>
   <dt id="Spreadsheet.SpreadsheetID" class="text"><em>SpreadsheetID</em></dt>
-  <dd>The ID for the Google Sheets file you want to edit. You can find the spreadsheetID in the URL of the Google Sheets file.</dd>
+  <dd>The ID for the Google Sheets file you want to edit. You can find the spreadsheetID in the URL of the Google Sheets file. Look for the part between '/d/' and '/edit' in the URL, e.g. in https://docs.google.com/spreadsheets/d/1234abcd/edit the ID is '1234abcd'.</dd>
 </dl>
 
 <h3 id="Spreadsheet-Events">Events</h3>

--- a/appinventor/docs/markdown/reference/components/storage.md
+++ b/appinventor/docs/markdown/reference/components/storage.md
@@ -325,7 +325,7 @@ Spreadsheet is a non-visible component for storing and receiving data from
 : The JSON File with credentials for the Service Account
 
 {:id="Spreadsheet.SpreadsheetID" .text} *SpreadsheetID*
-: The ID for the Google Sheets file you want to edit. You can find the spreadsheetID in the URL of the Google Sheets file.
+: The ID for the Google Sheets file you want to edit. You can find the spreadsheetID in the URL of the Google Sheets file. Look for the part between '/d/' and '/edit' in the URL, e.g. in https://docs.google.com/spreadsheets/d/1234abcd/edit the ID is '1234abcd'.
 
 ### Events  {#Spreadsheet-Events}
 


### PR DESCRIPTION
The previous help text said users could find the spreadsheetID in the URL but didn't explain where exactly. Updated the description to show the specific URL format with an example so it's easier to locate.

Resolves #3442

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?


*Description*

The SpreadsheetID help text told users the ID was in the URL but didn't explain where. Updated the description to show the URL format with an example so users can find the ID between /d/ and /edit.



Resolves #3442
