### PR TITLE
Fix: clarify Java version requirements for build and local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,20 @@ to build MIT App Inventor applications.
 We provide this code for reference and for experienced people who wish
 to operate their own App Inventor instance and/or contribute to the project.
 
-This code is tested and known to work with Java 11.
+This code is tested and known to work with Java 11 for building the project.
+
+### Java Version Requirements
+
+Note: Different parts of the App Inventor setup require different Java versions:
+
+- **Build (Ant / webapp):** Requires Java 11
+- **Local App Engine Development Server:** Requires Java 17 (as specified in appengine-web.xml)
+
+If you have multiple JDKs installed, ensure:
+- Java 11 is used when running Ant builds
+- Java 17 is used when running the local development server
+
+This distinction is important to avoid setup issues.
 
 ## Contributors
 


### PR DESCRIPTION
This PR clarifies the Java version requirements in the README.

Previously, the README stated that the project works with Java 11, but it did not clearly distinguish between:

- Java 11 required for building the project using Ant
- Java 17 required for running the local App Engine development server

This caused confusion for new contributors, especially those using multiple JDK versions.

This update adds a clear explanation to improve the setup experience.

Fixes #3876
