### PR TITLE
Fix iOS chart date/time formatting (locale + 24-hour consistency)

### DIFF
--- a/appinventor/components-ios/src/AxisChartView.swift
+++ b/appinventor/components-ios/src/AxisChartView.swift
@@ -155,13 +155,14 @@ open class AxisChartView : ChartView {
       } else if _vType == CHART_VALUE_DATE {
         
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let date = Date(timeIntervalSince1970: value)
-        let test = dateFormatter.string(from: date)
-        return test
+        return dateFormatter.string(from: date)
       } else if _vType == CHART_VALUE_TIME {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "hh:mm:ss"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "HH:mm:ss"
         let date = Date(timeIntervalSince1970: value)
         return dateFormatter.string(from: date)
       }


### PR DESCRIPTION
Fixes #3894

Fixes iOS chart date and time formatting inconsistencies.

Problem:
Date and time formatting depended on the device locale and used a 12-hour format ("hh"), causing inconsistent output across regions and mismatch with Android behavior.

Solution:
- Set the formatter locale to en_US_POSIX for deterministic and locale-independent output
- Updated the time format from "hh:mm:ss" to "HH:mm:ss" for 24-hour consistency

Result:
- Consistent date/time formatting across devices and locales
- Behavior aligned with Android implementation