### PR TITLE
Add @DefaultValue annotation to attach default blocks in the drawer

### DIFF
--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -1,7 +1,7 @@
 /* -*- mode: javascript; js-indent-level 2; -*- */
 /**
  * @license
- * Copyright © 2016-2021 Massachusetts Institute of Technology. All rights reserved.
+ * Copyright © 2016-2026 Massachusetts Institute of Technology. All rights reserved.
  */
 
 /**
@@ -513,6 +513,12 @@ Blockly.ComponentDatabase.prototype.processParameters = function(paramData) {
     var param = {};
     param.name = datum.name;
     param.type = datum.type;
+    if (datum.defaultValue !== undefined) {
+     param.defaultValue = datum.defaultValue; 
+    }
+    if (datum.valueType !== undefined) {
+      param.valueType = datum.valueType;
+    }
     param.helperKey = this.processHelper(datum.helper);
     params.push(param);
   }

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -514,7 +514,7 @@ Blockly.ComponentDatabase.prototype.processParameters = function(paramData) {
     param.name = datum.name;
     param.type = datum.type;
     if (datum.defaultValue !== undefined) {
-     param.defaultValue = datum.defaultValue; 
+      param.defaultValue = datum.defaultValue; 
     }
     if (datum.defaultValueType !== undefined) {
       param.defaultValueType = datum.defaultValueType;

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -516,8 +516,8 @@ Blockly.ComponentDatabase.prototype.processParameters = function(paramData) {
     if (datum.defaultValue !== undefined) {
      param.defaultValue = datum.defaultValue; 
     }
-    if (datum.valueType !== undefined) {
-      param.valueType = datum.valueType;
+    if (datum.defaultValueType !== undefined) {
+      param.defaultValueType = datum.defaultValueType;
     }
     param.helperKey = this.processHelper(datum.helper);
     params.push(param);

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright © 2013-2021 MIT, All rights reserved
+// Copyright © 2013-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 /**
@@ -312,11 +312,9 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
     }
 
     // Create event blocks.
-    Object.entries(componentInfo.eventDictionary).forEach(function (pair) {
-      const name = pair[0];
-      const event = pair[1];
+    for (const [name, event] of Object.entries(componentInfo.eventDictionary)) {
       if (event.deprecated) {
-        return;
+        continue;
       }
 
       var eventObj = {
@@ -330,14 +328,12 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
       // Determine if any parameters are associated with a helper which should
       // be added at the bottom of the drawer.
       event.parameters.forEach(getHelper);
-    }, this);
+    }
 
     // Create method blocks.
-    Object.entries(componentInfo.methodDictionary).forEach(function (pair) {
-      const name = pair[0];
-      const method = pair[1];
+    for (const [name, method] of Object.entries(componentInfo.methodDictionary)) {
       if (method.deprecated) {
-        return;
+        continue;
       }
 
       var methodObj = {
@@ -347,32 +343,35 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
       };
       var methodXml = this.blockTypeToXML('component_method', methodObj);
 
-      method.parameters.forEach(function(param, index) {
-        if (!param.helperKey) {
-          return;
+      method.parameters.forEach(function (param, index) {
+        if (param.helperKey) {
+          // Determine if any parameters are associated with a helper which should
+          // be added at the bottom of the drawer.
+          getHelper(param);
+          // Adds dropdown blocks to inputs which expect them.
+          var inputXml = xmlUtils.valueWithHelperXML('ARG' + index, param.helperKey);
+          // First child b/c these are wrapped in an <xml/> node.
+          methodXml.firstChild.appendChild(inputXml.firstChild);
+        } else if (param.defaultValue !== undefined) {
+          // Add blocks with the default value.
+          var defaultXml = xmlUtils.valueWithDefaultXML('ARG' + index, param);
+          if (defaultXml !== null) {
+            methodXml.firstChild.appendChild(defaultXml.firstChild);
+          }
         }
-        // Determine if any parameters are associated with a helper which should
-        // be added at the bottom of the drawer.
-        getHelper(param);
-        // Adds dropdown blocks to inputs which expect them.
-        var inputXml = xmlUtils.valueWithHelperXML('ARG' + index, param.helperKey);
-        // First child b/c these are wrapped in an <xml/> node.
-        methodXml.firstChild.appendChild(inputXml.firstChild);
-      }.bind(this));
+      });
 
       Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(methodXml));
-    }, this);
+    }
 
     // Create getter and setter blocks.
-    Object.entries(componentInfo.properties).forEach(function(pair) {
-      const name = pair[0];
-      const property = pair[1];
+    for (const [name, property] of Object.entries(componentInfo.properties)) {
       if (property.deprecated) {
-        return;
+        continue;
       }
 
       if ((name == 'Left' || name == 'Top') && !freePosition) {
-        return;
+        continue;
       }
 
       var propertyObj = {
@@ -397,6 +396,12 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
           var inputXml = xmlUtils.valueWithHelperXML('VALUE', property.helperKey);
           // First child b/c these are wrapped in an <xml/> node.
           setXml.firstChild.appendChild(inputXml.firstChild);
+        } else if (property.defaultValue !== undefined) {
+          // Add blocks with the default value.
+          var defaultXml = xmlUtils.valueWithDefaultXML('VALUE', property);
+          if (defaultXml !== null) {
+            setXml.firstChild.appendChild(defaultXml.firstChild);
+          }
         }
 
         Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(setXml));
@@ -405,7 +410,7 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
       // Collects up helper blocks for properties which use them so they can
       // be added to the bottom of the drawer.
       getHelper(property);
-    }, this);
+    }
 
     // Create helper blocks at the bottom of the drawer, right above the
     // component block.
@@ -415,7 +420,7 @@ Blockly.Drawer.prototype.createAllComponentBlocks =
     helperKeys.forEach(function(helper) {
       var xml = xmlUtils.helperKeyToXML(helper);
       Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(xml));
-    }.bind(this));
+    });
 
     // Create component literal block.
     var componentObj = {
@@ -463,10 +468,8 @@ Blockly.Drawer.prototype.componentTypeToXMLArray = function(typeName) {
   }
 
   //create generic event blocks
-  Object.entries(componentInfo.eventDictionary).forEach(function(pair){
-    const name = pair[0];
-    const event = pair[1];
-    if(!event.deprecated){
+  for (const [name, event] of Object.entries(componentInfo.eventDictionary)) {
+    if (!event.deprecated) {
       Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_event', {
         component_type: typeName, event_name: name, is_generic: 'true'
       }));
@@ -475,39 +478,41 @@ Blockly.Drawer.prototype.componentTypeToXMLArray = function(typeName) {
       // be added at the bottom of the drawer.
       event.parameters.forEach(getHelper);
     }
-  }, this);
+  }
 
   //create generic method blocks
-  Object.entries(componentInfo.methodDictionary).forEach(function(pair) {
-    const name = pair[0];
-    const method = pair[1];
+  for (const [name, method] of Object.entries(componentInfo.methodDictionary)) {
     if (!method.deprecated) {
       var methodXml = this.blockTypeToXML('component_method', {
         component_type: typeName, method_name: name, is_generic: "true"
       });
 
-
-      method.parameters.forEach(function(param, index) {
-        if (!param.helperKey) {
-          return;
+      method.parameters.forEach(function (param, index) {
+        if (param.helperKey) {
+          // Determine if any parameters are associated with a helper which should
+          // be added at the bottom of the drawer.
+          getHelper(param);
+          // Adds dropdown blocks to inputs which expect them.
+          var inputXml = xmlUtils.valueWithHelperXML('ARG' + index, param.helperKey);
+          // First child b/c these are wrapped in an <xml/> node.
+          methodXml.firstChild.appendChild(inputXml.firstChild);
+        } else if (param.defaultValue !== undefined) {
+          // Add blocks with the default value.
+          var defaultXml = xmlUtils.valueWithDefaultXML('ARG' + index, param);
+          if (defaultXml !== null) {
+            methodXml.firstChild.appendChild(defaultXml.firstChild);
+          }
         }
-        // Determine if any parameters are associated with a helper which should
-        // be added at the bottom of the drawer.
-        getHelper(param);
-        // Adds dropdown blocks to inputs which expect them.
-        var inputXml = xmlUtils.valueWithHelperXML('ARG' + index, param.helperKey);
-        // First child b/c these are wrapped in an <xml/> node.
-        methodXml.firstChild.appendChild(inputXml.firstChild);
-      }.bind(this));
+      });
 
       Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(methodXml));
     }
-  }, this);
+  }
 
   //for each property
   for (const [name, property] of Object.entries(componentInfo.properties)) {
     if (!property.deprecated) {
-      var params = {component_type: typeName, property_name: name};
+      var params = { component_type: typeName, property_name: name };
       if ((property.mutability & Blockly.PROPERTY_READABLE) == Blockly.PROPERTY_READABLE) {
         params.set_or_get = 'get';
         Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_set_get', params));
@@ -521,6 +526,12 @@ Blockly.Drawer.prototype.componentTypeToXMLArray = function(typeName) {
           var inputXml = xmlUtils.valueWithHelperXML('VALUE', property.helperKey);
           // First child b/c these are wrapped in an <xml/> node.
           setXml.firstChild.appendChild(inputXml.firstChild);
+        } else if (property.defaultValue !== undefined) {
+          // Add blocks with the default value.
+          var defaultXml = xmlUtils.valueWithDefaultXML('VALUE', property);
+          if (defaultXml !== null) {
+            setXml.firstChild.appendChild(defaultXml.firstChild);
+          }
         }
 
         Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(setXml));
@@ -536,7 +547,7 @@ Blockly.Drawer.prototype.componentTypeToXMLArray = function(typeName) {
   helperKeys.forEach(function(helper) {
     var xml = xmlUtils.helperKeyToXML(helper);
     Array.prototype.push.apply(xmlArray, xmlUtils.XMLToArray(xml));
-  }.bind(this));
+  });
 
   // add the all components getter
   Array.prototype.push.apply(xmlArray, this.blockTypeToXMLArray('component_all_component_block', {

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -182,9 +182,9 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
     // Not a DesignerProperty, take param type.
     typeStr = param.type;
   }
-  if ((typeStr === 'any' || typeStr === 'unknown') && param.valueType !== undefined) {
-    // Take the optional valueType if defined
-    typeStr = param.valueType;
+  if ((typeStr === 'any' || typeStr === 'unknown') && param.defaultValueType !== undefined) {
+    // Take the optional defaultValueType if defined and only when the param type is 'any' or 'unknown'
+    typeStr = param.defaultValueType;
   }
 
   var valueStr = String(param.defaultValue);
@@ -219,7 +219,7 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       xmlString += '<mutation items="' + items.length + '"></mutation>';
       var blockType = 'text';
       var fieldName = 'TEXT';
-      if (param.valueType !== undefined && param.valueType === 'number') {
+      if (param.defaultValueType !== undefined && param.defaultValueType === 'number') {
         blockType = 'math_number';
         fieldName = 'NUM';
       }

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -211,8 +211,7 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
     xmlString += '<field name="BOOL">' + valueStr.toUpperCase() + '</field></block>';
   } else if (typeStr === 'list') {
     xmlString += '<block type="lists_create_with">';
-    var isEmpty = valueStr.trim() === '';
-    if (isEmpty) {
+    if (!valueStr.trim()) {
       xmlString += '<mutation items="0"></mutation>';
     } else {
       var items = valueStr.split(',').map(item => item.trim());
@@ -234,8 +233,7 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
     xmlString += '</block>';
   } else if (typeStr === 'dictionary') {
     xmlString += '<block type="dictionaries_create_with">';
-    var isEmpty = valueStr.trim() === '';
-    if (isEmpty) {
+    if (!valueStr.trim()) {
       xmlString += '<mutation items="0"></mutation>';
     } else {
       var items = valueStr.split(',').map(item => item.trim());

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -224,6 +224,9 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       } else if (param.defaultValueType !== undefined && param.defaultValueType === 'color') {
         blockType = 'color_white';
         fieldName = 'COLOR';
+      } else if (param.defaultValueType !== undefined && param.defaultValueType === 'boolean') {
+        blockType = 'logic_boolean';
+        fieldName = 'BOOL';
       }
       items.forEach((item, idx) => {
         xmlString += '<value name="ADD' + idx + '">' +

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -227,7 +227,7 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       }
       items.forEach((item, idx) => {
         xmlString += '<value name="ADD' + idx + '">' +
-          '<block type="' + blockType + '"><field name="' + fieldName + '">' + item + '</field></block></value>';
+          '<block type="' + blockType + '"><field name="' + fieldName + '">' + this.escapeXml(item) + '</field></block></value>';
       });
     }
     xmlString += '</block>';
@@ -241,14 +241,14 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       items.forEach((item, idx) => {
         var [key, value] = item.split(':');
         xmlString += '<value name="ADD' + idx + '"><block type="pair">';
-        xmlString += '<value name="KEY"><block type="text"><field name="TEXT">' + key + '</field></block></value>';
-        xmlString += '<value name="VALUE"><block type="text"><field name="TEXT">' + value + '</field></block></value>';
+        xmlString += '<value name="KEY"><block type="text"><field name="TEXT">' + this.escapeXml(key) + '</field></block></value>';
+        xmlString += '<value name="VALUE"><block type="text"><field name="TEXT">' + this.escapeXml(value) + '</field></block></value>';
         xmlString += '</block></value>';
       });
     }
     xmlString += '</block>';
   } else if (typeStr === 'text' || typeStr === 'textArea' || typeStr === 'string') {
-    xmlString += '<block type="text"><field name="TEXT">' + valueStr + '</field></block>';
+    xmlString += '<block type="text"><field name="TEXT">' + this.escapeXml(valueStr) + '</field></block>';
   } else {
     // Return null is the type is unknown
     return null;
@@ -256,4 +256,17 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
 
   xmlString += '</value></xml>';
   return Blockly.utils.xml.textToDom(xmlString);
+};
+
+/**
+ * Escapes special characters for use in XML text nodes.
+ * @param {string} unsafe The string to escape.
+ * @return {string} The escaped string safe for XML.
+ */
+Blockly.Util.xml.escapeXml = function (unsafe) {
+  return unsafe.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 };

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -222,6 +222,9 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       if (param.defaultValueType !== undefined && param.defaultValueType === 'number') {
         blockType = 'math_number';
         fieldName = 'NUM';
+      } else if (param.defaultValueType !== undefined && param.defaultValueType === 'color') {
+        blockType = 'color_white';
+        fieldName = 'COLOR';
       }
       items.forEach((item, idx) => {
         xmlString += '<value name="ADD' + idx + '">' +

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -246,7 +246,7 @@ Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
       });
     }
     xmlString += '</block>';
