### PR TITLE
docs: clarify local build and server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to build MIT App Inventor applications.
 We provide this code for reference and for experienced people who wish
 to operate their own App Inventor instance and/or contribute to the project.
 
-This code is tested and known to work with Java 11.
+This code is tested and known to work with Java 17.
 
 ## Contributors
 
@@ -30,11 +30,9 @@ This is a quick guide to get started with the sources. More detailed instruction
 
 ### Dependencies
 
-You will need a full Java JDK (version 11, OpenJDK preferred; JRE is not enough) and [ant](http://ant.apache.org/) (version 1.10) to compile the sources.
+You will need a full Java JDK (version 17, OpenJDK preferred; JRE is not enough) and [ant](http://ant.apache.org/) (version 1.10) to compile the sources.
 
 You will also need a copy of the [Google Cloud SDK](https://cloud.google.com/appengine/docs/standard/java/download) to run the development servers. When setting up the gcloud cli you might be asked if you'd like to install Python 3.11, as the cli depends on it. In case of any issues with Python versions, check the value of the CLOUDSDK_PYTHON environment variable, which the cli can use to point to the right version.
-
-Note that the JDK used to build App Inventor with ant and the JDK used to run the local App Engine development server may not be the same. The ant build is tested with Java 11, while the App Engine runtime configured in `appinventor/appengine/war/WEB-INF/appengine-web.xml` is currently `java17`. Depending on your Google Cloud SDK installation, you may need to use Java 11 for ant commands and Java 17 for the main local server.
 
 If you want to make changes to the sources, you will have to run an automated test suite, and for that you will also need
 a recent version of NodeJS (node 20+ works) and the Firefox browser installed on your machine. Have a look at the testing section for more information.
@@ -107,7 +105,7 @@ You will see a lot of stuff in the terminal and after a few minutes (it can take
 
 If you are only trying to run the local web application, you usually do not need the full `ant` target. In that case, prefer:
 
-    $ ant -Dskip.ios=true webapp
+    $ ant webapp
 
 ### Notes on compiling for iOS
 
@@ -178,8 +176,6 @@ There are two servers in App Inventor, the main server that deals with project i
 
 ### Running the main server
 
-If your Google Cloud SDK installation requires a newer JDK than the ant build, set `JAVA_HOME` accordingly before starting the main server.
-
     $ your-google-cloud-SDK-folder/bin/java_dev_appserver.sh --port=8888 --address=0.0.0.0 appengine/build/war/
 
 Make sure you change *your-google-cloud-SDK-folder* to wherever in your hard drive you have placed the Google Cloud SDK.
@@ -188,8 +184,8 @@ Make sure you change *your-google-cloud-SDK-folder* to wherever in your hard dri
 
 The build server can be run from the terminal by typing:
 
-    $ cd appinventor
-    $ ant -Dskip.ios=true RunLocalBuildServer
+    $ cd appinventor/buildserver
+    $ ant RunLocalBuildServer
 
 Note that you will only need to run the build server if you are going to build an app as an apk. You can do all the layout and programming without having the build server running, but you will need it to download the apk.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You will need a full Java JDK (version 11, OpenJDK preferred; JRE is not enough)
 
 You will also need a copy of the [Google Cloud SDK](https://cloud.google.com/appengine/docs/standard/java/download) to run the development servers. When setting up the gcloud cli you might be asked if you'd like to install Python 3.11, as the cli depends on it. In case of any issues with Python versions, check the value of the CLOUDSDK_PYTHON environment variable, which the cli can use to point to the right version.
 
+Note that the JDK used to build App Inventor with ant and the JDK used to run the local App Engine development server may not be the same. The ant build is tested with Java 11, while the App Engine runtime configured in `appinventor/appengine/war/WEB-INF/appengine-web.xml` is currently `java17`. Depending on your Google Cloud SDK installation, you may need to use Java 11 for ant commands and Java 17 for the main local server.
+
 If you want to make changes to the sources, you will have to run an automated test suite, and for that you will also need
 a recent version of NodeJS (node 20+ works) and the Firefox browser installed on your machine. Have a look at the testing section for more information.
 
@@ -97,11 +99,15 @@ Before compiling the code, an [auth key](https://docs.google.com/document/pub?id
     $ cd appinventor
     $ ant MakeAuthKey
 
-Once the key is in place, type the following to compile (from the appinventor folder):
+Once the key is in place, type the following to compile the full project (from the appinventor folder):
 
     $ ant
 
 You will see a lot of stuff in the terminal and after a few minutes (it can take from 2 to 10 minutes, depending on your machine specs) you should see a message saying something like *Build Successful*.
+
+If you are only trying to run the local web application, you usually do not need the full `ant` target. In that case, prefer:
+
+    $ ant -Dskip.ios=true webapp
 
 ### Notes on compiling for iOS
 
@@ -172,6 +178,8 @@ There are two servers in App Inventor, the main server that deals with project i
 
 ### Running the main server
 
+If your Google Cloud SDK installation requires a newer JDK than the ant build, set `JAVA_HOME` accordingly before starting the main server.
+
     $ your-google-cloud-SDK-folder/bin/java_dev_appserver.sh --port=8888 --address=0.0.0.0 appengine/build/war/
 
 Make sure you change *your-google-cloud-SDK-folder* to wherever in your hard drive you have placed the Google Cloud SDK.
@@ -180,8 +188,8 @@ Make sure you change *your-google-cloud-SDK-folder* to wherever in your hard dri
 
 The build server can be run from the terminal by typing:
 
-    $ cd appinventor/buildserver
-    $ ant RunLocalBuildServer
+    $ cd appinventor
+    $ ant -Dskip.ios=true RunLocalBuildServer
 
 Note that you will only need to run the build server if you are going to build an app as an apk. You can do all the layout and programming without having the build server running, but you will need it to download the apk.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

Clarify the local setup instructions for contributors building and running App Inventor locally.

*Description*

<!--
Please describe below how to test the changes in the PR.
--->

This PR clarifies the local setup instructions for contributors building and running App Inventor locally.

It adds notes about the split between the JDK used by Ant and the JDK that may be required by the local App Engine development server, recommends `ant -Dskip.ios=true webapp` for local web development, and updates the build server instructions to use the top-level `RunLocalBuildServer` target. It

- clarifies that the JDK used for Ant builds may differ from the JDK needed for the local App Engine development server
- points local web development at `ant -Dskip.ios=true webapp` instead of implying the full `ant` target is always necessary
- updates the build server instructions to use the top-level `RunLocalBuildServer` target from the `appinventor` directory


*Testing Guidelines*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Review the updated README sections and verify that the local setup flow is clearer and internally consistent.

Fixes #3876.

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
