### PR TITLE
Add drag-and-drop media asset helper block creation in Blocks workspace

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
@@ -146,10 +146,10 @@ public class AssetList extends Composite implements ProjectChangeListener {
         // Add the name to the tree. We need to enclose it in a span
         // because the CSS style for selection specifies a span.
         String assetName = node.getName();
-        String nodeName = assetName;
-        if (nodeName.length() > 20)
-          nodeName = nodeName.substring(0, 8) + "..." + nodeName.substring(nodeName.length() - 9,
-              nodeName.length());
+        String displayName = assetName;
+        if (displayName.length() > 20)
+          displayName = displayName.substring(0, 8) + "..." +
+              displayName.substring(displayName.length() - 9, displayName.length());
 
         String fileSuffix = node.getProjectId() + "/" + node.getFileId();
         String treeItemText = "<span style='cursor: grab'>";
@@ -160,7 +160,7 @@ public class AssetList extends Composite implements ProjectChangeListener {
         } else if (StorageUtil.isVideoFile(fileSuffix )) {
           treeItemText += new Image(images.mediaIconVideo());
         }
-        treeItemText += nodeName + "</span>";
+        treeItemText += displayName + "</span>";
         final HTML treeItemWidget = new HTML(treeItemText);
         final TreeItem treeItem = new TreeItem(treeItemWidget);
         // keep a pointer from the tree item back to the actual node

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
@@ -20,6 +20,7 @@ import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetN
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
 import com.google.appinventor.shared.storage.StorageUtil;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.MouseMoveEvent;
@@ -137,13 +138,14 @@ public class AssetList extends Composite implements ProjectChangeListener {
       for (ProjectNode node : assetsFolder.getChildren()) {
         // Add the name to the tree. We need to enclose it in a span
         // because the CSS style for selection specifies a span.
-        String nodeName = node.getName();
+        String assetName = node.getName();
+        String nodeName = assetName;
         if (nodeName.length() > 20)
           nodeName = nodeName.substring(0, 8) + "..." + nodeName.substring(nodeName.length() - 9,
               nodeName.length());
 
         String fileSuffix = node.getProjectId() + "/" + node.getFileId();
-        String treeItemText = "<span style='cursor: pointer'>";
+        String treeItemText = "<span style='cursor: grab'>";
         if (StorageUtil.isImageFile(fileSuffix)) {
           treeItemText += new Image(images.mediaIconImg());
         } else if (StorageUtil.isAudioFile(fileSuffix )) {
@@ -156,6 +158,7 @@ public class AssetList extends Composite implements ProjectChangeListener {
         // keep a pointer from the tree item back to the actual node
         treeItem.setUserObject(node);
         assetList.addItem(treeItem);
+        configureDraggable(treeItem.getElement(), assetName);
       }
     }
   }
@@ -206,6 +209,57 @@ public class AssetList extends Composite implements ProjectChangeListener {
       refreshAssetList();
     }
   }
+
+  private static native void configureDraggable(Element el, String assetName)/*-{
+    function setCursor(root, cursor) {
+      root.style.cursor = cursor;
+      if (root.querySelectorAll) {
+        var descendants = root.querySelectorAll('*');
+        for (var i = 0; i < descendants.length; i++) {
+          descendants[i].style.cursor = cursor;
+        }
+      }
+    }
+    if (!el) {
+      return;
+    }
+    el.setAttribute('draggable', 'true');
+    el.setAttribute('data-assetname', assetName);
+    setCursor(el, 'grab');
+    if (el.getAttribute('data-ai-assetdrag') == 'true') {
+      return;
+    }
+    el.setAttribute('data-ai-assetdrag', 'true');
+    el.addEventListener('dragstart', function(e) {
+      var name = this.getAttribute('data-assetname');
+      this.classList.add('ode-AssetItem-dragging');
+      setCursor(this, 'grabbing');
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.clearData();
+      e.dataTransfer.setData('application/x-appinventor-asset', name);
+      $wnd.__aiAssetDragName = name;
+      if (e.dataTransfer.setDragImage) {
+        var dragGhost = $wnd.__aiAssetDragGhost;
+        if (!dragGhost) {
+          dragGhost = $doc.createElement('img');
+          dragGhost.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+          dragGhost.style.position = 'fixed';
+          dragGhost.style.top = '-1000px';
+          dragGhost.style.left = '-1000px';
+          $doc.body.appendChild(dragGhost);
+          $wnd.__aiAssetDragGhost = dragGhost;
+        }
+        e.dataTransfer.setDragImage(dragGhost, 0, 0);
+      }
+    });
+    el.addEventListener('dragend', function() {
+      this.classList.remove('ode-AssetItem-dragging');
+      setCursor(this, 'grab');
+      if ($wnd.__aiAssetDragName === this.getAttribute('data-assetname')) {
+        $wnd.__aiAssetDragName = null;
+      }
+    });
+  }-*/;
 
   public Tree getTree() {
     return assetList;

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/AssetList.java
@@ -21,19 +21,24 @@ import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssets
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
 import com.google.appinventor.shared.storage.StorageUtil;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.MouseMoveEvent;
-import com.google.gwt.event.dom.client.MouseMoveHandler;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.event.dom.client.MouseDownHandler;
+import com.google.gwt.event.dom.client.MouseMoveEvent;
+import com.google.gwt.event.dom.client.MouseMoveHandler;
+import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
@@ -61,6 +66,7 @@ public class AssetList extends Composite implements ProjectChangeListener {
   private YoungAndroidAssetsFolder assetsFolder;
   private int clientX;
   private int clientY;
+  private boolean ignoreNextSelection;
 
   /**
    * Creates a new AssetList
@@ -106,11 +112,12 @@ public class AssetList extends Composite implements ProjectChangeListener {
     assetList.addSelectionHandler(new SelectionHandler<TreeItem>() {
       @Override
       public void onSelection(SelectionEvent<TreeItem> event) {
+        if (ignoreNextSelection) {
+          ignoreNextSelection = false;
+          return;
+        }
         TreeItem selected = event.getSelectedItem();
-        ProjectNode node = (ProjectNode) selected.getUserObject();
-        // The actual menu is determined by what is registered for the filenode
-        // type in CommandRegistry.java
-        ProjectNodeContextMenu.show(node, selected.getWidget(), clientX, clientY);
+        showContextMenu(selected, clientX, clientY);
       }});
     assetList.addFocusHandler(new FocusHandler() {
       @Override
@@ -154,11 +161,39 @@ public class AssetList extends Composite implements ProjectChangeListener {
           treeItemText += new Image(images.mediaIconVideo());
         }
         treeItemText += nodeName + "</span>";
-        TreeItem treeItem = new TreeItem(new HTML(treeItemText));
+        final HTML treeItemWidget = new HTML(treeItemText);
+        final TreeItem treeItem = new TreeItem(treeItemWidget);
         // keep a pointer from the tree item back to the actual node
         treeItem.setUserObject(node);
         assetList.addItem(treeItem);
         configureDraggable(treeItem.getElement(), assetName);
+        treeItemWidget.addDomHandler(new MouseDownHandler() {
+          @Override
+          public void onMouseDown(MouseDownEvent event) {
+            clientX = event.getClientX();
+            clientY = event.getClientY();
+            suppressNextSelection();
+            event.stopPropagation();
+          }
+        }, MouseDownEvent.getType());
+        treeItemWidget.addDomHandler(new MouseUpHandler() {
+          @Override
+          public void onMouseUp(MouseUpEvent event) {
+            event.stopPropagation();
+          }
+        }, MouseUpEvent.getType());
+        treeItemWidget.addClickHandler(new ClickHandler() {
+          @Override
+          public void onClick(ClickEvent event) {
+            clientX = event.getClientX();
+            clientY = event.getClientY();
+            event.stopPropagation();
+            suppressNextSelection();
+            if (!isAssetDragClick(treeItem.getElement())) {
+              showContextMenu(treeItem, clientX, clientY);
+            }
+          }
+        });
       }
     }
   }
@@ -220,6 +255,28 @@ public class AssetList extends Composite implements ProjectChangeListener {
         }
       }
     }
+    function setAssetDragName(name) {
+      $wnd.__aiAssetDragName = name;
+      try {
+        if ($wnd.top) {
+          $wnd.top.__aiAssetDragName = name;
+        }
+      } catch (err) {
+        // Ignore cross-frame access errors. The data transfer payload is primary.
+      }
+    }
+    function clearAssetDragName(name) {
+      if ($wnd.__aiAssetDragName === name) {
+        $wnd.__aiAssetDragName = null;
+      }
+      try {
+        if ($wnd.top && $wnd.top.__aiAssetDragName === name) {
+          $wnd.top.__aiAssetDragName = null;
+        }
+      } catch (err) {
+        // Ignore cross-frame access errors. The data transfer payload is primary.
+      }
+    }
     if (!el) {
       return;
     }
@@ -233,11 +290,13 @@ public class AssetList extends Composite implements ProjectChangeListener {
     el.addEventListener('dragstart', function(e) {
       var name = this.getAttribute('data-assetname');
       this.classList.add('ode-AssetItem-dragging');
+      this.setAttribute('data-ai-assetdragging', 'true');
       setCursor(this, 'grabbing');
       e.dataTransfer.effectAllowed = 'move';
       e.dataTransfer.clearData();
       e.dataTransfer.setData('application/x-appinventor-asset', name);
-      $wnd.__aiAssetDragName = name;
+      e.dataTransfer.setData('text/plain', name);
+      setAssetDragName(name);
       if (e.dataTransfer.setDragImage) {
         var dragGhost = $wnd.__aiAssetDragGhost;
         if (!dragGhost) {
@@ -254,12 +313,35 @@ public class AssetList extends Composite implements ProjectChangeListener {
     });
     el.addEventListener('dragend', function() {
       this.classList.remove('ode-AssetItem-dragging');
+      this.removeAttribute('data-ai-assetdragging');
+      $wnd.__aiAssetDragSuppressClickUntil = new Date().getTime() + 250;
       setCursor(this, 'grab');
-      if ($wnd.__aiAssetDragName === this.getAttribute('data-assetname')) {
-        $wnd.__aiAssetDragName = null;
-      }
+      clearAssetDragName(this.getAttribute('data-assetname'));
     });
   }-*/;
+
+  private static native boolean isAssetDragClick(Element el)/*-{
+    var now = new Date().getTime();
+    return !!(el && el.getAttribute('data-ai-assetdragging') == 'true') ||
+        !!($wnd.__aiAssetDragSuppressClickUntil && now < $wnd.__aiAssetDragSuppressClickUntil);
+  }-*/;
+
+  private void showContextMenu(TreeItem selected, int clientX, int clientY) {
+    ProjectNode node = (ProjectNode) selected.getUserObject();
+    // The actual menu is determined by what is registered for the filenode
+    // type in CommandRegistry.java
+    ProjectNodeContextMenu.show(node, selected.getWidget(), clientX, clientY);
+  }
+
+  private void suppressNextSelection() {
+    ignoreNextSelection = true;
+    new Timer() {
+      @Override
+      public void run() {
+        ignoreNextSelection = false;
+      }
+    }.schedule(250);
+  }
 
   public Tree getTree() {
     return assetList;

--- a/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
@@ -309,6 +309,12 @@ body {
   background-color: clr-primary-700;
 }
 
+.gwt-Tree .gwt-TreeItem.ode-AssetItem-dragging span,
+.gwt-Tree .gwt-TreeItem.ode-AssetItem-dragging span:hover {
+  background-color: clr-primary-700;
+  opacity: 0.85;
+}
+
 .gwt-Tree-focused {
   outline: solid 2px border-color;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -626,6 +626,13 @@ body {
   color: text-highlight;
 }
 
+.gwt-Tree .gwt-TreeItem.ode-AssetItem-dragging span,
+.gwt-Tree .gwt-TreeItem.ode-AssetItem-dragging span:hover {
+  background-color: row-highlight !important;
+  color: text-highlight;
+  opacity: 0.85;
+}
+
 /* Young Android Toolbar */
 
 .ya-Toolbar {

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -77,7 +77,48 @@ var ASSET_DRAG_TYPE = 'application/x-appinventor-asset';
  * @return {boolean} True if the payload contains the type.
  */
 var hasDragType = function(dataTransfer, type) {
-  return dataTransfer && dataTransfer.types && dataTransfer.types.indexOf(type) >= 0;
+  if (!dataTransfer || !dataTransfer.types) {
+    return false;
+  }
+  if (typeof dataTransfer.types.indexOf == 'function') {
+    return dataTransfer.types.indexOf(type) >= 0;
+  }
+  if (typeof dataTransfer.types.contains == 'function') {
+    return dataTransfer.types.contains(type);
+  }
+  for (var i = 0; i < dataTransfer.types.length; i++) {
+    if (dataTransfer.types[i] == type) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Returns the globally tracked asset drag name if one is in progress.
+ * @return {string} The asset name or empty string if unavailable.
+ */
+var getGlobalAssetDragName = function() {
+  if (window.__aiAssetDragName) {
+    return window.__aiAssetDragName;
+  }
+  try {
+    if (window.top && window.top.__aiAssetDragName) {
+      return window.top.__aiAssetDragName;
+    }
+  } catch (err) {
+    // Ignore cross-frame access errors. The data transfer payload is primary.
+  }
+  return '';
+};
+
+/**
+ * Returns true if the event represents an App Inventor asset drag.
+ * @param {DragEvent} e The drag/drop event.
+ * @return {boolean} True when an asset is being dragged.
+ */
+var isAssetDrag = function(e) {
+  return hasDragType(e.dataTransfer, ASSET_DRAG_TYPE) || !!getGlobalAssetDragName();
 };
 
 /**
@@ -92,7 +133,7 @@ var getDraggedAssetName = function(e) {
       return dataName;
     }
   }
-  return window.__aiAssetDragName || '';
+  return getGlobalAssetDragName();
 };
 
 /**
@@ -239,10 +280,11 @@ Blockly.WorkspaceSvg.prototype.createDom = (function(func) {
       };
       // BEGIN: Configure drag and drop of blocks images to workspace
       result.addEventListener('dragenter', function(e) {
-        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE) ||
+        var assetDrag = isAssetDrag(e);
+        if (assetDrag ||
             hasDragType(e.dataTransfer, 'Files') ||
             hasDragType(e.dataTransfer, 'text/uri-list')) {
-          if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+          if (assetDrag) {
             e.dataTransfer.dropEffect = 'move';
             // Asset drags use a block preview instead of a full workspace tint.
             self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
@@ -256,10 +298,11 @@ Blockly.WorkspaceSvg.prototype.createDom = (function(func) {
         }
       }, true);
       result.addEventListener('dragover', function(e) {
-        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE) ||
+        var assetDrag = isAssetDrag(e);
+        if (assetDrag ||
             hasDragType(e.dataTransfer, 'Files') ||
             hasDragType(e.dataTransfer, 'text/uri-list')) {
-          if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+          if (assetDrag) {
             e.dataTransfer.dropEffect = 'move';
             self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
             maybeUpdateAssetDragPreview(e);
@@ -281,7 +324,7 @@ Blockly.WorkspaceSvg.prototype.createDom = (function(func) {
       }, true);
       result.addEventListener('drop', function(e) {
         self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
-        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+        if (isAssetDrag(e)) {
           var assetName = getDraggedAssetName(e);
           if (assetName) {
             e.preventDefault();

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -15,6 +15,7 @@ goog.provide('AI.Blockly.WorkspaceSvg');
 
 goog.require('AI.Blockly.ExportBlocksImage');
 goog.require('AI.Blockly.SaveFile');
+goog.require('AI.Blockly.Util.xml');
 goog.require('AI.Blockly.Versioning');
 goog.require('AI.Blockly.WarningHandler');
 goog.require('AI.Blockly.WarningIndicator');
@@ -67,6 +68,136 @@ Blockly.WorkspaceSvg.prototype.blocksNeedingRendering = null;
  */
 Blockly.WorkspaceSvg.prototype.chromeHidden = false;
 
+var ASSET_DRAG_TYPE = 'application/x-appinventor-asset';
+
+/**
+ * Returns true if the data transfer payload includes the given MIME type.
+ * @param {?DataTransfer} dataTransfer The browser drop payload.
+ * @param {string} type The type to check.
+ * @return {boolean} True if the payload contains the type.
+ */
+var hasDragType = function(dataTransfer, type) {
+  return dataTransfer && dataTransfer.types && dataTransfer.types.indexOf(type) >= 0;
+};
+
+/**
+ * Returns the currently dragged asset name from data transfer or global state.
+ * @param {DragEvent} e The drag/drop event.
+ * @return {string} The asset name or empty string if unavailable.
+ */
+var getDraggedAssetName = function(e) {
+  if (e.dataTransfer) {
+    var dataName = e.dataTransfer.getData(ASSET_DRAG_TYPE);
+    if (dataName) {
+      return dataName;
+    }
+  }
+  return window.__aiAssetDragName || '';
+};
+
+/**
+ * Converts a drag event into workspace coordinates.
+ * @param {Blockly.WorkspaceSvg} workspace The drop target workspace.
+ * @param {DragEvent} e The drag event.
+ * @return {{x: number, y: number}} Workspace coordinates.
+ */
+var dropPointToWorkspaceCoordinates = function(workspace, e) {
+  var metrics = workspace.getMetrics();
+  var point = Blockly.utils.browserEvents.mouseToSvg(
+      e, workspace.getParentSvg(), workspace.getInverseScreenCTM());
+  point.x = (point.x + metrics.viewLeft) / workspace.scale;
+  point.y = (point.y + metrics.viewTop) / workspace.scale;
+  return point;
+};
+
+/**
+ * Creates an XML document for a helpers_assets block pre-configured with the
+ * given asset name.
+ * @param {string} assetName The asset to pre-select.
+ * @return {!Element} XML with a single helpers_assets block.
+ */
+var createAssetHelperXml = function(assetName) {
+  var xml = Blockly.Util.xml.blockTypeToXML('helpers_assets');
+  var blockNode = xml.firstChild;
+  var field = document.createElement('field');
+  field.setAttribute('name', 'ASSET');
+  field.appendChild(document.createTextNode(assetName));
+  blockNode.appendChild(field);
+  return xml;
+};
+
+/**
+ * Creates an asset helper block at the given point.
+ * @param {Blockly.WorkspaceSvg} workspace The drop target workspace.
+ * @param {{x: number, y: number}} point The point to place the block.
+ * @param {string} assetName The asset to pre-select on the helper block.
+ */
+var createAssetHelperBlock = function(workspace, point, assetName) {
+  if (!assetName || workspace.getAssetList().indexOf(assetName) < 0) {
+    return null;
+  }
+  var xml = createAssetHelperXml(assetName);
+  var block = /** @type {Blockly.BlockSvg} */ (
+      Blockly.Xml.domToBlock(xml.firstChild, workspace));
+  block.moveBy(point.x, point.y);
+  block.initSvg();
+  workspace.requestRender(block);
+  return block;
+};
+
+/**
+ * Creates a transient preview block used while dragging an asset over the
+ * workspace.
+ * @param {Blockly.WorkspaceSvg} workspace The target workspace.
+ * @param {{x: number, y: number}} point The position for the preview.
+ * @param {string} assetName The dragged asset name.
+ * @return {?Blockly.BlockSvg} The preview block.
+ */
+var createAssetDragPreviewBlock = function(workspace, point, assetName) {
+  if (!assetName || workspace.getAssetList().indexOf(assetName) < 0) {
+    return null;
+  }
+  var xml = createAssetHelperXml(assetName);
+  var previewBlock = /** @type {Blockly.BlockSvg} */ (
+      Blockly.Xml.domToBlock(xml.firstChild, workspace));
+  previewBlock.moveBy(point.x, point.y);
+  previewBlock.setMovable(false);
+  previewBlock.setDeletable(false);
+  previewBlock.setEditable(false);
+  previewBlock.initSvg();
+  workspace.requestRender(previewBlock);
+  var svgRoot = previewBlock.getSvgRoot && previewBlock.getSvgRoot();
+  if (svgRoot) {
+    svgRoot.style.opacity = '0.7';
+    svgRoot.style.pointerEvents = 'none';
+  }
+  return previewBlock;
+};
+
+/**
+ * Moves an existing preview block to the new workspace point.
+ * @param {Blockly.BlockSvg} previewBlock The preview block.
+ * @param {{x: number, y: number}} point The destination point.
+ */
+var updateAssetDragPreviewBlock = function(previewBlock, point) {
+  var xy = previewBlock.getRelativeToSurfaceXY();
+  previewBlock.moveBy(point.x - xy.x, point.y - xy.y);
+};
+
+/**
+ * Disposes a preview block if it exists.
+ * @param {?Blockly.BlockSvg} previewBlock The preview block.
+ */
+var disposeAssetDragPreviewBlock = function(previewBlock) {
+  if (!previewBlock) {
+    return;
+  }
+  if (previewBlock.isDisposed && previewBlock.isDisposed()) {
+    return;
+  }
+  previewBlock.dispose(false);
+};
+
 Blockly.WorkspaceSvg.prototype.createDom = (function(func) {
   if (func.isWrapped) {
     return func;
@@ -74,58 +205,122 @@ Blockly.WorkspaceSvg.prototype.createDom = (function(func) {
     var f = function() {
       var self = /** @type {Blockly.WorkspaceSvg} */ (this);
       var result = func.apply(this, Array.prototype.slice.call(arguments));
+      var assetDragPreviewBlock = null;
+      var assetDragAssetName = null;
+      var clearAssetDragPreview = function() {
+        disposeAssetDragPreviewBlock(assetDragPreviewBlock);
+        assetDragPreviewBlock = null;
+        assetDragAssetName = null;
+      };
+      var maybeUpdateAssetDragPreview = function(e) {
+        var assetName = getDraggedAssetName(e);
+        if (!assetName || self.getAssetList().indexOf(assetName) < 0) {
+          clearAssetDragPreview();
+          return;
+        }
+        var point = dropPointToWorkspaceCoordinates(self, e);
+        if (!assetDragPreviewBlock || assetDragAssetName !== assetName) {
+          clearAssetDragPreview();
+          assetDragPreviewBlock = createAssetDragPreviewBlock(self, point, assetName);
+          assetDragAssetName = assetDragPreviewBlock ? assetName : null;
+        } else {
+          updateAssetDragPreviewBlock(assetDragPreviewBlock, point);
+        }
+      };
+      var maybeClearAssetDragPreviewOnLeave = function(e) {
+        if (!assetDragPreviewBlock) {
+          return;
+        }
+        var rect = result.getBoundingClientRect();
+        if (e.clientX < rect.left || e.clientX > rect.right ||
+            e.clientY < rect.top || e.clientY > rect.bottom) {
+          clearAssetDragPreview();
+        }
+      };
       // BEGIN: Configure drag and drop of blocks images to workspace
       result.addEventListener('dragenter', function(e) {
-        if (e.dataTransfer.types.indexOf('Files') >= 0 ||
-            e.dataTransfer.types.indexOf('text/uri-list') >= 0) {
-          self.svgBackground_.style.fill = 'rgba(0, 255, 0, 0.3)';
-          e.dataTransfer.dropEffect = 'copy';
+        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE) ||
+            hasDragType(e.dataTransfer, 'Files') ||
+            hasDragType(e.dataTransfer, 'text/uri-list')) {
+          if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+            e.dataTransfer.dropEffect = 'move';
+            // Asset drags use a block preview instead of a full workspace tint.
+            self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
+            maybeUpdateAssetDragPreview(e);
+          } else {
+            e.dataTransfer.dropEffect = 'copy';
+            self.svgBackground_.style.fill = 'rgba(0, 255, 0, 0.3)';
+            clearAssetDragPreview();
+          }
           e.preventDefault();
         }
       }, true);
       result.addEventListener('dragover', function(e) {
-        if (e.dataTransfer.types.indexOf('Files') >= 0 ||
-            e.dataTransfer.types.indexOf('text/uri-list') >= 0) {
-          self.svgBackground_.style.fill = 'rgba(0, 255, 0, 0.3)';
-          e.dataTransfer.dropEffect = 'copy';
+        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE) ||
+            hasDragType(e.dataTransfer, 'Files') ||
+            hasDragType(e.dataTransfer, 'text/uri-list')) {
+          if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+            e.dataTransfer.dropEffect = 'move';
+            self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
+            maybeUpdateAssetDragPreview(e);
+          } else {
+            e.dataTransfer.dropEffect = 'copy';
+            self.svgBackground_.style.fill = 'rgba(0, 255, 0, 0.3)';
+            clearAssetDragPreview();
+          }
           e.preventDefault();
         }
       }, true);
       result.addEventListener('dragleave', function(e) {
+        maybeClearAssetDragPreviewOnLeave(e);
         self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
       }, true);
       result.addEventListener('dragexit', function(e) {
+        maybeClearAssetDragPreviewOnLeave(e);
         self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
       }, true);
       result.addEventListener('drop', function(e) {
         self.setGridSettings(self.options.gridOptions['enabled'], self.getGrid().shouldSnap());
-        if (e.dataTransfer.types.indexOf('Files') >= 0) {
+        if (hasDragType(e.dataTransfer, ASSET_DRAG_TYPE)) {
+          var assetName = getDraggedAssetName(e);
+          if (assetName) {
+            e.preventDefault();
+            var point = dropPointToWorkspaceCoordinates(self, e);
+            if (assetDragPreviewBlock) {
+              clearAssetDragPreview();
+            }
+            var block = createAssetHelperBlock(self, point, assetName);
+            if (block) {
+              block.select();
+            }
+          } else {
+            clearAssetDragPreview();
+          }
+        } else if (hasDragType(e.dataTransfer, 'Files')) {
+          clearAssetDragPreview();
           if (e.dataTransfer.files.item(0).type === 'image/png') {
             e.preventDefault();
-            var metrics = Blockly.common.getMainWorkspace().getMetrics();
-            var point = Blockly.utils.browserEvents.mouseToSvg(e, self.getParentSvg(), self.getInverseScreenCTM());
-            point.x = (point.x + metrics.viewLeft) / self.scale;
-            point.y = (point.y + metrics.viewTop) / self.scale;
-            Blockly.importPngAsBlock(self, point, e.dataTransfer.files.item(0));
+            var pngPoint = dropPointToWorkspaceCoordinates(self, e);
+            Blockly.importPngAsBlock(self, pngPoint, e.dataTransfer.files.item(0));
           }
-        } else if (e.dataTransfer.types.indexOf('text/uri-list') >= 0) {
-          var data = e.dataTransfer.getData('text/uri-list')
+        } else if (hasDragType(e.dataTransfer, 'text/uri-list')) {
+          clearAssetDragPreview();
+          var data = e.dataTransfer.getData('text/uri-list');
           if (data.match(/\.png$/)) {
             e.preventDefault();
             var xhr = new XMLHttpRequest();
             xhr.onreadystatechange = function() {
               if (xhr.readyState === 4 && xhr.status === 200) {
-                var metrics = Blockly.common.getMainWorkspace().getMetrics();
-                var point = Blockly.utils.browserEvents.mouseToSvg(e, self.getParentSvg(), self.getInverseScreenCTM());
-                point.x = (point.x + metrics.viewLeft) / self.scale;
-                point.y = (point.y + metrics.viewTop) / self.scale;
-                Blockly.importPngAsBlock(self, point, xhr.response);
+                var pngPoint = dropPointToWorkspaceCoordinates(self, e);
+                Blockly.importPngAsBlock(self, pngPoint, xhr.response);
               }
             };
             xhr.responseType = 'blob';
             xhr.open('GET', data, true);
             xhr.send();
           }
+        } else {
+          clearAssetDragPreview();
         }
       });
       // END: Configure drag and drop of blocks images to workspace


### PR DESCRIPTION
**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

![WhatsApp GIF 2026-03-28 at 03 20 46](https://github.com/user-attachments/assets/07bf281b-824f-40b3-a8dc-35ece53c2b97)


*Description*

Implements issue #2412 by allowing users to drag a media file from the Media pane (Blocks view) into the workspace to create an asset helper block.

This PR:
- Adds drag-and-drop handling for media assets in the Blocks workspace.
- Creates a `helpers_assets` block on drop with the dragged asset name selected.
- Preserves existing `.png` workspace import drag/drop behavior.
- Improves drag UX for media items (grab/grabbing cursor and cleaner drag feedback).

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

1. Run App Inventor locally and open/create a project.
2. Go to the **Blocks** tab.
3. Upload a file in the **Media** section.
4. Drag the media item from the Media list into the blocks workspace.
5. Verify an asset helper block is created and uses the dropped file name.
6. Verify standard block drag/drop behavior is unchanged.
7. Verify dragging a `.png` blocks export into the workspace still imports blocks.
8. (Optional) Repeat in both Classic and Neo themes.

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #2412.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base
- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch
- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
- [x] My code follows the [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
- [ ] My code follows the [Swift style guide](https://google.github.io/swift/) (for .swift files)
- [x] Indentation has been doubled checked
- [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
