### PR TITLE
Ensure consistent selection state after ListView mutations

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -335,6 +335,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty
   public void Elements(List<Object> itemsList) {
     items = new ArrayList<>(itemsList);
+    ensureValidSelection();
     updateAdapterData();
     listAdapterWithRecyclerView.notifyDataSetChanged();
   }
@@ -366,6 +367,7 @@ public final class ListView extends AndroidViewComponent {
       category = PropertyCategory.BEHAVIOR)
   public void ElementsFromString(String itemstring) {
     items = new ArrayList<Object>(ElementsUtil.elementsListFromString(itemstring));
+    ensureValidSelection();
     updateAdapterData();
     listAdapterWithRecyclerView.notifyDataSetChanged();
   }
@@ -1159,6 +1161,7 @@ public final class ListView extends AndroidViewComponent {
       return;
     }
     items.remove(index - 1);
+    ensureValidSelection();
     updateAdapterData();
     listAdapterWithRecyclerView.notifyItemRemoved(index - 1);
   }
@@ -1186,6 +1189,7 @@ public final class ListView extends AndroidViewComponent {
         items.add(CreateElement(mainText, detailText, imageName));
       }
     }
+    ensureValidSelection();
     updateAdapterData();
     listAdapterWithRecyclerView.notifyItemChanged(listAdapterWithRecyclerView.getItemCount() - 1);
   }
@@ -1199,6 +1203,7 @@ public final class ListView extends AndroidViewComponent {
       int positionStart = items.size();
       int itemCount = itemsList.size();
       items.addAll(itemsList);
+      ensureValidSelection();
       updateAdapterData();
       listAdapterWithRecyclerView.notifyItemRangeChanged(positionStart, itemCount);
     }
@@ -1232,6 +1237,7 @@ public final class ListView extends AndroidViewComponent {
         items.add(index - 1, CreateElement(mainText, detailText, imageName));
       }
     }
+    ensureValidSelection();
     updateAdapterData();
     listAdapterWithRecyclerView.notifyItemInserted(index - 1);
   }
@@ -1250,6 +1256,7 @@ public final class ListView extends AndroidViewComponent {
       int positionStart = index - 1;
       int itemCount = itemsList.size();
       items.addAll(positionStart, itemsList);
+      ensureValidSelection();
       updateAdapterData();
       listAdapterWithRecyclerView.notifyItemRangeChanged(positionStart, itemCount);
     }
@@ -1299,6 +1306,35 @@ public final class ListView extends AndroidViewComponent {
   public void updateAdapterData() {
     SelectionIndex(0);
     listAdapterWithRecyclerView.updateData(items);
+  }
+
+  /**
+   * Ensures that selectionIndex, selection, and selectionDetailText
+   * remain consistent with the current items list.
+   *
+   * Must be called after any mutation (insert/remove/replace).
+   */
+  private void ensureValidSelection() {
+    if (selectionIndex <= 0 || selectionIndex > items.size()) {
+      selectionIndex = 0;
+      selection = "";
+      selectionDetailText = "";
+      return;
+    }
+
+    Object item = items.get(selectionIndex - 1);
+
+    if (item instanceof YailDictionary) {
+      selection = ElementsUtil.toStringEmptyIfNull(
+          ((YailDictionary) item).get(Component.LISTVIEW_KEY_MAIN_TEXT));
+      selectionDetailText = ElementsUtil.toStringEmptyIfNull(
+          ((YailDictionary) item).get(Component.LISTVIEW_KEY_DESCRIPTION));
+    } else {
+      // Item is a plain string, not a YailDictionary,
+      // so no detail text is available for this layout type
+      selection = item.toString();
+      selectionDetailText = "";
+    }
   }
 
   /**


### PR DESCRIPTION

**What does this PR accomplish?**

***Description***
This PR ensures that the ListView selection state remains consistent after list mutations and data updates.
Currently, operations such as adding, removing, or replacing items can leave the selection state (selectionIndex, selection, selectionDetailText) in an invalid or stale state. This happens because there is no centralized validation of selection invariants after modifying the underlying items list.

This PR introduces a private helper method ensureValidSelection() that enforces the following invariants:

- selectionIndex always remains within valid bounds
- selection and selectionDetailText are synchronized with the current item
- selection is reset when it becomes invalid (e.g., after item removal or full list replacement)

The helper is invoked after all mutation and data reset operations (e.g., ElementsFromString, Elements, AddItem, RemoveItemAtIndex, etc.), ensuring consistent behaviour across the component.

***Testing Guidelines***
The following scenarios can be used to verify the changes:

1. Set items using ElementsFromString or Elements and verify:

- No selection exists initially
- No stale selection persists from previous data

2. Select an item, then:

- Remove the selected item → selection should reset
- Add items before/after selection → selection remains valid

3. Replace the entire list after selecting an item:

- Selection should not point to old data

4. Clear the list:

- selectionIndex becomes 0
- selection and selectionDetailText become empty

5. General regression check:

- Existing ListView behavior remains unchanged for valid states

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
- [x] `ant tests` passes on my machine
