### PR TITLE
fix iOS Layout autosize, and ListView UI bugs

### DIFF
--- a/appinventor/components-ios/src/AbsoluteArrangement.swift
+++ b/appinventor/components-ios/src/AbsoluteArrangement.swift
@@ -25,12 +25,16 @@ open class AbsoluteArrangement: ViewComponent, ComponentContainer, AbstractMetho
 
   // Layout
   private var viewLayout: RelativeLayout
+  private var _widthConstraints = [ObjectIdentifier: NSLayoutConstraint]()
+  private var _heightConstraints = [ObjectIdentifier: NSLayoutConstraint]()
   
   // MARK: - Constants
   private let NOT_VALID: Int = -1
   
   // MARK: - Custom View for Absolute Layout
   private class AbsoluteView: UIView {
+    weak var contentView: UIView?
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       translatesAutoresizingMaskIntoConstraints = false
@@ -47,15 +51,16 @@ open class AbsoluteArrangement: ViewComponent, ComponentContainer, AbstractMetho
     }
     
     override var intrinsicContentSize: CGSize {
-      // Let parent layout determine size
-      return UIView.layoutFittingExpandedSize
+      return contentView?.intrinsicContentSize ?? CGSize(width: CGFloat(kEmptyHVArrangementWidth),
+                                                         height: CGFloat(kEmptyHVArrangementHeight))
     }
   }
   
   // MARK: - Initialization
   public override init(_ parent: ComponentContainer) {
     _view = AbsoluteView(frame: .zero)
-    viewLayout = RelativeLayout(preferredEmptyWidth: kEmptyHVArrangementWidth,preferredEmptyHeight: kEmptyHVArrangementWidth)
+    viewLayout = RelativeLayout(preferredEmptyWidth: kEmptyHVArrangementWidth,
+                                preferredEmptyHeight: kEmptyHVArrangementHeight)
     
     super.init(parent)
     super.setDelegate(self)
@@ -63,6 +68,7 @@ open class AbsoluteArrangement: ViewComponent, ComponentContainer, AbstractMetho
   
     // Add the layout view to our view
     _view.addSubview(viewLayout.getLayoutManager())
+    _view.contentView = viewLayout.getLayoutManager()
     viewLayout.getLayoutManager().translatesAutoresizingMaskIntoConstraints = false
     
     // Make the layout view fill our view
@@ -126,6 +132,8 @@ open class AbsoluteArrangement: ViewComponent, ComponentContainer, AbstractMetho
     
     if x != NOT_VALID && y != NOT_VALID {
       viewLayout.updateComponentPosition(component: component)
+      setChildWidth(of: component, to: component._lastSetWidth)
+      setChildHeight(of: component, to: component._lastSetHeight)
     }
   }
   
@@ -134,62 +142,82 @@ open class AbsoluteArrangement: ViewComponent, ComponentContainer, AbstractMetho
     guard let form = form else {
       return
     }
-    
+
+    replaceConstraint(&_widthConstraints, for: component, with: nil)
+    let constraint: NSLayoutConstraint?
     if width <= kLengthPercentTag {
-      let parentWidth = form.Width
-      let childWidth = parentWidth * Int32(-(width - kLengthPercentTag)) / 100
-      component._lastSetWidth = width
-      
-      NSLayoutConstraint.activate([
-        component.view.widthAnchor.constraint(equalToConstant: CGFloat(childWidth))
-      ])
+      let percent = CGFloat(-(width - kLengthPercentTag)) / 100.0
+      constraint = component.view.widthAnchor.constraint(equalTo: form.scaleFrameLayout.widthAnchor,
+                                                         multiplier: percent)
     } else if width == kLengthPreferred {
-      // Let view size itself
-      component._lastSetWidth = width
-      // Remove width constraints
-      component.view.constraints.filter { $0.firstAttribute == .width }.forEach { $0.isActive = false }
+      constraint = nil
     } else if width == kLengthFillParent {
-      component._lastSetWidth = width
-      NSLayoutConstraint.activate([
-        component.view.widthAnchor.constraint(equalTo: _view.widthAnchor)
-      ])
+      constraint = component.view.widthAnchor.constraint(equalTo: _view.widthAnchor)
     } else {
-      component._lastSetWidth = width
-      NSLayoutConstraint.activate([
-        component.view.widthAnchor.constraint(equalToConstant: CGFloat(width))
-      ])
+      constraint = component.view.widthAnchor.constraint(equalToConstant: CGFloat(width))
     }
