### PR TITLE
Fix: Resolve extension property descriptions in Designer using metada…

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -623,6 +623,45 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     properties.addProperty(name, defaultValue, ComponentTranslationTable.getPropertyName(caption),
         ComponentTranslationTable.getCategoryName(category),  propertyDesc, editor, propertyType, editorType, editorArgs);
   }
+  
+  /**
+   * Extended version of addProperty to support extension metadata descriptions.
+   * Falls back to metadata when translation lookup fails.
+   */
+  public final void addProperty(String name, String defaultValue, String caption, String category,
+                               String editorType, String[] editorArgs, String description, PropertyEditor editor) {
+
+    String propertyDesc = ComponentTranslationTable.getPropertyDescription(name 
+      + "PropertyDescriptions");
+
+    // Step 1: component-specific lookup
+    if (propertyDesc.equals(name + "PropertyDescriptions")) {
+      propertyDesc = ComponentTranslationTable.getPropertyDescription(
+          (type.equals("Form") ? "Screen" : type) + "." + name + "PropertyDescriptions");
+    }
+
+    // Step 2: fallback for extensions
+    if ((propertyDesc.equals(name + "PropertyDescriptions") ||
+        propertyDesc.equals((type.equals("Form") ? "Screen" : type) + "." + name + "PropertyDescriptions"))
+        && description != null) {
+
+      propertyDesc = description;
+    }
+
+    int propertyType = EditableProperty.TYPE_NORMAL;
+    if (!isPropertyPersisted(name)) {
+      propertyType |= EditableProperty.TYPE_NONPERSISTED;
+    }
+    if (!isPropertyVisible(name)) {
+      propertyType |= EditableProperty.TYPE_INVISIBLE;
+    }
+    if (isPropertyforYail(name)) {
+      propertyType |= EditableProperty.TYPE_DOYAIL;
+    }
+
+    properties.addProperty(name,defaultValue,ComponentTranslationTable.getPropertyName(caption),
+        ComponentTranslationTable.getCategoryName(category), propertyDesc, editor, propertyType, editorType, editorArgs);
+  }
 
   /**
    * Returns the component name.

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -599,9 +599,10 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    * @param editorType  editor type for the property
    * @param editorArgs  additional editor arguments
    * @param editor  property editor
+   * @param description property description for use in the ui. Used as a fallback when no translation is found.
    */
   public final void addProperty(String name, String defaultValue, String caption, String category,
-                                String editorType, String[] editorArgs, PropertyEditor editor) {
+                                String editorType, String[] editorArgs, PropertyEditor editor, String description) {
 
     String propertyDesc = ComponentTranslationTable.getPropertyDescription(name
       + "PropertyDescriptions");
@@ -609,38 +610,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       propertyDesc = ComponentTranslationTable.getPropertyDescription((type.equals("Form")
           ? "Screen" : type) + "." + propertyDesc);
     }
