### PR TITLE
Allow reorg of components from tree (like alt+up and alt+down)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
@@ -79,6 +79,20 @@ public final class BlockSelectorBox extends Box {
     @Override
     public void delete() {
     }
+
+    @Override
+    public boolean canDrag() {
+      return false;
+    }
+
+    @Override
+    public boolean isContainer() {
+      return false;
+    }
+
+    @Override
+    public void moveTo(SourceStructureExplorerItem target, int position) {
+    }
   }
 
   // Singleton block selector box instance

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -32,6 +32,7 @@ import com.google.appinventor.client.editor.youngandroid.YaBlocksEditor;
 import com.google.appinventor.client.editor.youngandroid.YaFormEditor;
 import com.google.appinventor.client.editor.youngandroid.YaProjectEditor;
 import com.google.appinventor.client.explorer.SourceStructureExplorer;
+import com.google.appinventor.client.explorer.SourceStructureExplorerItem;
 import com.google.appinventor.client.properties.json.ClientJsonParser;
 import com.google.appinventor.client.tracking.Tracking;
 import com.google.appinventor.client.widgets.dnd.DropTarget;
@@ -698,69 +699,34 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
       return;  // Not the active editor
     }
     if (event.isAltKeyDown()) {
-      List<MockComponent> allComponents = new ArrayList<>(getComponents().values());
       MockComponent selectedComponent = root.getLastSelectedComponent();
-      int index = root.getChildren().indexOf(selectedComponent);
-
-      if (selectedComponent.isVisibleComponent()) {
-        switch (event.getNativeKeyCode()) {
-          case KeyCodes.KEY_DOWN:
-            if (index < 0) {
-              MockContainer container = selectedComponent.getContainer();
-              List<MockComponent> containerComponents = container.getChildren();
-              int indexC = containerComponents.indexOf(selectedComponent);
-              int indexOfContainer = allComponents.indexOf(container);
-              selectedComponent.getContainer().removeComponent(selectedComponent, false);
-
-              if (indexC == containerComponents.size() && container.getContainer().willAcceptComponentType(selectedComponent.getType())) {
-                container.getContainer().addVisibleComponent(selectedComponent, indexOfContainer);
-              } else {
-                container.addVisibleComponent(selectedComponent, indexC + 1);
+      if (selectedComponent != null && selectedComponent.isVisibleComponent()) {
+        MockContainer parent = selectedComponent.getContainer();
+        if (parent != null) {
+          // Snapshot sibling list before any mutation so indices are stable.
+          List<MockComponent> siblings = new ArrayList<>(parent.getChildren());
+          int posInParent = siblings.indexOf(selectedComponent);
+          SourceStructureExplorerItem source = selectedComponent.getSourceStructureExplorerItem();
+          switch (event.getNativeKeyCode()) {
+            case KeyCodes.KEY_DOWN:
+              if (posInParent < siblings.size() - 1) {
+                MockComponent next = siblings.get(posInParent + 1);
+                source.moveTo(next.getSourceStructureExplorerItem(), 1);
+              } else if (!parent.isRoot()) {
+                source.moveTo(parent.getSourceStructureExplorerItem(), 1);
               }
-            } else {
-              index++;
-              root.removeComponent(selectedComponent, false);
-              MockComponent nextComponent = allComponents.get(index + 1);
-              int nextComponentindex = root.getChildren().indexOf(nextComponent);
-              if(nextComponent instanceof MockContainer && ((MockContainer) nextComponent).willAcceptComponentType(selectedComponent.getType())) {
-                ((MockContainer)nextComponent).addVisibleComponent(selectedComponent, 0);
-              } else if (nextComponentindex < 0 && ((MockContainer) nextComponent.getContainer()).willAcceptComponentType(selectedComponent.getType())) {
-                nextComponent.getContainer().addVisibleComponent(selectedComponent, 0);
-              } else {
-                root.addVisibleComponent(selectedComponent, index);
+              break;
+            case KeyCodes.KEY_UP:
+              if (posInParent > 0) {
+                MockComponent prev = siblings.get(posInParent - 1);
+                source.moveTo(prev.getSourceStructureExplorerItem(), -1);
+              } else if (!parent.isRoot()) {
+                source.moveTo(parent.getSourceStructureExplorerItem(), -1);
               }
-            }
-            break;
-
-          case KeyCodes.KEY_UP:
-            if (index < 0) {
-              MockContainer container = selectedComponent.getContainer();
-              List<MockComponent> containerComponents = container.getChildren();
-              int indexC = containerComponents.indexOf(selectedComponent);
-              int indexOfContainer = allComponents.indexOf(container);
-              selectedComponent.getContainer().removeComponent(selectedComponent, false);
-              if (indexC == 0 && container.getContainer().willAcceptComponentType(selectedComponent.getType())) {
-                container.getContainer().addVisibleComponent(selectedComponent, indexOfContainer - 1);
-              } else {
-                container.addVisibleComponent(selectedComponent, indexC - 1);
-              }
-            } else {
-              index++;
-              root.removeComponent(selectedComponent, false);
-              MockComponent prevComponent = allComponents.get(index - 1);
-              int prevComponentIndex = root.getChildren().indexOf(prevComponent);
-              if(prevComponent instanceof MockContainer && ((MockContainer) prevComponent).willAcceptComponentType(selectedComponent.getType())) {
-                ((MockContainer)prevComponent).addVisibleComponent(selectedComponent, -1);
-              } else if (prevComponentIndex < 0 && ((MockContainer) prevComponent).willAcceptComponentType(selectedComponent.getType())) {
-                prevComponent.getContainer().addVisibleComponent(selectedComponent, -1);
-              } else {
-                root.addVisibleComponent(selectedComponent, index - 2);
-              }
-            }
-            break;
-
-          default:
-            break;
+              break;
+            default:
+              break;
+          }
         }
       }
     } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.isTextboxFocused()) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -700,7 +700,7 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
     }
     if (event.isAltKeyDown()) {
       MockComponent selectedComponent = root.getLastSelectedComponent();
-      if (selectedComponent != null && selectedComponent.isVisibleComponent()) {
+      if (selectedComponent != null) {
         MockContainer parent = selectedComponent.getContainer();
         if (parent != null) {
           // Snapshot sibling list before any mutation so indices are stable.

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1417,11 +1417,6 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
         return;
       }
 
-      // Non-visible components must remain at the root (Screen) level
-      if (!source.isVisibleComponent() && !targetContainer.isRoot()) {
-        return;
-      }
-
       // Determine target container and insertion index
       MockContainer targetContainer;
       int insertIndex;
@@ -1440,6 +1435,11 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
         }
         int targetIdx = targetContainer.getChildren().indexOf(target);
         insertIndex = (position < 0) ? targetIdx : targetIdx + 1;
+      }
+
+      // Non-visible components must remain at the root (Screen) level
+      if (!source.isVisibleComponent() && !targetContainer.isRoot()) {
+        return;
       }
 
       // Handle coordinate properties when moving to/from AbsoluteArrangement

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1417,6 +1417,11 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
         return;
       }
 
+      // Non-visible components must remain at Form (Screen) level
+      if (source instanceof MockNonVisibleComponent && !(targetContainer instanceof MockForm)) {
+        return;
+      }
+
       // Determine target container and insertion index
       MockContainer targetContainer;
       int insertIndex;
@@ -1435,11 +1440,6 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
         }
         int targetIdx = targetContainer.getChildren().indexOf(target);
         insertIndex = (position < 0) ? targetIdx : targetIdx + 1;
-      }
-
-      // Non-visible components must remain at Form (Screen) level
-      if (source instanceof MockNonVisibleComponent && !(targetContainer instanceof MockForm)) {
-        return;
       }
 
       // Handle coordinate properties when moving to/from AbsoluteArrangement

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -357,52 +357,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     COMPONENT_DATABASE = editor.getComponentDatabase();
     componentDefinition = COMPONENT_DATABASE.getComponentDefinition(type);
 
