### PR TITLE
Fix: Add fallback image for ListView items when image fails to load

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
@@ -105,8 +105,9 @@ public final class MockListView extends MockVisibleComponent {
     detailTypeface = "0";
     mainFontSize = "22.0";
     detailFontSize = "14.0";
-    imageHeight = 40; // (200 / 5)
-    imageWidth = 40; // (200 / 5)
+    // TODO (Jose) extract magic numbers as ComponentConstants.java
+    imageHeight = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_HEIGHT;
+    imageWidth = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_WIDTH;
 
     initComponent(listViewWidget);
     MockComponentsUtil.setWidgetBackgroundColor(listViewWidget, DEFAULT_BACKGROUND_COLOR);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
@@ -106,8 +106,8 @@ public final class MockListView extends MockVisibleComponent {
     mainFontSize = "22.0";
     detailFontSize = "14.0";
     // TODO (Jose) extract magic numbers as ComponentConstants.java
-    imageHeight = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_HEIGHT;
-    imageWidth = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_WIDTH;
+    imageHeight = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_HEIGHT; // (200 / 5)
+    imageWidth = ComponentConstants.LISTVIEW_DEFAULT_IMAGE_WIDTH;  // (200 / 5)
 
     initComponent(listViewWidget);
     MockComponentsUtil.setWidgetBackgroundColor(listViewWidget, DEFAULT_BACKGROUND_COLOR);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
@@ -382,9 +382,14 @@ public final class MockListView extends MockVisibleComponent {
     if (url == null) {
       // text was not recognized as an asset. Just display the icon for this type of component.
       image.setUrl(getIconImage().getUrl());
-    } else {
-      image.setUrl(url);
-    }    
+  } else {
+  image.setUrl(url);
+
+  // fallback if image fails
+  image.addErrorHandler(event -> {
+    image.setUrl("https://via.placeholder.com/80");
+  });
+}    
     container.setSize(widthValue, heightValue);
     image.setSize("100%", "100%");
     image.getElement().getStyle().setProperty("objectFit", "contain");

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -83,7 +83,7 @@ public class ComponentConstants {
   public static final int LISTVIEW_PREFERRED_HEIGHT = 40;
   public static final int LISTVIEW_FILTER_PREFERRED_HEIGHT = 30;
   public static final int LISTVIEW_DEFAULT_IMAGE_WIDTH = 40;
-public static final int LISTVIEW_DEFAULT_IMAGE_HEIGHT = 40;
+  public static final int LISTVIEW_DEFAULT_IMAGE_HEIGHT = 40;
 
   /**
    * Scrollable Arrangements

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -82,6 +82,8 @@ public class ComponentConstants {
   public static final int LISTVIEW_PREFERRED_WIDTH = 315;
   public static final int LISTVIEW_PREFERRED_HEIGHT = 40;
   public static final int LISTVIEW_FILTER_PREFERRED_HEIGHT = 30;
+  public static final int LISTVIEW_DEFAULT_IMAGE_WIDTH = 40;
+public static final int LISTVIEW_DEFAULT_IMAGE_HEIGHT = 40;
 
   /**
    * Scrollable Arrangements


### PR DESCRIPTION
## What does this PR accomplish?

This PR adds a fallback image for ListView items when the provided image fails to load.

## Description

Currently, if an image URL is invalid or fails to load, the UI may display a broken or empty image.  
This PR improves the robustness of the ListView component by handling image load failures gracefully.

## Changes Made

- Added an error handler to detect image loading failures
- Displays a placeholder image when loading fails

## Testing Guidelines

1. Add a ListView item with an invalid image URL
2. Verify that a placeholder image is shown instead of a broken image

## Context for the changes

- This change does not affect the companion
- This PR is based on the `master` branch

## Note

This improvement aligns with ongoing enhancements to the ListView component.