### PR TITLE
Fix download button text contrast in APK dialog

### DIFF
--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3397,6 +3397,12 @@ div.dropdiv p {
   height: 130px;
 }
 
+.download-button span {
+  color: #000;
+  text-shadow: none;
+  font-weight: 600;
+}
+
 .download-icon {
   height: 110px;
   width: 110px;


### PR DESCRIPTION
## Description

Fixes #3729

This PR improves the accessibility of the Download APK dialog by increasing the contrast of the download button text.

## Problem

The "Download .apk now" (and similar) button text in the Download APK/AAB/IPA dialog had insufficient contrast against its background, making it difficult to read and failing accessibility guidelines. The text reportedly used to be black but had become low-contrast.