-  } else if (typeStr === 'text' || typeStr === 'textArea' || typeStr === 'string' || typeStr === 'choices') {
+  } else if (typeStr === 'text' || typeStr === 'textArea' || typeStr === 'string') {
     xmlString += '<block type="text"><field name="TEXT">' + valueStr + '</field></block>';
   } else {
     // Return null is the type is unknown

--- a/appinventor/blocklyeditor/src/utils_xml.js
+++ b/appinventor/blocklyeditor/src/utils_xml.js
@@ -1,5 +1,5 @@
 // -*- mode: Javascript; js-indent-level: 2; -*-
-// Copyright © 2020 MIT, All rights reserved
+// Copyright © 2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -163,3 +163,96 @@ Blockly.Util.xml.valueWithHelperXML = function(name, helperKey) {
   inputXml.firstChild.appendChild(helperXml.firstChild);
   return inputXml;
 }
+
+/**
+ * Creates XML for a value input pre-filled with a default block.
+ * Supported types: "text", "number", "boolean", "color", "list", "dictionary".
+ * @param {string} inputName  The input slot name (e.g. 'ARG0', 'VALUE').
+ * @param {Object} param The parameter object from components.json.
+ * @return {Node} (Nullable) A <xml> node whose first child is a <value> node.
+ */
+Blockly.Util.xml.valueWithDefaultXML = function (inputName, param) {
+  var xmlString = '<xml><value name="' + inputName + '">';
+
+  var typeStr = 'unknown';
+  if (param.editorType !== undefined) {
+    // Accepts param type from DesignerProperty
+    typeStr = param.editorType;
+  } else if (param.type !== undefined) {
+    // Not a DesignerProperty, take param type.
+    typeStr = param.type;
+  }
+  if ((typeStr === 'any' || typeStr === 'unknown') && param.valueType !== undefined) {
+    // Take the optional valueType if defined
+    typeStr = param.valueType;
+  }
+
+  var valueStr = String(param.defaultValue);
+  var isNumericType = ['number', 'int', 'integer', 'float', 'double', 'short', 'long', 'non_negative_integer', 'non_negative_float'].includes(typeStr);
+
+  if ((isNumericType || typeStr === 'color')) {
+    if (valueStr.startsWith('&HFF')) {
+      // Convert DesignerProperty color value to Hex code
+      valueStr = valueStr.replace('&HFF', '#');
+    } else if (valueStr.startsWith('&H00')) {
+      // Convert DesignerProperty color value to Hex code
+      valueStr = valueStr.replace('&H00', '#');
+    }
+  }
+
+  if (valueStr.startsWith('#') && (isNumericType || typeStr === 'color')) {
+    xmlString += '<block type="color_white">';
+    xmlString += '<field name="COLOR">' + valueStr.toLowerCase() + '</field></block>';
+  } else if (isNumericType) {
+    xmlString += '<block type="math_number">';
+    xmlString += '<field name="NUM">' + valueStr + '</field></block>';
+  } else if (typeStr === 'boolean') {
+    xmlString += '<block type="logic_boolean">';
+    xmlString += '<field name="BOOL">' + valueStr.toUpperCase() + '</field></block>';
+  } else if (typeStr === 'list') {
+    xmlString += '<block type="lists_create_with">';
+    var isEmpty = valueStr.trim() === '';
+    if (isEmpty) {
+      xmlString += '<mutation items="0"></mutation>';
+    } else {
+      var items = valueStr.split(',').map(item => item.trim());
+      xmlString += '<mutation items="' + items.length + '"></mutation>';
+      var blockType = 'text';
+      var fieldName = 'TEXT';
+      if (param.valueType !== undefined && param.valueType === 'number') {
+        blockType = 'math_number';
+        fieldName = 'NUM';
+      }
+      items.forEach((item, idx) => {
+        xmlString += '<value name="ADD' + idx + '">' +
+          '<block type="' + blockType + '"><field name="' + fieldName + '">' + item + '</field></block></value>';
+      });
+    }
+    xmlString += '</block>';
+  } else if (typeStr === 'dictionary') {
+    xmlString += '<block type="dictionaries_create_with">';
+    var isEmpty = valueStr.trim() === '';
+    if (isEmpty) {
+      xmlString += '<mutation items="0"></mutation>';
+    } else {
+      var items = valueStr.split(',').map(item => item.trim());
+      xmlString += '<mutation items="' + items.length + '"></mutation>';
+      items.forEach((item, idx) => {
+        var [key, value] = item.split(':');
+        xmlString += '<value name="ADD' + idx + '"><block type="pair">';
+        xmlString += '<value name="KEY"><block type="text"><field name="TEXT">' + key + '</field></block></value>';
+        xmlString += '<value name="VALUE"><block type="text"><field name="TEXT">' + value + '</field></block></value>';
+        xmlString += '</block></value>';
+      });
+    }
+    xmlString += '</block>';
+  } else if (typeStr === 'text' || typeStr === 'textArea' || typeStr === 'string' || typeStr === 'choices') {
+    xmlString += '<block type="text"><field name="TEXT">' + valueStr + '</field></block>';
+  } else {
+    // Return null is the type is unknown
+    return null;
+  }
+
+  xmlString += '</value></xml>';
+  return Blockly.utils.xml.textToDom(xmlString);
+};