+    component._lastSetWidth = width
+    replaceConstraint(&_widthConstraints, for: component, with: constraint)
+    _view.invalidateIntrinsicContentSize()
   }
   
   open func setChildHeight(of component: ViewComponent, to height: Int32) {
     guard let form = form else {
       return
     }
-    
+
+    replaceConstraint(&_heightConstraints, for: component, with: nil)
+    let constraint: NSLayoutConstraint?
     if height <= kLengthPercentTag {
-      let parentHeight = form.Height
-      let childHeight = parentHeight * Int32(-(height - kLengthPercentTag)) / 100
-      component._lastSetHeight = height
-      
-      NSLayoutConstraint.activate([
-        component.view.heightAnchor.constraint(equalToConstant: CGFloat(childHeight))
-      ])
+      let percent = CGFloat(-(height - kLengthPercentTag)) / 100.0
+      constraint = component.view.heightAnchor.constraint(equalTo: form.scaleFrameLayout.heightAnchor,
+                                                          multiplier: percent)
     } else if height == kLengthPreferred {
-      // Let view size itself
-      component._lastSetHeight = height
-      // Remove height constraints
-      component.view.constraints.filter { $0.firstAttribute == .height }.forEach { $0.isActive = false }
+      constraint = nil
     } else if height == kLengthFillParent {
-      component._lastSetHeight = height
-      NSLayoutConstraint.activate([
-        component.view.heightAnchor.constraint(equalTo: _view.heightAnchor)
-      ])
+      constraint = component.view.heightAnchor.constraint(equalTo: _view.heightAnchor)
     } else {
-      component._lastSetHeight = height
-      NSLayoutConstraint.activate([
-        component.view.heightAnchor.constraint(equalToConstant: CGFloat(height))
-      ])
+      constraint = component.view.heightAnchor.constraint(equalToConstant: CGFloat(height))
     }
+    component._lastSetHeight = height
+    replaceConstraint(&_heightConstraints, for: component, with: constraint)
+    _view.invalidateIntrinsicContentSize()
+  }
+
+  private func replaceConstraint(_ constraints: inout [ObjectIdentifier: NSLayoutConstraint],
+                                 for component: ViewComponent,
+                                 with constraint: NSLayoutConstraint?) {
+    let key = ObjectIdentifier(component)
+    constraints[key]?.isActive = false
+    constraints[key] = constraint
+    if let constraint = constraint, canActivate(constraint) {
+      constraint.isActive = true
+    }
+  }
+
+  private func canActivate(_ constraint: NSLayoutConstraint) -> Bool {
+    guard let first = constraint.firstItem as? UIView,
+          let second = constraint.secondItem as? UIView else {
+      return true
+    }
+    return sharesViewHierarchy(first, second)
+  }
+
+  private func sharesViewHierarchy(_ first: UIView, _ second: UIView) -> Bool {
+    var ancestors = Set<ObjectIdentifier>()
+    var current: UIView? = first
+    while let view = current {
+      ancestors.insert(ObjectIdentifier(view))
+      current = view.superview
+    }
+    current = second
+    while let view = current {
+      if ancestors.contains(ObjectIdentifier(view)) {
+        return true
+      }
+      current = view.superview
+    }
+    return false
   }
   
   // MARK: - Properties

