### PR TITLE
TinyDB iOS: enable PRAGMA fullfsync and surface silent failures

### DIFF
--- a/appinventor/components-ios/src/TinyDB.swift
+++ b/appinventor/components-ios/src/TinyDB.swift
@@ -17,16 +17,27 @@ open class TinyDB: NonvisibleComponent {
 
   public override init(_ parent: ComponentContainer) {
     let assetmgr = parent.form?.application?.assetManager
-    let sqlitedb = (assetmgr?.pathForPrivateAsset("TinyDb1.sqlite"))!
+    let sqlitedb = assetmgr?.pathForPrivateAsset("TinyDb1.sqlite") ?? ""
     do {
-      _database = try? Connection(sqlitedb)
+      _database = try Connection(sqlitedb)
+    } catch {
+      NSLog("TinyDB: Unable to open database at \(sqlitedb): \(error.localizedDescription)")
     }
     super.init(parent)
-    do {
-      _ = try? _database.run(_table.create(ifNotExists: true) { t in
-        t.column(_key, primaryKey: true)
-        t.column(_value)
-      })
+    if let db = _database {
+      do {
+        try db.run("PRAGMA fullfsync = 1")
+      } catch {
+        NSLog("TinyDB: Unable to enable fullfsync: \(error.localizedDescription)")
+      }
+      do {
+        try db.run(_table.create(ifNotExists: true) { t in
+          t.column(_key, primaryKey: true)
+          t.column(_value)
+        })
+      } catch {
+        NSLog("TinyDB: Unable to create table \(_namespace): \(error.localizedDescription)")
+      }
     }
   }
 
@@ -37,14 +48,20 @@ open class TinyDB: NonvisibleComponent {
       return _namespace
     }
     set (namespace) {
+      guard let db = _database else {
+        NSLog("TinyDB: Database not initialized; cannot switch to namespace \(namespace)")
+        return
+      }
+      let new_table = Table(namespace)
       do {
-        let new_table = Table(namespace)
-        _ = try? _database.run(new_table.create(ifNotExists: true) { t in
+        try db.run(new_table.create(ifNotExists: true) { t in
           t.column(_key, primaryKey: true)
           t.column(_value)
         })
         _table = new_table
         _namespace = namespace
+      } catch {
+        NSLog("TinyDB: Unable to switch to namespace \(namespace): \(error.localizedDescription)")
       }
     }
   }
@@ -52,18 +69,26 @@ open class TinyDB: NonvisibleComponent {
   /// MARK: TinyDB Methods
 
   @objc open func StoreValue(_ tag: String, _ valueToStore: AnyObject) {
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; cannot store value for tag \(tag)")
+      return
+    }
     do {
       let valueAsString = try getJsonRepresentation(valueToStore)
-      _ = try _database.run(_table.insert(or: .replace, _key <- tag, _value <- valueAsString))
+      _ = try db.run(_table.insert(or: .replace, _key <- tag, _value <- valueAsString))
     } catch {
-      NSLog("Unable to write to TinyDB")
+      NSLog("TinyDB: Unable to write tag \(tag): \(error.localizedDescription)")
     }
   }
 
   @objc open func GetEntries() -> YailDictionary {
     let result = YailDictionary()
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; cannot read entries")
+      return result
+    }
     do {
-      let statement = try _database.run("SELECT _key, _value FROM \(_namespace)")
+      let statement = try db.run("SELECT _key, _value FROM \(_namespace)")
       for row in statement {
         guard let key = row[0] as? NSString else {
           continue
@@ -76,48 +101,64 @@ open class TinyDB: NonvisibleComponent {
         }
       }
     } catch {
-      NSLog("Unable to read from TinyDB")
+      NSLog("TinyDB: Unable to read entries: \(error.localizedDescription)")
     }
     return result
   }
 
   @objc open func GetValue(_ tag: String, _ valueIfTagNotThere: AnyObject) -> AnyObject {
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; returning default for tag \(tag)")
+      return valueIfTagNotThere
+    }
     do {
-      if let value = try _database.pluck(_table.select(_value).filter(_key == tag)),
+      if let value = try db.pluck(_table.select(_value).filter(_key == tag)),
         let result = try getObjectFromJson(value[_value]) {
           return result
       }
     } catch {
-      NSLog("Unable to read value from TinyDB")
+      NSLog("TinyDB: Unable to read value for tag \(tag): \(error.localizedDescription)")
     }
     return valueIfTagNotThere
   }
 
   @objc open func GetTags() -> [String] {
     var result: [String] = []
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; cannot read tags")
+      return result
+    }
     do {
-      for tag in try _database.prepare(_table.select(_key)) {
+      for tag in try db.prepare(_table.select(_key)) {
         result.append(tag[_key])
       }
     } catch {
-      NSLog("Unable to read tags from TinyDB")
+      NSLog("TinyDB: Unable to read tags: \(error.localizedDescription)")
     }
     return result
   }
 
   @objc open func ClearAll() {
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; cannot clear all tags")
+      return
+    }
     do {
-      _ = try _database.run(_table.delete())
+      _ = try db.run(_table.delete())
     } catch {
-      NSLog("Unable to clear all tags")
+      NSLog("TinyDB: Unable to clear all tags: \(error.localizedDescription)")
     }
   }
 
   @objc open func ClearTag(_ tag: String) {
+    guard let db = _database else {
+      NSLog("TinyDB: Database not initialized; cannot clear tag \(tag)")
+      return
+    }
     do {
-      _ = try _database.run(_table.filter(_key == tag).delete())
+      _ = try db.run(_table.filter(_key == tag).delete())
     } catch {
-      NSLog("Unable to clear tag from TinyDB")
+      NSLog("TinyDB: Unable to clear tag \(tag): \(error.localizedDescription)")
     }
   }
 }


### PR DESCRIPTION

**What does this PR accomplish?**

Addresses #3967 — iOS `TinyDB` data disappears overnight on iOS 26.5.

*Description*
iOS's `fsync()` doesn't actually flush to disk: the OS returns success while the bytes are still in a write buffer. The only call that forces a real flush on iOS is `F_FULLFSYNC`, exposed in SQLite as `PRAGMA fullfsync`, and it's off by default for performance.
TinyDB opens its SQLite `Connection` with all defaults, so every write sits in an unflushed buffer. Foreground reads find it in the buffer and look fine. But once the app is suspended and an OS-level event happens overnight (low-battery shutdown, force restart, memory reclaim, OS update), the buffer can be discarded before reaching disk — and the data is silently gone the next day, matching the report.

Fix is one line right after opening the connection:

try db.run("PRAGMA fullfsync = 1")

This is Apple's documented recommendation for durable SQLite on iOS ([QA1809](https://developer.apple.com/library/archive/qa/qa1809/_index.html), [PRAGMA fullfsync](https://sqlite.org/pragma.html#pragma_fullfsync)).

Also cleans up the silent-failure paths that hid the bug — try? → try/catch with error.localizedDescription, guard let db = _database in every method, and removed the ! force-unwrap on pathForPrivateAsset. No behaviour change on the happy path.

*Testing Guidelines*

1. Build the iOS Companion on an iPhone running iOS 26.x.
2. Load ImageTextGallery.aia from the issue, save several entries.
3. Background the app, lock the device, leave overnight.
4. Before this PR: entries are gone the next day.
5. After this PR: entries persist.
6. Regression check: store/get/clear/namespace all behave identically; no new logs during normal use.

Fixes #3967



**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
