### PR TITLE
Fix SpeechRecognizer lifecycle to prevent overlapping sessions and in…

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
@@ -69,6 +69,15 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
   private boolean useLegacy = true;
 
   private String language = "";
+  
+  // --- Lifecycle state management ---
+  private enum RecognizerState {
+    IDLE,
+    LISTENING
+  }
+
+  private RecognizerState state = RecognizerState.IDLE;
+  private long lastStartTime = 0;
 
   /**
    * Creates a SpeechRecognizer component.
@@ -148,9 +157,25 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
       });
       return;
     }
+    
+    long now = System.currentTimeMillis();
+
+    // debounce rapid calls
+    if (now - lastStartTime < 300) {
+      return;
+    }
+
+    // prevent overlapping sessions
+    if (state != RecognizerState.IDLE) {
+      return;
+    }
+    lastStartTime = now;
+
     BeforeGettingText();
     speechRecognizerController.addListener(this);
     speechRecognizerController.start();
+
+    state = RecognizerState.LISTENING;
   }
 
   /**
@@ -161,9 +186,15 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
    */
   @SimpleFunction
   public void Stop() {
+    if (state == RecognizerState.IDLE) {
+      return;
+    }
+
     if (speechRecognizerController != null) {
       speechRecognizerController.stop();
     }
+
+    state = RecognizerState.IDLE;
   }
 
   /**
@@ -203,6 +234,7 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
    */
   @Override
   public void onResult(String text) {
+    state = RecognizerState.IDLE;
     result = text;
     AfterGettingText(result, false);
   }
@@ -212,6 +244,12 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
    */
   @Override
   public void onError(int errorNumber) {
+    state = RecognizerState.IDLE;
+
+    // Ignore NO_MATCH (not a real failure)
+    if (errorNumber == 3806) {
+      return;
+    }
     String functionName = "GetText";
     form.dispatchErrorOccurredEvent(this, functionName, errorNumber);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
@@ -246,10 +246,6 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
   public void onError(int errorNumber) {
     state = RecognizerState.IDLE;
 
-    // Ignore NO_MATCH (not a real failure)
-    if (errorNumber == 3806) {
-      return;
-    }
     String functionName = "GetText";
     form.dispatchErrorOccurredEvent(this, functionName, errorNumber);
   }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
This PR fixes lifecycle/state management issues in the Speech Recognizer component

Previously:
- Multiple GetText() calls could start overlapping recognition sessions
- Calling Stop() when the recognizer was not active could lead to errors
- The recognizer state was not reset consistently after completion or error
- Rapid repeated calls could cause unstable behavior

This PR introduces a minimal internal state (IDLE / LISTENING) to ensure valid transitions and prevent overlapping sessions. A small debounce is also added to guard against rapid repeated calls.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
The changes were tested using the MIT App Inventor Companion with the following scenarios:
- Rapid repeated GetText() calls (no overlapping sessions observed)
- Continuous recognition loop (restart after final result works correctly)
- Normal speech flow across multiple utterances
- Calling Stop() during active and inactive states
- Silence / no speech scenarios (handled gracefully without crashes)
- Repeated cycles (5–10+) without degradation or stuck states
- No crashes or unexpected behavior were observed.
<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3825 .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

This change affects the runtime component (SpeechRecognizer), but it is a minimal internal bug fix with no API or user-facing changes, so targeting the master branch is appropriate instead of ucr.

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:
- [ ] I have made no changes that affect the master branch
- [X] I branched from `master`
- [X] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [X] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [X] Indentation has been doubled checked
    - [X] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine master branch.