### PR TITLE
Added @UsesApplicationAttributes annotation

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/context/ComponentInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/context/ComponentInfo.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2025 MIT, All rights reserved
+// Copyright 2021-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -10,6 +10,7 @@ import com.google.appinventor.buildserver.util.AARLibraries;
 import com.google.appinventor.buildserver.util.PermissionConstraint;
 import com.google.common.collect.Sets;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +39,7 @@ public class ComponentInfo {
   private final ConcurrentMap<String, Set<String>> contentProvidersNeeded;
   private final ConcurrentMap<String, Set<String>> xmlsNeeded;
   private final ConcurrentMap<String, Set<String>> featuresNeeded;
+  private final Map<String, String> applicationAttributes;
 
   private Set<String> uniqueLibsNeeded;
   private AARLibraries explodedAarLibs;
@@ -62,6 +64,7 @@ public class ComponentInfo {
     contentProvidersNeeded = new ConcurrentHashMap<>();
     xmlsNeeded = new ConcurrentHashMap<>();
     featuresNeeded = new ConcurrentHashMap<>();
+    applicationAttributes = new HashMap<>();
 
     uniqueLibsNeeded = Sets.newHashSet();
   }
@@ -147,6 +150,10 @@ public class ComponentInfo {
     return featuresNeeded;
   }
 
+  public Map<String, String> getApplicationAttributes() {
+    return applicationAttributes;
+  }
+
   @Override
   public String toString() {
     return "JsonInfo{"
@@ -161,6 +168,7 @@ public class ComponentInfo {
         + ", uniqueLibsNeeded=" + uniqueLibsNeeded
         + ", xmlsNeeded=" + xmlsNeeded
         + ", featuresNeeded=" + featuresNeeded
+        + ", applicationAttributes=" + applicationAttributes
         + '}';
   }
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2025 MIT, All rights reserved
+// Copyright 2021-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -26,8 +26,10 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -255,6 +257,16 @@ public class CreateManifest implements AndroidTask {
       // Write theme info if we are not using the "Classic" theme (i.e., no theme)
       //      if (!"Classic".equalsIgnoreCase(project.getTheme())) {
       out.write("android:theme=\"@style/AppTheme\" ");
+
+      // Write all the user provided attributes here
+      Map<String, String> userAttributes = context.getComponentInfo().getApplicationAttributes();
+      for (Map.Entry<String, String> entry : userAttributes.entrySet()) {
+        String key = entry.getKey();
+        if (isAllowedAttribute(key)) {
+          out.write("android:" + key + "=\"" + entry.getValue() + "\" ");
+        }
+      }
+
       out.write(">\n");
 
       out.write("<uses-library android:name=\"org.apache.http.legacy\" "
@@ -509,5 +521,13 @@ public class CreateManifest implements AndroidTask {
 
   private String cleanName(String name) {
     return name.replace("&", "and");
+  }
+
+  private boolean isAllowedAttribute(String key) {
+    // Prevents overriding these important attributes
+    List<String> values = Arrays.asList("debuggable", "label",
+      "networkSecurityConfig", "requestLegacyExternalStorage", "preserveLegacyExternalStorage",
+      "icon", "roundIcon", "name", "theme");
+    return !values.contains(key);
   }
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/common/LoadComponentInfo.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2021-2025 MIT, All rights reserved
+// Copyright 2021-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -459,6 +459,7 @@ public class LoadComponentInfo implements CommonTask {
         JSONObject compJson = buildInfo.getJSONObject(i);
         JSONArray infoArray = null;
         String type = compJson.getString("type");
+        processApplicationAttributes(compJson);
         infoArray = compJson.optJSONArray(targetInfo);
         if (infoArray == null) {
           context.getReporter().info("Component \"" + type + "\" does not specify " + targetInfo);
@@ -484,6 +485,19 @@ public class LoadComponentInfo implements CommonTask {
         }
 
         processConditionalInfo(compJson, type, targetInfo);
+      }
+    }
+  }
+
+  private void processApplicationAttributes(JSONObject component) throws JSONException {
+    if (component.has(ComponentDescriptorConstants.APPLICATION_ATTRIBUTES)) {
+      JSONObject attributes = component.getJSONObject(ComponentDescriptorConstants.APPLICATION_ATTRIBUTES);
+      if (attributes != null && attributes.length() > 0) {
+        Iterator<String> keys = attributes.keys();
+        while (keys.hasNext()) {
+          String key = keys.next();
+          context.getComponentInfo().getApplicationAttributes().putIfAbsent(key, attributes.getString(key));
+        }
       }
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/annotations/UsesApplicationAttributes.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/UsesApplicationAttributes.java
@@ -1,0 +1,41 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations;
+
+import com.google.appinventor.components.annotations.androidmanifest.ApplicationAttribute;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate that a component requires specific attributes to be
+ * added to the {@code <application>} tag in the generated AndroidManifest.xml.
+ * <p>
+ * This allows extension and component developers to modify application-level
+ * settings such as {@code android:largeHeap}, {@code android:appCategory}, or
+ * {@code android:usesCleartextTraffic} directly from the component's Java
+ * source.
+ * </p>
+ * Note: If multiple components define the same attribute, we'll take only the
+ * first one.
+ *
+ * @author https://github.com/jewelshkjony (Jewel Shikder Jony)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface UsesApplicationAttributes {
+
+  /**
+   * An array of {@link ApplicationAttribute} annotations, each representing
+   * a single attribute-value pair to be injected into the manifest's
+   * {@code <application>} element.
+   *
+   * @return the array of application attribute data
+   */
+  ApplicationAttribute[] attributes();
+}

--- a/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/ApplicationAttribute.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/androidmanifest/ApplicationAttribute.java
@@ -1,0 +1,46 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations.androidmanifest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a single attribute-value pair to be injected into the
+ * {@code <application>} tag of the Android Manifest.
+ *
+ * @author https://github.com/jewelshkjony (Jewel Shikder Jony)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ApplicationAttribute {
+
+  /**
+   * The name of the Android attribute.
+   * <p>
+   * This should exclude the {@code android:} namespace prefix, as it is
+   * automatically prepended by the compiler. For example: {@code "largeHeap"}
+   * or {@code "appCategory"}.
+   * </p>
+   * See valid attributes <a href="https://developer.android.com/guide/topics/manifest/application-element">from here</a
+   *
+   * @return the name of the attribute
+   */
+  String name();
+
+  /**
+   * The value to be assigned to the attribute.
+   * <p>
+   * For example: {@code "true"}, {@code "social"}, or a resource identifier
+   * like {@code "@style/AppTheme"}.
+   * </p>
+   *
+   * @return the value of the attribute
+   */
+  String value();
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/AllowedAttributes.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/AllowedAttributes.java
@@ -1,0 +1,26 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AllowedAttributes {
+  private AllowedAttributes() {
+    // nothing
+  }
+
+  // Returns allowed application attributes
+  public static final List<String> getAllowedApplicationAttributes() {
+    return Arrays.asList("allowTaskReparenting", "allowBackup", "allowClearUserData", "allowNativeHeapPointerTagging",
+        "appCategory", "backupAgent", "backupInForeground", "banner", "dataExtractionRules", "description", "enabled",
+        "enableOnBackInvokedCallback", "extractNativeLibs", "fullBackupContent", "fullBackupOnly", "gwpAsanMode",
+        "hasCode", "hasFragileUserData", "hardwareAccelerated", "isGame", "isMonitoringTool", "killAfterRestore",
+        "largeHeap", "logo", "manageSpaceActivity", "permission", "persistent", "process", "restoreAnyVersion",
+        "requiredAccountType", "resizeableActivity", "restrictedAccountType", "supportsRtl", "taskAffinity",
+        "testOnly", "uiOptions", "usesCleartextTraffic", "vmSafeMode");
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentDescriptorConstants.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2011-2025 MIT, All rights reserved
+// Copyright 2011-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -34,6 +34,7 @@ public final class ComponentDescriptorConstants {
   public static final String CONDITIONALS_TARGET = "conditionals";
   public static final String XMLS_TARGET = "xmls";
   public static final String FEATURES_TARGET = "features";
+  public static final String APPLICATION_ATTRIBUTES = "applicationAttributes";
 
   // TODO(Will): Remove the following target once the deprecated
   //             @SimpleBroadcastReceiver annotation is removed. It should

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentListGenerator.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2025 MIT, All rights reserved
+// Copyright 2011-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -90,6 +90,8 @@ public final class ComponentListGenerator extends ComponentProcessor {
         component.contentProviders);
     appendComponentInfo(json, ComponentDescriptorConstants.XMLS_TARGET, component.xmls);
     appendComponentInfo(json, ComponentDescriptorConstants.FEATURES_TARGET, component.features);
+    appendApplicationAttributes(json, ComponentDescriptorConstants.APPLICATION_ATTRIBUTES,
+      component.applicationAttributes);
     appendConditionalComponentInfo(component, json);
     // TODO(Will): Remove the following call once the deprecated
     //             @SimpleBroadcastReceiver annotation is removed. It should
@@ -158,6 +160,15 @@ public final class ComponentListGenerator extends ComponentProcessor {
   private static void appendComponentInfo(JSONObject parent,
       String infoName, Set<String> infoEntries) {
     parent.put(infoName, new JSONArray(infoEntries));
+  }
+
+  private static void appendApplicationAttributes(JSONObject parent,
+    String infoName, Map<String, String> attributes) {
+      JSONObject attrObject = new JSONObject();
+      for (Map.Entry<String, String> entry : attributes.entrySet()) {
+        attrObject.put(entry.getKey(), entry.getValue());
+      }
+      parent.put(infoName, attrObject);
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2025 MIT, All rights reserved
+// Copyright 2011-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -30,6 +30,8 @@ import com.google.appinventor.components.annotations.UsesServices;
 import com.google.appinventor.components.annotations.UsesXmls;
 import com.google.appinventor.components.annotations.XmlElement;
 import com.google.appinventor.components.annotations.UsesFeatures;
+import com.google.appinventor.components.annotations.UsesApplicationAttributes;
+import com.google.appinventor.components.annotations.androidmanifest.ApplicationAttribute;
 import com.google.appinventor.components.annotations.androidmanifest.FeatureElement;
 import com.google.appinventor.components.annotations.androidmanifest.ActivityElement;
 import com.google.appinventor.components.annotations.androidmanifest.ReceiverElement;
@@ -42,6 +44,7 @@ import com.google.appinventor.components.annotations.androidmanifest.ServiceElem
 import com.google.appinventor.components.annotations.androidmanifest.ProviderElement;
 import com.google.appinventor.components.annotations.androidmanifest.PathPermissionElement;
 import com.google.appinventor.components.annotations.androidmanifest.GrantUriPermissionElement;
+import com.google.appinventor.components.common.AllowedAttributes;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -107,6 +110,7 @@ import javax.lang.model.util.Types;
 
 import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
+
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
@@ -1193,6 +1197,11 @@ public abstract class ComponentProcessor extends AbstractProcessor {
      * Uses features required by this component.
      */
     protected final Set<String> features;
+    
+    /**
+     * Uses application attributes required by this component.
+     */
+    protected final Map<String, String> applicationAttributes;
 
     /**
      * TODO(Will): Remove the following field once the deprecated {@link SimpleBroadcastReceiver}
@@ -1288,6 +1297,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       services = Sets.newHashSet();
       xmls = Sets.newHashSet();
       features = Sets.newHashSet();
+      applicationAttributes = Maps.newTreeMap();
 
       designerProperties = Maps.newTreeMap();
       properties = Maps.newTreeMap();
@@ -1656,6 +1666,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
         componentInfo.contentProviders.addAll(parentComponent.contentProviders);
         componentInfo.xmls.addAll(parentComponent.xmls);
         componentInfo.features.addAll(parentComponent.features);
+        componentInfo.applicationAttributes.putAll(parentComponent.applicationAttributes);
+
         // TODO(Will): Remove the following call once the deprecated
         //             @SimpleBroadcastReceiver annotation is removed. It should
         //             should remain for the time being because otherwise we'll break
@@ -1882,6 +1894,20 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       }
       for (FeatureElement fe : featureMap.values()) {
         updateWithNonEmptyValue(componentInfo.features, featureElementToString(fe));
+      }
+    }
+
+    // Gather the required application attributes and build JSON object
+    UsesApplicationAttributes usesApplicationAttributes = element.getAnnotation(UsesApplicationAttributes.class);
+    if (usesApplicationAttributes != null) {
+      for (ApplicationAttribute aa : usesApplicationAttributes.attributes()) {
+        if (aa.name() != null && aa.value() != null) {
+          if (AllowedAttributes.getAllowedApplicationAttributes().contains(aa.name())) {
+            componentInfo.applicationAttributes.putIfAbsent(aa.name(), aa.value());
+          } else {
+            messager.printMessage(Kind.ERROR, aa.name() + " is not allowed or invalid attribute!", element);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
General items:

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [x] `ant tests` passes on my machine

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

What does this PR accomplish?

This PR introduces a new annotation system that allows component and extension developers to inject attributes directly into the <[application](https://developer.android.com/guide/topics/manifest/application-element)> tag of the AndroidManifest.xml.

Example usages:

```java
@UsesApplicationAttributes(attributes = {
  @ApplicationAttribute(name = "appCategory", value = "social"),
  @ApplicationAttribute(name = "usesCleartextTraffic", value = "true")
})
```

Example manifest:

<img width="1171" height="513" alt="image" src="https://github.com/user-attachments/assets/dc22f919-609f-4323-9f75-b88759d39c79" />