### PR TITLE
blocklyeditor: use relative Closure compiler paths

### DIFF
--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -49,15 +49,13 @@
 
 	<property name="blockly.src.dir" location="${lib.dir}/blockly" />
 	<property name="blockly.plugin.dir" location="${lib.dir}/blockly-plugins" />
-	<property name="blockly.src.dir.relative" value="lib/blockly" />
-	<property name="blockly.plugin.dir.relative" value="lib/blockly-plugins" />
-	<property name="closure.base.js.relative" value="lib/closure-compiler/base.js" />
-	<property name="blockly.output.js.relative" value="build/blocklyeditor/blockly-all.js" />
-	<property name="blockly.output.map.relative" value="build/blocklyeditor/blockly-all.js.map" />
 	<property name="i18n.src.dir" location="${src.dir}/msg" />
 	<property name="ai.i18n.src.dir" location="${i18n.src.dir}/ai_blockly" />
 	<property name="BlocklyTranslator-class.dir" location="${class.dir}/BlocklyTranslator-classes" />
 	<property name="BlocklyTranslations.dir" location="${public.build.dir}/msg" />
+	<property name="blockly.src.dir.relative" value="lib/blockly" />
+	<property name="blockly.plugin.dir.relative" value="lib/blockly-plugins" />
+	<property name="closure.base.js.relative" value="lib/closure-compiler/base.js" />
 
 	<property name="gwt.sdk" location="${lib.dir}/gwt/2.8.1-patched" />
 
@@ -129,11 +127,11 @@
 			<arg line="--language_in ECMASCRIPT_NEXT"/>
 			<arg line="--language_out ECMASCRIPT_NEXT"/>
 			<arg line="--js_output_file"/>
-			<arg value="${blockly.output.js.relative}"/>
+			<arg file="${public.build.dir}/blockly-all.js"/>
 			<arg line="--entry_point=goog:AI.Blockly.BlocklyEditor"/>
 			<arg line="--charset UTF-8"/>
 			<arg line="--create_source_map"/>
-			<arg value="${blockly.output.map.relative}"/>
+			<arg file="${public.build.dir}/blockly-all.js.map"/>
 			<arg line="--source_map_location_mapping src|/ode/static/js"/>
 			<arg line="--source_map_input"/>
 			<arg value="${blockly.src.dir.relative}/blockly_compressed.js|${blockly.src.dir.relative}/blockly_compressed.js.map"/>

--- a/appinventor/blocklyeditor/build.xml
+++ b/appinventor/blocklyeditor/build.xml
@@ -49,6 +49,11 @@
 
 	<property name="blockly.src.dir" location="${lib.dir}/blockly" />
 	<property name="blockly.plugin.dir" location="${lib.dir}/blockly-plugins" />
+	<property name="blockly.src.dir.relative" value="lib/blockly" />
+	<property name="blockly.plugin.dir.relative" value="lib/blockly-plugins" />
+	<property name="closure.base.js.relative" value="lib/closure-compiler/base.js" />
+	<property name="blockly.output.js.relative" value="build/blocklyeditor/blockly-all.js" />
+	<property name="blockly.output.map.relative" value="build/blocklyeditor/blockly-all.js.map" />
 	<property name="i18n.src.dir" location="${src.dir}/msg" />
 	<property name="ai.i18n.src.dir" location="${i18n.src.dir}/ai_blockly" />
 	<property name="BlocklyTranslator-class.dir" location="${class.dir}/BlocklyTranslator-classes" />
@@ -124,23 +129,23 @@
 			<arg line="--language_in ECMASCRIPT_NEXT"/>
 			<arg line="--language_out ECMASCRIPT_NEXT"/>
 			<arg line="--js_output_file"/>
-			<arg file="${public.build.dir}/blockly-all.js"/>
+			<arg value="${blockly.output.js.relative}"/>
 			<arg line="--entry_point=goog:AI.Blockly.BlocklyEditor"/>
 			<arg line="--charset UTF-8"/>
 			<arg line="--create_source_map"/>
-			<arg file="${public.build.dir}/blockly-all.js.map"/>
+			<arg value="${blockly.output.map.relative}"/>
 			<arg line="--source_map_location_mapping src|/ode/static/js"/>
 			<arg line="--source_map_input"/>
-			<arg value="${blockly.src.dir}/blockly_compressed.js|${blockly.src.dir}/blockly_compressed.js.map"/>
+			<arg value="${blockly.src.dir.relative}/blockly_compressed.js|${blockly.src.dir.relative}/blockly_compressed.js.map"/>
 			<arg line="--output_wrapper='%output%&#10;//# sourceMappingURL=/static/js/blockly-all.js.map'" if:true="${release}"/>
 			<arg line="--dependency_mode=PRUNE_LEGACY"/>
-			<arg value="--js='${blockly.src.dir}/blockly_compressed.js'"/>
-			<arg value="--js='${blockly.plugin.dir}/block-lexical-variables-core-62b3583.min.js'"/>
-			<arg value="--js='${blockly.plugin.dir}/typeblocking-josmas-pr4-cb783e3.min.js'"/>
+			<arg value="--js='${blockly.src.dir.relative}/blockly_compressed.js'"/>
+			<arg value="--js='${blockly.plugin.dir.relative}/block-lexical-variables-core-62b3583.min.js'"/>
+			<arg value="--js='${blockly.plugin.dir.relative}/typeblocking-josmas-pr4-cb783e3.min.js'"/>
 			<arg value="--js='blocklyeditor/src/**.js'"/>
-			<arg value="--js='${lib.dir}/closure-compiler/base.js'"/>
-		</java>
-	</target>
+			<arg value="--js='${closure.base.js.relative}'"/>
+			</java>
+		</target>
 
 	<!-- =====================================================================
        BlocklyeditorTests: build and run the Blocklyeditor tests and


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

This PR updates the Blockly build to use relative Closure compiler input/output paths instead of absolute paths.

*Description*

This fixes a local build failure that occurs when the App Inventor source tree is checked out under a filesystem path containing spaces. In that situation, the Blockly compile step can fail with a URI/path parsing error during the Closure compiler phase.


<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

1. Check out the App Inventor sources under a path containing spaces.
2. Run:
   ```bash
   cd appinventor/blocklyeditor
   JAVA_HOME=/opt/homebrew/Cellar/openjdk@11/11.0.30/libexec/openjdk.jdk/Contents/Home ant clean
   JAVA_HOME=/opt/homebrew/Cellar/openjdk@11/11.0.30/libexec/openjdk.jdk/Contents/Home ant
3. Verify that the Blockly build succeeds.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3875.

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
