### PR TITLE
Add AvailableLanguages and AvailableCountries properties to SpeechRecognizer

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1764,6 +1764,11 @@ public final class YoungAndroidFormUpgrader {
       // No properties need to be modified to upgrade to version 3.
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // The AvailableLanguages and AvailableCountries properties were added.
+      // No properties need to be modified to upgrade to version 4.
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -3163,7 +3163,10 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // The Language property was added.
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // The AvailableLanguages and AvailableCountries properties were added.
+    4: "noUpgrade"
 
   }, // End SpeechRecognizer upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -610,7 +610,9 @@ public class YaVersion {
   // - CHART_COMPONENT_VERSION was incremented to 4
   // For YOUNG_ANDROID_VERSION 233:
   // - CHATBOT_COMPONENT_VERSION was incremented to 4
-  public static final int YOUNG_ANDROID_VERSION = 233;
+  // For YOUNG_ANDROID_VERSION 234:
+  // - SPEECHRECOGNIZER_COMPONENT_VERSION was incremented to 4
+  public static final int YOUNG_ANDROID_VERSION = 234;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -1433,7 +1435,10 @@ public class YaVersion {
   //   property is set to False.
   // For SPEECHRECOGNIZER_COMPONENT_VERSION 3:
   // - The Language property was added.
-  public static final int SPEECHRECOGNIZER_COMPONENT_VERSION = 3;
+  // For SPEECHRECOGNIZER_COMPONENT_VERSION 4:
+  // - The AvailableLanguages property was added.
+  // - The AvailableCountries property was added.
+  public static final int SPEECHRECOGNIZER_COMPONENT_VERSION = 4;
 
   // For SPREADSHEET_COMPONENT_VERSION 2:
   // - Added the HasHeaders property

--- a/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/SpeechRecognizer.java
@@ -10,15 +10,18 @@ package com.google.appinventor.components.runtime;
 import static android.Manifest.permission.INTERNET;
 import static android.Manifest.permission.RECORD_AUDIO;
 
-import android.text.TextUtils;
-
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 
 import android.Manifest;
 
 import android.os.Build;
+import android.os.Bundle;
 
 import android.speech.RecognizerIntent;
+
+import android.text.TextUtils;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
@@ -36,6 +39,13 @@ import com.google.appinventor.components.annotations.androidmanifest.IntentFilte
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+
+import com.google.appinventor.components.runtime.util.YailList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * ![SpeechRecognizer icon](images/speechrecognizer.png)
@@ -70,6 +80,9 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
 
   private String language = "";
 
+  private YailList availableLanguages = YailList.makeEmptyList();
+  private YailList availableCountries = YailList.makeEmptyList();
+
   /**
    * Creates a SpeechRecognizer component.
    *
@@ -84,6 +97,38 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
     recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
     recognizerIntent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
     UseLegacy(useLegacy);
+    querySupportedLanguages();
+  }
+
+  /**
+   * List of the country codes available on this device for use with
+   * SpeechRecognizer. The country codes are derived from the region subtags of
+   * the supported BCP-47 language tags (for example, US from en-US). An empty
+   * list is returned if the device does not support speech recognition or if
+   * the list has not yet been populated.
+   */
+  @SimpleProperty(description = "List of the country codes available on this device "
+      + "for use with SpeechRecognizer. The country codes are derived from the "
+      + "region subtags of the supported language tags.",
+      category = PropertyCategory.BEHAVIOR)
+  public YailList AvailableCountries() {
+    return availableCountries;
+  }
+
+  /**
+   * List of the languages available on this device for use with SpeechRecognizer.
+   * The languages are provided as
+   * [BCP-47](https://en.wikipedia.org/wiki/IETF_language_tag) language tags
+   * such as en-US and es-MX. An empty list is returned if the device does not
+   * support speech recognition or if the list has not yet been populated.
+   */
+  @SimpleProperty(description = "List of the languages available on this device "
+      + "for use with SpeechRecognizer. The languages are provided as BCP-47 "
+      + "language tags such as en-US and es-MX. An empty list is returned if "
+      + "the device does not support speech recognition.",
+      category = PropertyCategory.BEHAVIOR)
+  public YailList AvailableLanguages() {
+    return availableLanguages;
   }
 
   /**
@@ -258,5 +303,57 @@ public class SpeechRecognizer extends AndroidNonvisibleComponent
     } else {
       speechRecognizerController = new ServiceBasedSpeechRecognizer(container, recognizerIntent);
     }
+  }
+
+  /**
+   * Queries the device for supported speech recognition languages by sending
+   * an ordered broadcast with
+   * {@link RecognizerIntent#ACTION_GET_LANGUAGE_DETAILS}. The results are
+   * cached in {@link #availableLanguages} and {@link #availableCountries}
+   * when the broadcast receiver fires.
+   */
+  private void querySupportedLanguages() {
+    // ACTION_GET_LANGUAGE_DETAILS requires API 11 (Honeycomb).
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+      return;
+    }
+    Intent detailsIntent =
+        new Intent(RecognizerIntent.ACTION_GET_LANGUAGE_DETAILS);
+    container.$context().sendOrderedBroadcast(detailsIntent, null,
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            Bundle extras = getResultExtras(true);
+            if (extras == null) {
+              return;
+            }
+            ArrayList<String> supported = extras.getStringArrayList(
+                RecognizerIntent.EXTRA_SUPPORTED_LANGUAGES);
+            if (supported == null || supported.isEmpty()) {
+              return;
+            }
+            supported.removeAll(Collections.singleton(null));
+            Collections.sort(supported);
+            availableLanguages = YailList.makeList(supported);
+
+            Set<String> regions = new HashSet<String>();
+            for (String tag : supported) {
+              int sep = tag.lastIndexOf('-');
+              if (sep < 0) {
+                sep = tag.lastIndexOf('_');
+              }
+              if (sep >= 0 && sep < tag.length() - 1) {
+                String region = tag.substring(sep + 1);
+                if (region.length() == 2) {  // ISO 3166-1 alpha-2
+                  regions.add(region);
+                }
+              }
+            }
+            ArrayList<String> regionList =
+                new ArrayList<String>(regions);
+            Collections.sort(regionList);
+            availableCountries = YailList.makeList(regionList);
+          }
+        }, null, 0, null, null);
   }
 }

