### PR TITLE
Fix iOS Sharing layout bug (#3968)

### DIFF
--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -1168,6 +1168,10 @@ let kMinimumToastWait = 10.0
   }
 
   @objc public func keyboardWillHide(_ notification: NSNotification) {
+    guard _keyboardVisible else {
+      return
+    }
+    
     _keyboardVisible = false
     if let userInfo = notification.userInfo,
         let frame = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {

--- a/appinventor/components-ios/src/Sharing.swift
+++ b/appinventor/components-ios/src/Sharing.swift
@@ -17,8 +17,15 @@ open class Sharing: NonvisibleComponent {
       view = vc.view
     }
     DispatchQueue.main.async {
-      activityVC.popoverPresentationController?.sourceView = view  // For iPad popover
-      self._form?.present(activityVC, animated: true, completion: nil)
+      if let popover = activityVC.popoverPresentationController {
+        popover.sourceView = view
+        popover.sourceRect = view.bounds
+      }
+      if let rootVC = UIApplication.shared.keyWindow?.rootViewController {
+        rootVC.present(activityVC, animated: true, completion: nil)
+      } else {
+        self._form?.present(activityVC, animated: true, completion: nil)
+      }
     }
   }
 


### PR DESCRIPTION
Guards keyboardWillHide in Form.swift and updates UIActivityViewController presentation context in Sharing.swift to prevent the bottom buttons from disappearing on cancel.

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

*Description*
This PR fixes a layout bug on the iOS Companion where dismissing the `UIActivityViewController` (via the Sharing component) causes the UI to break, resulting in buttons at the bottom of the screen disappearing into a black region.

Two overlapping issues caused this:
1. When the `UIActivityViewController` is dismissed, iOS sometimes broadcasts a `keyboardWillHide` notification. The observer in `Form.swift` was blindly appending height to the view without validating if the keyboard was actually shown (`_keyboardVisible`), pushing the bottom content off-screen. This PR adds a `guard _keyboardVisible` check to prevent this.
2. `Sharing.swift` was presenting the activity view controller directly from `_form`. On iOS 13+, this triggers the `.pageSheet` scale-down animation directly on the custom-layout `Form`, leading to constraint conflicts upon restoration. This PR shifts the presentation context to the `rootViewController` (similar to how `BarcodeScanner.swift` operates) to prevent the animation from scaling the `Form`.

*Testing Guidelines*
1. Open an App Inventor app on the iOS companion that has buttons aligned to the bottom of the screen.
2. Trigger the `Sharing` component (e.g., ShareMessage).
3. Swipe down or tap outside to cancel the share sheet.
4. Verify that the UI layout remains intact and the bottom buttons do not disappear.

Fixes #3968.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion (Note: This PR affects the *iOS* companion, not the Android companion).

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine