### PR TITLE
Pass Locale.US to Chart SimpleDateFormat constructors

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/AxisChartView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AxisChartView.java
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Base class for Chart Views (Chart UI) for Charts types that
@@ -100,13 +101,13 @@ public abstract class AxisChartView<
           } else if (valueType == CHART_VALUE_DATE) {
             //display x-axis labels as Date
             Date mDate = new Date((long) value);
-            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
             chart.getXAxis().setLabelRotationAngle(-90);
             return dateFormat.format(mDate);
           } else if (valueType == CHART_VALUE_TIME) {
             //display x-axis labels as Time
             Date mDate = new Date((long) value);
-            DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+            DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss", Locale.US);
             chart.getXAxis().setLabelRotationAngle(-90);
             return dateFormat.format(mDate);
           } else {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/BarChartDataModel.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/BarChartDataModel.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -111,13 +112,13 @@ public class BarChartDataModel
       try {
         float x = (float) Math.floor(Float.parseFloat(rawX));
         if (DATE_PATTERN_PATTERN.matcher(rawX).matches()) {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
           Date date = sdf.parse(rawX);
           if (date != null) {
             x = date.getTime();
           }
         } else if (TIME_PATTERN_PATTERN.matcher(rawX).matches()) {
-          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss", Locale.US);
           Date date = sdf.parse(rawX);
           if (date != null) {
             x = date.getTime();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PointChartDataModel.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PointChartDataModel.java
@@ -20,6 +20,7 @@ import com.google.appinventor.components.runtime.util.YailList;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -67,12 +68,12 @@ public abstract class PointChartDataModel<
         float x;
         // Attempt to parse the x and y value String representations
         if(Pattern.compile(DATE_PATTERN).matcher(xValue).matches()){
-          SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+          SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy", Locale.US);
           Date date = sdf.parse(xValue);
           x = date.getTime();
         }
         else if(Pattern.compile(TIME_PATTERN).matcher(xValue).matches()){
-          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss", Locale.US);
           Date date = sdf.parse(xValue);
           x = date.getTime();
         }


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Chart-related `SimpleDateFormat` constructors in `AxisChartView`, `BarChartDataModel`, and `PointChartDataModel` are called without a `Locale` argument, so they use `Locale.getDefault()` at runtime. On Thai-locale devices the `y` pattern character resolves against `BuddhistCalendar`, producing Buddhist-year labels (e.g. `2569` instead of `2026`). On locales with non-Western digit shaping (Arabic, Persian, Myanmar) the numeric pattern characters render in the local script, which looks inconsistent next to the numeric axis tick values rendered by MPAndroidChart.

This PR passes `Locale.US` explicitly to all six affected `SimpleDateFormat` constructors so the ISO-style format strings are deterministic across all device locales:

- `AxisChartView.java`: `yyyy-MM-dd` and `HH:mm:ss` for axis label formatting.
- `BarChartDataModel.java`: `yyyy-MM-dd` and `HH:mm:ss` for parsing user-provided tuple strings.
- `PointChartDataModel.java`: `dd/MM/yyyy` and `HH:mm:ss` for parsing user-provided tuple strings.

This PR is Android-only. The iOS runtime under `components-ios/` was not examined and may need a follow-up if the same pattern exists there.

*Testing Guidelines*

1. Set an Android device or emulator locale to Thai (Settings → System → Languages → Thai).
2. In App Inventor Designer, create a chart with date-type X values.
3. Run the app in Companion.

Before this PR: axis date labels render with Buddhist-year numbers (e.g. `2569-04-17` instead of `2026-04-17`).

After this PR: axis date labels render with Gregorian-year Western digits regardless of device locale.

**Context for the changes**

This PR touches chart-rendering runtime code that runs on the Android companion, so it targets the `ucr` branch per the contributing guidelines.

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion
- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

For all other changes:

- [x] I have made no changes that affect the master branch
- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine

Notes on the unchecked boxes:
- No user-facing documentation under `docs/` describes these format strings, so no doc update was needed.
- I ran `ant tests` locally. The Java compile step succeeded for all 398 source files under `AndroidRuntime` (including the three modified files) and all Java JUnit targets (`AiClientLibTests`, `AiSharedLibTests`, `AiServerLibTests`) passed with 0 failures. `BlocklyeditorTests` and `BuildDocs` failed for environmental reasons unrelated to this change (missing Firefox for Karma headless tests, and missing Ruby bundler 2.4.22). Happy to rerun any target if the reviewer wants.
