### PR TITLE
Nested More Category for Lambda Procedures

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1094,7 +1094,7 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Label on built-in-Procedures-blocks branch of block selector tree")
   String builtinProceduresLabel();
 
-  @DefaultMessage("More")
+  @DefaultMessage("More...")
   @Description("Label on nested branch for additional built-in blocks")
   String builtinMoreLabel();
 

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1094,6 +1094,10 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Label on built-in-Procedures-blocks branch of block selector tree")
   String builtinProceduresLabel();
 
+  @DefaultMessage("More")
+  @Description("Label on nested branch for additional built-in blocks")
+  String builtinMoreLabel();
+
   @DefaultMessage("Any component")
   @Description("Label on any-component branch of block selector tree")
   String anyComponentLabel();

--- a/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
@@ -109,7 +109,7 @@ public final class BlockSelectorBox extends Box {
   // Source structure explorer (for components and built-in blocks)
   private final SourceStructureExplorer sourceStructureExplorer;
 
-  private final Map<BlocksLanguage, TreeItem> languageTreeItems;
+  private final Map<String, TreeItem> languageTreeItems;
 
   private List<BlockDrawerSelectionListener> drawerListeners;
 
@@ -183,8 +183,10 @@ public final class BlockSelectorBox extends Box {
    *
    * @return tree item
    */
-  public TreeItem getBuiltInBlocksTree(BlocksLanguage language, DesignerRootComponent form) {
-    TreeItem rootItem = languageTreeItems.get(language);
+  public TreeItem getBuiltInBlocksTree(BlocksLanguage language, DesignerRootComponent form,
+      String contextId) {
+    String cacheKey = language.getName() + ":" + contextId;
+    TreeItem rootItem = languageTreeItems.get(cacheKey);
     if (rootItem != null) {
       return rootItem;
     }
@@ -199,9 +201,15 @@ public final class BlockSelectorBox extends Box {
         public void onSelected(NativeEvent event) {
           fireBuiltinDrawerSelected(category.getCategory());
         }
+
+        @Override
+        public boolean isInitiallyExpanded() {
+          return !"Procedures".equals(category.getCategory());
+        }
       };
       itemNode.setUserObject(sourceItem);
       if ("Procedures".equals(category.getCategory())) {
+        itemNode.getElement().setAttribute("data-name", contextId + "_builtin_Procedures");
         TreeItem moreItemNode = new TreeItem(new HTML("<span>" + MESSAGES.builtinMoreLabel()
             + "</span>"));
         SourceStructureExplorerItem moreSourceItem = new BlockSelectorItem() {
@@ -212,12 +220,11 @@ public final class BlockSelectorBox extends Box {
         };
         moreItemNode.setUserObject(moreSourceItem);
         itemNode.addItem(moreItemNode);
-        itemNode.setState(true);
       }
       rootItem.addItem(itemNode);
     }
     rootItem.setState(true);
-    languageTreeItems.put(language, rootItem);
+    languageTreeItems.put(cacheKey, rootItem);
     return rootItem;
   }
 
@@ -229,10 +236,17 @@ public final class BlockSelectorBox extends Box {
    *          only component types that appear in this Form will be included
    * @return tree item for this form
    */
-  public TreeItem getGenericComponentsTree(DesignerRootComponent form) {
+  public TreeItem getGenericComponentsTree(DesignerRootComponent form, String contextId) {
     Map<String, String> typesAndIcons = Maps.newHashMap();
     form.collectTypesAndIcons(typesAndIcons);
     TreeItem advanced = new TreeItem(new HTML("<span>" + MESSAGES.anyComponentLabel() + "</span>"));
+    advanced.getElement().setAttribute("data-name", contextId + "_builtin_AnyComponent");
+    advanced.setUserObject(new BlockSelectorItem() {
+      @Override
+      public boolean isInitiallyExpanded() {
+        return false;
+      }
+    });
     List<String> typeList = new ArrayList<String>(typesAndIcons.keySet());
     Collections.sort(typeList);
     for (final String typeName : typeList) {

--- a/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/boxes/BlockSelectorBox.java
@@ -201,6 +201,19 @@ public final class BlockSelectorBox extends Box {
         }
       };
       itemNode.setUserObject(sourceItem);
+      if ("Procedures".equals(category.getCategory())) {
+        TreeItem moreItemNode = new TreeItem(new HTML("<span>" + MESSAGES.builtinMoreLabel()
+            + "</span>"));
+        SourceStructureExplorerItem moreSourceItem = new BlockSelectorItem() {
+          @Override
+          public void onSelected(NativeEvent event) {
+            fireBuiltinDrawerSelected("ProceduresMore");
+          }
+        };
+        moreItemNode.setUserObject(moreSourceItem);
+        itemNode.addItem(moreItemNode);
+        itemNode.setState(true);
+      }
       rootItem.addItem(itemNode);
     }
     rootItem.setState(true);

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/blocks/BlocksEditor.java
@@ -684,9 +684,10 @@ public abstract class BlocksEditor<S extends SourceNode, T extends DesignerEdito
   private void updateBlocksTree(DesignerRootComponent root,
                                 SourceStructureExplorerItem itemToSelect) {
     TreeItem items[] = new TreeItem[3];
-    items[0] = BlockSelectorBox.getBlockSelectorBox().getBuiltInBlocksTree(language, root);
+    items[0] = BlockSelectorBox.getBlockSelectorBox().getBuiltInBlocksTree(language, root,
+        entityName);
     items[1] = root.buildComponentsTree();
-    items[2] = BlockSelectorBox.getBlockSelectorBox().getGenericComponentsTree(root);
+    items[2] = BlockSelectorBox.getBlockSelectorBox().getGenericComponentsTree(root, entityName);
     sourceStructureExplorer.updateTree(items, itemToSelect);
   }
 }

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -48,6 +48,17 @@ Blockly.Drawer = function(parentWorkspace, opt_options) {
 Blockly.Drawer.PREFIX_ = 'cat_';
 
 /**
+ * Blocks shown directly when opening the Procedures drawer.
+ * @private
+ */
+Blockly.Drawer.PROCEDURE_PRIMARY_BLOCKS_ = [
+  'procedures_defnoreturn',
+  'procedures_defreturn',
+  'procedures_callnoreturn',
+  'procedures_callreturn'
+];
+
+/**
  * Build the hierarchical tree of block types.
  * Note: taken from Blockly's toolbox.js
  * @return {!Object} Tree object.
@@ -129,17 +140,11 @@ Blockly.Drawer.prototype.showBuiltin = function(drawerName) {
   }
   var blockSet = this.options.languageTree[drawerName];
   if (drawerName == "cat_Procedures") {
-    var newBlockSet = [];
-    for (var i = 0; i < blockSet.length; i++) {
-      if(!(blockSet[i] == "procedures_callnoreturn" // Include callnoreturn only if at least one defnoreturn declaration
-           && this.workspace_.getProcedureDatabase().voidProcedures == 0)
-         &&
-         !(blockSet[i] == "procedures_callreturn" // Include callreturn only if at least one defreturn declaration
-           && this.workspace_.getProcedureDatabase().returnProcedures == 0)){
-        newBlockSet.push(blockSet[i]);
-      }
-    }
-    blockSet = newBlockSet;
+    this.showProcedurePrimary_(blockSet);
+    return;
+  } else if (drawerName == "cat_ProceduresMore") {
+    this.showProcedureMore_();
+    return;
   }
 
   if (!blockSet) {
@@ -148,6 +153,66 @@ Blockly.Drawer.prototype.showBuiltin = function(drawerName) {
   Blockly.hideChaff();
   var xmlList = this.blockListToXMLArray(blockSet);
   this.flyout_.show(xmlList);
+};
+
+/**
+ * Show the primary Procedures drawer contents.
+ * @param {!Array<string>} blockSet All block types in the Procedures category.
+ * @private
+ */
+Blockly.Drawer.prototype.showProcedurePrimary_ = function(blockSet) {
+  if (!blockSet) {
+    throw "no such drawer: cat_Procedures";
+  }
+  Blockly.hideChaff();
+  var xmlList = this.blockListToXMLArray(
+      this.filterProcedureBlocks_(blockSet, true));
+  this.flyout_.show(xmlList);
+};
+
+/**
+ * Show procedure blocks that are tucked behind the More button.
+ * @private
+ */
+Blockly.Drawer.prototype.showProcedureMore_ = function() {
+  if (!this.options.languageTree) {
+    this.options.languageTree = Blockly.Drawer.buildTree_();
+  }
+  var blockSet = this.options.languageTree['cat_Procedures'];
+  if (!blockSet) {
+    throw "no such drawer: cat_Procedures";
+  }
+  Blockly.hideChaff();
+  this.flyout_.show(this.blockListToXMLArray(
+      this.filterProcedureBlocks_(blockSet, false)));
+};
+
+/**
+ * Filters procedure block types for the primary or More view.
+ * @param {!Array<string>} blockSet All block types in the Procedures category.
+ * @param {boolean} primaryView Whether to return primary procedure blocks.
+ * @return {!Array<string>}
+ * @private
+ */
+Blockly.Drawer.prototype.filterProcedureBlocks_ = function(blockSet, primaryView) {
+  var procDb = this.workspace_.getProcedureDatabase();
+  var primaryBlocks = Blockly.Drawer.PROCEDURE_PRIMARY_BLOCKS_;
+  var filteredBlockSet = [];
+  for (var i = 0; i < blockSet.length; i++) {
+    var blockType = blockSet[i];
+    var isPrimary = primaryBlocks.indexOf(blockType) != -1;
+    if (primaryView != isPrimary) {
+      continue;
+    }
+    if (blockType == "procedures_callnoreturn" && procDb.voidProcedures == 0) {
+      continue;
+    }
+    if (blockType == "procedures_callreturn" && procDb.returnProcedures == 0) {
+      continue;
+    }
+    filteredBlockSet.push(blockType);
+  }
+  return filteredBlockSet;
 };
 
 /**


### PR DESCRIPTION
**What does this PR accomplish?**

This is an attempt to clean our blocks category.

<img width="458" height="616" alt="Screenshot 2026-05-21 at 4 28 28 PM" src="https://github.com/user-attachments/assets/6ec54fde-307c-4df3-8ae7-e13c94007071" />

As you can see above, the regular "Procedure" Blocks will only contain the original Value/ Statement named procedure blcoks. However, if you click on the More category, which is nested under the Procedure category, you will able to see see the anonymous procedure blocks.

We plan to do something similar for all categories.