### PR TITLE
Prevent importing AIA project files as extensions

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/ComponentServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ComponentServiceImpl.java
@@ -168,6 +168,13 @@ public class ComponentServiceImpl extends OdeRemoteServiceServlet
     Set<String> sourceFiles = new HashSet<>(storageIo.getProjectSourceFiles(userInfoProvider.getUserId(), projectId));
     Map<String, String> nameMap = buildExtensionPathnameMap(contents.keySet());
 
+    // Reject if uploaded file is actually an App Inventor project (.aia)
+    if (contents.containsKey("youngandroidproject/project.properties")) {
+      response.setStatus(Status.FAILED);
+      response.setMessage("Uploaded file is an App Inventor project archive, not an extension.");
+      return;
+    }
+
     // Does the extension contain a file that could be a component descriptor file?
     if (!nameMap.containsKey("component.json") && !nameMap.containsKey("components.json")) {
       response.setMessage("Uploaded file does not contain any component definition files.");


### PR DESCRIPTION
Added a validation check to prevent importing App Inventor project files (.aia) as extensions.

Previously, the system could allow incorrectly renamed project files to be imported as extensions. This change checks for the presence of "youngandroidproject/project.properties" inside the uploaded archive and rejects it if found.

This ensures that only valid extension files are accepted and prevents incorrect imports.

Fixes #918