-    sourceStructureExplorerItem = new SourceStructureExplorerItem() {
-      @Override
-      public void onSelected(NativeEvent source) {
-        // are we showing the blocks editor? if so, toggle the component drawer
-        if (Ode.getInstance().getCurrentFileEditor() instanceof BlocksEditor) {
-          BlocksEditor<?, ?> blocksEditor =
-              (BlocksEditor<?, ?>) Ode.getInstance().getCurrentFileEditor();
-          LOG.info("Showing item " + getName());
-          blocksEditor.showComponentBlocks(getName());
-        } else {
-          select(source);
-        }
-      }
-
-      @Override
-      public void onStateChange(boolean open) {
-        // The user has expanded or collapsed the branch in the components tree corresponding to
-        // this component. Remember that by setting the expanded field so that when we re-build
-        // the tree, we will keep the branch in the same state.
-        expanded = open;
-      }
-
-      @Override
-      public boolean canRename() {
-        return !isRoot();
-      }
-
-      @Override
-      public void rename() {
-        if (!isRoot()) {
-          new RenameDialog(getName()).center();
-        }
-      }
-
-      @Override
-      public boolean canDelete() {
-        return !isRoot();
-      }
-
-      @Override
-      public void delete() {
-        if (!isRoot()) {
-          new DeleteDialog().center();
-        }
-      }
-    };
+    sourceStructureExplorerItem = new ComponentExplorerItem();
     expanded = true;
 
     // Create a default property set for the component
@@ -904,6 +859,12 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     };
     itemNode.setUserObject(sourceStructureExplorerItem);
 
+    // Mark non-root items as draggable for tree DnD reordering
+    if (!isRoot()) {
+      itemNode.getElement().setAttribute("draggable", "true");
+      itemNode.getElement().setAttribute("data-name", getName());
+    }
+
     // Set alt text on the icon image for accessibility
     // Use Scheduler to defer until DOM is attached
     final String altText = getName() + " " + getVisibleTypeName();
@@ -1362,5 +1323,179 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   public native boolean shouldCancel(Event event)/*-{
     return !event.shouldNotCancel;
   }-*/;