--- a/appinventor/components/src/com/google/appinventor/components/annotations/DefaultValue.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/DefaultValue.java
@@ -1,0 +1,45 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation lets us attach a default block to a component's parameter
+ * directly in the Blocks Drawer. Instead of dragging out an empty block and
+ * then searching for a math, text, etc block to fill it, the block will already
+ * come with these defaults attached when you see it in the drawer. These are
+ * real, draggable blocks that help users understand what kind of data is
+ * expected.
+ *
+ * @author https://github.com/jewelshkjony (Jewel Shikder Jony)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER })
+public @interface DefaultValue {
+
+  /**
+   * The initial value that goes inside the attached block.
+   * * Follow these formatting rules:
+   * - For colors: Start with a # (e.g., "#FFFFFF").
+   * - For lists: Use commas to separate items (e.g., "item1, item2, item3").
+   * - For dictionaries: Use key:value pairs (e.g., "key1:val1, key2:val2").
+   * - For simple types: Just use the value (e.g., "10" or "hello").
+   */
+  String value() default "";
+
+  /**
+   * The type of block to attach.
+   * * This is optional. Usually, the system figures out the block type from
+   * the parameter itself. You only need to set this manually if the parameter
+   * is an Object (any) and you want a specific block type to show up.
+   * * Allowed types: text, number, boolean, color, list, dictionary.
+   */
+  String type() default "";
+}

