### PR TITLE
Fix #709: Enable horizontal scrolling for long filenames in Media panel

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
@@ -71,6 +71,8 @@ public class AssetList extends Composite implements ProjectChangeListener {
 
     panel = new VerticalPanel();
     panel.setWidth("100%");
+    // Enable horizontal scrolling for long filenames instead of truncating them
+    panel.getElement().getStyle().setOverflowX(com.google.gwt.dom.client.Style.Overflow.AUTO);
 
     panel.add(assetList);
 
@@ -138,12 +140,9 @@ public class AssetList extends Composite implements ProjectChangeListener {
         // Add the name to the tree. We need to enclose it in a span
         // because the CSS style for selection specifies a span.
         String nodeName = node.getName();
-        if (nodeName.length() > 20)
-          nodeName = nodeName.substring(0, 8) + "..." + nodeName.substring(nodeName.length() - 9,
-              nodeName.length());
 
         String fileSuffix = node.getProjectId() + "/" + node.getFileId();
-        String treeItemText = "<span style='cursor: pointer'>";
+        String treeItemText = "<span style='cursor: pointer; white-space: nowrap;'>";
         if (StorageUtil.isImageFile(fileSuffix)) {
           treeItemText += new Image(images.mediaIconImg());
         } else if (StorageUtil.isAudioFile(fileSuffix )) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*

This PR fixes issue #709 by preventing long filenames in the Media panel from being truncated.

Previously, filenames were shortened for display, which caused confusion and incorrect usage when users copied them into blocks.

This change enables horizontal scrolling in the Media panel so that full filenames remain visible without truncation.

The solution:
- Removes reliance on truncation for long filenames
- Applies horizontal scrolling (`overflow-x: auto`) to the container
- Ensures filenames remain on a single line using `white-space: nowrap`
- Preserves existing layout behavior

This aligns with the suggested approach in the issue discussion.

*Testing Guidelines*

1. Open MIT App Inventor
2. Navigate to the Media panel in any project
3. Upload files with long filenames
4. Verify that:
   - Filenames are NOT truncated
   - A horizontal scrollbar appears when needed
   - Full filenames are visible upon scrolling
   - No layout breakage occurs

Fixes #709

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