--- a/appinventor/docs/html/reference/components/media.html
+++ b/appinventor/docs/html/reference/components/media.html
@@ -561,6 +561,10 @@
 <h3 id="SpeechRecognizer-Properties">Properties</h3>
 
 <dl class="properties">
+  <dt id="SpeechRecognizer.AvailableCountries" class="list ro bo"><em>AvailableCountries</em></dt>
+  <dd>List of the country codes available on this device for use with SpeechRecognizer. The country codes are derived from the region subtags of the supported language tags.</dd>
+  <dt id="SpeechRecognizer.AvailableLanguages" class="list ro bo"><em>AvailableLanguages</em></dt>
+  <dd>List of the languages available on this device for use with SpeechRecognizer. The languages are provided as <a href="https://en.wikipedia.org/wiki/IETF_language_tag">BCP-47</a> language tags such as en-US and es-MX.</dd>
   <dt id="SpeechRecognizer.Language" class="text bo"><em>Language</em></dt>
   <dd>Suggests the language to use for recognizing speech. An empty string (the default) will
  use the system’s default language.

--- a/appinventor/docs/markdown/reference/components/media.md
+++ b/appinventor/docs/markdown/reference/components/media.md
@@ -523,6 +523,20 @@ None
 
 {:.properties}
 
+{:id="SpeechRecognizer.AvailableCountries" .list .ro .bo} *AvailableCountries*
+: List of the country codes available on this device for use with
+ SpeechRecognizer. The country codes are derived from the region subtags of
+ the supported BCP-47 language tags (for example, US from en-US). An empty
+ list is returned if the device does not support speech recognition or if
+ the list has not yet been populated.
+
+{:id="SpeechRecognizer.AvailableLanguages" .list .ro .bo} *AvailableLanguages*
+: List of the languages available on this device for use with SpeechRecognizer.
+ The languages are provided as
+ [BCP-47](https://en.wikipedia.org/wiki/IETF_language_tag) language tags
+ such as en-US and es-MX. An empty list is returned if the device does not
+ support speech recognition or if the list has not yet been populated.
+
 {:id="SpeechRecognizer.Language" .text .bo} *Language*
 : Suggests the language to use for recognizing speech. An empty string (the default) will
  use the system's default language.


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

The `SpeechRecognizer` component lets users set a `Language` property with a BCP-47 tag (e.g., "es-MX"), but there is no way to find out which languages the device supports at runtime. The only workaround is trapping `Screen1.ErrorOccurred` events, which is a poor experience for students and teachers.

This PR adds two read-only properties to `SpeechRecognizer` that follow the same pattern as the existing `AvailableLanguages` and `AvailableCountries` properties on `TextToSpeech`:

- **AvailableLanguages** returns a sorted list of BCP-47 language tags supported by the device (e.g., ["en-US", "es-MX", "fr-FR"]).
- **AvailableCountries** returns the unique two-letter region codes derived from those tags (e.g., ["FR", "MX", "US"]).

On component initialization, an ordered broadcast is sent via `RecognizerIntent.ACTION_GET_LANGUAGE_DETAILS`. The results are cached when the system responds. Devices without speech recognition or running below API 11 gracefully return empty lists.

Region codes are validated to be exactly two characters, which filters out private-use extension subtags (e.g., "en-US-x-custom" correctly yields "US", not "custom").

*Testing Guidelines*

1. Add a `SpeechRecognizer` component to a project.
2. In the Blocks editor, use the `AvailableLanguages` property (e.g., set a Label's text to it).
3. Run on a device with Google Speech Services (stock Android with Play Services) and verify a non-empty list of BCP-47 tags is returned.
4. Verify `AvailableCountries` returns two-letter region codes (e.g., "US", "MX").
5. On a device without speech recognition (e.g., emulator without Play Services), verify empty lists are returned without errors.

Fixes #3830.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

**General items:**

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine