### PR TITLE
[iOS] fix TextToSpeech country property

### DIFF
--- a/appinventor/components-ios/src/TextToSpeech.swift
+++ b/appinventor/components-ios/src/TextToSpeech.swift
@@ -37,11 +37,13 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
       let langWithCountry = voice.language
       let parts = langWithCountry.split("-")
       // insertion sort, but we'll only do this once per companion session.
-      if (!LANGUAGES.contains(parts[0])) {
-        LANGUAGES.append(parts[0])
+      let language = String(parts[0])
+      let country = String(parts[1])
+      if (!LANGUAGES.contains(language)) {
+        LANGUAGES.append(language)
       }
-      if (!COUNTRIES.contains(parts[1])) {
-        COUNTRIES.append(parts[1])
+      if (!COUNTRIES.contains(country)) {
+        COUNTRIES.append(country)
       }
     }
     LANGUAGES.sort()
@@ -69,8 +71,8 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
     TextToSpeech.getLanguageCodes()
     _voice = AVSpeechSynthesisVoice(language: _language)
     let parts = _language.split("-")
-    _language = parts[0]
-    _countryCode2 = parts[1]
+    _language = String(parts[0])
+    _countryCode2 = String(parts[1])
     _countryCode = TextToSpeech.ISO_COUNTRY_2_TO_3[_countryCode2] ?? "USA"
     super.init(parent)
     _tts.delegate = self
@@ -124,8 +126,7 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
       return _language
     }
     set(language) {
-      let language = language.lowercased()
-      if (TextToSpeech.LANGUAGES.contains(language)) {
+      if let language = TextToSpeech.languageToISO2(language) {
         _language = language
         updateLanguage()
       }
@@ -137,13 +138,10 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
       return _countryCode
     }
     set(country) {
-      let countryUpper = country.uppercased()
-      if let country = TextToSpeech.ISO_COUNTRY_3_TO_2[countryUpper] {
-        if TextToSpeech.COUNTRIES.contains(country) {
-          _countryCode2 = country
-          _countryCode = countryUpper
-          updateLanguage()
-        }
+      if let country = TextToSpeech.countryCodes(country) {
+        _countryCode2 = country.iso2
+        _countryCode = country.iso3
+        updateLanguage()
       }
     }
   }
@@ -156,7 +154,9 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
 
   @objc open var AvailableCountries: [String] {
     get {
-      return TextToSpeech.COUNTRIES
+      return TextToSpeech.COUNTRIES.compactMap {
+        TextToSpeech.ISO_COUNTRY_2_TO_3[$0]
+      }.sorted()
     }
   }
 
@@ -214,6 +214,28 @@ open class TextToSpeech: NonvisibleComponent, AVSpeechSynthesizerDelegate {
     if let voice = AVSpeechSynthesisVoice(language: language) {
       _voice = voice
     }
+  }
+
+  fileprivate class func languageToISO2(_ language: String) -> String? {
+    let language = language.lowercased()
+    if LANGUAGES.contains(language) {
+      return language
+    }
+    if let language = ISO_LANG_3_TO_2[language], LANGUAGES.contains(language) {
+      return language
+    }
+    return nil
+  }
+
+  fileprivate class func countryCodes(_ country: String) -> (iso2: String, iso3: String)? {
+    let country = country.uppercased()
+    if let country2 = ISO_COUNTRY_3_TO_2[country] {
+      return (iso2: country2, iso3: country)
+    }
+    if let country3 = ISO_COUNTRY_2_TO_3[country] {
+      return (iso2: country, iso3: country3)
+    }
+    return nil
   }
 }
 

--- a/appinventor/components-ios/tests/Unit Tests/components/nonvisible/TextToSpeechTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/nonvisible/TextToSpeechTests.swift
@@ -22,11 +22,29 @@ class TextToSpeechTests: AppInventorTestCase {
     XCTAssertEqual("es", language)
   }
 
+  func testISO3Language() {
+    TextToSpeech1.Language = "spa"
+    XCTAssertEqual("es", TextToSpeech1.Language)
+  }
+
   func testCountry() {
     TextToSpeech1.Country = "IRL"
     let country = TextToSpeech1.voice.language.split("-").last
     XCTAssertEqual("IRL", TextToSpeech1.Country)
     XCTAssertEqual("IE", country)
+  }
+
+  func testISO2Country() {
+    TextToSpeech1.Country = "MX"
+    XCTAssertEqual("MEX", TextToSpeech1.Country)
+  }
+
+  func testMexicanSpanishCountry() {
+    TextToSpeech1.Language = "es"
+    TextToSpeech1.Country = "MEX"
+    let country = TextToSpeech1.voice.language.split("-").last
+    XCTAssertEqual("MEX", TextToSpeech1.Country)
+    XCTAssertEqual("MX", country)
   }
 
   func testPitchBounds() {
@@ -53,6 +71,8 @@ class TextToSpeechTests: AppInventorTestCase {
 
   func testAvailableCountries() {
     XCTAssertGreaterThan(TextToSpeech1.AvailableCountries.count, 0)
+    XCTAssertTrue(TextToSpeech1.AvailableCountries.contains("USA"))
+    XCTAssertFalse(TextToSpeech1.AvailableCountries.contains("US"))
   }
 
   func testAvailableLanguages() {


### PR DESCRIPTION
**What does this PR accomplish?**

The TextToSpeech Country property was not compatible with the Country codes in our designer. This PR fixes it

Here is a good text [example](https://drive.google.com/file/d/1BD51lKuyRN24mXaTOm_19sK7oqQC9jBR/view?usp=sharing)