### PR TITLE
Improve PIC image processing on iOS

### DIFF
--- a/appinventor/components-ios/src/PersonalImageClassifier.swift
+++ b/appinventor/components-ios/src/PersonalImageClassifier.swift
@@ -12,7 +12,7 @@ fileprivate let PERSONAL_MODEL_PREFIX = "appinventor://personal-image-classifier
 @objc open class PersonalImageClassifier: BaseClassifier, LifecycleDelegate {
   public static let MODE_VIDEO = "Video"
   public static let MODE_IMAGE = "Image"
-  public static let IMAGE_WIDTH = 500
+  public static let IMAGE_WIDTH = 224
   public static let ERROR_INVALID_INPUT_MODE = -6;
 
   private var _inputMode = PersonalImageClassifier.MODE_VIDEO
@@ -75,8 +75,8 @@ fileprivate let PERSONAL_MODEL_PREFIX = "appinventor://personal-image-classifier
       let width = PersonalImageClassifier.IMAGE_WIDTH
       let height = Int(image.size.height * CGFloat(PersonalImageClassifier.IMAGE_WIDTH) / image.size.width)
 
-      UIGraphicsBeginImageContext(CGSize(width: width, height: height))
-      image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
+      UIGraphicsBeginImageContext(CGSize(width: width, height: width))
+      image.draw(in: CGRect(x: 0, y: (PersonalImageClassifier.IMAGE_WIDTH - height) / 2, width: width, height: height))
       scaledImageBitmap = UIGraphicsGetImageFromCurrentImageContext()
       UIGraphicsEndImageContext()
     } else {
@@ -85,7 +85,7 @@ fileprivate let PERSONAL_MODEL_PREFIX = "appinventor://personal-image-classifier
 
     if let immagex = scaledImageBitmap {
       if let imageData = immagex.pngData() {
-        let imageEncodedBase64String = imageData.base64EncodedString(options: .lineLength64Characters).replacingOccurrences(of: "\n", with: "")
+        let imageEncodedBase64String = imageData.base64EncodedString(options: .lineLength64Characters).replacingOccurrences(of: "\r\n", with: "")
         print("imageEncodedBase64String: \(imageEncodedBase64String)")
         _webview?.evaluateJavaScript("classifyImageData(\"\(imageEncodedBase64String)\");", completionHandler: nil)
       }


### PR DESCRIPTION
Change-Id: I5eceabcf4323b26fbdf0ce360d8f88ade689e067

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR fixes a bug in the ClassifyImageData block of PIC. Base64 encoding the image results in lines ending with "\r\n" (Windows) rather than the assumed "\n" (macOS/iOS/Unix), so I adjusted the logic to take that into account. I also made it so that images are centered vertically in the viewport rather than truncated at the bottom. I think this is more closely what people might expect given the target of any given photo is likely to be close to the center of the camera.