### PR TITLE
Fix for iOS matrix serialization (used when paired with CloudDB)

### DIFF
--- a/appinventor/components-ios/src/CloudDB.swift
+++ b/appinventor/components-ios/src/CloudDB.swift
@@ -445,7 +445,7 @@ public class CloudDB: NonvisibleComponent, RedisManagerDelegate {
   @objc open func DataChanged(_ tag: String, _ value: AnyObject?) {
     var tagValue = "" as AnyObject?
     if let valAsString = value as? String {
-      tagValue = try? getObjectFromJson(valAsString) ?? "" as AnyObject
+      tagValue = try? getYailObjectFromJson(valAsString, true)
     }
     EventDispatcher.dispatchEvent(of: self, called: "DataChanged", arguments: tag as AnyObject, tagValue ?? "" as AnyObject)
   }

--- a/appinventor/components-ios/src/JsonUtil.swift
+++ b/appinventor/components-ios/src/JsonUtil.swift
@@ -5,10 +5,18 @@
 
 import Foundation
 
+let TYPE_FIELD = "\u{0002}$type$\u{0003}"
+
 // let numberRegex = NSRegularExpression(pattern: "-?[1-9]?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?")
 public func getJsonRepresentation(_ object: AnyObject?) throws -> String {
   guard let object = object else {
     return "null"
+  }
+  if let matrix = object as? YailMatrix {
+    let dict: NSDictionary = [TYPE_FIELD as NSString: "YailMatrix" as NSString,
+                              "data" as NSString: matrix.toDataArray()]
+    let jsonData = try JSONSerialization.data(withJSONObject: dict)
+    return String(data: jsonData, encoding: .utf8)!
   }
   let wrappedObject = [object]
   guard JSONSerialization.isValidJSONObject(wrappedObject) else {
@@ -27,7 +35,7 @@ public func getObjectFromJson(_ json: String?) throws -> AnyObject? {
     return "" as NSString
   }
   // NSJSONSerialization can only parse arrays and objects at the top level, so we wrap value here
-  let jsonArray = "[\(jsonString)]"
+  let jsonArray = "[\(jsonString)]".replace(target: "\u{02}", withString: "\\u0002").replace(target: "\u{03}", withString: "\\u0003")
   let result = try JSONSerialization.jsonObject(with: jsonArray.data(using: .utf8)!,
                                                 options: JSONSerialization.ReadingOptions.mutableContainers)
   if let array = result as? Array<AnyObject> {
@@ -82,6 +90,12 @@ fileprivate func convertJsonItem(_ item: AnyObject?, _ useDicts: Bool) -> AnyObj
   if item == nil || item is NSNull {
     return "null" as AnyObject
   } else if let jsonObject = item as? NSDictionary {
+    if let typeValue = jsonObject[TYPE_FIELD as NSString] as? String,
+       typeValue == "YailMatrix",
+       let dataArray = jsonObject["data"] as? NSArray,
+       let matrix = try? YailMatrix.fromJsonArray(dataArray) {
+      return matrix
+    }
     if useDicts {
       return getDictFromJsonObject(jsonObject) as AnyObject
     } else {

--- a/appinventor/components-ios/tests/Unit Tests/util/JsonUtilTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/util/JsonUtilTests.swift
@@ -50,6 +50,11 @@ class JsonUtilTests: XCTestCase {
     XCTAssertThrowsError(try getJsonRepresentation(NSObject()), "Expected bad object to throw")
   }
 
+  func testSerializeMatrix() throws {
+    XCTAssertEqual("{\"data\":[[1,2],[3,4]],\"\\u0002$type$\\u0003\":\"YailMatrix\"}",
+                   try getJsonRepresentation(try YailMatrix(rows: 2, cols: 2, data: [[1, 2], [3, 4]])))
+  }
+
   // MARK: Parsing Tests
 
   func testParseEmpty() throws {
@@ -147,5 +152,18 @@ class JsonUtilTests: XCTestCase {
       return
     }
     XCTAssertEqual(7, list.length)
+  }
+
+  func testParseMatrix() throws {
+    let result = try getYailObjectFromJson("{\"data\":[[1,2],[3,4]],\"\\u0002$type$\\u0003\":\"YailMatrix\"}", true)
+    guard let matrix = result as? YailMatrix else {
+      XCTFail("Expected result to be a YailMatrix")
+      return
+    }
+    XCTAssertEqual([2, 2], matrix.getDimensions())
+    XCTAssertEqual(1, matrix.getCell(1, 1))
+    XCTAssertEqual(2, matrix.getCell(1, 2))
+    XCTAssertEqual(3, matrix.getCell(2, 1))
+    XCTAssertEqual(4, matrix.getCell(2, 2))
   }
 }

--- a/appinventor/schemekit/src/YailMatrix.swift
+++ b/appinventor/schemekit/src/YailMatrix.swift
@@ -310,6 +310,41 @@
     builder += "]"
     return builder
   }
+
+  public func toDataArray() -> NSArray {
+    return data.map { row in row.map { NSNumber(value: $0) } as NSArray } as NSArray
+  }
+
+  @objc public static func fromJsonArray(_ arr: NSArray) throws -> YailMatrix {
+    guard arr.count > 0 else { return try YailMatrix(rows: 0, cols: 0, data: []) }
+    guard let firstRow = arr[0] as? NSArray else {
+      throw MatrixError.dimensionMismatch("Expected array of arrays")
+    }
+    let rows = arr.count, cols = firstRow.count
+    var matrixData: [[Double]] = []
+    for i in 0..<rows {
+      guard let row = arr[i] as? NSArray, row.count == cols else {
+        throw MatrixError.dimensionMismatch("Inconsistent row lengths")
+      }
+      matrixData.append(try row.map {
+        guard let n = $0 as? NSNumber else {
+          throw MatrixError.dimensionMismatch("Expected number in matrix data")
+        }
+        return n.doubleValue
+      })
+    }
+    return try YailMatrix(rows: rows, cols: cols, data: matrixData)
+  }
+
+  @objc public static func matrixToAlist(_ matrix: YailMatrix) -> YailList<AnyObject> {
+    let outer = YailList<AnyObject>()
+    for row in matrix.data {
+      let inner = YailList<AnyObject>()
+      for val in row { inner.add(NSNumber(value: val)) }
+      outer.add(inner)
+    }
+    return outer
+  }
 }
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
The iOS implementation of matrices does not have a way to serialize YailMatrix like the Android counterpart, so this PR adds both serialization and handling of TYPE_FIELD when reading back.

This was discovered while working on the CloudDB editor which makes use of this functionality, but editor usage is not needed to reproduce the problem.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
Create an app the adds a Matrix to CloudDB. It will crash the app with a json parse issue.
Rebuild the iOS companion and try the app again. It should work.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
