### PR TITLE
Fix #1029: Avoid orphan argument blocks when deleting a procedure

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/procedures.js
+++ b/appinventor/blocklyeditor/src/blocks/procedures.js
@@ -370,7 +370,9 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     if (editable) {
       // Dispose of any callers.
       //Blockly.Procedures.disposeCallers(name, workspace);
-      AI.Blockly.AIProcedure.removeProcedureValues(name, workspace);
+      // Skip callers in this procedure's own body so their argument blocks are
+      // not detached and left orphaned before this definition is disposed.
+      AI.Blockly.AIProcedure.removeProcedureValues(name, workspace, this);
     }
 
     // Call parent's destructor.

--- a/appinventor/blocklyeditor/src/field_procedure.js
+++ b/appinventor/blocklyeditor/src/field_procedure.js
@@ -108,15 +108,27 @@ AI.Blockly.AIProcedure.getAllProcedureDeclarationNames = function () {
   return procBlocks.map(function (decl) { return decl.getFieldValue('NAME'); });
 };
 
-AI.Blockly.AIProcedure.removeProcedureValues = function(name, workspace) {
+AI.Blockly.AIProcedure.removeProcedureValues = function(name, workspace, opt_excludedRoot) {
   if (workspace  // [lyn, 04/13/14] ensure workspace isn't undefined
       && workspace === Blockly.common.getMainWorkspace()) {
+    var isDescendantOf = function(block, root) {
+      if (!root) {
+        return false;
+      }
+      for (var parent = block.getParent(); parent; parent = parent.getParent()) {
+        if (parent === root) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     var blockArray = workspace.getAllBlocks();
     for(var i=0;i<blockArray.length;i++){
       var block = blockArray[i];
       if(block.type == "procedures_callreturn" || block.type == "procedures_callnoreturn" ||
                                                   block.type == "procedures_getWithDropdown") {
-        if(block.getFieldValue('PROCNAME') == name) {
+        if(block.getFieldValue('PROCNAME') == name && !isDescendantOf(block, opt_excludedRoot)) {
           block.removeProcedureValue();
         }
       }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*

Fixes #1029.

![ezgif-18135ee40c452b09](https://github.com/user-attachments/assets/7cac279a-f9fa-4a60-b173-375ed76812ae)

Deleting a procedure could leave orphan argument blocks behind in the workspace.  
This happened because procedure-call cleanup ran before the definition was disposed, including calls inside the same procedure body (recursive/self calls), which detached connected argument blocks.

This PR fixes that by excluding caller blocks that are descendants of the procedure definition currently being deleted, while still cleaning up callers outside that definition.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

1. Create a procedure with parameters.
2. Inside its body, add a call to the same procedure and connect blocks into its argument inputs.
3. Delete the procedure definition.
4. Verify no orphan argument blocks remain in workspace after deletion.
5. Also verify callers outside the deleted procedure are still cleaned up correctly.

Local checks run:
- `node --check` on changed JS files
- `git diff --check` (no whitespace/indentation issues)
- `JAVA_HOME=<openjdk11> ant -Dskip.ios=true noplay` (passes)

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #1029.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