--- a/appinventor/components/src/com/google/appinventor/components/annotations/DefaultValue.java
+++ b/appinventor/components/src/com/google/appinventor/components/annotations/DefaultValue.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.google.appinventor.components.common.DefaultValueType;
+
 /**
  * This annotation lets us attach a default block to a component's parameter
  * directly in the Blocks Drawer. Instead of dragging out an empty block and
@@ -39,7 +41,7 @@ public @interface DefaultValue {
    * * This is optional. Usually, the system figures out the block type from
    * the parameter itself. You only need to set this manually if the parameter
    * is an Object (any) and you want a specific block type to show up.
-   * * Allowed types: text, number, boolean, color, list, dictionary.
+   * * Allowed types: Text, Number, Boolean, Color, List, Dictionary.
    */
-  String type() default "";
+  DefaultValueType type() default DefaultValueType.Unknown;
 }

--- a/appinventor/components/src/com/google/appinventor/components/common/DefaultValueType.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/DefaultValueType.java
@@ -1,0 +1,26 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+public enum DefaultValueType {
+  Text("text"),
+  Number("number"),
+  Boolean("boolean"),
+  Color("color"),
+  List("list"),
+  Dictionary("dictionary"),
+  Unknown("");
+
+  private final String type;
+
+  DefaultValueType(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -303,7 +303,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       json.put("defaultValue", prop.getDefaultValue());
     }
     if (prop.getDefaultValueType() != null && !prop.getDefaultValueType().isEmpty()) {
-      json.put("valueType", prop.getDefaultValueType());
+      json.put("defaultValueType", prop.getDefaultValueType());
     }
     return json;
   }
