### PR TITLE
Add runtime i18n prototype for app text

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -791,7 +791,7 @@ public abstract class ButtonBase extends AndroidViewComponent
       defaultValue = "")
   @SimpleProperty
   public void Text(String text) {
-    TextViewUtil.setText(view, text);
+    TextViewUtil.setText(view, container.$form().getTextIfKey(text));
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -84,6 +84,7 @@ import com.google.appinventor.components.runtime.util.BulkPermissionRequest;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.FileUtil;
 import com.google.appinventor.components.runtime.util.FullScreenVideoUtil;
+import com.google.appinventor.components.runtime.util.I18nUtil;
 import com.google.appinventor.components.runtime.util.JsonUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.OnInitializeListener;
@@ -168,6 +169,9 @@ public class Form extends AppInventorCompatActivity
 
   private float deviceDensity;
   private float compatScalingFactor;
+
+  // Internationalization utility
+  private I18nUtil i18nUtil;
 
   // applicationIsBeingClosed is set to true during closeApplication.
   private static boolean applicationIsBeingClosed;
@@ -427,6 +431,9 @@ public class Form extends AppInventorCompatActivity
     int softInputMode = params.softInputMode;
     getWindow().setSoftInputMode(
         softInputMode | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+
+    i18nUtil = new I18nUtil(this);
+    i18nUtil.load();
 
     // Add application components to the form
     $define();
@@ -1175,6 +1182,44 @@ public class Form extends AppInventorCompatActivity
     }
   }
 
+  /**
+   * Resolve a translation key using the active locale.
+   *
+   * This method is intentionally not exposed as a user-visible block in the MVP.
+   * Blockly integration should add a proper translated-text block later.
+   */
+  public String getText(String key) {
+    return getText(key, key);
+  }
+
+  /**
+   * Resolve a translation key using the active locale, falling back safely.
+   */
+  public String getText(String key, String fallback) {
+    if (i18nUtil == null) {
+      i18nUtil = new I18nUtil(this);
+      i18nUtil.load();
+    }
+    return i18nUtil.resolveKey(key, fallback);
+  }
+
+  /**
+   * Resolve text only when it is explicitly marked as an i18n key.
+   *
+   * Example:
+   * 
+   * @i18n:screen1_button1_text
+   *
+   *                            Normal strings are returned unchanged, preserving
+   *                            backward compatibility.
+   */
+  public String getTextIfKey(String text) {
+    if (i18nUtil == null) {
+      i18nUtil = new I18nUtil(this);
+      i18nUtil.load();
+    }
+    return i18nUtil.resolveText(text);
+  }
 
   /**
    * BigDefaultText property getter method.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Label.java
@@ -377,11 +377,14 @@ private void setLabelMargins(boolean hasMargins) {
       defaultValue = "")
   @SimpleProperty
   public void Text(String text) {
+    String resolvedText = container.$form().getTextIfKey(text);
+
     if (htmlFormat) {
-      TextViewUtil.setTextHTML(view, text);
+      TextViewUtil.setTextHTML(view, resolvedText);
     } else {
-      TextViewUtil.setText(view, text);
+      TextViewUtil.setText(view, resolvedText);
     }
+
     htmlContent = text;
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextBoxBase.java
@@ -445,7 +445,7 @@ public abstract class TextBoxBase extends AndroidViewComponent
   @SimpleProperty
   public void Hint(String hint) {
     this.hint = hint;
-    view.setHint(hint);
+    view.setHint(container.$form().getTextIfKey(hint));
     view.invalidate();
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/I18nUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/I18nUtil.java
@@ -1,0 +1,221 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+
+package com.google.appinventor.components.runtime.util;
+
+import android.content.res.AssetManager;
+import android.util.Log;
+
+import com.google.appinventor.components.runtime.Form;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Minimal runtime internationalization helper for App Inventor applications.
+ *
+ * MVP behavior:
+ * - Loads i18n.json from app assets if present.
+ * - Resolves strings prefixed with @i18n:.
+ * - Falls back safely when file/key/language is missing.
+ *
+ * This is intentionally runtime-only. Designer key generation, Blockly
+ * integration,
+ * and build-time strings.xml generation should be added in later phases.
+ */
+public final class I18nUtil {
+    private static final String LOG_TAG = "I18nUtil";
+    private static final String I18N_PREFIX = "@i18n:";
+    private static final String I18N_FILE = "i18n.json";
+
+    private final Form form;
+    private final Map<String, Map<String, String>> translations = new HashMap<String, Map<String, String>>();
+
+    private String defaultLanguage = "en";
+    private String currentLanguage;
+    private String currentLanguageWithRegion;
+    private boolean loaded = false;
+
+    public I18nUtil(Form form) {
+        this.form = form;
+        Locale locale = Locale.getDefault();
+        currentLanguage = normalizeLanguage(locale.getLanguage());
+
+        String country = locale.getCountry();
+        if (country != null && country.length() > 0) {
+            currentLanguageWithRegion = currentLanguage + "-" + country.toLowerCase(Locale.US);
+        } else {
+            currentLanguageWithRegion = currentLanguage;
+        }
+    }
+
+    public void load() {
+        if (loaded) {
+            return;
+        }
+
+        loaded = true;
+
+        try {
+            String json = readAsset(I18N_FILE);
+            if (json == null || json.trim().length() == 0) {
+                return;
+            }
+
+            parse(json);
+            Log.i(LOG_TAG, "Loaded " + translations.size() + " translation keys from " + I18N_FILE);
+        } catch (FileNotFoundException e) {
+            // Backward compatibility: most existing apps will not have i18n.json.
+            Log.i(LOG_TAG, "No " + I18N_FILE + " found. Internationalization disabled.");
+        } catch (IOException e) {
+            Log.w(LOG_TAG, "Unable to read " + I18N_FILE + ". Internationalization disabled.", e);
+        } catch (JSONException e) {
+            Log.w(LOG_TAG, "Invalid " + I18N_FILE + ". Internationalization disabled.", e);
+            translations.clear();
+        }
+    }
+
+    public String resolveText(String text) {
+        if (text == null) {
+            return "";
+        }
+
+        if (!text.startsWith(I18N_PREFIX)) {
+            return text;
+        }
+
+        String key = text.substring(I18N_PREFIX.length());
+        return resolveKey(key, text);
+    }
+
+    public String resolveKey(String key, String fallback) {
+        if (key == null || key.length() == 0) {
+            return fallback == null ? "" : fallback;
+        }
+
+        Map<String, String> values = translations.get(key);
+        if (values == null) {
+            return fallback == null ? key : fallback;
+        }
+
+        String value = lookup(values, currentLanguageWithRegion);
+        if (value != null) {
+            return value;
+        }
+
+        value = lookup(values, currentLanguage);
+        if (value != null) {
+            return value;
+        }
+
+        value = lookup(values, defaultLanguage);
+        if (value != null) {
+            return value;
+        }
+
+        value = lookup(values, "en");
+        if (value != null) {
+            return value;
+        }
+
+        return fallback == null ? key : fallback;
+    }
+
+    private String lookup(Map<String, String> values, String language) {
+        if (language == null) {
+            return null;
+        }
+
+        String value = values.get(normalizeLanguage(language));
+        return value == null || value.length() == 0 ? null : value;
+    }
+
+    private void parse(String json) throws JSONException {
+        JSONObject root = new JSONObject(json);
+
+        if (root.has("defaultLanguage")) {
+            defaultLanguage = normalizeLanguage(root.optString("defaultLanguage", "en"));
+        }
+
+        JSONObject translationRoot;
+
+        // Supports MVP format:
+        // {
+        // "defaultLanguage": "en",
+        // "translations": {
+        // "screen1_button1_text": { "en": "Submit", "hi": "जमा करें" }
+        // }
+        // }
+        //
+        // Also supports flat prototype format:
+        // {
+        // "screen1_button1_text": { "en": "Submit", "hi": "जमा करें" }
+        // }
+        if (root.has("translations")) {
+            translationRoot = root.getJSONObject("translations");
+        } else {
+            translationRoot = root;
+        }
+
+        Iterator<String> keys = translationRoot.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+
+            if ("defaultLanguage".equals(key) || "schemaVersion".equals(key) || "meta".equals(key)) {
+                continue;
+            }
+
+            Object maybeValues = translationRoot.opt(key);
+            if (!(maybeValues instanceof JSONObject)) {
+                continue;
+            }
+
+            JSONObject valuesObject = (JSONObject) maybeValues;
+            Map<String, String> values = new HashMap<String, String>();
+
+            Iterator<String> languages = valuesObject.keys();
+            while (languages.hasNext()) {
+                String language = languages.next();
+                values.put(normalizeLanguage(language), valuesObject.optString(language, ""));
+            }
+
+            translations.put(key, values);
+        }
+    }
+
+    private String readAsset(String assetName) throws IOException {
+        AssetManager assets = form.getAssets();
+        InputStream inputStream = null;
+
+        try {
+            inputStream = assets.open(assetName);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            byte[] buffer = new byte[4096];
+            int count;
+            while ((count = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, count);
+            }
+
+            return outputStream.toString("UTF-8");
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+    }
+
+    private String normalizeLanguage(String language) {
+        return language == null ? "" : language.replace('_', '-').toLowerCase(Locale.US);
+    }
+}


