### PR TITLE
Fix #3372: Update Neo export dropdown label to reflect selection count

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectToolbar.java
@@ -104,6 +104,10 @@ public class ProjectToolbar extends Toolbar {
     int numAllItems = projectList.getMyProjectsCount();  // Get number of valid projects not in trash
     int numSelectedProjects = projectList.getSelectedProjectsCount();
     LOG.info("Set Project List variables");
+    String exportProjectLabel = numSelectedProjects > 1
+        ? Ode.MESSAGES.exportSelectedProjectsMenuItem(numSelectedProjects)
+        : Ode.MESSAGES.exportProjectMenuItem();
+    setDropDownItemHtml("Export", "ExportProject", exportProjectLabel);
     if (isReadOnly) {           // If we are read-only, we disable all buttons
       setButtonEnabled(WIDGET_NAME_NEW, false);
       setButtonEnabled(WIDGET_NAME_DELETE, false);


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*
Issue #3372 reports that the Neo UI export behavior does not match Classic when multiple projects are selected. After testing on current master, I confirmed that multi-select export itself works correctly (selecting 3 projects and clicking the export item downloads a .zip). The remaining issue is that the dropdown label never updates -- it always shows "Export selected project (.aia) to my computer" even when multiple projects are selected.

In Classic, `TopToolbar.updateMenuState()` dynamically switches the label to "Export N selected projects" when more than one project is selected. The Neo project toolbar was missing this because `ProjectToolbar.updateButtons()` delegates to `TopToolbar.updateMenuState()`, which only updates the top menu bar's own `fileDropDown`, not the project toolbar's separate Export dropdown.

This PR adds the same label-update pattern to `ProjectToolbar.updateButtons()`, using the existing `setDropDownItemHtml` method from the `Toolbar` base class. Classic UI is unaffected because its `ProjectToolbar.ui.xml` has no Export dropdown, and the null check in `Toolbar.setDropDownItemHtml` safely handles this.

*Testing Guidelines*

1. Switch to Neo UI
2. Create 3 projects
3. Select all 3 projects via checkboxes
4. Click the Export dropdown on the project toolbar
5. Verify the label now says "Export 3 selected projects"
6. Click it -- verify a .zip downloads containing all 3 projects
7. Deselect one -- label changes to "Export 2 selected projects"
8. Deselect all but one -- label reverts to "Export selected project (.aia) to my computer"
9. Click it -- verify a single .aia downloads
10. Deselect all projects -- label remains "Export selected project (.aia) to my computer"
11. Switch to Classic UI and verify export via the Projects menu still works

**Before (3 projects selected, label still shows singular):**

<img width="1235" height="737" alt="Before" src="https://github.com/user-attachments/assets/a32646f5-5772-4c72-97d0-d37d8eaacc51" />

**After (3 projects selected, label updates to reflect count):**

<img width="1241" height="741" alt="After" src="https://github.com/user-attachments/assets/c4040f3d-5f5f-453d-bf7d-8e589768581d" />

Fixes #3372.

**Context for the changes**

This is a GWT client-side only change in `ProjectToolbar.java`. No companion code, runtime components, or server-side code is affected.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
