### PR TITLE
Fix DatePicker and TimePicker cancellation state bug

### DIFF
--- a/appinventor/components-ios/src/DatePicker.swift
+++ b/appinventor/components-ios/src/DatePicker.swift
@@ -14,7 +14,6 @@ open class DatePicker: Picker, DateTimePickerDelegate {
   fileprivate var _year, _month, _day: Int
   fileprivate var _instant: Date
   fileprivate var _localizedMonths: [String]
-  fileprivate var _customDate = false
   fileprivate let _isPhone = UIDevice.current.userInterfaceIdiom == .phone
   
   public override init(_ parent: ComponentContainer) {
@@ -91,13 +90,17 @@ open class DatePicker: Picker, DateTimePickerDelegate {
     }
     _instant = date
     _viewController?.setDate(_instant)
-    _customDate = true
+    _year = Int(year)
+    _month = Int(month)
+    _day = Int(day)
   }
   
   @objc open func SetDateToDisplayFromInstant(_ instant: Date) {
     _instant = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: instant)!
     self._viewController?.setDate(_instant)
-    _customDate = true
+    _year = Calendar.current.component(.year, from: _instant)
+    _month = Calendar.current.component(.month, from: _instant)
+    _day = Calendar.current.component(.day, from: _instant)
   }
   
   @objc open func LaunchPicker() {
@@ -119,13 +122,6 @@ open class DatePicker: Picker, DateTimePickerDelegate {
   }
   
   open override func click() {
-    if !_customDate {
-      let now = Date()
-      _instant = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: now)!
-      _viewController?.setDate(_instant)
-    } else {
-      _customDate = false
-    }
     if !_isPhone {
       if let popover = (_viewController as! UIViewController).popoverPresentationController {
         popover.delegate = self

--- a/appinventor/components-ios/src/TimePicker.swift
+++ b/appinventor/components-ios/src/TimePicker.swift
@@ -13,7 +13,6 @@ open class TimePicker: Picker, DateTimePickerDelegate {
   fileprivate var _viewController: DateTimePickerController?
   fileprivate var _hour, _minute: Int
   fileprivate var _instant: Date
-  fileprivate var _customTime = false
   fileprivate let _isPhone = UIDevice.current.userInterfaceIdiom == .phone
   
   public override init(_ parent: ComponentContainer) {
@@ -69,7 +68,8 @@ open class TimePicker: Picker, DateTimePickerDelegate {
       let time = Calendar.current.date(from: timeComponents)!
       _instant = time
       _viewController?.setTime(_instant)
-      _customTime = true
+      _hour = Int(hour)
+      _minute = Int(minute)
     }
   }
   
@@ -77,7 +77,8 @@ open class TimePicker: Picker, DateTimePickerDelegate {
     let timeComponents = Calendar.current.dateComponents([.day, .month, .year, .hour, .minute, .timeZone], from: instant)
     _instant = Calendar.current.date(from: timeComponents)!
     self._viewController?.setTime(_instant)
-    _customTime = true
+    _hour = timeComponents.hour!
+    _minute = timeComponents.minute!
   }
   
   @objc open func LaunchPicker() {
@@ -100,12 +101,6 @@ open class TimePicker: Picker, DateTimePickerDelegate {
   }
   
   open override func click() {
-    if !_customTime {
-      _instant = Date()
-      _viewController?.setTime(_instant)
-    } else {
-      _customTime = false
-    }
     if !_isPhone {
       if let popover = (_viewController as! UIViewController).popoverPresentationController {
         popover.delegate = self

--- a/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/DatePicker.java
@@ -49,7 +49,6 @@ public class DatePicker extends ButtonBase {
   private int year, month, javaMonth, day;
   private Calendar instant;
   private String [] localizedMonths = new DateFormatSymbols().getMonths();
-  private boolean customDate = false;
   private Form form;
   private Handler androidUIHandler;
 
@@ -139,17 +138,24 @@ public class DatePicker extends ButtonBase {
     }
     date.updateDate(year, jMonth, day);
     instant = Dates.DateInstant(year, month, day);
-    customDate = true;
+    this.year = year;
+    this.month = month;
+    this.javaMonth = jMonth;
+    this.day = day;
   }
 
   @SimpleFunction(description = "Allows the user to set the date from the instant to be displayed when the date picker opens.")
   public void SetDateToDisplayFromInstant(Calendar instant) {
     int year = Dates.Year(instant);
-    int month = Dates.Month(instant);
+    int jMonth = Dates.Month(instant);
+    int month = jMonth + 1;
     int day = Dates.Day(instant);
-    date.updateDate(year, month, day);
-    instant = Dates.DateInstant(year, month, day);
-    customDate = true;
+    date.updateDate(year, jMonth, day);
+    this.instant = Dates.DateInstant(year, month, day);
+    this.year = year;
+    this.month = month;
+    this.javaMonth = jMonth;
+    this.day = day;
   }
 
   /**
@@ -166,16 +172,7 @@ public class DatePicker extends ButtonBase {
    */
   @Override
   public void click() {
-    if (!customDate) {
-      Calendar c = Calendar.getInstance();
-      int year = c.get(Calendar.YEAR);
-      int jMonth = c.get(Calendar.MONTH);
-      int day = c.get(Calendar.DAY_OF_MONTH);
-      date.updateDate(year, jMonth, day);
-      instant = Dates.DateInstant(year, jMonth+1, day);
-    } else {
-      customDate = false;
-    }
+    date.updateDate(year, javaMonth, day);
     date.show();
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TimePicker.java
@@ -49,7 +49,6 @@ public class TimePicker extends ButtonBase {
   private int hour = 0;
   private int minute = 0;
   private TimePickerDialog time;
-  private boolean customTime = false;
   private Form form;
   private Calendar instant;
   private Handler androidUIHandler;
@@ -128,7 +127,8 @@ public class TimePicker extends ButtonBase {
     } else {
       time.updateTime(hour, minute);
       instant = Dates.TimeInstant(hour, minute);
-      customTime = true;
+      this.hour = hour;
+      this.minute = minute;
     }
   }
 
@@ -144,8 +144,9 @@ public class TimePicker extends ButtonBase {
     int hour = Dates.Hour(instant);
     int minute = Dates.Minute(instant);
     time.updateTime(hour, minute);
-    instant = Dates.TimeInstant(hour, minute);
-    customTime = true;
+    this.instant = Dates.TimeInstant(hour, minute);
+    this.hour = hour;
+    this.minute = minute;
   }
 
   /**
@@ -158,15 +159,7 @@ public class TimePicker extends ButtonBase {
 
   @Override
   public void click() {
-    if (!customTime) {
-      Calendar c = Calendar.getInstance();
-      int h = c.get(Calendar.HOUR_OF_DAY);
-      int m = c.get(Calendar.MINUTE);
-      time.updateTime(h, m);
-      instant = Dates.TimeInstant(hour, minute);
-    } else {
-      customTime = false;
-    }
+    time.updateTime(hour, minute);
     time.show();
   }
 


### PR DESCRIPTION
Resolves issue #3909 where cancelling out of a DatePicker or TimePicker causes the component to overwrite its state and default to today/now on subsequent opens.

- Removed internal custom tracking booleans.
- Updated `click()` logic to open pickers using the component's correctly stored internal state.
- Fixed `SetDateToDisplay` and `SetTimeToDisplay` variants to proactively sync the internal state.

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

*Description*
This PR fixes a state overwrite bug in both the `DatePicker` and `TimePicker` components across Android and iOS. Previously, opening the picker would forcefully overwrite the component's internal state with the current system date/time (unless a custom date/time had just been explicitly set via blocks). Consequently, if a user made a selection, clicked "Done", and then later opened the picker and clicked "Cancel", the picker would "forget" their previous selection and reset to today/now.

By removing the conditional logic that forces the system time, pickers now natively open using the component's properly stored internal state, which preserves user selections across cancellations. Additionally, the `SetDateToDisplay` and `SetTimeToDisplay` methods have been updated to proactively sync their values to the internal component fields to prevent stale property reads.

*(Note on Component Versioning: `YaVersion.java` does not need to be incremented for these components because this PR strictly updates internal lifecycle logic and does not add, remove, or modify the signature of any user-facing blocks or properties.)*

*Testing Guidelines*
1. Compile the companion or build an APK using a test project with a `DatePicker` and `TimePicker`.
2. Open the `DatePicker`, select a distinct date (e.g., in the year 2025), and click "Done".
3. Open the `DatePicker` again. Verify it opens to the picked 2025 date.
4. Click "Cancel".
5. Open the `DatePicker` again. Verify it **still** opens to the picked 2025 date (instead of reverting to today).
6. Repeat the same test sequence for the `TimePicker`.
7. Verify this consistent behavior across both Android and iOS devices.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3909

**Context for the changes**

Branched from `master` as the changes span both Android (`.java`) and iOS (`.swift`) component codebases. 

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
