### PR TITLE
Fix iOS chart date/time formatting (locale + 24-hour consistency)

### DIFF
--- a/appinventor/components-ios/src/AxisChartView.swift
+++ b/appinventor/components-ios/src/AxisChartView.swift
@@ -155,13 +155,14 @@ open class AxisChartView : ChartView {
       } else if _vType == CHART_VALUE_DATE {
         
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let date = Date(timeIntervalSince1970: value)
-        let test = dateFormatter.string(from: date)
-        return test
+        return dateFormatter.string(from: date)
       } else if _vType == CHART_VALUE_TIME {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "hh:mm:ss"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "HH:mm:ss"
         let date = Date(timeIntervalSince1970: value)
         return dateFormatter.string(from: date)
       }


### PR DESCRIPTION
### Description

This PR addresses the iOS counterpart of #3891 by fixing locale-dependent date/time formatting issues in chart rendering.

### Problem

As described in the issue, date and time formatting in charts can produce incorrect values under certain locales. This occurs because the formatter relies on the device locale, leading to non-deterministic output.

Additionally, in `AxisChartView.swift`, the time format uses `"hh"` (12-hour format), which is inconsistent with Android behavior and results in incorrect time representation.

### Solution

- Set the formatter locale to `en_US_POSIX` to ensure deterministic and locale-independent formatting
- Updated the time format from `"hh:mm:ss"` to `"HH:mm:ss"` to enforce 24-hour consistency with Android

### Result

- Date/time values are now consistent across different locales
- Time formatting aligns with Android implementation
- Eliminates incorrect values caused by locale variations

### Testing Guidelines

- Verified date formatting remains consistent across different locale settings
- Verified time output uses 24-hour format correctly
- Confirmed no regression in existing chart behavior

### Context for the changes

This change applies to the iOS implementation to ensure behavior consistency with Android and to avoid locale-based discrepancies in chart formatting. Based on `master`.

---

### If your code changes how something works on the device (i.e., it affects the companion):

[x] I have made no changes that affect the companion  
[x] I branched from master  
[x] My pull request has master as the base  

---

### Further, if you've changed the blocks language or another user-facing designer/blocks API:

[ ] I have updated the corresponding version number  
[ ] I have updated the upgrader  
[ ] I have updated versioning.js  

---

### For all other changes:

[x] I have made no changes that affect the master branch  

---

### General items:

[x] My code follows the Swift style guide  
[x] This PR does not include unnecessary changes  
[x] Indentation has been checked  

---

### Fixes

Fixes #3894