### PR TITLE
Add TextAlignmentMain and TextAlignmentDetail properties to ListView

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
@@ -67,6 +67,8 @@ public final class MockListView extends MockVisibleComponent {
   private String detailTypeface;
   private String mainFontSize;
   private String detailFontSize;
+  private int mainTextAlignment = 0;
+  private int detailTextAlignment = 0;
   private int imageHeight;
   private int imageWidth;
   private int itemHeight;
@@ -200,12 +202,13 @@ public final class MockListView extends MockVisibleComponent {
   private void createSingleTextLayout(JSONObject object) {
     verticalItemPanel = new FlowPanel();
     String text1 = object.containsKey("Text1") ? object.get("Text1").isString().stringValue() : "";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);
+    main.setWidth("100%");
     verticalItemPanel.add(main);
     setItemHeight(false, false);
-    decorateWidget(verticalItemPanel);    
+    decorateWidget(verticalItemPanel);
     listPanel.add(verticalItemPanel);
   }
 
@@ -214,12 +217,12 @@ public final class MockListView extends MockVisibleComponent {
     FlowPanel container = new FlowPanel();
     String text1 = object.containsKey("Text1") ? object.get("Text1").isString().stringValue() : "";
     String text2 = object.containsKey("Text2") ? object.get("Text2").isString().stringValue() : "";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);
     main.setWidth("100%");
     main.getElement().getStyle().setDisplay(Display.BLOCK);
-    InlineLabel detail = createInlineLabel(text2, detailTextColor);
+    InlineLabel detail = createInlineLabel(text2, detailTextColor, detailTextAlignment);
     MockComponentsUtil.setWidgetFontSize(detail, detailFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, detail, detailTypeface);
     detail.setWidth("100%");
@@ -237,13 +240,14 @@ public final class MockListView extends MockVisibleComponent {
     horizontalItemPanel = new FlowPanel();
     String text1 = object.containsKey("Text1") ? object.get("Text1").isString().stringValue() : "";
     String text2 = object.containsKey("Text2") ? object.get("Text2").isString().stringValue() : "";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);
-    InlineLabel detail = createInlineLabel(text2, detailTextColor);
+    main.setWidth("50%");
+    InlineLabel detail = createInlineLabel(text2, detailTextColor, detailTextAlignment);
     MockComponentsUtil.setWidgetFontSize(detail, detailFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, detail, detailTypeface);
-    detail.getElement().getStyle().setMarginLeft(5, Unit.PX);
+    detail.setWidth("50%");
     horizontalItemPanel.add(main);
     horizontalItemPanel.add(detail);
     horizontalItemPanel.getElement().getStyle().setVerticalAlign(VerticalAlign.BASELINE);  
@@ -258,9 +262,10 @@ public final class MockListView extends MockVisibleComponent {
     String text1 = object.containsKey("Text1") ? object.get("Text1").isString().stringValue() : "";
     String image =
         object.containsKey("Image") ? object.get("Image").isString().stringValue() : "None";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     main.getElement().getStyle().setVerticalAlign(VerticalAlign.MIDDLE);
-    main.getElement().getStyle().setDisplay(Display.INLINE);
+    main.getElement().getStyle().setDisplay(Display.INLINE_BLOCK);
+    main.setWidth("calc(100% - " + imageWidth + "px)");
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);    
     horizontalItemPanel.add(createImage(image, imageWidth + "px", imageHeight + "px"));
@@ -277,12 +282,14 @@ public final class MockListView extends MockVisibleComponent {
     String text2 = object.containsKey("Text2") ? object.get("Text2").isString().stringValue() : "";
     String image =
         object.containsKey("Image") ? object.get("Image").isString().stringValue() : "None";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);
-    InlineLabel detail = createInlineLabel(text2, detailTextColor);
+    main.setWidth("100%");
+    InlineLabel detail = createInlineLabel(text2, detailTextColor, detailTextAlignment);
     MockComponentsUtil.setWidgetFontSize(detail, detailFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, detail, detailTypeface);
+    detail.setWidth("100%");
     verticalItemPanel.add(main);
     verticalItemPanel.add(detail);
     verticalItemPanel.getElement().getStyle().setDisplay(Display.INLINE_FLEX);
@@ -302,14 +309,14 @@ public final class MockListView extends MockVisibleComponent {
     String text1 = object.containsKey("Text1") ? object.get("Text1").isString().stringValue() : "";
     String text2 = object.containsKey("Text2") ? object.get("Text2").isString().stringValue() : "";
     String image = object.containsKey("Image") ? object.get("Image").isString().stringValue() : "None";
-    InlineLabel main = createInlineLabel(text1, textColor);
+    InlineLabel main = createInlineLabel(text1, textColor, mainTextAlignment);
     MockComponentsUtil.setWidgetFontSize(main, mainFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);
-    main.getElement().getStyle().setTextAlign(TextAlign.CENTER);
-    InlineLabel detail = createInlineLabel(text2, detailTextColor);
+    main.setWidth("100%");
+    InlineLabel detail = createInlineLabel(text2, detailTextColor, detailTextAlignment);
     MockComponentsUtil.setWidgetFontSize(detail, detailFontSize);
     MockComponentsUtil.setWidgetFontTypeface(this.editor, detail, detailTypeface);
-    detail.getElement().getStyle().setTextAlign(TextAlign.CENTER);
+    detail.setWidth("100%");
     verticalItemPanel.add(main);
     verticalItemPanel.add(detail);
     verticalItemPanel.getElement().getStyle().setDisplay(Display.FLEX);
@@ -398,11 +405,19 @@ public final class MockListView extends MockVisibleComponent {
    * @param value text to be displayed
    * @param color color of the text
    */
-  private InlineLabel createInlineLabel(String value, String color) {
+  private TextAlign toTextAlign(int alignment) {
+    switch (alignment) {
+      case 1:  return TextAlign.CENTER;
+      case 2:  return TextAlign.RIGHT;
+      default: return TextAlign.LEFT;
+    }
+  }
+
+  private InlineLabel createInlineLabel(String value, String color, int alignment) {
     InlineLabel label = new InlineLabel(value.isEmpty() ? " ​" : value);
     MockComponentsUtil.setWidgetTextColor(label, color);
     label.getElement().getStyle().setDisplay(Display.INLINE_BLOCK);
-    label.getElement().getStyle().setTextAlign(TextAlign.LEFT);    
+    label.getElement().getStyle().setTextAlign(toTextAlign(alignment));
     return label;
   }
 
@@ -508,6 +523,12 @@ public final class MockListView extends MockVisibleComponent {
       refreshElements();
     } else if (propertyName.equals(PROPERTY_NAME_IMAGEWIDTH)) {
       imageWidth = Integer.valueOf(newValue) / 5;
+      refreshElements();
+    } else if (propertyName.equals(PROPERTY_NAME_TEXT_ALIGNMENT_MAIN)) {
+      mainTextAlignment = Integer.parseInt(newValue);
+      refreshElements();
+    } else if (propertyName.equals(PROPERTY_NAME_TEXT_ALIGNMENT_DETAIL)) {
+      detailTextAlignment = Integer.parseInt(newValue);
       refreshElements();
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockListView.java
@@ -229,6 +229,7 @@ public final class MockListView extends MockVisibleComponent {
     detail.getElement().getStyle().setDisplay(Display.BLOCK);
     container.add(main);
     container.add(detail);
+    container.setWidth("100%");
     setItemHeight(true, false);
     decorateWidget(verticalItemPanel);
     container.getElement().getStyle().setProperty("flex-direction", "column");
@@ -250,8 +251,12 @@ public final class MockListView extends MockVisibleComponent {
     detail.setWidth("50%");
     horizontalItemPanel.add(main);
     horizontalItemPanel.add(detail);
-    horizontalItemPanel.getElement().getStyle().setVerticalAlign(VerticalAlign.BASELINE);  
-    //horizontalItemPanel.getElement().getStyle().setAlignItems(Style.AlignItems.BASELINE);
+    // The parent .listViewItemStyle is `display: flex; align-items: center`,
+    // which collapses mismatched-height labels to the vertical center.
+    // Override with baseline so the labels' first text lines align visually
+    // (top alignment makes the smaller detail font appear higher than the
+    // larger main font due to font-metric differences).
+    horizontalItemPanel.getElement().getStyle().setProperty("alignItems", "baseline");
     setItemHeight(false, false);
     decorateWidget(horizontalItemPanel);
     listPanel.add(horizontalItemPanel);
@@ -270,6 +275,9 @@ public final class MockListView extends MockVisibleComponent {
     MockComponentsUtil.setWidgetFontTypeface(this.editor, main, mainTypeface);    
     horizontalItemPanel.add(createImage(image, imageWidth + "px", imageHeight + "px"));
     horizontalItemPanel.add(main);
+    // Top-align image + text so the image stays at the top of the row when
+    // text wraps (parent .listViewItemStyle defaults to align-items: center).
+    horizontalItemPanel.getElement().getStyle().setProperty("alignItems", "flex-start");
     setItemHeight(false, true);
     decorateWidget(horizontalItemPanel);
     listPanel.add(horizontalItemPanel);
@@ -297,6 +305,9 @@ public final class MockListView extends MockVisibleComponent {
     verticalItemPanel.getElement().getStyle().setVerticalAlign(VerticalAlign.MIDDLE);    
     horizontalItemPanel.add(createImage(image, imageWidth + "px", imageHeight + "px"));
     horizontalItemPanel.add(verticalItemPanel);
+    // Top-align image + label stack so the image stays at the top of the row
+    // when text wraps (parent .listViewItemStyle defaults to align-items: center).
+    horizontalItemPanel.getElement().getStyle().setProperty("alignItems", "flex-start");
     setItemHeight(true, true);
     decorateWidget(horizontalItemPanel);
     listPanel.add(horizontalItemPanel);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -70,6 +70,8 @@ public abstract class MockVisibleComponent extends MockComponent {
   protected static final String PROPERTY_NAME_TOP = "Top";
   protected static final String PROPERTY_NAME_LISTVIEW_ADD_DATA = "ListData";
   protected static final String PROPERTY_NAME_LISTVIEW_LAYOUT = "ListViewLayout";
+  protected static final String PROPERTY_NAME_TEXT_ALIGNMENT_MAIN = "TextAlignmentMain";
+  protected static final String PROPERTY_NAME_TEXT_ALIGNMENT_DETAIL = "TextAlignmentDetail";
 
   // Note: the values below are duplicated in Component.java
   // If you change them here, change them there!

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1572,6 +1572,11 @@ public final class YoungAndroidFormUpgrader {
       // Properties related to this component have now been upgraded to version 10.
       srcCompVersion = 10;
     }
+    if (srcCompVersion < 11) {
+      // Added TextAlignmentMain property (default: 0 = left).
+      // Added TextAlignmentDetail property (default: 0 = left).
+      srcCompVersion = 11;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2476,10 +2476,15 @@ Blockly.Versioning.AllUpgradeMaps =
     8: "noUpgrade",
     // AI2: Fixed a designer property issue with ElementColor
     9: "noUpgrade",
-    // AI2: 
+    // AI2:
     // - Changed TextSize property to FontSize
     // - Add new layout
-    10: "noUpgrade"
+    10: "noUpgrade",
+
+    // AI2:
+    // - Added TextAlignmentMain property
+    // - Added TextAlignmentDetail property
+    11: "noUpgrade"
 
   }, // End ListView upgraders
 

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -707,11 +707,33 @@ let HORIZONTAL_LAYOUT = 1
       cell.textLabel?.lineBreakMode = .byWordWrapping
     } else {
       let listDataIndex = indexPath.row - _elements.count
-      if _listViewLayoutMode == 1{
+      if _listViewLayoutMode == 1 {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44
         cell.textLabel?.text = _listData[listDataIndex]["Text1"]
         cell.detailTextLabel?.text = _listData[listDataIndex]["Text2"]
+
+        // Wrap system labels in a full-width vertical stack so textAlignment
+        // is visible for short strings. (UIKit's default subtitle layout
+        // sizes labels to content for short text, making centering invisible.)
+        cell.layoutMargins = UIEdgeInsets.zero
+        cell.separatorInset = UIEdgeInsets.zero
+        cell.preservesSuperviewLayoutMargins = true
+
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.addArrangedSubview(cell.textLabel!)
+        stackView.addArrangedSubview(cell.detailTextLabel!)
+        cell.contentView.addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor)
+        ])
       } else if _listViewLayoutMode == 2 {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 60
@@ -729,10 +751,14 @@ let HORIZONTAL_LAYOUT = 1
         cell.separatorInset = UIEdgeInsets.zero
         cell.preservesSuperviewLayoutMargins = true
 
-        // Create a stack view to hold the labels horizontally
+        // Create a stack view to hold the labels horizontally. Align by
+        // first baseline so the labels' first text lines line up visually
+        // regardless of font-size differences (top alignment makes the
+        // smaller detail font appear higher than main due to font metrics;
+        // .fill stretches labels vertically and centers the text inside).
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.alignment = .fill
+        stackView.alignment = .firstBaseline
         stackView.distribution = .fillEqually
 
         // Add the labels to the stack view
@@ -811,10 +837,12 @@ let HORIZONTAL_LAYOUT = 1
           horizontalStackView.distribution = .fill
           horizontalStackView.spacing = 8.0
 
-          // Create a vertical stack view to hold the textLabel and detailTextLabel
+          // Create a vertical stack view to hold the textLabel and detailTextLabel.
+          // Use .fill so labels span the inner stack width and textAlignment is
+          // visible regardless of text length.
           let verticalStackView = UIStackView()
           verticalStackView.axis = .vertical
-          verticalStackView.alignment = .leading
+          verticalStackView.alignment = .fill
           verticalStackView.distribution = .fill
           verticalStackView.spacing = 8.0
 
@@ -855,22 +883,31 @@ let HORIZONTAL_LAYOUT = 1
           cell.separatorInset = UIEdgeInsets.zero
           cell.preservesSuperviewLayoutMargins = true
 
-          // Create a vertical stack view
+          // Inner stack: labels with .fill so they span the full label-stack
+          // width, making textAlignment visible regardless of text length.
+          let labelsStackView = UIStackView()
+          labelsStackView.axis = .vertical
+          labelsStackView.alignment = .fill
+          labelsStackView.distribution = .fill
+          labelsStackView.spacing = 8.0
+          labelsStackView.addArrangedSubview(cell.textLabel!)
+          labelsStackView.addArrangedSubview(cell.detailTextLabel!)
+
+          // Outer stack: image (centered) + labels stack
           let verticalStackView = UIStackView()
           verticalStackView.axis = .vertical
           verticalStackView.alignment = .center
           verticalStackView.distribution = .fill
           verticalStackView.spacing = 8.0
-
-          // Add the imageView, textLabel and detailTextLabel to the vertical stack view
           verticalStackView.addArrangedSubview(cell.imageView!)
-          verticalStackView.addArrangedSubview(cell.textLabel!)
-          verticalStackView.addArrangedSubview(cell.detailTextLabel!)
+          verticalStackView.addArrangedSubview(labelsStackView)
 
-          // Add the horizontal stack view to the cell's content view
+          // Add the outer stack to the cell's content view
           cell.contentView.addSubview(verticalStackView)
 
-          // Set up constraints
+          // Set up constraints. The labelsStackView width is pinned to the
+          // outer stack so labels span full row width while the image stays
+          // centered at its intrinsic / explicit size.
           verticalStackView.translatesAutoresizingMaskIntoConstraints = false
           NSLayoutConstraint.activate([
             verticalStackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
@@ -878,7 +915,8 @@ let HORIZONTAL_LAYOUT = 1
             verticalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
             verticalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0),
             cell.imageView!.widthAnchor.constraint(equalToConstant: CGFloat(_imageWidth / 4)),
-            cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4))
+            cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4)),
+            labelsStackView.widthAnchor.constraint(equalTo: verticalStackView.widthAnchor)
           ])
         }
       } else {
@@ -889,6 +927,8 @@ let HORIZONTAL_LAYOUT = 1
 
       cell.textLabel?.numberOfLines = 0
       cell.textLabel?.lineBreakMode = .byWordWrapping
+      cell.detailTextLabel?.numberOfLines = 0
+      cell.detailTextLabel?.lineBreakMode = .byWordWrapping
     }
 
     cell.textLabel?.font = cell.textLabel?.font.withSize(CGFloat(_fontSize))

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -52,6 +52,8 @@ let HORIZONTAL_LAYOUT = 1
   fileprivate var _elementMarginsWidth = Int32(0)
   fileprivate var _imageHeight = Int32(200)
   fileprivate var _imageWidth = Int32(200)
+  fileprivate var _textAlignmentMain = Alignment.normal.rawValue
+  fileprivate var _textAlignmentDetail = Alignment.normal.rawValue
 
   let COMPANION_CORRECTION = 5
 
@@ -551,6 +553,56 @@ let HORIZONTAL_LAYOUT = 1
     }
   }
 
