### PR TITLE
corrected a small listener bug in setDivider()

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -1305,16 +1305,15 @@ public final class ListView extends AndroidViewComponent {
    * Sets new dividers or margins in RecyclerView
    */
   private void setDivider() {
-    DividerItemDecoration dividerDecoration = new DividerItemDecoration();
-    dividerDecoration.removeLayoutChangeListener();
     for (int i = 0; i < recyclerView.getItemDecorationCount(); i++) {
       RecyclerView.ItemDecoration decoration = recyclerView.getItemDecorationAt(i);
       if (decoration instanceof DividerItemDecoration) {
+        ((DividerItemDecoration) decoration).removeLayoutChangeListener();
         recyclerView.removeItemDecorationAt(i);
         break;
       }
     }
-    recyclerView.addItemDecoration(dividerDecoration);
+    recyclerView.addItemDecoration(new DividerItemDecoration());
   }
 
   public void setListAdapter(ListAdapterWithRecyclerView adapter) {


### PR DESCRIPTION
**What does this PR accomplish?**

Fixes a listener leak in `ListView.setDivider()`. The method was calling `removeLayoutChangeListener()` on the newly created `DividerItemDecoration` instead of the existing one being replaced. As a result, the old decoration's `OnLayoutChangeListener` — which gets registered on the `RecyclerView` when horizontal orientation and margins are both active — was never unregistered before the old decoration was discarded. Every subsequent call to `setDivider()` (triggered by changing `DividerColor`, `DividerThickness`, or `ElementMarginsWidth`) would leave another orphaned listener registered on the `RecyclerView`.

Fixes #2597

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base
- [x] Google Java style guide
- [x] Indentation has been double checked
- [x] This PR does not include unnecessary changes such as formatting or white space
