### PR TITLE
Fix Blocks Editor refresh when BlocksToolkit changes without runtime reset errors

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
@@ -217,6 +217,14 @@ public final class BlockSelectorBox extends Box {
     return advanced;
   }
 
+  /**
+   * Clears the cached built-in blocks tree so the next access rebuilds from
+   * the latest BlocksToolkit value.
+   */
+  public void clearBuiltInBlocksCache() {
+    languageTreeItems.clear();
+  }
+
   public void addBlockDrawerSelectionListener(BlockDrawerSelectionListener listener) {
     drawerListeners.add(listener);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocklyPanel.java
@@ -927,6 +927,33 @@ public class BlocklyPanel extends HTMLPanel {
       .isDrawerShowing();
   }-*/;
 
+  /**
+   * Reset cached built-in drawer language tree data.
+   *
+   * Uses feature detection so this is safe across environments where
+   * blocklyeditor source updates may lag behind Java changes.
+   */
+  public native void resetDrawerLanguageTreeCache()/*-{
+    var workspace = this.@com.google.appinventor.client.editor.blocks.BlocklyPanel::workspace;
+    if (!workspace) {
+      return;
+    }
+    if (typeof workspace.resetDrawerLanguageTree === 'function') {
+      try {
+        workspace.resetDrawerLanguageTree();
+        return;
+      } catch (e) {
+        // Fall through to direct cache invalidation for compatibility.
+      }
+    }
+    if (workspace.options) {
+      workspace.options.languageTree = null;
+    }
+    if (workspace.drawer_ && workspace.drawer_.options) {
+      workspace.drawer_.options.languageTree = null;
+    }
+  }-*/;
+
   public native void render()/*-{
     this.@com.google.appinventor.client.editor.blocks.BlocklyPanel::workspace
       .resize()

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
@@ -27,6 +27,7 @@ import com.google.appinventor.client.editor.youngandroid.events.EventHelper;
 import com.google.appinventor.client.explorer.SourceStructureExplorer;
 import com.google.appinventor.client.explorer.SourceStructureExplorerItem;
 import com.google.appinventor.client.tracking.Tracking;
+import com.google.appinventor.shared.settings.SettingsConstants;
 import com.google.appinventor.shared.properties.json.JSONArray;
 import com.google.appinventor.shared.properties.json.JSONValue;
 import com.google.appinventor.shared.rpc.project.ChecksumedFileException;
@@ -385,7 +386,15 @@ public abstract class BlocksEditor<S extends SourceNode, T extends DesignerEdito
   // Note: our companion designer adds us as a listener on the form
   @Override
   public void onComponentPropertyChanged(MockComponent component, String propertyName, String propertyValue) {
-    // nothing to do here
+    if (!SettingsConstants.YOUNG_ANDROID_SETTINGS_BLOCK_SUBSET.equals(propertyName) || !loadComplete) {
+      return;
+    }
+
+    BlockSelectorBox.getBlockSelectorBox().clearBuiltInBlocksCache();
+    blocksArea.resetDrawerLanguageTreeCache();
+    updateSourceStructureExplorer();
+    // Close any open drawer because its contents may no longer match the toolkit.
+    hideBlocksDrawer();
   }
 
   @Override


### PR DESCRIPTION
## General items

- [ ] I have updated the relevant documentation files under `docs/`
- [x] My code follows:
  - Google Java style guide (for `.java` files)
  - Google JavaScript style guide (for `.js` files)
- [x] Ant tests pass on my machine

---

## Branching

- [x] I branched from `master`
- [x] My pull request has `master` as the base

---

## What does this PR accomplish?

### Description

Changing `BlocksToolkit` on `Screen1` in the Designer did not refresh built-in categories and drawer contents in the Blocks Editor until a full page reload.

This PR fixes that by invalidating both cache layers used by the Blocks Editor when `BlocksToolkit` changes:

- Java-side built-in tree cache in `BlockSelectorBox`
- Drawer language tree cache in Blockly workspace

---

## Implementation details

- `BlocksEditor` now handles `BlocksToolkit` property changes and triggers cache invalidation.
- `BlockSelectorBox` now exposes a `clearBuiltInBlocksCache` method.
- `BlocklyPanel` now uses a defensive `resetDrawerLanguageTreeCache` method:
  - Calls workspace reset function when available
  - Falls back to direct `languageTree` cache reset when not available
  - Includes safe fallback behavior for runtime compatibility

After invalidation:
- Source structure is rebuilt
- Any open drawer is closed

This ensures updated blocks are shown immediately.

---

## Why this differs from the previous closed PR

The previous approach depended on a direct `resetDrawerLanguageTree` runtime path and could throw errors in some environments.

This version:
- Uses a defensive approach
- Is backward-compatible
- Avoids runtime errors caused by missing or uninitialized drawer methods

---

## Testing

### Manual testing

1. Create a new project  
2. Open Blocks and note current built-in categories/drawers  
3. Switch to Designer and change `Screen1.BlocksToolkit`  
4. Return to Blocks  
5. Verify:
   - Categories/drawers update immediately (no reload required)
   - No `resetDrawerLanguageTree` errors in browser console  

---

Fixes #2596.
Supersedes the earlier closed PR #3800.

https://github.com/user-attachments/assets/d7b05674-2133-4af4-a85b-498997747296

### Local commands run

```bash
ant -Dskip.ios=true noplay
ant -Dskip.ios=true tests

