### PR TITLE
Fix screen dropdown caption inconsistency on hover

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
@@ -283,6 +283,7 @@ public class DesignToolbar extends Toolbar {
             screen.screenName, new SwitchScreenAction(projectId, screen.screenName),
             new Image(Ode.getImageBundle().form())));
       }
+      setDropDownButtonCaption(WIDGET_NAME_SCREENS_DROPDOWN, currentProject.currentScreen);
       String fauxProjectName = Ode.getInstance().getFauxProjectName();
       if (fauxProjectName != null && !fauxProjectName.isEmpty()) {
         projectNameLabel.setText(fauxProjectName);
@@ -317,6 +318,7 @@ public class DesignToolbar extends Toolbar {
       if (currentProject == project) {
         addDropDownButtonItem(WIDGET_NAME_SCREENS_DROPDOWN, new DropDownItem(name,
             name, new SwitchScreenAction(projectId, name), new Image(Ode.getImageBundle().form())));
+              setDropDownButtonCaption(WIDGET_NAME_SCREENS_DROPDOWN, currentProject.currentScreen);
       }
     }
   }
@@ -389,6 +391,7 @@ public class DesignToolbar extends Toolbar {
         switchToScreen(projectId, YoungAndroidSourceNode.SCREEN1_FORM_NAME, View.DESIGNER);
       }
       removeDropDownButtonItem(WIDGET_NAME_SCREENS_DROPDOWN, name);
+      setDropDownButtonCaption(WIDGET_NAME_SCREENS_DROPDOWN, currentProject.currentScreen);
     }
     project.removeScreen(name);
   }


### PR DESCRIPTION
### Problem
The screen dropdown caption becomes inconsistent when hovering/opening the dropdown. 
This happens because the dropdown is rebuilt, but the caption is not updated accordingly, 
leading to stale or incorrect UI state.

### Fix
Added a call to update the dropdown caption after rebuilding the screen dropdown items:
setDropDownButtonCaption(WIDGET_NAME_SCREENS_DROPDOWN, currentProject.currentScreen);

This ensures that the dropdown caption always reflects the current active screen.

### Testing
- Verified logic ensures caption sync after dropdown rebuild
- Prevents stale UI state during hover/open

### Note
Could not fully test in local environment due to setup complexity,
but fix is based on correct UI state synchronization logic.