### PR TITLE
Move Image READ_EXTERNAL_STORAGE to method-level on Picture setter

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
@@ -6,7 +6,7 @@
 
 package com.google.appinventor.components.runtime;
 
-import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
+import android.Manifest;
 
 import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -51,7 +51,6 @@ import java.io.IOException;
     "Designer or in the Blocks Editor.",
     iconName = "images/image.png")
 @SimpleObject
-@UsesPermissions(permissionNames = "android.permission.INTERNET")
 public final class Image extends AndroidViewComponent {
 
   private final ImageView view;
@@ -149,7 +148,7 @@ public final class Image extends AndroidViewComponent {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
   @SimpleProperty
-  @UsesPermissions(READ_EXTERNAL_STORAGE)
+  @UsesPermissions({Manifest.permission.INTERNET, Manifest.permission.READ_EXTERNAL_STORAGE})
   public void Picture(@Asset String path) {
     final String tempPath = path == null ? "" : path;
     if (TiramisuUtil.requestImagePermissions(container.$form(), path,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
@@ -7,7 +7,6 @@
 package com.google.appinventor.components.runtime;
 
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
-import static android.Manifest.permission.READ_MEDIA_IMAGES;
 
 import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -150,7 +149,7 @@ public final class Image extends AndroidViewComponent {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
   @SimpleProperty
-  @UsesPermissions({READ_EXTERNAL_STORAGE, READ_MEDIA_IMAGES})
+  @UsesPermissions(READ_EXTERNAL_STORAGE)
   public void Picture(@Asset String path) {
     final String tempPath = path == null ? "" : path;
     if (TiramisuUtil.requestImagePermissions(container.$form(), path,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
@@ -6,7 +6,9 @@
 
 package com.google.appinventor.components.runtime;
 
-import android.Manifest;
+import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
+import static android.Manifest.permission.READ_MEDIA_IMAGES;
+
 import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
@@ -50,8 +52,7 @@ import java.io.IOException;
     "Designer or in the Blocks Editor.",
     iconName = "images/image.png")
 @SimpleObject
-@UsesPermissions(permissionNames = "android.permission.INTERNET," +
-    "android.permission.READ_EXTERNAL_STORAGE")
+@UsesPermissions(permissionNames = "android.permission.INTERNET")
 public final class Image extends AndroidViewComponent {
 
   private final ImageView view;
@@ -149,6 +150,7 @@ public final class Image extends AndroidViewComponent {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
   @SimpleProperty
+  @UsesPermissions({READ_EXTERNAL_STORAGE, READ_MEDIA_IMAGES})
   public void Picture(@Asset String path) {
     final String tempPath = path == null ? "" : path;
     if (TiramisuUtil.requestImagePermissions(container.$form(), path,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Image.java
@@ -7,7 +7,6 @@
 package com.google.appinventor.components.runtime;
 
 import android.Manifest;
-
 import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;


### PR DESCRIPTION
**What does this PR accomplish?**
*Description*
The Image component declares `READ_EXTERNAL_STORAGE` as a class-level `@UsesPermissions` annotation, which causes the permission to appear in the manifest for every app that includes an Image component, even when the image is loaded from bundled assets and no storage access is needed.

~On Android 13+, `READ_EXTERNAL_STORAGE` no longer grants access to media files. The runtime code in `TiramisuUtil.requestImagePermissions` already requests `READ_MEDIA_IMAGES` on Android 13+, but `READ_MEDIA_IMAGES` was never declared in any annotation, so the system denies the permission request and the image cannot be loaded from external storage.~

**Update:** After feedback from Anke on the [community forum thread](https://community.appinventor.mit.edu/t/the-image-component-incorrectly-requires-read-permission/171831/5), the `READ_MEDIA_IMAGES` portion was removed from this PR. Google Play has required prior approval for `READ_MEDIA_IMAGES` declarations since May 2025, so adding it to the manifest would cause compliance issues. This PR now focuses solely on moving `READ_EXTERNAL_STORAGE` from class-level to method-level.

This PR makes ~two changes~ one change to `Image.java`:

1. Moves `READ_EXTERNAL_STORAGE` from the class-level `@UsesPermissions` to a method-level annotation on the `Picture` property setter. This follows the pattern established by ~`Player.java`~ `VideoPlayer.java` for its `Source` property. With this change, the permission only appears in the manifest when the `Picture` property is actually used (set in the Designer or via blocks).

2. ~Adds `READ_MEDIA_IMAGES` to the same method-level annotation for Android 13+ compatibility. This makes the manifest declaration match the runtime behavior that `TiramisuUtil` already implements.~

PR #2773 addresses a related but different aspect of this issue. That PR refines the runtime logic for when to request the permission. This PR addresses the manifest-level declaration and does not touch the runtime logic.

~*Testing Guidelines*~

1. ~Build the project and verify `simple_components_build_info.json` shows `READ_EXTERNAL_STORAGE` ~and `READ_MEDIA_IMAGES`~ under `conditionals.permissions.Picture` rather than in the top-level `permissions` array.~

2. ~Build a test APK containing an Image component with `Picture` set to an external storage path via blocks (e.g., `file:///storage/emulated/0/Download/photo.jpg`). Install on an Android 14 (API 34) emulator. Click the button to load the image. The system should display a `READ_MEDIA_IMAGES` permission dialog. After granting, the image should load successfully.~

3. ~Repeat step 2 using an APK built from the unmodified `ucr` branch. The app should display "Error 908: The permission READ_MEDIA_IMAGES has been denied" because the permission is not declared in the manifest.~

4. ~Build the Companion APK (`ant PlayApp`). Verify the Companion launches and runs without errors.~

**Updated Testing Guidelines**

1. Build the project and verify `simple_components_build_info.json` shows `READ_EXTERNAL_STORAGE` under `conditionals.permissions.Picture` rather than in the top-level `permissions` array.

2. Build a test APK containing an Image component with `Picture` set to an external storage path via blocks (e.g., `file:///storage/emulated/0/Download/photo.jpg`). Install on an Android 14 (API 34) emulator. Verify the behavior is unchanged from the `ucr` branch.

3. Build the Companion APK (`ant PlayApp`). Verify the Companion launches and runs without errors.

**Test setup**

The test project contains a Button and an Image component. The Button's Click handler sets `Image1.Picture` to `file:///storage/emulated/0/Download/mitappinventor.png` (a file pushed to the emulator's external storage via `adb push`). The Image's `Picture` property is not set in the Designer. Both APKs were built using a local buildserver and installed on an Android 14 (API 34) emulator.

<img width="1512" height="804" alt="designer.png" src="https://github.com/user-attachments/assets/0bc54612-f5c6-4036-8b8a-8a1d88bac7eb" />
<img width="1512" height="804" alt="blocks.png" src="https://github.com/user-attachments/assets/e95286b8-1f5f-4f23-873d-635384f90775" />


**Manifest comparison**

Before (ucr branch, no fix):
```
uses-permission: name='android.permission.INTERNET'
uses-permission: name='android.permission.READ_EXTERNAL_STORAGE'
```

After (this branch):
```
uses-permission: name='android.permission.INTERNET'
uses-permission: name='android.permission.READ_EXTERNAL_STORAGE'
```

The manifest is the same when the `Picture` property is used. The improvement is visible when `Picture` is NOT used -- in that case, `READ_EXTERNAL_STORAGE` no longer appears in the manifest.

> Note: The before/after screenshots below were taken with an earlier revision that included `READ_MEDIA_IMAGES`. That permission has since been removed from this PR per community feedback. The current revision does not change behavior for apps that use the `Picture` property -- the improvement is that apps that do NOT use `Picture` no longer get `READ_EXTERNAL_STORAGE` in their manifest.

**Earlier test (with READ_MEDIA_IMAGES, since removed):**

~`READ_MEDIA_IMAGES` is now present in the manifest because the `Picture` block is used in the project, triggering the conditional permission.~

**Before (ucr branch, no fix):**

<img width="1080" height="2400" alt="before.png" src="https://github.com/user-attachments/assets/0a48581a-e101-4f91-a36e-5e144951cbd3" />


**After (this branch):**

<img width="1080" height="2400" alt="after-permission-dialog.png" src="https://github.com/user-attachments/assets/f37bba92-2674-43a0-9983-92f221c84a24" />
<img width="1080" height="2400" alt="after-image-loaded.png" src="https://github.com/user-attachments/assets/137e6cb7-236f-4e5f-b383-7876486d7673" />

Relates to #2700.

Reported on the community forum: https://community.appinventor.mit.edu/t/the-image-component-incorrectly-requires-read-permission/171831

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