@@ -347,7 +347,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
         param.put("defaultValue", p.defaultValue);
       }
       if (p.defaultValueType != null && !p.defaultValueType.isEmpty()) {
-        param.put("valueType", p.defaultValueType);
+        param.put("defaultValueType", p.defaultValueType);
       }
       json.put(param);
     }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2016 MIT, All rights reserved
+// Copyright 2011-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -1,6 +1,6 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2019 MIT, All rights reserved
+// Copyright 2011-2016 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -299,6 +299,12 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       json.put("alwaysSend", true);
       json.put("defaultValue", defaultValue);
     }
+    if (prop.getDefaultValue() != null) {
+      json.put("defaultValue", prop.getDefaultValue());
+    }
+    if (prop.getDefaultValueType() != null && !prop.getDefaultValueType().isEmpty()) {
+      json.put("valueType", prop.getDefaultValueType());
+    }
     return json;
   }
 
@@ -337,6 +343,12 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       param.put("name", p.name);
       param.put("type", p.getYailType());
       outputHelper(p.getHelperKey(), param);
+      if (p.defaultValue != null) {
+        param.put("defaultValue", p.defaultValue);
+      }
+      if (p.defaultValueType != null && !p.defaultValueType.isEmpty()) {
+        param.put("valueType", p.defaultValueType);
+      }
       json.put(param);
     }
     return json;

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -2039,9 +2039,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
           }
           ensureEachPair(dv, ve, javaTypeToYailType(typeMirror));
           property.defaultValue = dv.value();
-          if (dv.type() != null && !dv.type().trim().isEmpty()) {
-            checkForAllowedTypes(dv.type().trim(), ve);
-            property.defaultValueType = dv.type();
+          if (dv.type() != null && !dv.type().getType().trim().isEmpty()) {
+            property.defaultValueType = dv.type().getType();
           }
         }
       }
@@ -2421,9 +2420,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
         }
         ensureEachPair(dv, varElem, javaTypeToYailType(type));
         param.defaultValue = dv.value();
-        if (dv.type() != null && !dv.type().trim().isEmpty()) {
-          checkForAllowedTypes(dv.type().trim(), varElem);
-          param.defaultValueType = dv.type();
+        if (dv.type() != null && !dv.type().getType().trim().isEmpty()) {
+          param.defaultValueType = dv.type().getType();
         }
       }
       return param;
