### PR TITLE
Use Screen1 if lastOpened not in loaded project

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -845,7 +845,7 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   private boolean isLastOpened(String formName) {
     String lastOpened = this.getProjectSettingsProperty(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED);
-    if (lastOpened.isEmpty()) { // This happens sometimes when a screen is deleted
+    if (lastOpened.isEmpty() || !editorMap.containsKey(lastOpened)) { // This happens sometimes when a screen is deleted
       lastOpened = "Screen1";   // Haven't found the cause, so this is a workaround
     }
     return lastOpened.equals(formName);


### PR DESCRIPTION
**What does this PR accomplish?**

This fixes an issue where, if the last opened project property is present after a screen is deleted, we will default to Screen1 when loading the project.

*Description*

Previously, projects would still contain the last opened property if the current screen was deleted. This was patched, but there are still projects out there in an inconsistent state. This fixes it so that if we detect a project has been opened but the last opened entity is missing, we will default to Screen1.

*Testing Guidelines*

You can add a `lastopened` property to any project to point to a non-existent screen and it will fail to load in ai2. After this patch it should switch to Screen1.

**Context for the changes**

- [x] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [ ] Indentation has been doubled checked
    - [ ] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
