### PR TITLE
git commit -m "Fix #3661: Fix block workspace gestures not working"

### DIFF
--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -973,41 +973,65 @@ Blockly.BlocklyEditor['create'] = function(container, formName, readOnly, rtl) {
       // Thrown if we've already registered the CSS. This should only happen in unit tests.
     }
   }
-  var options = {
-    'toolbox': {
-      'kind': 'flyoutToolbox',
-      'contents': []
-    },
-    'readOnly': readOnly,
-    'rtl': rtl,
-    'collapse': true,
+ var options = {
+  'toolbox': {
+    'kind': 'flyoutToolbox',
+    'contents': []
+  },
+  'readOnly': readOnly,
+  'rtl': rtl,
+  'collapse': true,
+  'scrollbars': true,
+
+  'move': {
     'scrollbars': true,
-    'trashcan': true,
-    'comments': true,
-    'disable': true,
-    'media': './static/media/',
-    'grid': {'spacing': '20', 'length': '5', 'snap': false, 'colour': '#ccc'},
-    'zoom': {'controls': true, 'wheel': true, 'scaleSpeed': 1.1, 'maxScale': 3, 'minScale': 0.1},
-    plugins: {
-      blockDragger: ScrollBlockDragger,
-      metricsManager: ScrollMetricsManager,
-      connectionPreviewer: decoratePreviewer(Blockly.InsertionMarkerPreviewer),
-      [Blockly.registry.Type.CONNECTION_CHECKER]: 'CustomizableConnectionChecker',
-    },
-    useDoubleClick: true,
-    bumpNeighbours: true,
-    multiselectIcon: {
-      hideIcon: false,
-      enabledIcon: 'static/images/select.svg',
-      disabledIcon: 'static/images/unselect.svg',
-    },
-    multiselectCopyPaste: {
-      crossTab: true,
-      menu: true,
-    },
-    renderer: 'geras2_renderer',
-  };
+    'drag': true,
+    'wheel': true
+  },
+
+  'trashcan': true,
+  'comments': true,
+  'disable': true,
+  'media': './static/media/',
+  'grid': {'spacing': '20', 'length': '5', 'snap': false, 'colour': '#ccc'},
+
+  'zoom': {
+    'controls': true,
+    'wheel': true,
+    'pinch': true,
+    'scaleSpeed': 1.1,
+    'maxScale': 3,
+    'minScale': 0.1
+  },
+
+  plugins: {
+    blockDragger: ScrollBlockDragger,
+    metricsManager: ScrollMetricsManager,
+    connectionPreviewer: decoratePreviewer(Blockly.InsertionMarkerPreviewer),
+    [Blockly.registry.Type.CONNECTION_CHECKER]: 'CustomizableConnectionChecker',
+  },
+
+  useDoubleClick: true,
+  bumpNeighbours: true,
+  multiselectIcon: {
+    hideIcon: false,
+    enabledIcon: 'static/images/select.svg',
+    disabledIcon: 'static/images/unselect.svg',
+  },
+  multiselectCopyPaste: {
+    crossTab: true,
+    menu: true,
+  },
+  renderer: 'geras2_renderer',
+};
   var workspace = Blockly.inject(container, options);
+  container.addEventListener("touchstart", function(e) {
+  e.preventDefault();
+}, { passive: false });
+
+container.addEventListener("touchmove", function(e) {
+  e.preventDefault();
+}, { passive: false });
   AI.Blockly.multiselect = Multiselect;
   var multiselectPlugin = new AI.Blockly.multiselect(workspace);
   multiselectPlugin.init(options);


### PR DESCRIPTION
### What does this PR accomplish?

Fixes the issue where block workspace gestures (drag, pan, zoom) were not working properly.

---

### Description

This PR improves gesture handling in the Blockly workspace by:

- Ensuring proper workspace configuration for scrolling and zooming
- Preventing default browser touch behavior interfering with gestures
- Improving drag, pan, and zoom interactions

---

### Testing Guidelines

- Verified that blocks can be dragged correctly
- Verified that zoom in/out works
- Verified workspace panning works
- Tested on desktop browser

---

### Fixes

Fixes #3661

---

### Context for the changes

This change only affects the Blockly editor (frontend JavaScript).
No changes were made to the companion or backend.

---

### Checklist

- [x] I have made no changes that affect the companion
- [x] I branched from master
- [x] My pull request has master as the base
- [x] ant tests passes on my machine