### PR TITLE
Fix property descriptions showing translation keys for extensions

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockComponent.java
@@ -605,12 +605,22 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
    */
   public final void addProperty(String name, String defaultValue, String caption, String category,
                                 String editorType, String[] editorArgs, PropertyEditor editor) {
+    addProperty(name, defaultValue, caption, category, editorType, editorArgs, editor, "");
+  }
+
+  public final void addProperty(String name, String defaultValue, String caption, String category,
+                                String editorType, String[] editorArgs, PropertyEditor editor,
+                                String fallbackDescription) {
 
     String propertyDesc = ComponentTranslationTable.getPropertyDescription(name
       + "PropertyDescriptions");
     if (propertyDesc.equals(name + "PropertyDescriptions")) {
-      propertyDesc = ComponentTranslationTable.getPropertyDescription((type.equals("Form")
-          ? "Screen" : type) + "." + propertyDesc);
+      String compositeKey = (type.equals("Form") ? "Screen" : type) + "." + name + "PropertyDescriptions";
+      propertyDesc = ComponentTranslationTable.getPropertyDescription(compositeKey);
+      if (propertyDesc.equals(compositeKey)) {
+        propertyDesc = (fallbackDescription != null && !fallbackDescription.isEmpty())
+            ? fallbackDescription : "";
+      }
     }
 
     int propertyType = EditableProperty.TYPE_NORMAL;
@@ -624,7 +634,7 @@ public abstract class MockComponent extends Composite implements PropertyChangeL
       propertyType |= EditableProperty.TYPE_DOYAIL;
     }
     properties.addProperty(name, defaultValue, ComponentTranslationTable.getPropertyName(caption),
-        ComponentTranslationTable.getCategoryName(category),  propertyDesc, editor, propertyType, editorType, editorArgs);
+        ComponentTranslationTable.getCategoryName(category), propertyDesc, editor, propertyType, editorType, editorArgs);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -139,7 +139,7 @@ public class PropertiesUtil {
       mockComponent.addProperty(property.getName(), property.getDefaultValue(),
           property.getCaption(), property.getCategory(), property.getEditorType(), property.getEditorArgs(),
           PropertiesUtil.createPropertyEditor(property.getEditorType(), property.getDefaultValue(), editor,
-          property.getEditorArgs()));
+          property.getEditorArgs()), property.getDescription());
       /*OdeLog.log("Property Caption: " + property.getCaption() + ", "
           + TranslationComponentProperty.getName(property.getCaption()));*/
     }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
Fix property descriptions showing translation keys for extensions in props panel by passing a fallback description.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
Upload an extension like ble, click on the ? for a property and you'll see the translation key
Build this branch and it should show the description instead, same as with built in components. The issue linked below also has info and screenshots in the community thread.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3258 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
