### PR TITLE
fix(a11y): Replace outline:none with visible focus rings for keyboard accessibility

### DIFF
--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -670,13 +670,19 @@ div.StatusPanel {
 
 .ode-TopPanelButton:hover,
 .ActionDropDown-Default:hover,
-.ActionDropDown-Options:hover,
+.ActionDropDown-Options:hover {
+  background: #E6E6E6;
+  color: #5B5B5B;
+}
+
+/* Accessibility: separate :focus selector so keyboard users get a visible focus ring (WCAG 2.1 SC 2.4.7) */
 .ode-TopPanelButton:focus,
 .ActionDropDown-Default:focus,
 .ActionDropDown-Options:focus {
   background: #E6E6E6;
   color: #5B5B5B;
-  outline: none;
+  outline: 2px solid #669900;
+  outline-offset: -2px;
 }
 
 /* Improvement: added visible active/pressed state for toolbar buttons */
@@ -1921,7 +1927,7 @@ path.ode-SimpleMockMapFeature-selected {
   border: 0px;
   border-right: 2px solid black;
   padding-right: 20px;
-  outline: none;
+  /* Removed outline:none — see :focus rule below for accessible focus style */
   overflow: auto;
 }
 
@@ -1967,8 +1973,10 @@ path.ode-SimpleMockMapFeature-selected {
   border-radius: 10px;
 }
 
+/* Accessibility: replaced outline:none with a visible focus ring (WCAG 2.1 SC 2.4.7) */
 .ode-projectPropertyCategoryTitlePanel:focus {
-  outline: none;
+  outline: 2px solid #669900;
+  outline-offset: 1px;
 }
 
 .ode-propertyDialogVerticalPanel {


### PR DESCRIPTION
## Summary

This PR fixes WCAG 2.1 SC 2.4.7 (Focus Visible) violations in `Ya.css`
caused by `outline: none` being applied to interactive elements.

## Problem

Several UI elements — including toolbar buttons and the project properties
panel — had `outline: none` applied to their `:focus` state. This removes
the visible focus indicator that keyboard users rely on to know which element
is currently active. It also fails accessibility audits (Lighthouse, axe-core).

## Changes

- **Toolbar buttons** (`.ode-TopPanelButton`, `.ActionDropDown-*`): Split the
  combined `hover`+`focus` selector into two separate rules. The hover behavior
  is unchanged for mouse users. Keyboard users now see a `2px solid #669900`
  focus ring matching App Inventor's green brand color.

- **Project Properties panel** (`.ode-projectPropertyCategoryTitlePanel`):
  Removed `outline: none` from the base element style and replaced the
  `:focus` suppression with a proper visible focus ring.

## Testing

1. Open the App Inventor UI in a browser.
2. Press Tab to navigate to the top menu bar (Connect, Build, Settings, etc.).
3. **Before fix:** No visible focus indicator appears on toolbar buttons.
4. **After fix:** A green 2px outline appears around the focused button.
5. Press Tab again to navigate to the Project Properties panel and confirm
   the focus ring appears there too.

## Accessibility Reference

- WCAG 2.1 SC 2.4.7: https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html
- CSS-only change. No Java compilation required to verify the diff.