+  @objc open var TextAlignmentMain: Int32 {
+    get {
+      return _textAlignmentMain
+    }
+    set(alignment) {
+      if Alignment(rawValue: alignment) != nil {
+        _textAlignmentMain = alignment
+        _view.reloadData()
+        _collectionView.reloadData()
+      }
+    }
+  }
+
+  @objc open var TextAlignmentDetail: Int32 {
+    get {
+      return _textAlignmentDetail
+    }
+    set(alignment) {
+      if Alignment(rawValue: alignment) != nil {
+        _textAlignmentDetail = alignment
+        _view.reloadData()
+        _collectionView.reloadData()
+      }
+    }
+  }
+
+  fileprivate func nsTextAlignment(for value: Int32, in view: UIView) -> NSTextAlignment {
+    var rtl = false
+    if #available(iOS 9.0, *) {
+      if UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft {
+        rtl = true
+      }
+    } else {
+      if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+        rtl = true
+      }
+    }
+    guard let align = Alignment(rawValue: value) else {
+      return rtl ? .right : .left
+    }
+    switch align {
+      case .normal:
+        return rtl ? .right : .left
+      case .center:
+        return .center
+      case .opposite:
+        return rtl ? .left : .right
+    }
+  }
+
   // MARK: Methods
 
   @objc open func AddItem(_ mainText: String, _ detailText: String, _ imageName: String) {
@@ -666,6 +718,12 @@ let HORIZONTAL_LAYOUT = 1
         cell.textLabel?.text = _listData[listDataIndex]["Text1"]
         cell.detailTextLabel?.text = _listData[listDataIndex]["Text2"]
 
+        // Both labels wrap inside their 50% half (matches the Designer mock).
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.lineBreakMode = .byWordWrapping
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.detailTextLabel?.lineBreakMode = .byWordWrapping
+
         // Configure the layout
         cell.layoutMargins = UIEdgeInsets.zero
         cell.separatorInset = UIEdgeInsets.zero
@@ -675,7 +733,7 @@ let HORIZONTAL_LAYOUT = 1
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .fill
-        stackView.distribution = .fill
+        stackView.distribution = .fillEqually
 
         // Add the labels to the stack view
         stackView.addArrangedSubview(cell.textLabel!)
@@ -906,6 +964,10 @@ let HORIZONTAL_LAYOUT = 1
     cell.selectedBackgroundView?.backgroundColor =
         argbToColor(_selectionColor == Int32(bitPattern: Color.default.rawValue)
         ? Int32(bitPattern: kListViewDefaultSelectionColor.rawValue) : _selectionColor)
+
+    cell.textLabel?.textAlignment = nsTextAlignment(for: _textAlignmentMain, in: cell)
+    cell.detailTextLabel?.textAlignment = nsTextAlignment(for: _textAlignmentDetail, in: cell)
+
     return cell
   }
 