### PR DESCRIPTION
**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
This is a draft PR for early architectural feedback on a runtime-only MVP for app-level internationalisation.
The PR adds a small `I18nUtil` runtime helper that loads an `i18n.json` file from app assets, resolves strings marked with the `@i18n:` prefix using the device locale, and falls back safely when translations are missing.

For this prototype, the integration is intentionally limited to:

- `Button.Text`
- `Label.Text`
- `TextBox.Hint`

Normal strings remain unchanged, so existing projects should continue to work without modification.

Example:

```text
@i18n:screen1_button1_text

with i18n.json:

{
  "defaultLanguage": "en",
  "translations": {
    "screen1_button1_text": {
      "en": "Submit",
      "hi": "जमा करें"
    }
  }
}

```
The runtime resolves the value based on the device locale.

This PR does not yet include:

- Designer-generated translation keys
- Translation Editor UI
- Blockly translated-text blocks
- Build-time Android strings.xml generation
- Runtime UI refresh after device language changes
Known limitation: the locale is read at app startup. If the device language changes while the app is already running, existing UI does not refresh automatically yet.

Testing Guidelines

I tested this manually with a small sample app containing:

- Button1.Text = @ i18n:screen1_button1_text
- Label1.Text = @ i18n:screen1_label1_text
- TextBox1.Hint = @ i18n:screen1_textbox1_hint

and an uploaded i18n.json media asset.

Manual checks performed:

1. Button.Text resolves translated values
2. Label.Text resolves translated values
3. TextBox.Hint resolves translated values
4. Plain strings remain unchanged
5. TextBox.Text is intentionally not translated
6. Runtime updates from Blocks work for Button.Text, Label.Text, and TextBox.Hint
7. Changing language while the app is already running does not refresh UI automatically, which is expected for this MVP

This is currently a draft for feedback before expanding the implementation.