@@ -2432,7 +2430,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
 
   private void ensureEachPair(DefaultValue dv, VariableElement ve, String type) {
     if (dv.value() != null && !dv.value().trim().isEmpty()
-        && (type.equals("dictionary") || "dictionary".equals(dv.type().trim()))) {
+        && (type.equals("dictionary") || "dictionary".equals(dv.type().getType().trim()))) {
       String[] pairs = dv.value().split(",");
       for (String pair : pairs) {
         String trimmed = pair.trim();
@@ -2441,13 +2439,6 @@ public abstract class ComponentProcessor extends AbstractProcessor {
           messager.printMessage(Kind.ERROR, "Each dictionary entry must be a 'key:value' pair. Problem found in: '" + trimmed + "'", ve);
         }
       }
-    }
-  }
-
-  private void checkForAllowedTypes(String type, VariableElement ve) {
-    List<String> allowedTypes = Arrays.asList("text", "number", "boolean", "list", "color", "dictionary");
-    if (!allowedTypes.contains(type)) {
-      messager.printMessage(Kind.ERROR, "'" + type + "' is not allowed! Allowed types are: text, number, boolean, list, color, dictionary", ve);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -2036,6 +2036,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
                     + "Please use the 'defaultValue' attribute within @DesignerProperty instead!",
                 ve);
           }
+          ensureSinglePair(dv, ve, javaTypeToYailType(typeMirror));
           property.defaultValue = dv.value();
           if (dv.type() != null && !dv.type().isEmpty()) {
             property.defaultValueType = dv.type();
@@ -2416,12 +2417,26 @@ public abstract class ComponentProcessor extends AbstractProcessor {
               "Default values cannot be assigned to Event parameters because they are values provided by the component!",
               varElem);
         }
+        ensureSinglePair(dv, varElem, javaTypeToYailType(type));
         param.defaultValue = dv.value();
         if (dv.type() != null && !dv.type().isEmpty()) {
           param.defaultValueType = dv.type();
         }
       }
       return param;
+    }
+  }
+
+  private void ensureSinglePair(DefaultValue dv, VariableElement ve, String type) {
+    if (dv.value() != null && !dv.value().isEmpty() && (type.equals("dictionary") || "dictionary".equals(dv.type()))) {
+      String[] pairs = dv.value().split(",");
+      for (String pair : pairs) {
+        String trimmed = pair.trim();
+        String[] parts = trimmed.split(":", 2);
+        if (parts.length < 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+          messager.printMessage(Kind.ERROR, "Each dictionary entry must be a 'key:value' pair. Problem found in: '" + trimmed + "'", ve);
+        }
+      }
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -59,6 +59,7 @@ import java.lang.reflect.Type;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -2036,9 +2037,10 @@ public abstract class ComponentProcessor extends AbstractProcessor {
                     + "Please use the 'defaultValue' attribute within @DesignerProperty instead!",
                 ve);
           }
-          ensureSinglePair(dv, ve, javaTypeToYailType(typeMirror));
+          ensureEachPair(dv, ve, javaTypeToYailType(typeMirror));
           property.defaultValue = dv.value();
-          if (dv.type() != null && !dv.type().isEmpty()) {
+          if (dv.type() != null && !dv.type().trim().isEmpty()) {
+            checkForAllowedTypes(dv.type().trim(), ve);
             property.defaultValueType = dv.type();
           }
         }
@@ -2417,9 +2419,10 @@ public abstract class ComponentProcessor extends AbstractProcessor {
               "Default values cannot be assigned to Event parameters because they are values provided by the component!",
               varElem);
         }
-        ensureSinglePair(dv, varElem, javaTypeToYailType(type));
+        ensureEachPair(dv, varElem, javaTypeToYailType(type));
         param.defaultValue = dv.value();
-        if (dv.type() != null && !dv.type().isEmpty()) {
+        if (dv.type() != null && !dv.type().trim().isEmpty()) {
+          checkForAllowedTypes(dv.type().trim(), varElem);
           param.defaultValueType = dv.type();
         }
       }
@@ -2427,16 +2430,24 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     }
   }
 
