### PR TITLE
Fix ResourceMerger for AAR font resources

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibraries.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibraries.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright © 2017 Massachusetts Institute of Technology, All rights reserved.
+// Copyright © 2017-2026 Massachusetts Institute of Technology, All rights reserved.
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -8,6 +8,11 @@ package com.google.appinventor.buildserver.util;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -170,6 +175,11 @@ public class AARLibraries extends HashSet<AARLibrary> {
    * @return true if the merge was successful, otherwise false.
    */
   public boolean mergeResources(File outputDir, File mainResDir, PngCruncher cruncher) {
+    // Move fonts from AAR res/font/ directly to the merged output directory,
+    // bypassing ResourceMerger which does not support font resources and would
+    // fail trying to parse binary .ttf/.otf files as XML.
+    moveFontsToOutputDir(outputDir);
+
     List<ResourceSet> resourceSets = getResourceSets();
     ResourceSet mainResSet = new ResourceSet("main");
     mainResSet.addSource(mainResDir);
@@ -189,6 +199,56 @@ public class AARLibraries extends HashSet<AARLibrary> {
     } catch(MergingException e) {
       e.printStackTrace();
       return false;
+    }
+  }
+
+  /**
+   * Moves font directories from AAR res/font/ directly into the merged resource output
+   * directory, including any subdirectories and their contents. Fonts are written straight
+   * to {@code outputDir/font/} so {@code aapt} can package them without passing through
+   * {@link ResourceMerger}, which does not support font resources and will fail trying to
+   * parse binary font files as XML.
+   *
+   * <p>Using {@link Files#walkFileTree} ensures all files are moved and directories are
+   * deleted bottom-up in a single pass, so no {@code font/} directory remains in the AAR
+   * {@code res/} after this method returns.
+   *
+   * @param outputDir the merged resource output directory (same one passed to
+   *                  {@link #mergeResources(File, File, PngCruncher)})
+   */
+  private void moveFontsToOutputDir(File outputDir) {
+    Path mergedFontDir = outputDir.toPath().resolve("font");
+  
+    for (AARLibrary library : this) {
+      File resDir = library.getResDirectory();
+      if (resDir == null) continue;
+    
+      Path fontDir = resDir.toPath().resolve("font");
+      if (!Files.isDirectory(fontDir)) continue;
+    
+      try {
+        Files.walkFileTree(fontDir, new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path src, BasicFileAttributes attrs) throws IOException {
+            Path dest = mergedFontDir.resolve(fontDir.relativize(src));
+            Files.createDirectories(dest.getParent());
+            if (!Files.exists(dest)) {
+              Files.move(src, dest);
+            } else {
+              LOG.warning(null, "Skipping duplicate font file: %s", src.getFileName());
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        
+          @Override
+          public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+      } catch (IOException e) {
+        LOG.warning(null, "Failed to move font directory from %s: %s", fontDir, e.getMessage());
+      }
     }
   }
 


### PR DESCRIPTION
**What does this PR accomplish?**
When an AAR library contains font resources under `res/font/` (e.g. `res/font/myfont.ttf`), the build fails with:
````
[Fatal Error] :1:1: Content is not allowed in prolog.
[MergeResources] ERROR: Could not merge resources
````

This happens because the `ResourceMerger` attempts to parse binary `.ttf`/`.otf` files as XML, causing a `MergingException`.

This PR fixes the issue by introducing `moveFontsToOutputDir()` in [AARLibraries.java](https://github.com/jewelshkjony/appinventor-sources/blob/923365e5b2079560a256070bc771ec3309611ba7/appinventor/buildserver/src/com/google/appinventor/buildserver/util/AARLibraries.java#L219), which walks the AAR's `res/font/` directory using `Files.walkFileTree()` and moves all font files (including subdirectories) directly into the merged resource output directory before `ResourceMerger` runs.
This ensures:
- `ResourceMerger` never encounters font files.
- `aapt` picks up the fonts from the merged output and packages them into the APK/AAB correctly.
- Resource IDs (e.g. `R.font.myfont`) are correctly assigned and linked in `R.class`.

*Testing Guidelines*
1. Add an AAR that contains font (`res/font/myfont.ttf`) as a dependency to an App Inventor extension or component.
2. Build the application as APK/AAB.
3. Verify the build completes without `MergingException`.
4. Decompile the resulting APK and confirm:
   - `res/font/` contains the expected font files.
   - The expected package's `R.class` contains a `font` inner class with correct
     `aapt`-assigned resource IDs (e.g. `0x7f04xxxx`).
5. Run the app and verify font resources load correctly at runtime without
   `Resources.NotFoundException`.

Testing Results #.
1. Font files are packaged correctly:
<img width="457" height="274" alt="image" src="https://github.com/user-attachments/assets/6e6b1335-6352-47e9-bdfa-dba1406524bb" />
<img width="456" height="275" alt="image" src="https://github.com/user-attachments/assets/4aaadbef-e174-4134-be88-63fecc30ef51" />

2. IDs linked correctly to R.class
<img width="966" height="193" alt="image" src="https://github.com/user-attachments/assets/1557ea5f-cc59-47b0-9819-cf6ead15d9fa" />
<img width="971" height="164" alt="image" src="https://github.com/user-attachments/assets/e2b64e67-c25b-49ed-9608-efd0f1d90242" />

Fixes # .
#3610

Resolves # .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch
- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