+
+  /**
+   * Implementation of {@link SourceStructureExplorerItem} for this component. Named (not
+   * anonymous) so that its type is accessible for instanceof checks in {@link #moveTo}.
+   */
+  private class ComponentExplorerItem implements SourceStructureExplorerItem {
+
+    /** Returns the {@link MockComponent} this item represents. */
+    MockComponent getMockComponent() {
+      return MockComponent.this;
+    }
+
+    @Override
+    public void onSelected(NativeEvent source) {
+      if (Ode.getInstance().getCurrentFileEditor() instanceof BlocksEditor) {
+        BlocksEditor<?, ?> blocksEditor =
+            (BlocksEditor<?, ?>) Ode.getInstance().getCurrentFileEditor();
+        LOG.info("Showing item " + getName());
+        blocksEditor.showComponentBlocks(getName());
+      } else {
+        select(source);
+      }
+    }
+
+    @Override
+    public void onStateChange(boolean open) {
+      expanded = open;
+    }
+
+    @Override
+    public boolean canRename() {
+      return !isRoot();
+    }
+
+    @Override
+    public void rename() {
+      if (!isRoot()) {
+        new RenameDialog(getName()).center();
+      }
+    }
+
+    @Override
+    public boolean canDelete() {
+      return !isRoot();
+    }
+
+    @Override
+    public void delete() {
+      if (!isRoot()) {
+        new DeleteDialog().center();
+      }
+    }
+
+    @Override
+    public boolean canDrag() {
+      return !isRoot();
+    }
+
+    @Override
+    public boolean isContainer() {
+      return MockComponent.this instanceof MockContainer;
+    }
+
+    @Override
+    public void moveTo(SourceStructureExplorerItem targetItem, int position) {
+      if (!(targetItem instanceof ComponentExplorerItem)) {
+        return;
+      }
+      MockComponent source = MockComponent.this;
+      MockComponent target = ((ComponentExplorerItem) targetItem).getMockComponent();
+
+      if (source == target) {
+        return;
+      }
+      // Cannot drop a component into one of its own descendants
+      if (isAncestorOf(source, target)) {
+        return;
+      }
+
+      // Determine target container and insertion index
+      MockContainer targetContainer;
+      int insertIndex;
+      if (position == 0) {
+        // Drop INTO target — target must be a container
+        if (!(target instanceof MockContainer)) {
+          return;
+        }
+        targetContainer = (MockContainer) target;
+        insertIndex = targetContainer.getChildren().size();
+      } else {
+        // Drop BEFORE (position < 0) or AFTER (position > 0) target
+        targetContainer = target.getContainer();
+        if (targetContainer == null) {
+          return; // target is root — can't insert before/after it
+        }
+        int targetIdx = targetContainer.getChildren().indexOf(target);
+        insertIndex = (position < 0) ? targetIdx : targetIdx + 1;
+      }
+
+      // Non-visible components must remain at Form (Screen) level
+      if (source instanceof MockNonVisibleComponent && !(targetContainer instanceof MockForm)) {
+        return;
+      }
+
+      // Handle coordinate properties when moving to/from AbsoluteArrangement
+      if (source instanceof MockVisibleComponent) {
+        MockVisibleComponent visSource = (MockVisibleComponent) source;
+        if (targetContainer instanceof MockAbsoluteArrangement) {
+          visSource.setCoordPropertiesVisible(true);
+          source.changeProperty(MockVisibleComponent.PROPERTY_NAME_LEFT, "0");
+          source.changeProperty(MockVisibleComponent.PROPERTY_NAME_TOP, "0");
+        } else {
+          visSource.setCoordPropertiesVisible(false);
+        }
+      }
+
+      // Capture same-container info before removal (removal shifts indices)
+      MockContainer sourceContainer = source.getContainer();
+      boolean sameContainer = (sourceContainer == targetContainer);
+      int sourceIdx = sameContainer ? targetContainer.getChildren().indexOf(source) : -1;
+
+      // Remove from current container (permanentlyDeleted=false: it's a move, not a delete)
+      sourceContainer.removeComponent(source, false);
+
+      // Adjust for same-container index shift caused by the removal
+      if (sameContainer && sourceIdx < insertIndex) {
+        insertIndex--;
+      }
+
+      // Re-insert at the new position
+      if (insertIndex >= targetContainer.getChildren().size()) {
+        targetContainer.addComponent(source);
+      } else {
+        targetContainer.addComponent(source, insertIndex);
+      }
+
+      // For non-visible components, rebuild the non-visible panel to match children order
+      if (source instanceof MockNonVisibleComponent) {
+        rebuildNonVisiblePanel(targetContainer);
+      }
+    }
+
+    /**
+     * Rebuilds the non-visible components panel in the order that non-visible components appear
+     * in the given container's children list.
+     */
+    private void rebuildNonVisiblePanel(MockContainer form) {
+      for (MockComponent child : form.getChildren()) {
+        if (child instanceof MockNonVisibleComponent) {
+          MockComponent.this.editor.getNonVisibleComponentsPanel().removeComponent(child);
+        }
+      }
+      for (MockComponent child : form.getChildren()) {
+        if (child instanceof MockNonVisibleComponent) {
+          MockComponent.this.editor.getNonVisibleComponentsPanel().addComponent(child);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns true if {@code ancestor} is a strict ancestor (parent, grandparent, etc.) of
+   * {@code component} in the component containment hierarchy.
+   */
+  private static boolean isAncestorOf(MockComponent ancestor, MockComponent component) {
+    MockContainer parent = component.getContainer();
+    while (parent != null) {
+      if (parent == ancestor) {
+        return true;
+      }
+      parent = parent.getContainer();
+    }
+    return false;
+  }
 
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -322,10 +322,6 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   private Image iconImage;
 
   private final SourceStructureExplorerItem sourceStructureExplorerItem;
-  /**
-   * The state of the branch in the components tree corresponding to this component.
-   */
-  protected boolean expanded;
 
   // Properties of the component
   // Expose these to individual component subclasses, which might need to
@@ -358,7 +354,6 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     componentDefinition = COMPONENT_DATABASE.getComponentDefinition(type);
 
     sourceStructureExplorerItem = new ComponentExplorerItem();
-    expanded = true;
 
     // Create a default property set for the component
     properties = new EditableProperties(true);
@@ -837,6 +832,14 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
 
     }
   };
+
+  /**
+   * Returns false if this component's tree node should start collapsed on first display.
+   * Subclasses may override; defaults to true (expanded).
+   */
+  protected boolean isInitiallyExpanded() {
+    return true;
+  }
 
   /**
    * Constructs a tree item for the component which will be displayed in the
@@ -1349,7 +1352,12 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
 
     @Override
     public void onStateChange(boolean open) {
-      expanded = open;
+      // Expansion state is now tracked by SourceStructureExplorer.
+    }
+
+    @Override
+    public boolean isInitiallyExpanded() {
+      return MockComponent.this.isInitiallyExpanded();
     }
 
     @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -722,6 +722,13 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
   public abstract boolean isVisibleComponent();
 
   /**
+   * Returns true if this component can contain child components. Overridden in MockContainer.
+   */
+  public boolean isContainer() {
+    return false;
+  }
+
+  /**
    * Selects this component in the visual editor.
    */
   public final void select(NativeEvent event) {
@@ -1391,7 +1398,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
 
     @Override
     public boolean isContainer() {
-      return MockComponent.this instanceof MockContainer;
+      return MockComponent.this.isContainer();
     }
 
     @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1417,8 +1417,8 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
         return;
       }
 
-      // Non-visible components must remain at Form (Screen) level
-      if (source instanceof MockNonVisibleComponent && !(targetContainer instanceof MockForm)) {
+      // Non-visible components must remain at the root (Screen) level
+      if (!source.isVisibleComponent() && !targetContainer.isRoot()) {
         return;
       }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -1402,44 +1402,71 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     }
 
     @Override
-    public void moveTo(SourceStructureExplorerItem targetItem, int position) {
+    public boolean canMoveTo(SourceStructureExplorerItem targetItem, int position) {
       if (!(targetItem instanceof ComponentExplorerItem)) {
+        return false;
+      }
+      MockComponent source = MockComponent.this;
+      MockComponent target = ((ComponentExplorerItem) targetItem).getMockComponent();
+      if (source == target || isAncestorOf(source, target)) {
+        return false;
+      }
+      MockContainer targetContainer;
+      int insertIndex;
+      if (position == 0) {
+        if (!(target instanceof MockContainer)) {
+          return false;
+        }
+        targetContainer = (MockContainer) target;
+        insertIndex = targetContainer.getChildren().size();
+      } else {
+        targetContainer = target.getContainer();
+        if (targetContainer == null) {
+          return false;
+        }
+        int targetIdx = targetContainer.getChildren().indexOf(target);
+        insertIndex = (position < 0) ? targetIdx : targetIdx + 1;
+      }
+      if (!source.isVisibleComponent() && !targetContainer.isRoot()) {
+        return false;
+      }
+      List<MockComponent> currentChildren = targetContainer.getChildren();
+      if (source.isVisibleComponent()) {
+        for (int i = 0; i < insertIndex && i < currentChildren.size(); i++) {
+          MockComponent sibling = currentChildren.get(i);
+          if (sibling != source && !sibling.isVisibleComponent()) {
+            return false;
+          }
+        }
+      } else {
+        for (int i = insertIndex; i < currentChildren.size(); i++) {
+          MockComponent sibling = currentChildren.get(i);
+          if (sibling != source && sibling.isVisibleComponent()) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public void moveTo(SourceStructureExplorerItem targetItem, int position) {
+      if (!canMoveTo(targetItem, position)) {
         return;
       }
       MockComponent source = MockComponent.this;
       MockComponent target = ((ComponentExplorerItem) targetItem).getMockComponent();
 
-      if (source == target) {
-        return;
-      }
-      // Cannot drop a component into one of its own descendants
-      if (isAncestorOf(source, target)) {
-        return;
-      }
-
       // Determine target container and insertion index
       MockContainer targetContainer;
       int insertIndex;
       if (position == 0) {
-        // Drop INTO target — target must be a container
-        if (!(target instanceof MockContainer)) {
-          return;
-        }
         targetContainer = (MockContainer) target;
         insertIndex = targetContainer.getChildren().size();
       } else {
-        // Drop BEFORE (position < 0) or AFTER (position > 0) target
         targetContainer = target.getContainer();
-        if (targetContainer == null) {
-          return; // target is root — can't insert before/after it
-        }
         int targetIdx = targetContainer.getChildren().indexOf(target);
         insertIndex = (position < 0) ? targetIdx : targetIdx + 1;
-      }
-
-      // Non-visible components must remain at the root (Screen) level
-      if (!source.isVisibleComponent() && !targetContainer.isRoot()) {
-        return;
       }
 
       // Handle coordinate properties when moving to/from AbsoluteArrangement

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -113,8 +113,6 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
       itemNode.addItem(childNode);
     }
 
-    itemNode.setState(expanded);
-
     return itemNode;
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -180,7 +180,7 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
    * @param beforeIndex  index at which the inserted component will reside in the children,
    *                     or {@code -1} to insert the component at the end
    */
-  private void addComponent(MockComponent component, int beforeIndex) {
+  void addComponent(MockComponent component, int beforeIndex) {
 
     // Set the container to be the parent of the component
     component.setContainer(this);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -56,11 +56,6 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
    *
    * @param editor  editor of source file the component belongs to
    */
-  @Override
-  public final boolean isContainer() {
-    return true;
-  }
-
   MockContainer(SimpleEditor editor, String type, ImageResource icon,
       MockLayout layout) {
     super(editor, type, icon);
@@ -70,6 +65,11 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
 
     children = new ArrayList<MockComponent>();
     rootPanel = new AbsolutePanel();
+  }
+
+  @Override
+  public final boolean isContainer() {
+    return true;
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockContainer.java
@@ -56,6 +56,11 @@ public abstract class MockContainer extends MockVisibleComponent implements Drop
    *
    * @param editor  editor of source file the component belongs to
    */
+  @Override
+  public final boolean isContainer() {
+    return true;
+  }
+
   MockContainer(SimpleEditor editor, String type, ImageResource icon,
       MockLayout layout) {
     super(editor, type, icon);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -175,13 +175,12 @@ public abstract class MockVisibleComponent extends MockComponent {
   }
 
   private void setVisibleProperty(String text) {
-    boolean visible = Boolean.parseBoolean(text);
-    if (!visible && !editor.isLoadComplete()) {
-      // As we are loading the scm file and encounter a visble property being set to false, set the
-      // expanded field to false. This will make that branch of the components tree initially
-      // collapsed.
-      expanded = false;
-    }
+  }
+
+  @Override
+  protected boolean isInitiallyExpanded() {
+    String visible = properties.getPropertyValue("Visible");
+    return visible == null || !visible.equalsIgnoreCase("false");
   }
 
   // PropertyChangeListener implementation

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -50,8 +50,10 @@ import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Label;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
 
@@ -80,6 +82,11 @@ public class SourceStructureExplorer extends Composite {
   private int hoverPosition = 0;
   /** Absolutely-positioned div injected into the scroll panel as the drop indicator. */
   private Element indicatorDiv;
+
+  /** Names of components that the user has explicitly collapsed in the tree. */
+  private final Set<String> collapsedNames = new HashSet<>();
+  /** Names of components whose initial expansion state has already been determined. */
+  private final Set<String> seenNames = new HashSet<>();
   /** True when the indicator is currently showing as a box (drop-into); false for a line. */
   private boolean indicatorIsBox = false;
 
@@ -119,10 +126,13 @@ public class SourceStructureExplorer extends Composite {
       public void onClose(CloseEvent<TreeItem> event) {
         TreeItem treeItem = event.getTarget();
         if (treeItem != null) {
+          String name = treeItem.getElement().getAttribute("data-name");
+          if (name != null && !name.isEmpty()) {
+            collapsedNames.add(name);
+          }
           Object userObject = treeItem.getUserObject();
           if (userObject instanceof SourceStructureExplorerItem) {
-            SourceStructureExplorerItem item = (SourceStructureExplorerItem) userObject;
-            item.onStateChange(false);
+            ((SourceStructureExplorerItem) userObject).onStateChange(false);
           }
         }
       }
@@ -132,10 +142,13 @@ public class SourceStructureExplorer extends Composite {
       public void onOpen(OpenEvent<TreeItem> event) {
         TreeItem treeItem = event.getTarget();
         if (treeItem != null) {
+          String name = treeItem.getElement().getAttribute("data-name");
+          if (name != null && !name.isEmpty()) {
+            collapsedNames.remove(name);
+          }
           Object userObject = treeItem.getUserObject();
           if (userObject instanceof SourceStructureExplorerItem) {
-            SourceStructureExplorerItem item = (SourceStructureExplorerItem) userObject;
-            item.onStateChange(true);
+            ((SourceStructureExplorerItem) userObject).onStateChange(true);
           }
         }
       }
@@ -457,6 +470,7 @@ public class SourceStructureExplorer extends Composite {
     tree.clear();
     nameToItem.clear();
     for (TreeItem root : roots) {
+      applyExpansionState(root);  // before addItem so setState doesn't trigger animation
       tree.addItem(root);
       collectNameToItem(root);
     }
@@ -531,6 +545,26 @@ public class SourceStructureExplorer extends Composite {
     }
     for (int i = 0; i < item.getChildCount(); i++) {
       collectNameToItem(item.getChild(i));
+    }
+  }
+
+  /**
+   * Recursively applies expansion state to freshly built tree items.
+   * Items whose data-name is in {@link #collapsedNames} are closed; all others are opened.
+   */
+  private void applyExpansionState(TreeItem item) {
+    String name = item.getElement().getAttribute("data-name");
+    if (name != null && !name.isEmpty() && !seenNames.contains(name)) {
+      seenNames.add(name);
+      Object userObj = item.getUserObject();
+      if (userObj instanceof SourceStructureExplorerItem
+          && !((SourceStructureExplorerItem) userObj).isInitiallyExpanded()) {
+        collapsedNames.add(name);
+      }
+    }
+    item.setState(name == null || name.isEmpty() || !collapsedNames.contains(name));
+    for (int i = 0; i < item.getChildCount(); i++) {
+      applyExpansionState(item.getChild(i));
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -8,7 +8,19 @@ package com.google.appinventor.client.explorer;
 
 import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.widgets.TextButton;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.DragEndEvent;
+import com.google.gwt.event.dom.client.DragEndHandler;
+import com.google.gwt.event.dom.client.DragLeaveEvent;
+import com.google.gwt.event.dom.client.DragLeaveHandler;
+import com.google.gwt.event.dom.client.DragOverEvent;
+import com.google.gwt.event.dom.client.DragOverHandler;
+import com.google.gwt.event.dom.client.DragStartEvent;
+import com.google.gwt.event.dom.client.DragStartHandler;
+import com.google.gwt.event.dom.client.DropEvent;
+import com.google.gwt.event.dom.client.DropHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -25,6 +37,7 @@ import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.OpenEvent;
 import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.aria.client.Roles;
 
@@ -36,7 +49,9 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Label;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import static com.google.appinventor.client.Ode.MESSAGES;
 
@@ -50,8 +65,23 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 public class SourceStructureExplorer extends Composite {
   // UI elements
   private final EventCaptureTree tree;
+  private ScrollPanel scrollPanel;
   private final TextButton renameButton;
   private final TextButton deleteButton;
+
+  // Drag-and-drop state
+  /** Maps component name → SourceStructureExplorerItem; rebuilt on every tree update. */
+  private final Map<String, SourceStructureExplorerItem> nameToItem = new HashMap<>();
+  /** Name of the component currently being dragged, or null if no drag is in progress. */
+  private String draggingName = null;
+  /** Name of the component currently hovered as a drop target, or null if none. */
+  private String hoverName = null;
+  /** Current drop position relative to the hover target: -1=before, 0=into, 1=after. */
+  private int hoverPosition = 0;
+  /** Absolutely-positioned div injected into the scroll panel as the drop indicator. */
+  private Element indicatorDiv;
+  /** True when the indicator is currently showing as a box (drop-into); false for a line. */
+  private boolean indicatorIsBox = false;
 
   /**
    * This is a hack to work around the fact that for multiselect we need to have
@@ -160,12 +190,145 @@ public class SourceStructureExplorer extends Composite {
       @Override
       public void onMouseUp(MouseUpEvent event) {
         tree.setFocus(true);
-      } 
+      }
     });
 
+    // drag-and-drop for component tree reordering
+    tree.addBitlessDomHandler(new DragStartHandler() {
+      @Override
+      public void onDragStart(DragStartEvent event) {
+        Element target = event.getNativeEvent().getEventTarget().cast();
+        String name = findDataName(target);
+        if (name == null) {
+          event.getNativeEvent().preventDefault();
+          return;
+        }
+        SourceStructureExplorerItem item = nameToItem.get(name);
+        if (item == null || !item.canDrag()) {
+          event.getNativeEvent().preventDefault();
+          return;
+        }
+        draggingName = name;
+        initDragTransfer(event.getNativeEvent(), name);
+      }
+    }, DragStartEvent.getType());
+
+    tree.addBitlessDomHandler(new DragOverHandler() {
+      @Override
+      public void onDragOver(DragOverEvent event) {
+        if (draggingName == null) {
+          return;
+        }
+        event.getNativeEvent().preventDefault(); // required to allow drop
+        setDropEffect(event.getNativeEvent(), "move");
+
+        Element target = event.getNativeEvent().getEventTarget().cast();
+        Element nameEl = findDataNameElement(target);
+        if (nameEl == null) {
+          hideIndicator();
+          hoverName = null;
+          return;
+        }
+
+        String targetName = nameEl.getAttribute("data-name");
+        if (targetName.equals(draggingName)) {
+          hideIndicator();
+          hoverName = null;
+          return;
+        }
+
+        SourceStructureExplorerItem targetItem = nameToItem.get(targetName);
+        if (targetItem == null) {
+          hideIndicator();
+          hoverName = null;
+          return;
+        }
+
+        // Compute drop position from mouse Y relative to the item row
+        int mouseY = event.getNativeEvent().getClientY();
+        int elTop = nameEl.getAbsoluteTop();
+        int elHeight = nameEl.getOffsetHeight();
+        if (elHeight == 0) {
+          elHeight = 20; // fallback
+        }
+        int relY = mouseY - elTop;
+
+        int position;
+        if (targetItem.isContainer()) {
+          // Three zones: top third = before, middle = into, bottom third = after
+          if (relY < elHeight / 3) {
+            position = -1;
+          } else if (relY > 2 * elHeight / 3) {
+            position = 1;
+          } else {
+            position = 0;
+          }
+        } else {
+          // Two zones: top half = before, bottom half = after
+          position = (relY < elHeight / 2) ? -1 : 1;
+        }
+
+        // Update visual indicator
+        hoverName = targetName;
+        hoverPosition = position;
+        showIndicator(nameEl, position);
+      }
+    }, DragOverEvent.getType());
+
+    tree.addBitlessDomHandler(new DragLeaveHandler() {
+      @Override
+      public void onDragLeave(DragLeaveEvent event) {
+        // Only clear the highlight when the pointer leaves the tree entirely
+        Element relatedTarget = getRelatedTarget(event.getNativeEvent());
+        if (relatedTarget == null || !tree.getElement().isOrHasChild(relatedTarget)) {
+          hideIndicator();
+          hoverName = null;
+        }
+      }
+    }, DragLeaveEvent.getType());
+
+    tree.addBitlessDomHandler(new DropHandler() {
+      @Override
+      public void onDrop(DropEvent event) {
+        event.getNativeEvent().preventDefault();
+        event.getNativeEvent().stopPropagation();
+        if (draggingName != null && hoverName != null) {
+          SourceStructureExplorerItem source = nameToItem.get(draggingName);
+          SourceStructureExplorerItem target = nameToItem.get(hoverName);
+          if (source != null && target != null) {
+            source.moveTo(target, hoverPosition);
+          }
+        }
+        clearDragState();
+      }
+    }, DropEvent.getType());
+
+    tree.addBitlessDomHandler(new DragEndHandler() {
+      @Override
+      public void onDragEnd(DragEndEvent event) {
+        clearDragState();
+      }
+    }, DragEndEvent.getType());
+
     // Put a ScrollPanel around the tree.
-    ScrollPanel scrollPanel = new ScrollPanel(tree);
+    scrollPanel = new ScrollPanel(tree);
     scrollPanel.setStyleName("ode-SourceScrollPanel");
+    // The scroll panel must be position:relative so the absolute indicator div is contained within it.
+    scrollPanel.getElement().getStyle().setProperty("position", "relative");
+
+    // Create a dedicated drop indicator div, injected into the scroll panel.
+    // Initialised in line mode (matches indicatorIsBox = false).
+    indicatorDiv = Document.get().createDivElement();
+    indicatorDiv.getStyle().setProperty("position",     "absolute");
+    indicatorDiv.getStyle().setProperty("pointerEvents","none");
+    indicatorDiv.getStyle().setProperty("display",      "none");
+    indicatorDiv.getStyle().setProperty("zIndex",       "1000");
+    indicatorDiv.getStyle().setProperty("left",         "0");
+    indicatorDiv.getStyle().setProperty("width",        "100%");
+    indicatorDiv.getStyle().setProperty("height",       "2px");
+    indicatorDiv.getStyle().setProperty("background",   "#4285F4");
+    indicatorDiv.getStyle().setProperty("border",       "none");
+    scrollPanel.getElement().appendChild(indicatorDiv);
 
     HorizontalPanel buttonPanel = new HorizontalPanel();
     buttonPanel.setStyleName("ode-PanelButtons");
@@ -292,8 +455,10 @@ public class SourceStructureExplorer extends Composite {
    */
   public void updateTree(TreeItem[] roots, SourceStructureExplorerItem itemToSelect) {
     tree.clear();
+    nameToItem.clear();
     for (TreeItem root : roots) {
       tree.addItem(root);
+      collectNameToItem(root);
     }
     if (itemToSelect != null) {
       selectItem(itemToSelect, true);
@@ -351,4 +516,124 @@ public class SourceStructureExplorer extends Composite {
   public Tree getTree() {
     return tree;
   }
+
+  /** Recursively walks a TreeItem hierarchy and populates {@link #nameToItem}. */
+  private void collectNameToItem(TreeItem item) {
+    if (item == null) {
+      return;
+    }
+    String name = item.getElement().getAttribute("data-name");
+    if (name != null && !name.isEmpty()) {
+      Object userObject = item.getUserObject();
+      if (userObject instanceof SourceStructureExplorerItem) {
+        nameToItem.put(name, (SourceStructureExplorerItem) userObject);
+      }
+    }
+    for (int i = 0; i < item.getChildCount(); i++) {
+      collectNameToItem(item.getChild(i));
+    }
+  }
+
+  /** Hides the drop indicator div. */
+  private void hideIndicator() {
+    indicatorDiv.getStyle().setProperty("display", "none");
+  }
+
+  /**
+   * Positions and shows the drop indicator div relative to {@code target}.
+   * For position 0 (drop-into): draws a dashed outline box around the element.
+   * For position -1/1 (before/after): draws a 2px horizontal line above or below the element.
+   */
+  private void showIndicator(Element target, int position) {
+    int elAbsTop     = target.getAbsoluteTop();
+    int panelAbsTop  = scrollPanel.getElement().getAbsoluteTop();
+    int scrollTop    = scrollPanel.getElement().getScrollTop();
+
+    if (position == 0) {
+      // Box mode: outline around the target element
+      if (!indicatorIsBox) {
+        indicatorDiv.getStyle().setProperty("height",     "");
+        indicatorDiv.getStyle().setProperty("left",       "");
+        indicatorDiv.getStyle().setProperty("background", "transparent");
+        indicatorDiv.getStyle().setProperty("border",     "2px dashed #4285F4");
+        indicatorIsBox = true;
+      }
+      int panelAbsLeft = scrollPanel.getElement().getAbsoluteLeft();
+      indicatorDiv.getStyle().setProperty("top",    (elAbsTop - panelAbsTop + scrollTop) + "px");
+      indicatorDiv.getStyle().setProperty("left",   (target.getAbsoluteLeft() - panelAbsLeft) + "px");
+      indicatorDiv.getStyle().setProperty("width",  target.getOffsetWidth()  + "px");
+      indicatorDiv.getStyle().setProperty("height", target.getOffsetHeight() + "px");
+    } else {
+      // Line mode: 2px horizontal bar above or below the target element
+      if (indicatorIsBox) {
+        indicatorDiv.getStyle().setProperty("left",       "0");
+        indicatorDiv.getStyle().setProperty("width",      "100%");
+        indicatorDiv.getStyle().setProperty("height",     "2px");
+        indicatorDiv.getStyle().setProperty("background", "#4285F4");
+        indicatorDiv.getStyle().setProperty("border",     "none");
+        indicatorIsBox = false;
+      }
+      int lineY = elAbsTop - panelAbsTop + scrollTop + (position > 0 ? target.getOffsetHeight() : 0);
+      indicatorDiv.getStyle().setProperty("top", lineY + "px");
+    }
+    indicatorDiv.getStyle().setProperty("display", "block");
+  }
+
+  /** Clears all drag state (called on drop or dragend). */
+  private void clearDragState() {
+    draggingName = null;
+    hoverName = null;
+    hoverPosition = 0;
+    hideIndicator();
+  }
+
+  /**
+   * Walks up the DOM from {@code el} and returns the first element that has a
+   * {@code data-name} attribute, or {@code null} if none is found before body.
+   */
+  private static native String findDataName(Element el) /*-{
+    var current = el;
+    while (current && current.tagName && current.tagName.toLowerCase() !== 'body') {
+      var n = current.getAttribute ? current.getAttribute('data-name') : null;
+      if (n) return n;
+      current = current.parentElement;
+    }
+    return null;
+  }-*/;
+
+  /**
+   * Walks up the DOM from {@code el} and returns the first element that has a
+   * {@code data-name} attribute, or {@code null} if none is found before body.
+   */
+  private static native Element findDataNameElement(Element el) /*-{
+    var current = el;
+    while (current && current.tagName && current.tagName.toLowerCase() !== 'body') {
+      var n = current.getAttribute ? current.getAttribute('data-name') : null;
+      if (n) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }-*/;
+
+  /** Returns the {@code relatedTarget} of a drag/mouse event, or {@code null}. */
+  private static native Element getRelatedTarget(NativeEvent event) /*-{
+    return event.relatedTarget || null;
+  }-*/;
+
+  /** Sets {@code dataTransfer.dropEffect} on a native drag event. */
+  private static native void setDropEffect(NativeEvent event, String effect) /*-{
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = effect;
+    }
+  }-*/;
+
+  /** Sets the drag transfer data so the browser shows a "move" cursor. */
+  private static native void initDragTransfer(NativeEvent event, String data) /*-{
+    if (event.dataTransfer) {
+      try {
+        event.dataTransfer.setData('text/plain', data);
+        event.dataTransfer.effectAllowed = 'move';
+      } catch (e) { }
+    }
+  }-*/;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorer.java
@@ -281,6 +281,14 @@ public class SourceStructureExplorer extends Composite {
           position = (relY < elHeight / 2) ? -1 : 1;
         }
 
+        // Suppress indicator for positions that would be rejected by canMoveTo
+        SourceStructureExplorerItem sourceItem = nameToItem.get(draggingName);
+        if (sourceItem == null || !sourceItem.canMoveTo(targetItem, position)) {
+          hideIndicator();
+          hoverName = null;
+          return;
+        }
+
         // Update visual indicator
         hoverName = targetName;
         hoverPosition = position;

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
@@ -62,4 +62,12 @@ public interface SourceStructureExplorerItem {
    *                 be a container), 1 to insert after target
    */
   void moveTo(SourceStructureExplorerItem target, int position);
+
+  /**
+   * Returns false if this item should start collapsed the first time it appears in the tree.
+   * Defaults to true (expanded).
+   */
+  default boolean isInitiallyExpanded() {
+    return true;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
@@ -43,4 +43,23 @@ public interface SourceStructureExplorerItem {
    * Invoked when the source structure explorer's Delete button is clicked.
    */
   void delete();
+
+  /**
+   * Returns true if this item can be dragged to reorder it in the tree.
+   */
+  boolean canDrag();
+
+  /**
+   * Returns true if this item is a container that can receive child components.
+   */
+  boolean isContainer();
+
+  /**
+   * Moves this item relative to the given target.
+   *
+   * @param target the drop target item
+   * @param position -1 to insert before target, 0 to insert as last child of target (target must
+   *                 be a container), 1 to insert after target
+   */
+  void moveTo(SourceStructureExplorerItem target, int position);
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/SourceStructureExplorerItem.java
@@ -55,6 +55,17 @@ public interface SourceStructureExplorerItem {
   boolean isContainer();
 
   /**
+   * Returns true if this item can be moved to the given position relative to target.
+   * Used to suppress the drop indicator for invalid positions during drag-over.
+   *
+   * @param target the candidate drop target
+   * @param position -1 before, 0 into (last child), 1 after
+   */
+  default boolean canMoveTo(SourceStructureExplorerItem target, int position) {
+    return true;
+  }
+
+  /**
    * Moves this item relative to the given target.
    *
    * @param target the drop target item


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
There is a shortcut (alt+up or alt+down) to move components in the tree and reorganise them. This PR adds mouse drag and drop with visual cues. See image:

![dndtree](https://github.com/user-attachments/assets/99c7fce0-ad87-4032-8966-47494a171ebe)

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
See image above but basically just drag components in the tree to see them get reorganised in the designer. It is a UX improvement (in my opinion!).

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