-  private void ensureSinglePair(DefaultValue dv, VariableElement ve, String type) {
-    if (dv.value() != null && !dv.value().isEmpty() && (type.equals("dictionary") || "dictionary".equals(dv.type()))) {
+  private void ensureEachPair(DefaultValue dv, VariableElement ve, String type) {
+    if (dv.value() != null && !dv.value().trim().isEmpty()
+        && (type.equals("dictionary") || "dictionary".equals(dv.type().trim()))) {
       String[] pairs = dv.value().split(",");
       for (String pair : pairs) {
         String trimmed = pair.trim();
         String[] parts = trimmed.split(":", 2);
-        if (parts.length < 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+        if (parts.length < 2 || parts[0].trim().isEmpty() || parts[1].trim().isEmpty()) {
           messager.printMessage(Kind.ERROR, "Each dictionary entry must be a 'key:value' pair. Problem found in: '" + trimmed + "'", ve);
         }
       }
+    }
+  }
+
+  private void checkForAllowedTypes(String type, VariableElement ve) {
+    List<String> allowedTypes = Arrays.asList("text", "number", "boolean", "list", "color", "dictionary");
+    if (!allowedTypes.contains(type)) {
+      messager.printMessage(Kind.ERROR, "'" + type + "' is not allowed! Allowed types are: text, number, boolean, list, color, dictionary", ve);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1,11 +1,12 @@
 // -*- mode: java; c-basic-offset: 2; -*-
 // Copyright 2009-2011 Google, All Rights reserved
-// Copyright 2011-2025 MIT, All rights reserved
+// Copyright 2011-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
 package com.google.appinventor.components.scripts;
 
+import com.google.appinventor.components.annotations.DefaultValue;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.IsColor;
@@ -280,6 +281,16 @@ public abstract class ComponentProcessor extends AbstractProcessor {
      * The helper key associated with this parameter, if any.
      */
     protected HelperKey helper;
+
+    /**
+     * Default value for this parameter
+     */
+    protected String defaultValue;
+
+    /**
+     * Default value type
+     */
+    protected String defaultValueType;
 
     /**
      * Constructs a Parameter.
@@ -718,6 +729,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     private String componentInfoName;
     private boolean color;
     private HelperKey helper;
+    private String defaultValue;
+    private String defaultValueType;
 
     protected Property(String name, String description, String longDescription,
         PropertyCategory category, boolean userVisible, boolean deprecated) {
@@ -804,6 +817,14 @@ public abstract class ComponentProcessor extends AbstractProcessor {
 
     protected boolean isColor() {
       return color;
+    }
+
+    protected String getDefaultValue() {
+      return defaultValue;
+    }
+
+    protected String getDefaultValueType() {
+      return defaultValueType;
     }
 
     /**
@@ -2006,6 +2027,20 @@ public abstract class ComponentProcessor extends AbstractProcessor {
         if (ve.getAnnotation(IsColor.class) != null) {
           property.color = true;
         }
+        DefaultValue dv = ve.getAnnotation(DefaultValue.class);
+        if (dv != null) {
+          boolean isDesigner = element.getAnnotation(DesignerProperty.class) != null;
+          if (isDesigner) {
+            messager.printMessage(Kind.ERROR,
+                "The @DefaultValue annotation is not allowed here because this property already uses @DesignerProperty. "
+                    + "Please use the 'defaultValue' attribute within @DesignerProperty instead!",
+                ve);
+          }
+          property.defaultValue = dv.value();
+          if (dv.type() != null && !dv.type().isEmpty()) {
+            property.defaultValueType = dv.type();
+          }
+        }
       }
     }
 
@@ -2371,6 +2406,21 @@ public abstract class ComponentProcessor extends AbstractProcessor {
       Parameter param = new Parameter(varElem.getSimpleName().toString(), type,
           varElem.getAnnotation(IsColor.class) != null);
       param.helper = elementToHelperKey(varElem, varElem.asType());
+
+      DefaultValue dv = varElem.getAnnotation(DefaultValue.class);
+      if (dv != null) {
+        Element methodElem = varElem.getEnclosingElement();
+        boolean isEvent = methodElem.getAnnotation(SimpleEvent.class) != null;
+        if (isEvent) {
+          messager.printMessage(Kind.ERROR,
+              "Default values cannot be assigned to Event parameters because they are values provided by the component!",
+              varElem);
+        }
+        param.defaultValue = dv.value();
+        if (dv.type() != null && !dv.type().isEmpty()) {
+          param.defaultValueType = dv.type();
+        }
+      }
       return param;
     }
   }


### PR DESCRIPTION
**What does this PR accomplish?**
This PR introduces the `@DefaultValue` annotation, which allows component and extension developers to attach real, editable blocks to parameters directly within the Blocks drawer.

*Description*
Currently, when a user drags a component block from the drawer, the parameter sockets are empty, which can be confusing for beginners. With this change, the component appears in the palette with a reasonable default value (e.g., a math "0" or a text "hello") already attached. This provides immediate visual guidance on the expected data type and saves the user from manually searching for basic data blocks to fill the sockets.

*Testing Guidelines*
1. Create or modify a component method/property in Java.
2. Annotate a parameter with @DefaultValue("50") for an int or @DefaultValue("#FFFFFF") for a color.
3. Build the project and open the Blocks Editor.
4. Open the component's drawer; the block should appear with the default value block already attached.
5. Drag the block into the workspace and verify the attached block remains editable and detachable.
6. Here is a demo extension:

```java
package com.jewel.defaultvaluetest;

import com.google.appinventor.components.annotations.Asset;
import com.google.appinventor.components.annotations.DefaultValue;
import com.google.appinventor.components.annotations.DesignerComponent;
import com.google.appinventor.components.annotations.DesignerProperty;
import com.google.appinventor.components.annotations.PropertyCategory;
import com.google.appinventor.components.runtime.AndroidNonvisibleComponent;
import com.google.appinventor.components.runtime.ComponentContainer;
import com.google.appinventor.components.annotations.SimpleFunction;
import com.google.appinventor.components.annotations.SimpleObject;
import com.google.appinventor.components.annotations.SimpleProperty;
import com.google.appinventor.components.runtime.util.YailDictionary;
import com.google.appinventor.components.runtime.util.YailList;
import com.google.appinventor.components.common.ComponentCategory;
import com.google.appinventor.components.common.DefaultValueType;
import com.google.appinventor.components.common.PropertyTypeConstants;
import com.jewel.defaultvaluetest.helpers.TestPriority;

@DesignerComponent(
  version = 7, 
  versionName = "1.0", 
  description = "An extension to test parameters default values.", 
  category = ComponentCategory.EXTENSION,
  nonVisible = true, 
  iconName = "aiwebres/icon.png"
)
@SimpleObject(external = true)
public class DefaultValueTest extends AndroidNonvisibleComponent {

  public DefaultValueTest(ComponentContainer container) {
    super(container.$form());
  }

  @SimpleFunction(description = "A return type method with three parameters. First parameter has default value.")
  public int MethodA(@DefaultValue("10") int firstNumber, int secondNumber, TestPriority priority) {
    System.out.println(priority.toUnderlyingValue());
    return firstNumber + secondNumber;
  }

  @SimpleFunction(description = "A void method with three parameters. Second parameter has default value.")
  public void MethodB(String text, @DefaultValue("20") int number, TestPriority priority) {
    System.out.println(text);
    System.out.println(number);
    System.out.println(priority.toUnderlyingValue());
  }

  @SimpleFunction(description = "A void method with two color parameters.")
  public void MethodC(@DefaultValue("#f70feb") int colorA, @DefaultValue("#f5bd05") int colorB) {
    System.out.println(colorA + colorB);
  }

  @SimpleFunction(description = "A void method without default values but asset.")
  public void MethodD(int number, String text, @Asset String name) {
    System.out.println(number);
    System.out.println(text);
    System.out.println(name);
  }

  @SimpleFunction(description = "A void method with default value that contains special characters.")
  public void MethodE(@DefaultValue("<hello>") String text) {
    System.out.println(text);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter without DesignerProperty but default value.")
  public void SetterA(@DefaultValue("no designer but value") String text) {
    System.out.println(text);
  }

  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXT, defaultValue = "designer setter value")
  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter with DesignerProperty.")
  public void SetterB(String text) {
    System.out.println(text);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter without DesignerProperty and no value.")
  public void SetterC(String text) {
    System.out.println(text);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter without default value but asset.")
  public void SetterD(@Asset String name) {
    System.out.println(name);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter without default value but helper.")
  public void SetterE(TestPriority priority) {
    System.out.println(priority.toUnderlyingValue());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept empty list.")
  public void SetterF(@DefaultValue YailList list) {
    System.out.println(list.toString());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept list with three arguments.")
  public void SetterG(@DefaultValue("Value1, Value2, Value3") YailList list) {
    System.out.println(list.toString());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept an empty dictionary.")
  public void SetterH(@DefaultValue YailDictionary dictionary) {
    System.out.println(dictionary.toString());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept color.")
  public void SetterI(@DefaultValue("#f7df0b") int color) {
    System.out.println(color);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept boolean.")
  public void SetterJ(@DefaultValue("False") boolean enabled) {
    System.out.println(enabled);
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept list with (number type) three arguments.")
  public void SetterK(@DefaultValue(value = "10, 20, 30", type = DefaultValueType.Number) YailList list) {
    System.out.println(list.toString());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept list with (color type) four arguments.")
  public void SetterL(@DefaultValue(value = "#eb0a0a, #23e909, #0b22f1, #f1c707", type = DefaultValueType.Color) YailList list) {
    System.out.println(list.toString());
  }

  @SimpleProperty(category = PropertyCategory.APPEARANCE, description = "A setter that accept dictionary with three pairs.")
  public void SetterM(@DefaultValue("key1:value1, key2:value2, key3:value3") YailDictionary dictionary) {
    System.out.println(dictionary.toString());
  }
}
```

7. Example output:

https://github.com/user-attachments/assets/eb7a1878-0327-471a-95c6-00784dbca13d

![default-blocks](https://github.com/user-attachments/assets/e70c7bbf-acea-4a08-a001-5f1b943d1564)

Resolves # .
#2384

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch
- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine

### **Key Changes**
* **New Annotation:** Added `@DefaultValue`  with support for `value` and an optional `type`.
* **Compiler Integration:** Updated the `ComponentProcessor` to parse these values and include them in the component descriptor JSON.
* **Blockly Editor Support:** Modified the blocklyeditor logic to recognize these default values and render the corresponding blocks (text, number, boolean, color, list, dictionary) as attached inputs in the drawer.
* **Smart Validation:** Added compiler-level checks to prevent errors:
    * **Events:** Prevents using `@DefaultValue` on Event parameters (since they are output values).
    * **Designer Properties:** Prevents conflicts by ensuring `@DesignerProperty` setters use their own `defaultValue` attribute instead.

### **Usage & Formatting**
The system automatically infers the block type from the parameter (e.g., `int` becomes a math block), but it can be manually specified for `Object` types.

* **Colors:** Use 6 digit hex format (e.g., `#FFFFFF`).
* **Lists:** Use comma-separated values (e.g., `item1, item2`).
* **Dictionaries:** Use key-value pairs (e.g., `key1:val1, key2:val2`).
* **Primitives:** Standard strings, numbers, or booleans (e.g., `100`, `hello`, `true`).

```java
@SimpleProperty
public void LedColor(@DefaultValue("#00FF00") int color) {
  // This block will now appear in the drawer with a green color block attached.
}
```