### PR TITLE
Fix #3826: guard against null in CredentialsJson setter and fix validation logic

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Spreadsheet.java
@@ -33,6 +33,7 @@ import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
+import com.google.appinventor.components.annotations.Asset;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
@@ -157,7 +158,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
 
   // Designer Properties
   private String apiKey;
-  private String credentialsPath;
+  private String credentialsPath = "";
   private String spreadsheetID = "";
   // This gets changed to the name of the project by MockSpreadsheet by default
   private String applicationName = "App Inventor";
@@ -234,8 +235,8 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_ASSET,
       defaultValue = "")
   @SimpleProperty(description = "The JSON File with credentials for the Service Account")
-  public void CredentialsJson(String credentialsPath) {
-    this.credentialsPath = credentialsPath;
+  public void CredentialsJson(@Asset String credentialsPath) {
+    this.credentialsPath = (credentialsPath == null) ? "" : credentialsPath;
   }
 
   @SimpleProperty(category = PropertyCategory.BEHAVIOR)
@@ -500,7 +501,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       "callback event.")
   public void ReadRow (String sheetName, int rowNumber) {
 
-    if (spreadsheetID == "" || spreadsheetID == null) {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("ReadRow: " + "SpreadsheetID is empty.");
       return;
     }
@@ -519,7 +520,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       public void run () {
         try {
           // If no Credentials.json is provided, attempt the HTTP request
-          if (credentialsPath == null) {
+          if (credentialsPath == null || credentialsPath.isEmpty()) {
             // Cleans the formatted url in case the sheetname needs to be cleaned
             String cleanRangeReference = "";
             try {
@@ -623,10 +624,10 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       "row of the sheet with the given row number.")
   public void WriteRow (String sheetName, int rowNumber, YailList data) {
 
-    if (spreadsheetID == "" || spreadsheetID == null) {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("WriteRow: " + "SpreadsheetID is empty.");
       return;
-    } else if (credentialsPath == "" || credentialsPath == null) {
+    } else if (credentialsPath == null || credentialsPath.isEmpty()) {
       ErrorOccurred("WriteRow: " + "Credentials JSON file is required.");
       return;
     }
@@ -1032,7 +1033,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       public void run() {
         try {
           // If no Credentials.json is provided, attempt the HTTP request
-          if (credentialsPath == null) {
+          if (credentialsPath == null || credentialsPath.isEmpty()) {
             // Cleans the formatted url in case the sheetname needs to be cleaned
             String cleanRangeReference = "";
             try {
@@ -1396,7 +1397,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
 
         try {
           // If no Credentials.json is provided, attempt the HTTP request
-          if (credentialsPath == null) {
+          if (credentialsPath == null || credentialsPath.isEmpty()) {
             // Cleans the formatted url in case the sheetname needs to be cleaned
             String cleanRangeReference = "";
             try {
@@ -1513,10 +1514,10 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
     description="Given text or a number as `data`, writes the value into the " +
       "cell. Once complete, it triggers the FinishedWriteCell callback event")
   public void WriteCell (String sheetName, String cellReference, Object data) {
-    if (spreadsheetID == "") {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("WriteCell: " + "SpreadsheetID is empty.");
       return;
-    } else if (credentialsPath == null) {
+    } else if (credentialsPath == null || credentialsPath.isEmpty()) {
       ErrorOccurred("WriteCell: " + "Credentials JSON is required.");
       return;
     }
@@ -1594,7 +1595,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
     description="On the page with the provided sheetName, reads the cells at " +
       "the given range. Triggers the getRangeReference once complete.")
   public void ReadRange (final String sheetName, final String rangeReference) {
-    if (spreadsheetID == "" || spreadsheetID == null) {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("ReadRange: " + "SpreadsheetID is empty.");
       return;
     }
@@ -1612,7 +1613,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
 
         try {
           // If no Credentials.json is provided, attempt the HTTP request
-          if (credentialsPath == null) {
+          if (credentialsPath == null || credentialsPath.isEmpty()) {
             // Cleans the formatted url in case the sheetname needs to be cleaned
             String cleanRangeReference = "";
             try {
@@ -1714,10 +1715,10 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
       "range. The number of rows and columns in the range reference must " +
       "match the dimensions of the data.")
   public void WriteRange (String sheetName, String rangeReference, YailList data) {
-    if (spreadsheetID == "" || spreadsheetID == null) {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("WriteRange: " + "SpreadsheetID is empty.");
       return;
-    } else if (credentialsPath == null) {
+    } else if (credentialsPath == null || credentialsPath.isEmpty()) {
       ErrorOccurred("WriteRange: " + "Credentials JSON is required.");
       return;
     }
@@ -1807,10 +1808,10 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
     description="Empties the cells in the given range. Once complete, this " +
       "block triggers the FinishedClearRange callback event.")
   public void ClearRange (String sheetName, String rangeReference) {
-    if (spreadsheetID == "" || spreadsheetID == null) {
+    if (spreadsheetID == null || spreadsheetID.isEmpty()) {
       ErrorOccurred("ClearRange: " + "SpreadsheetID is empty.");
       return;
-    } else if (credentialsPath == null) {
+    } else if (credentialsPath == null || credentialsPath.isEmpty()) {
       ErrorOccurred("ClearRange: " + "Credential JSON is required.");
       return;
     }
@@ -1892,7 +1893,7 @@ public class Spreadsheet extends AndroidNonvisibleComponent implements Component
 
         try {
           // If no Credentials.json is provided, attempt the HTTP request
-          if (credentialsPath == null) {
+          if (credentialsPath == null || credentialsPath.isEmpty()) {
             Log.d(LOG_TAG, "Reading Sheet: No credentials");
             // Cleans the formatted url in case the sheetname needs to be cleaned
             String cleanRangeReference = "";


### PR DESCRIPTION
**What does this PR accomplish?**
**Core fix:** Initializes `credentialsPath` as an empty string to prevent the runtime error.

<img width="638" height="104" alt="image" src="https://github.com/user-attachments/assets/75027e74-3e09-4de2-a17f-9b2915aa08f3" />

<img width="640" height="220" alt="telegram-cloud-photo-size-5-6325715438456737680-x" src="https://github.com/user-attachments/assets/039fe0cb-f4e4-40f2-8c87-0f8014a6c482" />


**Validation consistency:** The existing code used `== null` checks for both `credentialsPath` and `spreadsheetID`, which doesn't catch empty strings. Updated both to:
```java
credentialsPath == null || credentialsPath.isEmpty()
spreadsheetID == null || spreadsheetID.isEmpty()
```

**Missing `@Asset` annotation:** Since `credentialJson` is of type `asset`, the setter is missing the `@Asset` annotation. Added it along with the same null/empty validation to prevent the same runtime error.

<img width="540" height="104" alt="image" src="https://github.com/user-attachments/assets/de466282-d263-4e2e-a7c8-bf54947928b6" />
<!--
Please describe below how to test the changes in the PR.
--->
<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3826

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