@@ -1072,6 +1134,9 @@ let HORIZONTAL_LAYOUT = 1
     // Image
     cell.imageView.image = image
     cell.imageView.isHidden = (image == nil)
+
+    cell.titleLabel.textAlignment = nsTextAlignment(for: _textAlignmentMain, in: cell)
+    cell.detailLabel.textAlignment = nsTextAlignment(for: _textAlignmentDetail, in: cell)
 
     return cell
   }

--- a/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
@@ -152,6 +152,57 @@ class ListViewTests: AppInventorTestCase {
     }
   }
 
+  func testTextAlignmentMain() {
+    testList.Elements = ["Test"] as [AnyObject]
+
+    if let tableView = testList.view.subviews.first(where: { $0 is UITableView && !$0.isHidden }) as? UITableView {
+      // Default should be normal (left in LTR)
+      var cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(Alignment.normal.rawValue, testList.TextAlignmentMain)
+      XCTAssertEqual(NSTextAlignment.left, cell.textLabel?.textAlignment)
+
+      // Center
+      testList.TextAlignmentMain = Alignment.center.rawValue
+      XCTAssertEqual(Alignment.center.rawValue, testList.TextAlignmentMain)
+      cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(NSTextAlignment.center, cell.textLabel?.textAlignment)
+
+      // Opposite (right in LTR)
+      testList.TextAlignmentMain = Alignment.opposite.rawValue
+      XCTAssertEqual(Alignment.opposite.rawValue, testList.TextAlignmentMain)
+      cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(NSTextAlignment.right, cell.textLabel?.textAlignment)
+    } else {
+      XCTFail("Expected UITableView to be visible")
+    }
+  }
+
+  func testTextAlignmentDetail() {
+    testList.ListViewLayout = 1
+    testList.ListData = "[{\"Text1\": \"apple\", \"Text2\": \"2.99\", \"Image\": \"\"}]"
+
+    if let tableView = testList.view.subviews.first(where: { $0 is UITableView && !$0.isHidden }) as? UITableView {
+      // Default should be normal (left in LTR)
+      var cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(Alignment.normal.rawValue, testList.TextAlignmentDetail)
+      XCTAssertEqual(NSTextAlignment.left, cell.detailTextLabel?.textAlignment)
+
+      // Center
+      testList.TextAlignmentDetail = Alignment.center.rawValue
+      XCTAssertEqual(Alignment.center.rawValue, testList.TextAlignmentDetail)
+      cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(NSTextAlignment.center, cell.detailTextLabel?.textAlignment)
+
+      // Opposite (right in LTR)
+      testList.TextAlignmentDetail = Alignment.opposite.rawValue
+      XCTAssertEqual(Alignment.opposite.rawValue, testList.TextAlignmentDetail)
+      cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+      XCTAssertEqual(NSTextAlignment.right, cell.detailTextLabel?.textAlignment)
+    } else {
+      XCTFail("Expected UITableView to be visible")
+    }
+  }
+
   func testListData() {
     testList.ListData = "[{\"Text1\": \"apple\", \"Text2\": \"2.99\", \"Image\": \"apple.jpg\"}]"
     XCTAssertEqual(1, testList.Elements.count)

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1216,7 +1216,10 @@ public class YaVersion {
   // For LISTVIEW_COMPONENT_VERSION 10:
   // - Changed TextSize property to FontSize
   // - Add new layout
-  public static final int LISTVIEW_COMPONENT_VERSION = 10;
+  // For LISTVIEW_COMPONENT_VERSION 11:
+  // - Added TextAlignmentMain property
+  // - Added TextAlignmentDetail property
+  public static final int LISTVIEW_COMPONENT_VERSION = 11;
 
   // For LOCATIONSENSOR_COMPONENT_VERSION 2:
   // - The TimeInterval and DistanceInterval properties were added.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -124,6 +124,9 @@ public final class ListView extends AndroidViewComponent {
   private int layout;
   private String propertyValue;  // JSON string representing data entered through the Designer
 
+  private int textAlignmentMain;
+  private int textAlignmentDetail;
+
   private boolean multiSelect;
   private Paint dividerPaint;
   private int dividerColor;
@@ -233,6 +236,8 @@ public final class ListView extends AndroidViewComponent {
     ElementCornerRadius(DEFAULT_RADIUS);
     MultiSelect(false);
     BounceEdgeEffect(false);
+    TextAlignmentMain(Component.ALIGNMENT_NORMAL);
+    TextAlignmentDetail(Component.ALIGNMENT_NORMAL);
     ElementsFromString("");
     ListData("");
 
@@ -788,6 +793,70 @@ public final class ListView extends AndroidViewComponent {
   }
 
   /**
+   * Returns the alignment of the main text in ListView elements: center, normal
+   * (e.g., left-justified if text is written left to right), or opposite
+   * (e.g., right-justified if text is written left to right).
+   *
+   * @return one of {@link Component#ALIGNMENT_NORMAL},
+   *         {@link Component#ALIGNMENT_CENTER} or
+   *         {@link Component#ALIGNMENT_OPPOSITE}
+   */
+  @SimpleProperty(description = "Specifies the alignment of the main text in ListView elements.",
+      category = PropertyCategory.APPEARANCE)
+  public int TextAlignmentMain() {
+    return textAlignmentMain;
+  }
+
+  /**
+   * Specifies the alignment of the main text in ListView elements: center, normal
+   * (e.g., left-justified if text is written left to right), or opposite
+   * (e.g., right-justified if text is written left to right).
+   *
+   * @param alignment one of {@link Component#ALIGNMENT_NORMAL},
+   *                  {@link Component#ALIGNMENT_CENTER} or
+   *                  {@link Component#ALIGNMENT_OPPOSITE}
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTALIGNMENT,
+      defaultValue = Component.ALIGNMENT_NORMAL + "")
+  @SimpleProperty
+  public void TextAlignmentMain(int alignment) {
+    textAlignmentMain = alignment;
+    setAdapterData();
+  }
+
+  /**
+   * Returns the alignment of the detail text in ListView elements: center, normal
+   * (e.g., left-justified if text is written left to right), or opposite
+   * (e.g., right-justified if text is written left to right).
+   *
+   * @return one of {@link Component#ALIGNMENT_NORMAL},
+   *         {@link Component#ALIGNMENT_CENTER} or
+   *         {@link Component#ALIGNMENT_OPPOSITE}
+   */
+  @SimpleProperty(description = "Specifies the alignment of the detail text in ListView elements.",
+      category = PropertyCategory.APPEARANCE)
+  public int TextAlignmentDetail() {
+    return textAlignmentDetail;
+  }
+
+  /**
+   * Specifies the alignment of the detail text in ListView elements: center, normal
+   * (e.g., left-justified if text is written left to right), or opposite
+   * (e.g., right-justified if text is written left to right).
+   *
+   * @param alignment one of {@link Component#ALIGNMENT_NORMAL},
+   *                  {@link Component#ALIGNMENT_CENTER} or
+   *                  {@link Component#ALIGNMENT_OPPOSITE}
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_TEXTALIGNMENT,
+      defaultValue = Component.ALIGNMENT_NORMAL + "")
+  @SimpleProperty
+  public void TextAlignmentDetail(int alignment) {
+    textAlignmentDetail = alignment;
+    setAdapterData();
+  }
+
+  /**
    * Returns the image width of ListView layouts containing images
    *
    * @return width of image
@@ -1263,34 +1332,40 @@ public final class ListView extends AndroidViewComponent {
       case LISTVIEW_LAYOUT_SINGLE_TEXT:
         setListAdapter(new ListViewSingleTextAdapter(container, items,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight));
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT:
         setListAdapter(new ListViewTwoTextAdapter(container, items,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight));
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT_LINEAR:
         setListAdapter(new ListViewTwoTextLinearAdapter(container, items,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight));
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT:
         setListAdapter(new ListViewImageSingleTextAdapter(container, items,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight));
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TWO_TEXT:
         setListAdapter(new ListViewImageTwoTextVerticalAdapter(container, items,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight));
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT:
         setListAdapter(new ListViewImageTopTwoTextAdapter(container, items,
-          textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-          elementColor, selectionColor, radius, imageWidth, imageHeight));
+            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
+            elementColor, selectionColor, radius, imageWidth, imageHeight,
+            textAlignmentMain, textAlignmentDetail));
         break;
-    }    
+    }
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
@@ -31,11 +31,12 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
   private String textMainFont;
   private int imageWidth;
   private int imageHeight;
+  private int textMainAlignment;
 
   public ListViewImageSingleTextAdapter(ComponentContainer container, List<Object> data,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight) {
+      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
@@ -43,6 +44,7 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     this.textMainFont = textMainFont;
     this.imageWidth = imageWidth;
     this.imageHeight = imageHeight;
+    this.textMainAlignment = textMainAlignment;
   }  
 
   @Override
@@ -63,11 +65,12 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     TextView textViewFirst = new TextView(container.$context());
     final int idFirst = ViewCompat.generateViewId();
     textViewFirst.setId(idFirst);
-    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
@@ -32,6 +32,8 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
   private String textDetailFont;
   private int imageWidth;
   private int imageHeight;
+  private int textMainAlignment;
+  private int textDetailAlignment;
 
   public ListViewImageTopTwoTextAdapter(
       ComponentContainer container,
@@ -46,7 +48,9 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
       int selectionColor,
       int radius,
       int imageWidth,
-      int imageHeight) {
+      int imageHeight,
+      int textMainAlignment,
+      int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
@@ -57,6 +61,8 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     this.textDetailFont = textDetailFont;
     this.imageWidth = imageWidth;
     this.imageHeight = imageHeight;
+    this.textMainAlignment = textMainAlignment;
+    this.textDetailAlignment = textDetailAlignment;
   }
 
   @Override
@@ -79,11 +85,12 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 =
         new LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -91,11 +98,12 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     textViewSecond.setId(idSecond);
     LinearLayout.LayoutParams layoutParams2 =
         new LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewSecond.setTextSize(textDetailSize);
     TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
     textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
+    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayoutTexts = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinearTexts =

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
@@ -34,11 +34,13 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
   private String textDetailFont;
   private int imageWidth;
   private int imageHeight;
+  private int textMainAlignment;
+  private int textDetailAlignment;
 
   public ListViewImageTwoTextVerticalAdapter(ComponentContainer container, List<Object> data,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight) {
+      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
@@ -46,9 +48,11 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     this.textMainFont = textMainFont;
     this.textDetailColor = textDetailColor;
     this.textDetailSize = textDetailSize;
-    this.textDetailFont = textDetailFont;    
+    this.textDetailFont = textDetailFont;
     this.imageWidth = imageWidth;
     this.imageHeight = imageHeight;
+    this.textMainAlignment = textMainAlignment;
+    this.textDetailAlignment = textDetailAlignment;
   }  
 
   @Override
@@ -69,11 +73,12 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     TextView textViewFirst = new TextView(container.$context());
     final int idFirst = ViewCompat.generateViewId();
     textViewFirst.setId(idFirst);
-    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -81,11 +86,12 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     textViewSecond.setId(idSecond);
     LinearLayout.LayoutParams layoutParams2 =
             new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+                    LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewSecond.setTextSize(textDetailSize);
     TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
     textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
+    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout2 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear2 =

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
@@ -22,16 +22,18 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
   private int textMainColor;
   private float textMainSize;
   private String textMainFont;
+  private int textMainAlignment;
 
   public ListViewSingleTextAdapter(ComponentContainer container, List<Object> data,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight) {
+      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
     this.textMainFont = textMainFont;
+    this.textMainAlignment = textMainAlignment;
   }
   
 
@@ -44,11 +46,12 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
     TextView textViewFirst = new TextView(container.$context());
     final int idFirst = ViewCompat.generateViewId();
     textViewFirst.setId(idFirst);
-    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     linearLayout1.setLayoutParams(layoutParamslinear1);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
@@ -24,11 +24,13 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
   private int textDetailColor;
   private float textDetailSize;
   private String textDetailFont;
+  private int textMainAlignment;
+  private int textDetailAlignment;
 
   public ListViewTwoTextAdapter(ComponentContainer container, List<Object> data,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight) {
+      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
@@ -37,6 +39,8 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
     this.textDetailColor = textDetailColor;
     this.textDetailSize = textDetailSize;
     this.textDetailFont = textDetailFont;
+    this.textMainAlignment = textMainAlignment;
+    this.textDetailAlignment = textDetailAlignment;
   }
 
   @Override
@@ -50,11 +54,12 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 =
         new LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -62,11 +67,12 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
     textViewSecond.setId(idSecond);
     LinearLayout.LayoutParams layoutParams2 =
         new LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewSecond.setTextSize(textDetailSize);
     TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
     textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
+    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout2 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear2 =

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
@@ -24,11 +24,13 @@ public class ListViewTwoTextLinearAdapter extends ListAdapterWithRecyclerView {
   private int textDetailColor;
   private float textDetailSize;
   private String textDetailFont;
+  private int textMainAlignment;
+  private int textDetailAlignment;
 
   public ListViewTwoTextLinearAdapter(ComponentContainer container, List<Object> data,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight) {
+      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
     super(container, data, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
@@ -37,6 +39,8 @@ public class ListViewTwoTextLinearAdapter extends ListAdapterWithRecyclerView {
     this.textDetailColor = textDetailColor;
     this.textDetailSize = textDetailSize;
     this.textDetailFont = textDetailFont;
+    this.textMainAlignment = textMainAlignment;
+    this.textDetailAlignment = textDetailAlignment;
   }
 
   @Override
@@ -44,31 +48,29 @@ public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     CardView cardView = createCardView(parent);
     final int idCard = cardView.getId();
 
-    // MainText
+    // MainText — weight=1 gives it 50% of the row, enabling center/right alignment
     TextView textViewFirst = new TextView(container.$context());
     final int idFirst = ViewCompat.generateViewId();
     textViewFirst.setId(idFirst);
-    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
     textViewFirst.setLayoutParams(layoutParams1);
     textViewFirst.setTextSize(textMainSize);
     textViewFirst.setTextColor(textMainColor);
     TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
+    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
-    // DetailText
+    // DetailText — weight=1 gives it the remaining 50%, so it can never be pushed off-screen
     TextView textViewSecond = new TextView(container.$context());
     final int idSecond = ViewCompat.generateViewId();
     textViewSecond.setId(idSecond);
-    LinearLayout.LayoutParams layoutParams2 =
-            new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+    LinearLayout.LayoutParams layoutParams2 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
     textViewSecond.setTextSize(textDetailSize);
     TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
     textViewSecond.setTextColor(textDetailColor);
-    
-    layoutParams2.setMargins(50, 0, 0, 0);
     textViewSecond.setLayoutParams(layoutParams2);
     textViewSecond.setMaxLines(1);
     textViewSecond.setEllipsize(null);
+    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
@@ -68,8 +68,6 @@ public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
     textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
-    textViewSecond.setMaxLines(1);
-    textViewSecond.setEllipsize(null);
     TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout1 = new LinearLayout(container.$context());

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -933,6 +933,16 @@ This is a visible component that displays a list of text and image elements in y
 : Sets visibility of the filter bar. `true`{:.logic.block} will show the bar,
  `false`{:.logic.block} will hide it.
 
+{:id="ListView.TextAlignmentDetail" .number} *TextAlignmentDetail*
+: Specifies the alignment of the detail text in ListView elements: center, normal
+ (e.g., left-justified if text is written left to right), or opposite
+ (e.g., right-justified if text is written left to right).
+
+{:id="ListView.TextAlignmentMain" .number} *TextAlignmentMain*
+: Specifies the alignment of the main text in ListView elements: center, normal
+ (e.g., left-justified if text is written left to right), or opposite
+ (e.g., right-justified if text is written left to right).
+
 {:id="ListView.TextColor" .color} *TextColor*
 : The text color of the `ListView` items.
 


### PR DESCRIPTION
## What does this PR accomplish?

## Description

Adds two new designer/block properties to the `ListView` component — **`TextAlignmentMain`** and **`TextAlignmentDetail`** — allowing users to control the horizontal alignment (`normal`, `center`, `opposite`) of the primary and secondary text independently across all six ListView layouts on both Android and iOS. Both properties default to `ALIGNMENT_NORMAL`.

Fixes #2594.

### Core feature: TextAlignmentMain / TextAlignmentDetail

**Android:** Propagates the two new properties through every adapter (`ListViewSingleTextAdapter`, `ListViewTwoTextAdapter`, `ListViewTwoTextLinearAdapter`, `ListViewImageSingleTextAdapter`, `ListViewImageTwoTextVerticalAdapter`, `ListViewImageTopTwoTextAdapter`) and updates the designer mock (`MockListView`) so alignment is reflected at design time.

**iOS:** Adds `TextAlignmentMain` and `TextAlignmentDetail` to `components-ios/src/ListView.swift`, applied on both the `UITableView` cells (vertical orientation) and the `UICollectionView` cells (horizontal orientation), across all six layout modes. Introduces an internal `nsTextAlignment(for:in:)` helper that maps `Alignment(rawValue:)` to `NSTextAlignment` with RTL handling, mirroring `Label.swift`. Adds XCTest coverage in `ListViewTests.swift` (`testTextAlignmentMain`, `testTextAlignmentDetail`).

### Additional fixes uncovered while testing alignment

These were not previously filed as separate issues; they were noticed during manual verification of the alignment feature and folded into this PR per reviewer guidance.

**1. iOS — long main text in two-text horizontal layout (mode 2) no longer pushes detail off-screen.**
Previously, long `MainText` rendered as a single non-wrapping line that shoved the detail label past the right edge of the row. 
Fixed by switching the row's `UIStackView` from `distribution = .fill` to `.fillEqually`, and enabling word-wrap (`numberOfLines = 0`, `lineBreakMode = .byWordWrapping`) on both labels, so each gets exactly 50% of the row width and wraps within its half. Stack alignment changed to `.firstBaseline` so labels visually share a writing line regardless of font size. Related to (but distinct in scope from) the single-text wrap fix in #3051 which is already closed; this PR extends wrap support to two-text horizontal layouts and detail labels.

**2. iOS — detail text now wraps in modes 1, 4, and 5.**
Previously `cell.detailTextLabel` inherited UIKit's `numberOfLines = 1` default and truncated long detail text mid-content. Now sets `numberOfLines = 0` + `.byWordWrapping` for detail across all layout modes.

**3. iOS — short non-wrapping text now obeys alignment in modes 1, 4, and 5.**
`UITableViewCell`'s system labels are sized to content, so `textAlignment = .center` was a visual no-op on short text. Wrapped the system labels in a `UIStackView` pinned to the cell's `contentView` edges with `alignment = .fill`, forcing the labels to span the full row width so `textAlignment` is always visibly applied. Mode 5 uses an outer + inner stack with an explicit `widthAnchor` so the image stays centered above while labels span the full row.

**4. Android — long detail text in two-text horizontal layout (mode 2) no longer overflows the screen.**
`ListViewTwoTextLinearAdapter` previously set `setMaxLines(1)` + `setEllipsize(null)` on the detail `TextView`, telling Android "don't wrap and don't truncate." With `weight = 1` correctly bounding the view to 50% width, the text inside still visually overflowed. Dropped both lines so detail wraps naturally inside its 50% half — matching the Designer mock and the iOS runtime.

**5. Designer mock — text alignment now works for short text in vertical two-text layout.**
`createTwoTextVerticalLayout` wrapped both labels in a `FlowPanel` with no explicit width, so it shrank to content. `width: 100%` + `text-align: center` on the inner labels had no visible effect when the container was already exactly the text's width. Added `container.setWidth("100%")` so the container always spans the row.

**6. Designer mock — labels in horizontal two-text layout now baseline-align instead of centering vertically.**
The parent `.listViewItemStyle` rule in `Ya.css` uses `display: flex; align-items: center`, which silently collapsed mismatched-height columns to the vertical middle. Overrode with `align-items: baseline` (inline) on the horizontal layout's row container so columns share a text baseline, matching iOS `firstBaseline` behavior.

**7. Designer mock — image now stays at the top of the row in image+text layouts (modes 3 and 4).**
Same `align-items: center` cause as above. Overrode with `align-items: flex-start` on `horizontalItemPanel` in both image layouts so the image stays at the top, matching iOS.

### Component version

- Bumps `LISTVIEW_COMPONENT_VERSION` from 10 → 11 in `YaVersion.java`.
- Adds the corresponding `noUpgrade` entry in `versioning.js`.
- Updates `YoungAndroidFormUpgrader.java` for the new component version.
- Adds `TextAlignmentMain` and `TextAlignmentDetail` entries under `docs/markdown/reference/components/userinterface.md`.

### Manual verification

iOS Companion (simulator) and Android Companion, across all six layouts × normal / center / opposite for both `TextAlignmentMain` and `TextAlignmentDetail`. Two-text horizontal layout (mode 2) verified for short/short, long/short, short/long, and long/long combinations on both platforms. Image layouts (modes 3, 4, 5) verified for short non-wrapping text + Center alignment on iOS. iOS XCTest unit tests pass via the `AIComponentKit` scheme.

---

### Context for the changes

This PR changes how `ListView` renders text on the device (companion-affecting). The branch was created from `ucr`.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a `SimpleProperty`, etc.):

- [x] I have updated the corresponding version number in `appinventor/components/src/.../common/YaVersion.java`
- [x] I have updated the corresponding upgrader in `appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java` (components only)
- [x] I have updated the corresponding entries in `appinventor/blocklyeditor/src/versioning.js`

### General items

- [x] I have updated the relevant documentation files under `docs/`
- [x] My code follows the:
  - [x] Google Java style guide (for `.java` files)
  - [x] Google JavaScript style guide (for `.js` files)
  - [x] Swift style guide (for `.swift` files)
- [x] Indentation has been double-checked
- [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine