### PR TITLE
Fix #3793: Treat disabled blocks as empty setter sockets

### DIFF
--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -747,7 +747,7 @@ Blockly.WarningHandler.prototype.checkDisposedBlock = function(block) {
 Blockly.WarningHandler.prototype['checkEmptySetterSocket'] = function(block) {
   if (block.setOrGet === 'set') {
     var value = block.getInputTargetBlock('VALUE');
-    if (!value || value.isEnabled()) {
+    if (!value || !value.isEnabled()) {
       block.setErrorIconText(Blockly.Msg.ERROR_PROPERTY_SETTER_NEEDS_VALUE);
       return true;
     }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [X] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base

What does this PR accomplish?

<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*
Fixes an issue where disabled blocks connected to component property setter
sockets were incorrectly treated as valid inputs.

Previously, the `checkEmptySetterSocket` validation only checked whether a
block existed in the socket. However, disabled blocks still occupy the socket
even though they generate no code.

This change also checks `value.isEnabled()`, ensuring disabled blocks are
treated the same as empty sockets and the correct error is shown.
<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3793 .

