### PR TITLE
Fix missing hmac await in proxy and legacy REPL connections

### DIFF
--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -733,7 +733,7 @@ Blockly.ReplMgr.putYail = (function() {
             }
             var encoder = new URLSearchParams();
             console.log('Low Level Sending: ' + work.code)
-            encoder.append('mac', Blockly.ReplMgr.hmac(work.code + rs.seq_count + blockid));
+            encoder.append('mac', await Blockly.ReplMgr.hmac(work.code + rs.seq_count + blockid));
             encoder.append('seq', rs.seq_count);
             encoder.append('code', work.code);
             encoder.append('blockid', blockid);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
-->

General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base