### PR TITLE
Fix #3650: merge WRITE_EXTERNAL_STORAGE maxSdkVersion constraints

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/CreateManifest.java
@@ -193,21 +193,19 @@ public class CreateManifest implements AndroidTask {
         }
       }
 
+      // Add the platform-specific cap for WRITE_EXTERNAL_STORAGE as a regular permission
+      // constraint so it can be merged with extension-provided constraints.
+      if (!context.isForCompanion() && !context.usesLegacyFileAccess() && minSdk < 29) {
+        permissionConstraints.put("android.permission.WRITE_EXTERNAL_STORAGE",
+            new PermissionConstraint<>("android.permission.WRITE_EXTERNAL_STORAGE",
+                "maxSdkVersion", 29));
+      }
+
       for (String permission : permissions) {
-        if ("android.permission.WRITE_EXTERNAL_STORAGE".equals(permission)) {
-          out.write("  <uses-permission android:name=\"" + permission + "\"");
-
-          // we don't need these permissions post KitKat, but we do need them for the companion
-          if (!context.isForCompanion() && !context.usesLegacyFileAccess() && minSdk < 29) {
-            out.write(" android:maxSdkVersion=\"29\"");
-          }
-
-        } else {
-          out.write("  <uses-permission android:name=\""
-              // replace %packageName% with the actual packageName
-              + permission.replace("%packageName%", packageName)
-              + "\"");
-        }
+        out.write("  <uses-permission android:name=\""
+            // replace %packageName% with the actual packageName
+            + permission.replace("%packageName%", packageName)
+            + "\"");
         outputPermissionConstraints(out, permissionConstraints, permission);
         out.write(" />");
       }


### PR DESCRIPTION
## Summary\n- route the built-in WRITE_EXTERNAL_STORAGE maxSdkVersion cap through the existing permission-constraint aggregation path\n- remove the special-case direct manifest write that could duplicate ndroid:maxSdkVersion when extensions also provide permissionConstraints\n- keep existing behavior for companion/legacy-file-access builds and only cap non-companion modern-file-access builds\n\n## Why\nIssue #3650 reports APK build failures when an extension provides a maxSdkVersion constraint for ndroid.permission.WRITE_EXTERNAL_STORAGE. The manifest writer was emitting one maxSdkVersion directly and another via extension constraints, producing duplicate attributes.\n\nFixes #3650