### PR TITLE
Fix contrast of 'More information' link in extension help dialog (cla…

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/classic/variableColors.css
@@ -677,7 +677,12 @@ path.ode-SimpleMockMapFeature-selected {
 .ode-ComponentHelpPopup-Link a {
   color: clr-primary-600;
 }
-  
+
+.ode-DialogBox .dialogContent td .ode-ComponentHelpPopup-Link a {
+  color: clr-primary-600;
+  text-decoration: underline;
+}
+
 .compiler-ErrorMarker {
   color:  v-red;
 }


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Fixes the contrast of the "More information" link in the extension help dialog (classic UI).

Previously, the link appeared as a light green color on a light background, making it difficult to read and not meeting accessibility expectations. This was caused by a general dialog CSS rule (`.ode-DialogBox .dialogContent td a`) overriding the intended styling for `.ode-ComponentHelpPopup-Link a.`

This PR adds a more specific CSS rule to ensure the link uses the correct theme color (`clr-primary-600`) and improves visibility by adding underline styling.

*Testing Guidelines*
1. Open MIT App Inventor (classic UI)
2. Import any extension
3. Click the (?) help icon for the extension
4. Verify that the "More information" link:
    - is clearly visible
    - has sufficient contrast
    - is underlined

Fixes #3897 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [X] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [X] I have made no changes that affect the master branch

- [X] I branched from `master`
- [X] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [ ] Indentation has been doubled checked
    - [X] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
