### PR TITLE
Fix ProjectFolder checkbox UI state

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/explorer/folder/ProjectFolder.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/explorer/folder/ProjectFolder.java
@@ -190,6 +190,7 @@ public class ProjectFolder extends Composite {
     nameLabel.setText(name);
     dateCreatedLabel.setText(DATE_FORMAT.format(new Date(dateCreated)));
     dateModifiedLabel.setText(DATE_FORMAT.format(new Date(dateModified)));
+    setSelected(false);
     childrenContainer.clear();
     List<ProjectFolder> sortedChildren = getChildFolders();
     if (needToSort) {


### PR DESCRIPTION
*Description*
When a `ProjectFolder` row is moved to Trash or vice versa (restore), it is reused in the Trash view/Project view which is why `refresh()` on `ProjectFolder` previously did not clear the checkbox state.

_Before_

https://github.com/user-attachments/assets/280090fe-fc1a-49f6-9788-156954800e72

_Fixed now_

https://github.com/user-attachments/assets/101566ce-0997-45a7-ab15-90507fd55f38

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #3965 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
