### PR TITLE
Fix duplicate LOBFValues block rendering in Regression drawer

### DIFF
--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -1049,13 +1049,11 @@ Blockly.Drawer.defaultBlockXMLStrings = {
     {matchingMutatorAttributes:{component_type:"Regression", method_name:"CalculateLineOfBestFitValue"},
       mutatorXMLStringFunction: function(mutatorAttributes) {
         return (
-            '<xml>' +
-            '<block type="component_method">' +
-            // mutator generator
-            Blockly.Util.xml.mutatorAttributesXmlString(mutatorAttributes) +
-            '<value name="ARG2"><block type="helpers_dropdown"><mutation key="LOBFValues"></mutation><field name="OPTION">Slope</field></block></value>' +
-            '</block>' +
-            '</xml>'
+          '<xml>' +
+          '<block type="component_method">' +
+          Blockly.Util.xml.mutatorAttributesXmlString(mutatorAttributes) +
+          '</block>' +
+          '</xml>'
         );
       }},
     {matchingMutatorAttributes:{component_type:"Spreadsheet", method_name:"RemoveCol"},


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->
This PR fixes a UI issue in the Regression component drawer where an extra `LOBFValues` block was rendered incorrectly in the flyout.

*Description*
The issue was caused by manually injecting a `helpers_dropdown` block for the `ARG2` parameter in `defaultBlockXMLStrings`, while the parameter already uses `@Options(LOBFValues.class)`.

Since App Inventor automatically generates dropdowns for `@Options` parameters via `helperKey`, this resulted in duplicate rendering:
- One correctly attached dropdown inside the method block
- One mispositioned standalone block in the flyout

This PR removes the manual `helpers_dropdown` injection and relies on the existing automatic dropdown generation.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

1. Open the Blocks editor
2. Add a Regression component
3. Open the Regression drawer
4. Drag `CalculateLineOfBestFitValue`

Expected:
- No extra `LOBFValues` block appears in the flyout
- Dropdown is correctly rendered inside the method block

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3890 


**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [X] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I branched from `master`
- [X] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [X] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [X] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [X] Indentation has been doubled checked
    - [X] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine