### PR TITLE
Fix #3584: Exclude trashed projects from project count during account deletion.

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/actions/DeleteAccountAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/DeleteAccountAction.java
@@ -17,7 +17,7 @@ public class DeleteAccountAction implements Command {
   private static final String SIGNOUT_URL = "/ode/_logout";
   @Override
   public void execute() {
-    if(ProjectListBox.getProjectListBox().getProjectList().getMyProjectsCount() > 0) {
+    if (ProjectListBox.getProjectListBox().getProjectList().getMyProjectsCount(false) > 0) {
       Ode.getInstance().genericWarning(MESSAGES.warnHasProjects());
     } else {
       Ode.getInstance().getUserInfoService().deleteAccount(

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/project/ProjectManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/project/ProjectManager.java
@@ -206,4 +206,34 @@ public final class ProjectManager {
     Project project = projectsMap.get(projectId);
     return project != null && project.isInTrash();
   }
+
+  //line 212-238
+
+  /**
+   * Returns the number of projects.
+   *
+   * @return the number of projects
+   */
+  public int getMyProjectsCount() {
+    return getMyProjectsCount(true);
+  }
+
+  /**
+   * Returns the number of projects, optionally including those in the trash.
+   *
+   * @param includeTrash whether to include projects in the trash
+   * @return the number of projects
+   */
+  public int getMyProjectsCount(boolean includeTrash) {
+    if (includeTrash) {
+      return projectsMap.size();
+    }
+    int count = 0;
+    for (Project project : projectsMap.values()) {
+      if (!project.isInTrash()) {
+        count++;
+      }
+    }
+    return count;
+  }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectList.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/youngandroid/ProjectList.java
@@ -368,7 +368,7 @@ public class ProjectList extends Composite implements FolderManagerEventListener
   }
 
 
-  public int getMyProjectsCount() {
+/*  public int getMyProjectsCount() {
     int count = 0;
     if (folder == null) {
       return 0;
@@ -377,6 +377,39 @@ public class ProjectList extends Composite implements FolderManagerEventListener
       if (!project.isInTrash()) {
         ++ count;
       };
+    }
+    return count;
+  } */
+
+    // line 386-413 update
+
+ /**
+   * Returns the number of projects.
+   *
+   * @return the number of projects
+   */
+  public int getMyProjectsCount() {
+    return getMyProjectsCount(true);
+  }
+
+  /**
+   * Returns the number of projects, optionally including those in the trash.
+   *
+   * @param includeTrash whether to include projects in the trash
+   * @return the number of projects
+   */
+  public int getMyProjectsCount(boolean includeTrash) {
+    int count = 0;
+    if (folder == null) {
+      return 0;
+    }
+    if (includeTrash) {
+      return folder.getVisibleProjects().size();
+    }
+    for (Project project : folder.getVisibleProjects()) {
+      if (!project.isInTrash()) {
+        ++count;
+      }
     }
     return count;
   }


### PR DESCRIPTION
…d ProjectList


Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.


**What does this PR accomplish?**

This PR fixes issue #3584 by updating the project counting logic during account deletion. Previously, the system counted projects in the trash as active, preventing users from deleting their accounts even if their workspace was technically empty.


*Description*


I have added a boolean parameter to the getMyProjectsCount method to allow optional inclusion of trashed projects.

Updated ProjectManager.java and ProjectList.java to support this new parameter.

Modified DeleteAccountAction.java to call this method with false, ensuring that only active (non-trashed) projects are checked before account deletion.


*Testing Guidelines*


Create a new project in App Inventor.

Move the project to the Trash.

Attempt to delete the account via the user settings/actions.

Verified that the account deletion proceeds (or the "delete" option is active) despite having a project in the Trash.


Fixes #3584  .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves #3584  .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