--- a/appinventor/components-ios/src/LinearView.swift
+++ b/appinventor/components-ios/src/LinearView.swift
@@ -267,6 +267,32 @@ public class LinearView: UIView {
   }
 
   open func removeItem(_ view: UIView) {
+    if let length = widthConstraints.removeValue(forKey: view) {
+      length.constraint?.isActive = false
+      if length == .FillParent {
+        widthFillParent -= 1
+        if widthFillParent == 0 && orientation == .horizontal {
+          widthFillParentConstraint?.isActive = false
+          widthFillParentConstraint = nil
+          _innerEqualConstraint.isActive = true
+          _innerHeadZero.isActive = false
+          _innerTailZero.isActive = false
+        }
+      }
+    }
+    if let length = heightConstraints.removeValue(forKey: view) {
+      length.constraint?.isActive = false
+      if length == .FillParent {
+        heightFillParent -= 1
+        if heightFillParent == 0 && orientation == .vertical {
+          heightFillParentConstraint?.isActive = false
+          heightFillParentConstraint = nil
+          _innerEqualConstraint.isActive = true
+          _innerHeadZero.isActive = false
+          _innerTailZero.isActive = false
+        }
+      }
+    }
     _inner.removeArrangedSubview(view)
     view.removeFromSuperview()
     _items.removeAll { (item) -> Bool in
@@ -275,6 +301,13 @@ public class LinearView: UIView {
   }
 
   open func resetView() {
+    for length in widthConstraints.values {
+      length.constraint?.isActive = false
+    }
+    for length in heightConstraints.values {
+      length.constraint?.isActive = false
+    }
+
     /* Resets the all the width*/
     widthFillParent = 0
     widthFillParentConstraint?.isActive = false
@@ -297,9 +330,24 @@ public class LinearView: UIView {
 
   open func removeAllItems() {
     for item in _items {
+      if let length = widthConstraints.removeValue(forKey: item.view) {
+        length.constraint?.isActive = false
+      }
+      if let length = heightConstraints.removeValue(forKey: item.view) {
+        length.constraint?.isActive = false
+      }
       _inner.removeArrangedSubview(item.view)
       item.view.removeFromSuperview()
     }
+    widthFillParent = 0
+    heightFillParent = 0
+    widthFillParentConstraint?.isActive = false
+    widthFillParentConstraint = nil
+    heightFillParentConstraint?.isActive = false
+    heightFillParentConstraint = nil
+    _innerEqualConstraint.isActive = true
+    _innerHeadZero.isActive = false
+    _innerTailZero.isActive = false
     _items.removeAll()
   }
 
@@ -357,6 +405,7 @@ public class LinearView: UIView {
    * This method is not threadsafe. It should only be called from the UI thread.
    */
   open func setWidth(of view: UIView, to length: Length) {
+    let length = Length(length)
     // Remove old constraint
     if let oldLength = widthConstraints[view] {
       oldLength.constraint?.isActive = false
@@ -405,7 +454,7 @@ public class LinearView: UIView {
     } else {
       length.constraint = view.widthAnchor.constraint(equalToConstant: length.cgFloat)
     }
-    let shouldActivate = self.superview != nil
+    let shouldActivate = canActivateConstraint(for: view, relativeTo: length.view)
     length.constraint?.isActive = shouldActivate
     widthConstraints[view] = length
     invalidateIntrinsicContentSize()
@@ -417,6 +466,7 @@ public class LinearView: UIView {
    * This method is not threadsafe. It should only be called from the UI thread.
    */
   open func setHeight(of view: UIView, to length: Length) {
+    let length = Length(length)
     // Remove old constraint
     if let oldLength = heightConstraints[view] {
       oldLength.constraint?.isActive = false
@@ -463,7 +513,7 @@ public class LinearView: UIView {
     } else {
       length.constraint = view.heightAnchor.constraint(equalToConstant: length.cgFloat)
     }
-    let shouldActivate = self.superview != nil
+    let shouldActivate = canActivateConstraint(for: view, relativeTo: length.view)
     length.constraint?.isActive = shouldActivate
     heightConstraints[view] = length
     invalidateIntrinsicContentSize()
@@ -475,24 +525,29 @@ public class LinearView: UIView {
   }
 
   open override var intrinsicContentSize: CGSize {
-    if _items.count == 0 {
+    let visibleItems = _inner.arrangedSubviews.dropFirst().dropLast().filter {
+      !$0.isHidden && $0.superview != nil
+    }
+    if visibleItems.count == 0 {
       return CGSize(width: 100, height: 100)
     } else {
       var max = CGFloat(0.0), sum = CGFloat(0.0)
       if orientation == .horizontal {
-        _items.forEach { item in
-          if item.view.intrinsicContentSize.height > max {
-            max = item.view.intrinsicContentSize.height
+        visibleItems.forEach { view in
+          let size = preferredSize(of: view)
+          if size.height > max {
+            max = size.height
           }
-          sum += item.view.intrinsicContentSize.width
+          sum += size.width
         }
         return CGSize(width: sum, height: max)
       } else {
-        _items.forEach { item in
-          if item.view.intrinsicContentSize.width > max {
-            max = item.view.intrinsicContentSize.width
+        visibleItems.forEach { view in
+          let size = preferredSize(of: view)
+          if size.width > max {
+            max = size.width
           }
-          sum += item.view.intrinsicContentSize.height
+          sum += size.height
         }
         return CGSize(width: max, height: sum)
       }
@@ -500,6 +555,51 @@ public class LinearView: UIView {
   }
 
   // MARK: Private Implementation
+
+  private func canActivateConstraint(for view: UIView, relativeTo otherView: UIView?) -> Bool {
+    guard sharesViewHierarchy(view, _inner) else {
+      return false
+    }
+    guard let otherView = otherView else {
+      return true
+    }
+    return sharesViewHierarchy(view, otherView)
+  }
+
+  private func sharesViewHierarchy(_ first: UIView, _ second: UIView) -> Bool {
+    var ancestors = Set<ObjectIdentifier>()
+    var current: UIView? = first
+    while let view = current {
+      ancestors.insert(ObjectIdentifier(view))
+      current = view.superview
+    }
+    current = second
+    while let view = current {
+      if ancestors.contains(ObjectIdentifier(view)) {
+        return true
+      }
+      current = view.superview
+    }
+    return false
+  }
+
+  private func preferredSize(of view: UIView) -> CGSize {
+    let fitting = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    let intrinsic = view.intrinsicContentSize
+    return CGSize(width: preferredDimension(fitting.width, intrinsic.width),
+                  height: preferredDimension(fitting.height, intrinsic.height))
+  }
+
+  private func preferredDimension(_ fitting: CGFloat, _ intrinsic: CGFloat) -> CGFloat {
+    return max(sanitizedDimension(fitting), sanitizedDimension(intrinsic))
+  }
+
+  private func sanitizedDimension(_ dimension: CGFloat) -> CGFloat {
+    if dimension.isFinite && dimension >= 0 && dimension < CGFloat.greatestFiniteMagnitude {
+      return dimension
+    }
+    return 0
+  }
 
   private func updateHorizontalAlignment() {
     if _orientation == .vertical {

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -10,15 +10,24 @@ fileprivate let kListViewDefaultSelectionColor = Color.lightGray
 fileprivate let kListViewDefaultTextColor = Color.white
 fileprivate let kDefaultTableCell = "UITableViewCell"
 fileprivate let kDefaultTableCellHeight = CGFloat(44.0)
+fileprivate let kDefaultTableCellVerticalPadding = CGFloat(30.0)
 
 let VERTICAL_LAYOUT = 0
 let HORIZONTAL_LAYOUT = 1
+
+fileprivate final class ListViewRootView: UIView {
+  var preferredSizeProvider: (() -> CGSize)?
+
+  override var intrinsicContentSize: CGSize {
+    return preferredSizeProvider?() ?? super.intrinsicContentSize
+  }
+}
 
   open class ListView: ViewComponent, AbstractMethodsForViewComponent,
     UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate,
     UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
   fileprivate final var _view: UITableView
-  fileprivate let _rootView = UIView()
+  fileprivate let _rootView = ListViewRootView()
   fileprivate var _collectionView: UICollectionView
   fileprivate let kDefaultItemSize = CGSize(width: 160, height: 56)
     
@@ -33,7 +42,7 @@ let HORIZONTAL_LAYOUT = 1
   fileprivate var _textColor = Int32(bitPattern: Color.default.rawValue)
   fileprivate var _textColorDetail = Int32(bitPattern: Color.default.rawValue)
   fileprivate var _fontSize = Int32(22)
-  fileprivate var _automaticHeightConstraint: NSLayoutConstraint!
+  fileprivate var _automaticHeightConstraint: NSLayoutConstraint?
   fileprivate var _results: [String]? = nil
   fileprivate var _fontSizeDetail = Int32(16)
   //ListData
@@ -76,8 +85,11 @@ let HORIZONTAL_LAYOUT = 1
 
     // Auto height for the table (existing)
     _automaticHeightConstraint = _view.heightAnchor.constraint(equalToConstant: kDefaultTableCellHeight)
-    _automaticHeightConstraint.priority = UILayoutPriority(1.0)
-    _automaticHeightConstraint.isActive = true
+    _automaticHeightConstraint?.priority = UILayoutPriority(1.0)
+    _automaticHeightConstraint?.isActive = true
+    _rootView.preferredSizeProvider = { [weak self] in
+      return self?.preferredListViewSize ?? CGSize(width: 320, height: kDefaultTableCellHeight)
+    }
 
     // Create horizontal collection view
     let layout = UICollectionViewFlowLayout()
@@ -125,6 +137,15 @@ let HORIZONTAL_LAYOUT = 1
  
   open override var view: UIView { _rootView }
 
+  @objc open override var Width: Int32 {
+    get {
+      return super.Width
+    }
+    set(width) {
+      super.Width = width == kLengthPreferred ? kLengthFillParent : width
+    }
+  }
+
   // MARK: Properties
   @objc open var BackgroundColor: Int32 {
     get {
@@ -161,7 +182,7 @@ let HORIZONTAL_LAYOUT = 1
       _items = []
       _elements = []
       guard !elements.isEmpty else {
-        _view.reloadData()
+        elementsCount()
         return
       }
       addElements(elements)
@@ -227,8 +248,8 @@ let HORIZONTAL_LAYOUT = 1
     }
   func elementsCount() {
     //let rows = max(_items.count, _items.count)
-    let rows = max(_elements.count, _items.count)
-    _automaticHeightConstraint.constant = rows == 0 ? kDefaultTableCellHeight : kDefaultTableCellHeight * CGFloat(rows)
+    let rows = listItemCount
+    _automaticHeightConstraint?.constant = rows == 0 ? kDefaultTableCellHeight : preferredRowHeight * CGFloat(rows)
     if let searchBar = _view.tableHeaderView as? UISearchBar {
       self.searchBar(searchBar, textDidChange: searchBar.text ?? "")
     } else {
@@ -236,6 +257,7 @@ let HORIZONTAL_LAYOUT = 1
     }
     _collectionView.reloadData()
     _collectionView.collectionViewLayout.invalidateLayout()
+    invalidateListViewSize()
   }
 
   @objc open var FontTypeface: String {
@@ -244,17 +266,17 @@ let HORIZONTAL_LAYOUT = 1
     }
     set(fontTypeface) {
       _fontTypeface = fontTypeface
-      _view.reloadData()
+      elementsCount()
     }
   }
 
   @objc open var FontTypefaceDetail: String {
     get {
-      return _fontTypeface
+      return _fontTypefaceDetail
     }
     set(FontTypefaceDetail) {
       _fontTypefaceDetail = FontTypefaceDetail
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -383,7 +405,7 @@ let HORIZONTAL_LAYOUT = 1
 
             return nil
           }
-          _view.reloadData()
+          elementsCount()
         }
       } catch {
         print("Error parsing JSON: \(error)")
@@ -399,6 +421,7 @@ let HORIZONTAL_LAYOUT = 1
     set(listViewLayoutMode) {
       _listViewLayoutMode = listViewLayoutMode
       _view.reloadData()
+      invalidateListViewSize()
     }
   }
 
@@ -440,6 +463,7 @@ let HORIZONTAL_LAYOUT = 1
       _automaticHeightConstraint?.isActive = true
       _view.reloadData()
     }
+    invalidateListViewSize()
 
   }
 
@@ -530,6 +554,7 @@ let HORIZONTAL_LAYOUT = 1
       } else if !_showFilter && _view.tableHeaderView != nil {
         _view.tableHeaderView = nil
       }
+      invalidateListViewSize()
     }
   }
 
@@ -569,7 +594,7 @@ let HORIZONTAL_LAYOUT = 1
     }
     set(fontSize) {
       _fontSize = fontSize < 0 ? Int32(7) : fontSize
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -580,7 +605,7 @@ let HORIZONTAL_LAYOUT = 1
     }
     set(fontSizeDetail) {
       _fontSizeDetail = fontSizeDetail < 0 ? Int32(7) : fontSizeDetail
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -658,6 +683,9 @@ let HORIZONTAL_LAYOUT = 1
 
   @objc open func Refresh() {
     _view.reloadData()
+    _collectionView.reloadData()
+    _collectionView.collectionViewLayout.invalidateLayout()
+    invalidateListViewSize()
   }
 
   @objc open func RemoveItemAtIndex(_ index: Int32) {
@@ -697,19 +725,19 @@ let HORIZONTAL_LAYOUT = 1
           cell.detailTextLabel?.text = ""
           // Simple text-only layout
           tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 44
+          tableView.estimatedRowHeight = preferredRowHeight
         }
       } else {
         let item = _items[indexPath.row]
         if _listViewLayoutMode == 1 {
           
           tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 44
+          tableView.estimatedRowHeight = preferredRowHeight
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = item["Text2"] as? String
         } else if _listViewLayoutMode == 3 {
           tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 60
+          tableView.estimatedRowHeight = preferredRowHeight
           cell.textLabel?.text = item["Text1"] as? String
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
              let image = AssetManager.shared.imageFromPath(path: imagePath as! String) {
@@ -842,7 +870,7 @@ let HORIZONTAL_LAYOUT = 1
         
       } else {
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 44
+        tableView.estimatedRowHeight = preferredRowHeight
         cell.textLabel?.text = _items[listDataIndex]["Text1"] as? String
       }
     }
@@ -936,10 +964,18 @@ let HORIZONTAL_LAYOUT = 1
 
   
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-      return _items.isEmpty ? _elements.count : _items.count
+      return listItemCount
     }
 
     // MARK: UITableViewDelegate
+
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+      return preferredRowHeight
+    }
+
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+      return preferredRowHeight
+    }
 
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
       if indexPath.row < _elements.count {
@@ -975,6 +1011,69 @@ let HORIZONTAL_LAYOUT = 1
   }
 
   // MARK: Private implementation
+
+  private var preferredListViewSize: CGSize {
+    let width = preferredListViewWidth()
+    if _orientation == HORIZONTAL_LAYOUT {
+      return CGSize(width: width, height: max(kDefaultItemSize.height, 60.0))
+    }
+
+    let rows = listItemCount
+    let rowHeight = rows == 0 ? kDefaultTableCellHeight : preferredRowHeight * CGFloat(rows)
+    let headerHeight = _view.tableHeaderView?.bounds.height ?? 0
+    return CGSize(width: width, height: max(kDefaultTableCellHeight, rowHeight + headerHeight))
+  }
+
+  private var preferredRowHeight: CGFloat {
+    let mainTextHeight = ceil(listFont(typeface: _fontTypeface, size: _fontSize).lineHeight)
+    let detailTextHeight = ceil(listFont(typeface: _fontTypefaceDetail, size: _fontSizeDetail).lineHeight)
+    let singleTextHeight = mainTextHeight + kDefaultTableCellVerticalPadding
+    let twoTextVerticalHeight = mainTextHeight + detailTextHeight + kDefaultTableCellVerticalPadding
+    let twoTextHorizontalHeight = max(mainTextHeight, detailTextHeight) + kDefaultTableCellVerticalPadding
+
+    switch _listViewLayoutMode {
+    case 1:
+      return max(kDefaultTableCellHeight, twoTextVerticalHeight)
+    case 2:
+      return max(kDefaultTableCellHeight, twoTextHorizontalHeight)
+    case 3:
+      return max(60.0, singleTextHeight)
+    case 4:
+      return max(60.0, twoTextVerticalHeight)
+    case 5:
+      return max(120.0, twoTextVerticalHeight)
+    default:
+      return max(kDefaultTableCellHeight, singleTextHeight)
+    }
+  }
+
+  private func listFont(typeface: String, size: Int32) -> UIFont {
+    let pointSize = CGFloat(size)
+    if typeface == "1" {
+      return UIFont(name: "Helvetica", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    } else if typeface == "2" {
+      return UIFont(name: "Times New Roman", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    } else if typeface == "3" {
+      return UIFont(name: "Courier", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    }
+    return UIFont.systemFont(ofSize: pointSize)
+  }
+
+  private func preferredListViewWidth() -> CGFloat {
+    if let formWidth = form?.scaleFrameLayout.bounds.width, formWidth > 0 {
+      return formWidth
+    }
+    if let formWidth = form?.view.bounds.width, formWidth > 0 {
+      return formWidth
+    }
+    return 320
+  }
+
+  private func invalidateListViewSize() {
+    _rootView.invalidateIntrinsicContentSize()
+    _rootView.setNeedsLayout()
+    _rootView.superview?.setNeedsLayout()
+  }
 
   private final class HListCell: UICollectionViewCell {
   static let reuseId = "HListCell"
@@ -1030,10 +1129,14 @@ let HORIZONTAL_LAYOUT = 1
   var elements: [String] {
       return _results ?? _elements
     }
+
+  private var listItemCount: Int {
+    return max(_elements.count, _items.count)
+  }
     
   // UICollectionViewDataSource
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return _items.isEmpty ? _elements.count : _items.count
+    return listItemCount
   }
 
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/appinventor/components-ios/src/RelativeLayout.swift
+++ b/appinventor/components-ios/src/RelativeLayout.swift
@@ -146,14 +146,67 @@ open class RelativeLayout: Layout {
     }
     
     override var intrinsicContentSize: CGSize {
-      // If there are no subviews, return preferred empty size
-      if subviews.isEmpty {
-        return CGSize(width: Int(preferredEmptyWidth), height: Int(preferredEmptyHeight))
+      var maxX = CGFloat(0)
+      var maxY = CGFloat(0)
+      var hasPositionedSubview = false
+      for subview in subviews where !subview.isHidden {
+        guard let origin = originForSubview(subview) else {
+          continue
+        }
+        let size = preferredSize(of: subview)
+        maxX = max(maxX, origin.x + size.width)
+        maxY = max(maxY, origin.y + size.height)
+        hasPositionedSubview = true
       }
-      return UIView.layoutFittingExpandedSize
+      if !hasPositionedSubview {
+        return CGSize(width: CGFloat(preferredEmptyWidth), height: CGFloat(preferredEmptyHeight))
+      }
+      return CGSize(width: maxX, height: maxY)
     }
+
+    private func originForSubview(_ subview: UIView) -> CGPoint? {
+      var x: CGFloat?
+      var y: CGFloat?
+      for constraint in constraints {
+        if (constraint.firstItem as? UIView) == subview && (constraint.secondItem as? UIView) == self {
+          if constraint.firstAttribute == .left && constraint.secondAttribute == .left {
+            x = constraint.constant
+          } else if constraint.firstAttribute == .top && constraint.secondAttribute == .top {
+            y = constraint.constant
+          }
+        } else if (constraint.firstItem as? UIView) == self && (constraint.secondItem as? UIView) == subview {
+          if constraint.firstAttribute == .left && constraint.secondAttribute == .left {
+            x = -constraint.constant
+          } else if constraint.firstAttribute == .top && constraint.secondAttribute == .top {
+            y = -constraint.constant
+          }
+        }
+      }
+      if let x = x, let y = y {
+        return CGPoint(x: x, y: y)
+      }
+      return nil
+    }
+
+    private func preferredSize(of view: UIView) -> CGSize {
+      let fitting = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+      let intrinsic = view.intrinsicContentSize
+      return CGSize(width: preferredDimension(fitting.width, intrinsic.width, view.bounds.width),
+                    height: preferredDimension(fitting.height, intrinsic.height, view.bounds.height))
+    }
+
+    private func preferredDimension(_ values: CGFloat...) -> CGFloat {
+      return values.reduce(CGFloat(0)) { result, value in
+        if value.isFinite && value >= 0 && value < CGFloat.greatestFiniteMagnitude {
+          return max(result, value)
+        }
+        return result
+      }
+    }
+
     override func layoutSubviews() {
       super.layoutSubviews()
+      invalidateIntrinsicContentSize()
     }
   
 }

--- a/appinventor/components-ios/src/TableArrangement.swift
+++ b/appinventor/components-ios/src/TableArrangement.swift
@@ -77,18 +77,16 @@ fileprivate enum ConstraintUpdate {
    */
   fileprivate func updateComponentConstraints(for change: ConstraintUpdate) {
     if change == .height, let constraint = _heightConstraint {
-      component?.view.removeConstraint(constraint)
-      component?.form?.view.removeConstraint(constraint)
+      constraint.isActive = false
     }
     if change == .width, let constraint = _widthConstraint {
-      component?.view.removeConstraint(constraint)
-      component?.form?.view.removeConstraint(constraint)
+      constraint.isActive = false
     }
     if change == .height || change == .initialize {
-      addWidthConstraint()
+      addHeightConstraint()
     }
     if change == .width || change == .initialize {
-      addHeightConstraint()
+      addWidthConstraint()
     }
   }
 
@@ -98,15 +96,17 @@ fileprivate enum ConstraintUpdate {
     if let child = component {
       if child._lastSetHeight >= 0 {
         _heightConstraint = child.view.heightAnchor.constraint(equalToConstant: CGFloat(child._lastSetHeight))
-        child.view.addConstraint(_heightConstraint!)
+      } else if child._lastSetHeight == kLengthFillParent {
+        _heightConstraint = child.view.heightAnchor.constraint(equalTo: heightAnchor)
       } else if child._lastSetHeight <= kLengthPercentTag {
-        if let formView = child.form?.view, child.attachedToWindow {
+        if let scaleFrame = child.form?.scaleFrameLayout, sharesViewHierarchy(child.view, scaleFrame) {
           let height = -(child._lastSetHeight + 1000)
           let pHeight = CGFloat(height) / 100
-          _heightConstraint = child.view.heightAnchor.constraint(equalTo: formView.heightAnchor, multiplier: pHeight)
-          formView.addConstraint(_heightConstraint!)
+          _heightConstraint = child.view.heightAnchor.constraint(equalTo: scaleFrame.heightAnchor,
+                                                                 multiplier: pHeight)
         }
       }
+      _heightConstraint?.isActive = true
     }
   }
 
@@ -115,16 +115,35 @@ fileprivate enum ConstraintUpdate {
     if let child = component {
       if child._lastSetWidth >= 0 {
         _widthConstraint = child.view.widthAnchor.constraint(equalToConstant: CGFloat(child._lastSetWidth))
-        child.view.addConstraint(_widthConstraint!)
+      } else if child._lastSetWidth == kLengthFillParent {
+        _widthConstraint = child.view.widthAnchor.constraint(equalTo: widthAnchor)
       } else if child._lastSetWidth <= kLengthPercentTag {
-        if let formView = child.form?.view, child.attachedToWindow {
+        if let scaleFrame = child.form?.scaleFrameLayout, sharesViewHierarchy(child.view, scaleFrame) {
           let width = -(child._lastSetWidth + 1000)
           let pWidth = CGFloat(width) / 100
-          _widthConstraint = child.view.widthAnchor.constraint(equalTo: formView.widthAnchor, multiplier: pWidth)
-          formView.addConstraint(_widthConstraint!)
+          _widthConstraint = child.view.widthAnchor.constraint(equalTo: scaleFrame.widthAnchor,
+                                                               multiplier: pWidth)
         }
       }
+      _widthConstraint?.isActive = true
     }
+  }
+
+  private func sharesViewHierarchy(_ first: UIView, _ second: UIView) -> Bool {
+    var ancestors = Set<ObjectIdentifier>()
+    var current: UIView? = first
+    while let view = current {
+      ancestors.insert(ObjectIdentifier(view))
+      current = view.superview
+    }
+    current = second
+    while let view = current {
+      if ancestors.contains(ObjectIdentifier(view)) {
+        return true
+      }
+      current = view.superview
+    }
+    return false
   }
 }
 

--- a/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
@@ -36,6 +36,50 @@ class ListViewTests: AppInventorTestCase {
     XCTAssertEqual("DetailText", testList.GetDetailText(YailDictionary(dictionary: testList.Elements[0] as! Dictionary)))
     XCTAssertEqual("Image", testList.GetImageName(YailDictionary(dictionary: testList.Elements[0] as! Dictionary)))
   }
+
+  func testListViewInsideHorizontalArrangementHasSize() {
+    form.clear()
+    let row = HorizontalArrangement(form)
+    row.Width = kLengthFillParent
+    row.Height = kLengthPreferred
+    let listView = ListView(row)
+    listView.Height = kLengthPreferred
+    listView.Elements = ["apple", "banana", "cherry"] as [AnyObject]
+
+    form.view.setNeedsLayout()
+    form.view.layoutIfNeeded()
+    row.view.setNeedsLayout()
+    row.view.layoutIfNeeded()
+
+    XCTAssertGreaterThan(row.view.frame.height, 0)
+    XCTAssertGreaterThan(listView.view.frame.height, 0)
+    guard let tableView = listView.view.subviews.first(where: { $0 is UITableView }) as? UITableView else {
+      XCTFail("Expected ListView to contain a table view")
+      return
+    }
+    XCTAssertEqual(3, listView.tableView(tableView, numberOfRowsInSection: 0))
+    XCTAssertGreaterThan(tableView.frame.height, 0)
+  }
+
+  func testAutomaticVerticalHeightUsesRows() {
+    form.clear()
+    let listView = ListView(form)
+    listView.FontSize = 22
+    listView.Elements = ["apple", "banana", "cherry"] as [AnyObject]
+    form.onAttach()
+
+    form.view.setNeedsLayout()
+    form.view.layoutIfNeeded()
+
+    let oldCutoff = 44.0 * 3.0
+    XCTAssertGreaterThan(listView.view.intrinsicContentSize.height, oldCutoff)
+    XCTAssertGreaterThan(listView.view.frame.height, oldCutoff)
+    guard let tableView = listView.view.subviews.first(where: { $0 is UITableView }) as? UITableView else {
+      XCTFail("Expected ListView to contain a table view")
+      return
+    }
+    XCTAssertGreaterThan(listView.tableView(tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+  }
   
   func testElementAsDictItems() {
     testList.Elements = [["Text1": "MainText","Text2": "DetailText", "Image": "Image"] as YailDictionary]

--- a/appinventor/components-ios/tests/Unit Tests/util/LinearViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/util/LinearViewTests.swift
@@ -6,6 +6,24 @@
 import XCTest
 @testable import AIComponentKit
 
+private class IntrinsicTestView: UIView {
+  private let size: CGSize
+
+  init(width: CGFloat, height: CGFloat) {
+    size = CGSize(width: width, height: height)
+    super.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+  }
+
+  required init?(coder: NSCoder) {
+    return nil
+  }
+
+  override var intrinsicContentSize: CGSize {
+    return size
+  }
+}
+
 class LinearViewTests: XCTestCase {
 
   var testForm = ReplForm()
@@ -58,6 +76,56 @@ class LinearViewTests: XCTestCase {
     XCTAssertEqual([Button1.view, Button3.view], testView.arrangedSubviews)
     testView.setVisibility(of: Button2.view, to: true)
     XCTAssertEqual([Button1.view, Button2.view, Button3.view], testView.arrangedSubviews)
+  }
+
+  func testAutomaticSizingIgnoresInvisibleItems() {
+    let view1 = IntrinsicTestView(width: 30, height: 20)
+    let view2 = IntrinsicTestView(width: 70, height: 40)
+    testView.addItem(LinearViewItem(view1))
+    testView.addItem(LinearViewItem(view2))
+
+    XCTAssertEqual(CGSize(width: 70, height: 60), testView.intrinsicContentSize)
+
+    testView.setVisibility(of: view1, to: false)
+    testView.setVisibility(of: view2, to: false)
+
+    XCTAssertEqual(CGSize(width: 100, height: 100), testView.intrinsicContentSize)
+  }
+
+  func testHiddenComponentCanReplayAutomaticSizing() {
+    testForm.clear()
+    let row = HorizontalArrangement(testForm)
+    let Button1 = Button(row)
+
+    testForm.view.setNeedsLayout()
+    testForm.view.layoutIfNeeded()
+
+    Button1.Visible = false
+    Button1.Width = kLengthPreferred
+    Button1.Height = kLengthPreferred
+    Button1.Visible = true
+
+    testForm.view.setNeedsLayout()
+    testForm.view.layoutIfNeeded()
+    XCTAssertGreaterThan(Button1.view.frame.width, 0)
+    XCTAssertGreaterThan(Button1.view.frame.height, 0)
+  }
+
+  func testAbsoluteArrangementAutomaticSizeUsesPositionedChildren() {
+    testForm.clear()
+    let arrangement = AbsoluteArrangement(testForm)
+    let Button1 = Button(arrangement)
+
+    Button1.Left = 10
+    Button1.Top = 20
+    Button1.Width = 50
+    Button1.Height = 30
+
+    RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+    testForm.view.setNeedsLayout()
+    testForm.view.layoutIfNeeded()
+
+    XCTAssertEqual(CGSize(width: 60, height: 50), arrangement.view.intrinsicContentSize)
   }
 
   func testInvisibleComponents() {


### PR DESCRIPTION
**What does this PR accomplish?**

App Inventor has been having this long annoying bug when auto-sizing things in iOS. Especially when it comes to our Arrangements and ListView. This PR is an attempt to aliign autosize behavior close to the android behaviors as much as possible.

Problem
The iOS renderer was not consistently treating App Inventor Automatic as Android-style wrap_content.
On Android, arrangements and ListView naturally measure their children/items and then size themselves. On iOS, several components were either reporting no useful intrinsic size, keeping stale constraints, or sizing against the wrong parent. That caused cases like:
- ListView inside HorizontalArrangement measuring too small/zero, so items did not appear.
- ListView automatic height expanding too much, then later being too tight because it assumed 44pt × rows.
- Bigger text, like FontSize = 22, needing taller rows than the old hard cutoff allowed.
- Percent sizes and automatic sizes behaving differently depending on arrangement type.

Critical Changes
The biggest fix is in ListView.swift (line 18). I added a root view with a real intrinsic size, so arrangements can measure ListView properly. Then I made vertical automatic height come from item count and row height instead of “fill available space” or a fixed 44pt guess.

For the cutoff bug specifically, ListView.swift (line 1027) now computes row height from the configured fonts plus padding, and ListView.swift (line 972) makes the table rows use the same height. With three rows at FontSize = 22, the test now lays out at 171pt, not the old 132pt.

For arrangements, LinearView.swift (line 527), AbsoluteArrangement.swift (line 53), and RelativeLayout.swift (line 148) now report intrinsic sizes based on visible children. I also cleaned up stale constraint handling so hidden/removed/replayed components do not leave old sizing constraints behind.

For percentages, AbsoluteArrangement.swift (line 150) and TableArrangement.swift (line 102) now size percentage dimensions against the form scale frame where appropriate, which is closer to how App Inventor users expect percentage sizing to behave.

Added regression coverage in ListViewTests.swift (line 40) and LinearViewTests.swift (line 81).


- [x] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [ ] Indentation has been doubled checked
    - [ ] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
