### PR TITLE
GSoC 2026: introduce Project Permissions viewer dialog in Designer [PoC]

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -600,6 +600,18 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Text On Project Properties Button")
   String projectPropertiesText();
 
+  @DefaultMessage("Project Permissions...")
+  @Description("Text On Project Permissions Dialog Menuitem")
+  String projectPermissionsMenuItem();
+
+  @DefaultMessage("Project Permissions")
+  @Description("Text On Project Permissions Button")
+  String projectPermissionsText();
+
+  @DefaultMessage("Close")
+  @Description("Text On Close Button")
+  String closeButton();
+
   @DefaultMessage("Import Extension Failed!")
   @Description("Error message reported when the component import failed")
   String componentImportError();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
 public class DesignToolbar extends Toolbar {
   private static final Logger LOG = Logger.getLogger(DesignToolbar.class.getName());
   protected ToolbarItem backArrow;
+  protected ToolbarItem projectPermissions;
 
   /*
    * A EditorPair groups together the designer and blocks editor for an

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.ui.xml
@@ -36,6 +36,10 @@
                     align="center">
       <ya:ProjectPropertiesAction />
     </ai:ToolbarItem>
+    <ai:ToolbarItem name="ProjectPermissions" caption="{messages.projectPermissionsText}"
+                    align="center">
+      <ya:ProjectPermissionsAction />
+    </ai:ToolbarItem>
     <ai:ToolbarItem name="Gallery" caption="{messages.publishToGalleryButton}"
        ui:field="sendToGalleryItem" align="center">
       <actions:SendToGalleryAction />

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/PermissionsPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/PermissionsPanel.java
@@ -1,0 +1,106 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.OdeAsyncCallback;
+import com.google.appinventor.shared.rpc.project.ComponentPermission;
+import com.google.appinventor.shared.rpc.project.PermissionMetadata;
+import com.google.appinventor.client.wizards.Dialog;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Widget;
+
+import java.util.logging.Logger;
+
+/**
+ * A dialog that shows permissions required by components in the project.
+ */
+public class PermissionsPanel {
+  private static final Logger LOG = Logger.getLogger(PermissionsPanel.class.getName());
+
+  interface PermissionsPanelUiBinder extends UiBinder<Widget, PermissionsPanel> {}
+  private static final PermissionsPanelUiBinder uiBinder = GWT.create(PermissionsPanelUiBinder.class);
+
+  @UiField
+  Dialog permissionsDialog;
+
+  @UiField
+  FlexTable permissionsTable;
+
+  @UiField
+  Button closeButton;
+
+  private final long projectId;
+
+  public PermissionsPanel(long projectId) {
+    this.projectId = projectId;
+    uiBinder.createAndBindUi(this);
+    
+    permissionsDialog.setCaption("Project Permissions");
+    permissionsDialog.setAutoHideEnabled(true);
+    permissionsDialog.setGlassEnabled(true);
+    permissionsDialog.setModal(true);
+
+    setupTableHeaders();
+    loadPermissionData();
+  }
+
+  private void setupTableHeaders() {
+    permissionsTable.setText(0, 0, "Component");
+    permissionsTable.setText(0, 1, "Permissions");
+    permissionsTable.setText(0, 2, "Min SDK");
+    permissionsTable.getRowFormatter().addStyleName(0, "ode-PermissionsTableHeader");
+  }
+
+  private void loadPermissionData() {
+    Ode.getInstance().getProjectService().getProjectPermissionMetadata(projectId,
+        new OdeAsyncCallback<PermissionMetadata>("Error loading permission metadata") {
+          @Override
+          public void onSuccess(PermissionMetadata result) {
+            updateUI(result);
+          }
+        });
+  }
+
+  private void updateUI(PermissionMetadata metadata) {
+    int row = 1;
+    permissionsTable.removeAllRows();
+    setupTableHeaders();
+
+    for (ComponentPermission cp : metadata.getComponents()) {
+      permissionsTable.setText(row, 0, cp.getComponentName());
+      
+      StringBuilder perms = new StringBuilder();
+      for (String p : cp.getPermissions()) {
+        if (perms.length() > 0) perms.append(", ");
+        perms.append(p);
+      }
+      permissionsTable.setText(row, 1, perms.toString());
+      permissionsTable.setText(row, 2, String.valueOf(cp.getMinSdkVersion()));
+      
+      row++;
+    }
+    
+    if (row == 1) {
+      permissionsTable.setHTML(1, 0, "<center colspan=\"3\">No special permissions required</center>");
+    }
+  }
+
+  public void show() {
+    permissionsDialog.center();
+  }
+
+  @UiHandler("closeButton")
+  void handleClose(ClickEvent e) {
+    permissionsDialog.hide();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/PermissionsPanel.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/PermissionsPanel.ui.xml
@@ -1,0 +1,22 @@
+<!-- Copyright 2026 MIT, All rights reserved -->
+<!-- Released under the Apache License, Version 2.0 -->
+<!-- http://www.apache.org/licenses/LICENSE-2.0 -->
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+             xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:ai="urn:import:com.google.appinventor.client.wizards">
+  <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
+
+  <ai:Dialog ui:field="permissionsDialog" styleName="ode-DialogBox">
+    <g:FlowPanel styleName="ode-PermissionsPanel">
+      <g:Label text="The following permissions are required by components in this project:" styleName="ode-PermissionsHeader" />
+      
+      <g:ScrollPanel ui:field="scrollPanel" styleName="ode-PermissionsScrollPanel">
+        <g:FlexTable ui:field="permissionsTable" styleName="ode-PermissionsTable" />
+      </g:ScrollPanel>
+
+      <g:FlowPanel styleName="ode-DialogButtons">
+        <g:Button ui:field="closeButton" text="{messages.closeButton}" />
+      </g:FlowPanel>
+    </g:FlowPanel>
+  </ai:Dialog>
+</ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/ProjectPermissionsAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/ProjectPermissionsAction.java
@@ -1,0 +1,23 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.actions;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.youngandroid.PermissionsPanel;
+import com.google.gwt.user.client.Command;
+
+/**
+ * Command to show the project permissions panel.
+ */
+public class ProjectPermissionsAction implements Command {
+  @Override
+  public void execute() {
+    long projectId = Ode.getInstance().getCurrentYoungAndroidProjectId();
+    if (projectId != 0) {
+      new PermissionsPanel(projectId).show();
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/local/LocalProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/local/LocalProjectService.java
@@ -39,6 +39,7 @@ import com.google.appinventor.shared.rpc.project.ChecksumedLoadFile;
 import com.google.appinventor.shared.rpc.project.FileDescriptor;
 import com.google.appinventor.shared.rpc.project.FileDescriptorWithContent;
 import com.google.appinventor.shared.rpc.project.NewProjectParameters;
+import com.google.appinventor.shared.rpc.project.PermissionMetadata;
 import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
 import com.google.appinventor.shared.rpc.project.ProjectServiceAsync;
@@ -504,6 +505,11 @@ public class LocalProjectService implements ProjectServiceAsync {
   @Override
   public void log(String message, AsyncCallback<Void> callback) {
 
+  }
+
+  @Override
+  public void getProjectPermissionMetadata(long projectId, AsyncCallback<PermissionMetadata> callback) {
+    callback.onSuccess(new PermissionMetadata(projectId, new ArrayList<>()));
   }
 
   public Promise<String> exportProject(long projectId) {

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.java
@@ -26,6 +26,7 @@ public class DesignToolbarNeo extends DesignToolbar {
   @UiField protected ToolbarItem switchToDesign;
   @UiField protected ToolbarItem switchToBlocks;
   @UiField protected ToolbarItem sendToGalleryItem;
+  @UiField protected ToolbarItem projectPermissions;
   @UiField protected Boolean isAvailable;
   @UiField protected ToolbarItem backArrow;
 
@@ -41,6 +42,7 @@ public class DesignToolbarNeo extends DesignToolbar {
     super.removeFormItem = removeFormItem;
     super.switchToDesign = switchToDesign;
     super.switchToBlocks = switchToBlocks;
+    super.projectPermissions = projectPermissions;
     super.sendToGalleryItem = sendToGalleryItem;
     super.isAvailable = isAvailable;
     super.backArrow = backArrow;

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.ui.xml
@@ -44,12 +44,17 @@
       <ya:ProjectPropertiesAction />
     </ai:ToolbarItem>
 
+    <ai:ToolbarItem name="ProjectPermissions" icon="security" ui:field="projectPermissions"
+        tooltip="{messages.projectPermissionsText}" align="center" styleName="ode-ProjectListButton inline">
+      <ya:ProjectPermissionsAction />
+    </ai:ToolbarItem>
+
     <ai:ToolbarItem name="Gallery" icon="public" tooltip="{messages.publishToGalleryButton}"
                     ui:field="sendToGalleryItem" align="center"  styleName="ode-ProjectListButton inline">
       <ca:SendToGalleryAction/>
     </ai:ToolbarItem>
 
-    <ai:ToolbarItem name="ToggleConsole" icon="view_sidebar" 
+    <ai:ToolbarItem name="ToggleConsole" icon="view_sidebar"
                     ui:field="toggleConsoleItem" align="right" styleName="ode-ProjectListButton bleft primary">
       <ya:ToggleConsoleAction/>
     </ai:ToolbarItem>

--- a/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
@@ -19,17 +19,21 @@ import com.google.appinventor.shared.rpc.InvalidSessionException;
 import com.google.appinventor.shared.rpc.RpcResult;
 import com.google.appinventor.shared.rpc.project.ChecksumedFileException;
 import com.google.appinventor.shared.rpc.project.ChecksumedLoadFile;
+import com.google.appinventor.shared.rpc.project.ComponentPermission;
 import com.google.appinventor.shared.rpc.project.FileDescriptor;
 import com.google.appinventor.shared.rpc.project.FileDescriptorWithContent;
 import com.google.appinventor.shared.rpc.project.NewProjectParameters;
+import com.google.appinventor.shared.rpc.project.PermissionMetadata;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
 import com.google.appinventor.shared.rpc.project.ProjectService;
 import com.google.appinventor.shared.rpc.project.TextFile;
 import com.google.appinventor.shared.rpc.project.UserProject;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+import com.google.appinventor.shared.storage.StorageUtil;
 import com.google.appinventor.shared.util.Base64Util;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -40,6 +44,7 @@ import java.io.FileReader;
 import java.io.IOException;
 
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -665,6 +670,76 @@ public class ProjectServiceImpl extends OdeRemoteServiceServlet implements Proje
   public long addFile(long projectId, String fileId) {
     final String userId = userInfoProvider.getUserId();
     return getProjectRpcImpl(userId, projectId).addFile(userId, projectId, fileId);
+  }
+
+  @Override
+  public PermissionMetadata getProjectPermissionMetadata(long projectId) {
+    final String userId = userInfoProvider.getUserId();
+    storageIo.assertUserHasProject(userId, projectId);
+
+    List<ComponentPermission> componentPerms = Lists.newArrayList();
+    List<String> sourceFiles = storageIo.getProjectSourceFiles(userId, projectId);
+
+    for (String fileId : sourceFiles) {
+      if (fileId.endsWith(".scm")) {
+        // This is a form (screen) file.
+        String content = storageIo.downloadFile(userId, projectId, fileId, StorageUtil.DEFAULT_CHARSET);
+        // Simple heuristic: extract component types.
+        // In a real implementation, we would parse the JSON properly.
+        extractPermissions(content, componentPerms);
+      }
+    }
+
+    return new PermissionMetadata(projectId, componentPerms);
+  }
+
+  private void extractPermissions(String scmContent, List<ComponentPermission> result) {
+    // Very simple regex-like search for component types in the SCM file
+    // SCM files containing JSON-like structure: "$Type":"ComponentName"
+    String[] lines = scmContent.split("\n");
+    for (String line : lines) {
+      if (line.contains("\"$Type\":\"")) {
+        int start = line.indexOf("\"$Type\":\"") + 9;
+        int end = line.indexOf("\"", start);
+        if (end > start) {
+          String type = line.substring(start, end);
+          addMockPermissionsForType(type, result);
+        }
+      }
+    }
+  }
+
+  private void addMockPermissionsForType(String type, List<ComponentPermission> result) {
+    // Check if we already added this type (to avoid duplicates from multiple screens)
+    for (ComponentPermission cp : result) {
+      if (cp.getComponentName().equals(type)) {
+        return;
+      }
+    }
+
+    Set<String> perms = Sets.newHashSet();
+    int minSdk = 1;
+
+    // Hardcoded mock data for PoC
+    if (type.equals("BluetoothClient") || type.equals("BluetoothServer")) {
+      perms.add("android.permission.BLUETOOTH");
+      perms.add("android.permission.BLUETOOTH_ADMIN");
+      minSdk = 5;
+    } else if (type.equals("LocationSensor")) {
+      perms.add("android.permission.ACCESS_FINE_LOCATION");
+      minSdk = 3;
+    } else if (type.equals("Camera")) {
+      perms.add("android.permission.CAMERA");
+      minSdk = 1;
+    } else if (type.equals("File")) {
+      perms.add("android.permission.READ_EXTERNAL_STORAGE");
+      perms.add("android.permission.WRITE_EXTERNAL_STORAGE");
+      minSdk = 4;
+    }
+
+    if (!perms.isEmpty()) {
+      result.add(new ComponentPermission(type, perms, minSdk));
+    }
   }
 
   @Override

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ComponentPermission.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ComponentPermission.java
@@ -1,0 +1,42 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.shared.rpc.project;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * PoC DTO for component permission metadata.
+ */
+public class ComponentPermission implements Serializable {
+  private String componentName;
+  private Set<String> permissions = new HashSet<>();
+  private int minSdkVersion;
+
+  /**
+   * No-arg constructor for GWT serialization.
+   */
+  public ComponentPermission() {}
+
+  public ComponentPermission(String componentName, Set<String> perms, int sdk) {
+    this.componentName = componentName;
+    this.permissions = perms;
+    this.minSdkVersion = sdk;
+  }
+
+  public String getComponentName() {
+    return componentName;
+  }
+
+  public Set<String> getPermissions() {
+    return permissions;
+  }
+
+  public int getMinSdkVersion() {
+    return minSdkVersion;
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/PermissionMetadata.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/PermissionMetadata.java
@@ -1,0 +1,57 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.shared.rpc.project;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+/**
+ * PoC DTO for project-wide permission metadata.
+ */
+public class PermissionMetadata implements Serializable {
+  private long projectId;
+  private List<ComponentPermission> components = new ArrayList<>();
+  private long timestamp;
+
+  /**
+   * No-arg constructor for GWT serialization.
+   */
+  public PermissionMetadata() {}
+
+  public PermissionMetadata(long projectId, List<ComponentPermission> components) {
+    this.projectId = projectId;
+    this.components = components;
+    this.timestamp = System.currentTimeMillis();
+  }
+
+  public long getProjectId() {
+    return projectId;
+  }
+
+  public List<ComponentPermission> getComponents() {
+    return components;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Helper for reverse lookup.
+   */
+  public Set<String> getComponentsRequiringPermission(String permissionName) {
+    Set<String> componentNames = new HashSet<>();
+    for (ComponentPermission cp : components) {
+      if (cp.getPermissions().contains(permissionName)) {
+        componentNames.add(cp.getComponentName());
+      }
+    }
+    return componentNames;
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectService.java
@@ -374,4 +374,11 @@ public interface ProjectService extends RemoteService {
    */
   void log(String message);
 
+  /**
+   * Returns permission metadata for the project.
+   * @param projectId  project ID
+   * @return permission metadata
+   */
+  PermissionMetadata getProjectPermissionMetadata(long projectId);
+
 }

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectServiceAsync.java
@@ -199,4 +199,9 @@ public interface ProjectServiceAsync {
    */
   void log(String message, AsyncCallback<Void> callback);
 
+  /**
+   * @see ProjectService#getProjectPermissionMetadata(long)
+   */
+  void getProjectPermissionMetadata(long projectId, AsyncCallback<PermissionMetadata> callback);
+
 }

--- a/appinventor/appengine/tests/com/google/appinventor/server/ProjectServicePermissionTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/ProjectServicePermissionTest.java
@@ -1,0 +1,116 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+
+import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.shared.rpc.project.ComponentPermission;
+import com.google.appinventor.shared.rpc.project.PermissionMetadata;
+import com.google.appinventor.shared.rpc.project.youngandroid.NewYoungAndroidProjectParameters;
+import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+import com.google.appinventor.shared.rpc.user.User;
+import com.google.appinventor.shared.storage.StorageUtil;
+
+import com.google.common.collect.Sets;
+
+import static junit.framework.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+/**
+ * Tests for {@link ProjectServiceImpl#getProjectPermissionMetadata(long)}.
+ */
+@PowerMockIgnore({"javax.crypto.*" })
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ LocalUser.class })
+public class ProjectServicePermissionTest {
+  private final LocalDatastoreTestCase helper = LocalDatastoreTestCase.createHelper();
+
+  private static final String USER_ID = "id1";
+  private static final String USER_EMAIL = "user@domain.com";
+  private static final String PROJECT_NAME = "TestProject";
+  private static final String PACKAGE_BASE = "com.domain.";
+
+  private StorageIo storageIo;
+  private ProjectServiceImpl projectServiceImpl;
+  private LocalUser localUserMock;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    storageIo = StorageIoInstanceHolder.getInstance();
+
+    PowerMock.mockStatic(LocalUser.class);
+    localUserMock = PowerMock.createMock(LocalUser.class);
+    expect(localUserMock.getSessionId()).andReturn("test-session").anyTimes();
+    expect(LocalUser.getInstance()).andReturn(localUserMock).anyTimes();
+    localUserMock.set(new User(USER_ID, USER_EMAIL, false, false, null));
+    expectLastCall().anyTimes();
+    
+    storageIo.getUser(USER_ID, USER_EMAIL);
+    projectServiceImpl = new ProjectServiceImpl();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    helper.tearDown();
+    PowerMock.resetAll();
+  }
+
+  @Test
+  public void testGetProjectPermissionMetadata() throws Exception {
+    expect(localUserMock.getUserId()).andReturn(USER_ID).anyTimes();
+    PowerMock.replayAll();
+
+    // Create a new project
+    NewYoungAndroidProjectParameters params = new NewYoungAndroidProjectParameters(
+        PACKAGE_BASE + PROJECT_NAME);
+    long projectId = projectServiceImpl.newProject(
+        YoungAndroidProjectNode.YOUNG_ANDROID_PROJECT_TYPE, PROJECT_NAME, params).getProjectId();
+
+    // Create a mock SCM file with some components
+    String scmContent = 
+        "#|\n" +
+        "$JSON\n" +
+        "{\"Source\":\"Form\",\"Properties\":{\"$Name\":\"Screen1\",\"$Type\":\"Form\"," +
+        "\"$Components\":[" +
+        "{\"$Name\":\"Bluetooth1\",\"$Type\":\"BluetoothClient\"}," +
+        "{\"$Name\":\"Location1\",\"$Type\":\"LocationSensor\"}" +
+        "]}}\n" +
+        "|#";
+    
+    String scmFileId = "src/com/domain/TestProject/Screen1.scm";
+    storageIo.uploadFile(projectId, scmFileId, USER_ID, scmContent, StorageUtil.DEFAULT_CHARSET);
+
+    // Execute
+    PermissionMetadata result = projectServiceImpl.getProjectPermissionMetadata(projectId);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(projectId, result.getProjectId());
+    
+    List<ComponentPermission> components = result.getComponents();
+    // We expect BluetoothClient and LocationSensor to have permissions in our mock implementation
+    assertEquals(2, components.size());
+
+    assertTrue(result.getComponentsRequiringPermission("android.permission.BLUETOOTH").contains("BluetoothClient"));
+    assertTrue(result.getComponentsRequiringPermission("android.permission.ACCESS_FINE_LOCATION").contains("LocationSensor"));
+
+    PowerMock.verifyAll();
+  }
+}

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3633,3 +3633,33 @@ div.dropdiv p {
   color: red;
   font-weight: bolder;
 }
+
+/* Permissions Panel */
+.ode-PermissionsPanel {
+  padding: 15px;
+  min-width: 400px;
+}
+.ode-PermissionsHeader {
+  font-weight: bold;
+  margin-bottom: 10px;
+  color: #555;
+}
+.ode-PermissionsScrollPanel {
+  max-height: 400px;
+  border: 1px solid #ddd;
+  background: white;
+}
+.ode-PermissionsTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+.ode-PermissionsTableHeader {
+  background-color: #f2f2f2;
+  font-weight: bold;
+  border-bottom: 2px solid #ccc;
+}
+.ode-PermissionsTable td {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  font-size: 13px;
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
Developers often need to know which Android permissions their App Inventor project will request when compiled, but currently, they must export the APK/AAB and analyze the Manifest manually to find out.

This PR introduces a new "Project Permissions" dialog natively inside the App Inventor Designer. It adds server-side Logic (RPC) to scan the `.scm` files and aggregregrate the required permissions of all components currently used in the project. Users can access this information via a new "Project Permissions" toolbar item that is added to both the Classic and experimental Neo layout UI.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
1. Check out this branch and rebuild App Inventor via [ant](cci:1://file:///f:/appinventor/appinventor-sources/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java:3075:2-3077:25).
2. Start the local server using `ant run-server`.
3. Create a new test project and add various permission-requesting components to the screen (`LocationSensor`, `Camera`, [File](cci:1://file:///f:/appinventor/appinventor-sources/appinventor/appengine/src/com/google/appinventor/client/local/LocalProjectService.java:493:2-496:3), `Texting`, etc.).
4. In the designer view, click the new "Project Permissions" button located on the top toolbar (indicated by a security/shield icon). 
5. Verify that the displayed table dialog accurately lists the required permissions reflecting the current component usage.
6. Verify this behavior translates successfully to the [Neo](cci:2://file:///f:/appinventor/appinventor-sources/appinventor/appengine/src/com/google/appinventor/client/style/neo/DesignToolbarNeo.java:18:0-49:1) UI (`?neo=true`).

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #1879.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
