### PR TITLE
iOS: Gracefully handle unsupported components instead of crashing

### DIFF
--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -188,6 +188,46 @@ let kMinimumToastWait = 10.0
     _tapGesture = UITapGestureRecognizer(target: self, action: #selector(HideKeyboard))
     _tapGesture?.cancelsTouchesInView = false
     view.addGestureRecognizer(_tapGesture!)
+    // Listen for unsupported-component notifications posted from the YAIL runtime.
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleUnsupportedComponentNotification(_:)),
+      name: NSNotification.Name("AIUnsupportedComponentNotification"),
+      object: nil)
+  }
+
+  /**
+   * Called by the YAIL runtime (via NSNotificationCenter) when a project
+   * contains a component that is not implemented on iOS.
+   *
+   * Instead of crashing, the Companion shows this informational alert so the
+   * user understands what happened and can continue using the rest of the project.
+   */
+  @objc private func handleUnsupportedComponentNotification(_ notification: Notification) {
+    let componentName = (notification.userInfo?["componentName"] as? String) ?? "Unknown"
+    showUnsupportedComponentWarning(componentName)
+  }
+
+  /**
+   * Displays a user-friendly warning dialog when an unsupported component is
+   * encountered at runtime on iOS.
+   *
+   * - Parameter componentName: The class name of the unsupported component.
+   */
+  @objc open func showUnsupportedComponentWarning(_ componentName: String) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      // Extract just the simple class name (e.g. "BluetoothServer") from a
+      // fully qualified name like "AIComponentKit.BluetoothServer".
+      let simpleName = componentName.components(separatedBy: ".").last ?? componentName
+      let alert = UIAlertController(
+        title: "⚠️ Unsupported Component",
+        message: "\"\(simpleName)\" is not available on iOS.\n\nThe project will continue running without it.",
+        preferredStyle: .alert
+      )
+      alert.addAction(UIAlertAction(title: "OK", style: .default))
+      self.present(alert, animated: true)
+    }
   }
 
   open func add(_ component: NonvisibleComponent) {

--- a/appinventor/components-ios/src/runtime.scm
+++ b/appinventor/components-ios/src/runtime.scm
@@ -104,19 +104,44 @@
 
 (define-syntax gen-event-name (syntax-rules () ((_ component-name event-name) (symbol-append 'component-name (identifier-base '$) 'event-name))))
 
+; Show a user-visible warning when a component is not supported on iOS.
+; This is called instead of crashing the Companion app.
+(define (show-unsupported-component-warning component-type)
+  (android-log
+   (string-append "[AppInventor] Skipping unsupported iOS component: "
+                  (symbol->string (if (symbol? component-type)
+                                      component-type
+                                      'UnknownComponent))))
+  (yail:invoke AIComponentKit.Form 'activeForm
+               'showUnsupportedComponentWarning:
+               (if (symbol? component-type)
+                   (symbol->string component-type)
+                   "UnknownComponent")))
+
+; Create a component instance only if it is available on the current platform.
+; If the component class is not implemented on iOS, skip it gracefully and
+; inform the user instead of crashing.
 (define (make type container)
-  (yail:make-instance type container))
+  (if (yail:class-available? type)
+      (yail:make-instance type container)
+      (begin
+        (show-unsupported-component-warning type)
+        #f)))
 
 (define (add-component-within-repl container-name component-type component-name init-props-thunk)
   (let* ((container (lookup-in-current-form-environment container-name))
          (existing-component (lookup-in-current-form-environment component-name))
          (component-to-add (make component-type container)))
-    (add-to-current-form-environment component-name component-to-add)
-    (add-init-thunk component-name
-                    (lambda ()
-                      (when init-props-thunk (init-props-thunk))
-                      (when existing-component
-                            (copyComponentProperties existing-component component-to-add))))))
+    ; Only register and initialize if the component was successfully created.
+    ; If make returned #f the component is unsupported, so we skip it.
+    (when component-to-add
+      (add-to-current-form-environment component-name component-to-add)
+      (add-init-thunk component-name
+                      (lambda ()
+                        (when init-props-thunk (init-props-thunk))
+                        (when existing-component
+                              (copyComponentProperties existing-component component-to-add)))))))
+
 
 (define-syntax add-component
   (syntax-rules ()

--- a/appinventor/schemekit/src/yail.m
+++ b/appinventor/schemekit/src/yail.m
@@ -584,6 +584,25 @@ yail_set_current_form(pic_state *pic, pic_value form) {
   pic_set(pic, "yail", "*this-form*", form);
 }
 
+/**
+ * Returns YES if the given native class value has at least one initializer
+ * available, i.e. the component is implemented on iOS.
+ */
+static pic_value
+yail_class_available(pic_state *pic) {
+  pic_value native_class;
+  pic_get_args(pic, "o", &native_class);
+  if (!yail_native_class_p(pic, native_class)) {
+    return pic_false_value(pic);
+  }
+  Class clazz = yail_native_class_ptr(pic, native_class)->class_;
+  if (clazz == nil) {
+    return pic_false_value(pic);
+  }
+  SCMMethod *init = [SCMNameResolver naryInitializerForClass:clazz withName:"init" argCount:1];
+  return init ? pic_true_value(pic) : pic_false_value(pic);
+}
+
 pic_value
 yail_make_instance(pic_state *pic) {
   pic_value native_class, *args;
@@ -599,6 +618,15 @@ yail_make_instance(pic_state *pic) {
   selector[4+argc] = '\0';
 
   Class clazz = yail_native_class_ptr(pic, native_class)->class_;
+
+  // Guard: if the class itself is nil, this component doesn't exist on iOS.
+  // Return undef gracefully instead of crashing the Companion.
+  if (clazz == nil) {
+    NSLog(@"[AppInventor] Unsupported component: class not found on iOS. Skipping.");
+    free(selector);
+    return pic_undef_value(pic);
+  }
+
   SCMMethod *init = [SCMNameResolver naryInitializerForClass:clazz withName:"init" argCount:argc];
   if (init) {
     free(selector);
@@ -643,9 +671,20 @@ yail_make_instance(pic_state *pic) {
       return pic_undef_value(pic);
     }
   } else {
-    pic_value str = pic_cstr_value(pic, selector);
+    // No initializer found — this component is not implemented on iOS.
+    // Log a clear warning and return undef instead of crashing.
+    NSLog(@"[AppInventor] Unsupported component: '%s' has no initializer on iOS. Skipping.",
+          class_getName(clazz));
+    // Notify the active Form so it can show a user-visible warning.
+    NSString *className = NSStringFromClass(clazz);
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[NSNotificationCenter defaultCenter]
+          postNotificationName:@"AIUnsupportedComponentNotification"
+          object:nil
+          userInfo:@{@"componentName": className}];
+    });
     free(selector);
-    pic_error(pic, "undefined initializer", 2, native_class, str);
+    return pic_undef_value(pic);
   }
   
   return pic_undef_value(pic);
@@ -1678,6 +1717,7 @@ pic_init_yail(pic_state *pic)
   pic_defun(pic, "yail:call-instance-method", pic_yail_call_instance_method);
   pic_defun(pic, "yail:call-static-method", pic_yail_call_static_method);
   pic_defun(pic, "yail:make-instance", yail_make_instance);
+  pic_defun(pic, "yail:class-available?", yail_class_available);
   pic_defun(pic, "yail:invoke", yail_invoke);
   pic_defun(pic, "invoke", yail_invoke);
   pic_defun(pic, "yail:isa", yail_isa);


### PR DESCRIPTION
## Problem
When a project built in App Inventor contains a component that is not implemented in the iOS Companion (e.g. BluetoothServer, NxtDirectCommands), the Companion crashes with an unhandled picrin/YAIL error in `yail_make_instance()`.

## Root Cause
`yail_make_instance()` in `schemekit/src/yail.m` calls `pic_error()` (a fatal, unrecoverable error) when it cannot find an initializer for a requested class. If a class does not exist in the iOS binary at all, the symbol resolution step also fails silently, leading to a crash when instantiation is attempted.

## Fix
This PR implements a three-layer solution:

**1. `schemekit/src/yail.m`**
- Guard `yail_make_instance()` against `nil` class objects — returns `pic_undef_value` instead of calling `pic_error()`.
- Add a new `yail:class-available?` built-in function so the Scheme runtime can pre-check whether a component exists on iOS before trying to instantiate it.
- Post an `AIUnsupportedComponentNotification` via `NSNotificationCenter` so the UI layer can show a user-visible warning.

**2. `components-ios/src/runtime.scm`**
- Wrap the `make` helper with a `yail:class-available?` guard so unsupported components are skipped at the Scheme level.
- Guard `add-component-within-repl` so that `nil` (skipped) components are not registered or initialized.
- Add `show-unsupported-component-warning` to log and surface the warning to the Form layer.

**3. `components-ios/src/Form.swift`**
- Add `showUnsupportedComponentWarning(_:)` which presents a clear `UIAlertController` explaining which component is unsupported and that the rest of the project continues running.
- Register for `AIUnsupportedComponentNotification` in `viewDidLoad`.

## Result
**Before:** Loading a project with an Android-only component causes an immediate crash.

**After:** The Companion skips the unsupported component, shows the user:
> ⚠️ "BluetoothServer" is not available on iOS. The project will continue running without it.

…and continues executing the rest of the project normally.

---
*This is part of work toward the GSoC project idea: "Better behavior for unimplemented components in the iOS Companion".*