-
-    int propertyType = EditableProperty.TYPE_NORMAL;
-    if (!isPropertyPersisted(name)) {
-      propertyType |= EditableProperty.TYPE_NONPERSISTED;
-    }
-    if (!isPropertyVisible(name)) {
-      propertyType |= EditableProperty.TYPE_INVISIBLE;
-    }
-    if (isPropertyforYail(name)) {
-      propertyType |= EditableProperty.TYPE_DOYAIL;
-    }
-    properties.addProperty(name, defaultValue, ComponentTranslationTable.getPropertyName(caption),
-        ComponentTranslationTable.getCategoryName(category),  propertyDesc, editor, propertyType, editorType, editorArgs);
-  }
-  
-  /**
-   * Extended version of addProperty to support extension metadata descriptions.
-   * Falls back to metadata when translation lookup fails.
-   */
-  public final void addProperty(String name, String defaultValue, String caption, String category,
-                               String editorType, String[] editorArgs, String description, PropertyEditor editor) {
-
-    String propertyDesc = ComponentTranslationTable.getPropertyDescription(name 
-      + "PropertyDescriptions");
-
-    // Step 1: component-specific lookup
-    if (propertyDesc.equals(name + "PropertyDescriptions")) {
-      propertyDesc = ComponentTranslationTable.getPropertyDescription(
-          (type.equals("Form") ? "Screen" : type) + "." + name + "PropertyDescriptions");
-    }
-
-    // Step 2: fallback for extensions
+    // Fallback for extension metadata
     if ((propertyDesc.equals(name + "PropertyDescriptions") ||
         propertyDesc.equals((type.equals("Form") ? "Screen" : type) + "." + name + "PropertyDescriptions"))
         && description != null) {
@@ -658,11 +628,10 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
     if (isPropertyforYail(name)) {
       propertyType |= EditableProperty.TYPE_DOYAIL;
     }
-
-    properties.addProperty(name,defaultValue,ComponentTranslationTable.getPropertyName(caption),
-        ComponentTranslationTable.getCategoryName(category), propertyDesc, editor, propertyType, editorType, editorArgs);
+    properties.addProperty(name, defaultValue, ComponentTranslationTable.getPropertyName(caption),
+        ComponentTranslationTable.getCategoryName(category),  propertyDesc, editor, propertyType, editorType, editorArgs);
   }
-
+  
   /**
    * Returns the component name.
    * <p>
@@ -1339,7 +1308,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
             (DesignerEditor<?, ?, ?, ?, ?>) editor, property.getEditorArgs());
         addProperty(property.getName(), property.getDefaultValue(), property.getCaption(),
             property.getCategory(), property.getEditorType(),
-            property.getEditorArgs(), propertyEditor);
+            property.getEditorArgs(), propertyEditor, null);
       }
     }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockForm.java
@@ -762,10 +762,10 @@ public final class MockForm extends MockDesignerRoot implements DesignerRootComp
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + PORTRAIT_WIDTH, null,
         "Appearance", PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
-        new YoungAndroidLengthPropertyEditor());
+        new YoungAndroidLengthPropertyEditor(), null);
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, null,
         "Appearance", PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
-        new YoungAndroidLengthPropertyEditor());
+        new YoungAndroidLengthPropertyEditor(), null);
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -135,19 +135,19 @@ public abstract class MockVisibleComponent extends MockComponent {
     // Add standard per-child layout properties
     // NOTE: Not all layouts use these properties
     addProperty(PROPERTY_NAME_COLUMN, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        null, "Appearance", new TextPropertyEditor());
+        null, "Appearance", null, new TextPropertyEditor(), null);
     addProperty(PROPERTY_NAME_ROW, "" + ComponentConstants.DEFAULT_ROW_COLUMN, null,
-        null, "Appearance", new TextPropertyEditor());
+        null, "Appearance", null, new TextPropertyEditor(), null);
     addWidthHeightProperties();
   }
 
   protected void addWidthHeightProperties() {
     addProperty(PROPERTY_NAME_WIDTH, "" + LENGTH_PREFERRED, MESSAGES.widthPropertyCaption(),
         "Appearance", PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
-        new YoungAndroidLengthPropertyEditor());
+        new YoungAndroidLengthPropertyEditor(), null);
     addProperty(PROPERTY_NAME_HEIGHT, "" + LENGTH_PREFERRED, MESSAGES.heightPropertyCaption(),
         "Appearance", PropertyTypeConstants.PROPERTY_TYPE_LENGTH, null,
-        new YoungAndroidLengthPropertyEditor());
+        new YoungAndroidLengthPropertyEditor(), null);
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -137,9 +137,9 @@ public class PropertiesUtil {
     // Configure properties
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefinitions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
-          property.getCaption(), property.getCategory(), property.getEditorType(), property.getEditorArgs(),property.getDescription(),
+          property.getCaption(), property.getCategory(), property.getEditorType(), property.getEditorArgs(),
           PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), editor,
-          property.getEditorArgs()));
+          property.getEditorArgs()), property.getDescription());
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "
           + TranslationComponentProperty.getName(property.getCaption()));*/
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -137,7 +137,7 @@ public class PropertiesUtil {
     // Configure properties
     for (ComponentDatabaseInterface.PropertyDefinition property : propertyDefinitions) {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
-          property.getCaption(), property.getCategory(), property.getEditorType(), property.getEditorArgs(),
+          property.getCaption(), property.getCategory(), property.getEditorType(), property.getEditorArgs(),property.getDescription(),
           PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), editor,
           property.getEditorArgs()));
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "


### PR DESCRIPTION

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
*Description*

This PR fixes an issue where property descriptions for extension components are not displayed correctly in the Designer. Instead of showing human-readable text, raw translation keys (e.g., `Component.PropertyDescriptions`) are displayed.

The root cause is that the current implementation assumes all property descriptions exist in the translation table, which is not true for extension components. Extension descriptions are provided via metadata but are not passed through the existing pipeline.

This PR introduces a safe fallback mechanism:
- First, attempt to resolve the description using the existing translation lookup (unchanged behavior)
- If lookup fails, fallback to the description provided by the extension metadata

To maintain backward compatibility, an overloaded `addProperty` method is introduced without modifying existing call sites.

This ensures correct behavior for both built-in and extension components.
<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

1. Start App Inventor locally (`ant run`)
2. Create a new project
3. Add an extension component (.aix file)
4. In Designer, hover over a property of the extension:
   - Before fix: shows raw key (e.g., `Component.PropertyDescriptions`)
   - After fix: shows readable description
5. Verify built-in components still display correct property descriptions

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3569 .

**Context for the changes**
This change only affects the Designer (appengine) and does not impact the companion or runtime behavior.

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [X] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch
- [X] I branched from `master`
- [X] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [X] My code follows the:
    - [X] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [X] Indentation has been doubled checked
    - [X] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
