### PR TITLE
Add styling in App Store Settings dialog

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/neo.css
@@ -1072,6 +1072,10 @@ select.ode-PropertyEditor[disabled] {
   overflow: auto;
 }
 
+.ode-DialogBox-message a {
+  color: selected-color;
+}
+
 .ode-DialogBox .dialogContent td a {
     color: selected-color;
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/AppStoreSettingsDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/AppStoreSettingsDialog.ui.xml
@@ -12,12 +12,12 @@
   <wiz:Dialog ui:field="settingsDialog" role="dialog" ariaModal="true" ariaLabel="App Store Settings"
               caption="{messages.settingsTabName}" styleName="ode-DialogBox" width="400px">
     <g:FlowPanel>
-      <g:HTML>
+      <g:HTMLPanel styleName="ode-DialogBox-message">
         Please provide your Apple ID and App Specific Password for MIT App Inventor below. These
         values will be encrypted on the server and only read when deploying your app to App Store
         Connect.<br />
-        <a href="/reference/other/build-ios-apps.html" target="_blank">More information</a>
-      </g:HTML>
+        <g:Anchor href="/reference/other/build-ios-apps.html" target="_blank">More information</g:Anchor>
+      </g:HTMLPanel>
       <w:LabeledTextBox ui:field="appleIdTextbox" caption="Apple ID*: " />
       <w:LabeledTextBox ui:field="passwordTextbox" caption="App Specific Password*:" />
       <w:LabeledTextBox ui:field="shortNameTextbox" caption="ASC Short Name:" />


### PR DESCRIPTION
**What does this PR accomplish?**
1. Replace `g:HTML` with cleaner `g:HTMLPanel` and `g:Anchor` widgets
2. Add style `ode-DialogBox-message` in `g:HTMLPanel` widget
3. Add corresponding CSS selector in `neo.css`

Note: classic CSS (variablesColors.css) already has a selector with the same name, so no need to change anything in that

_Fixed now_

<img width="407" height="398" alt="image" src="https://github.com/user-attachments/assets/b4861546-3ac5-4d14-a909-e395d2f660b3" />

<img width="407" height="286" alt="image" src="https://github.com/user-attachments/assets/59bd0e69-e0f8-414a-965d-6b68717456c1" />

*Testing Guidelines*
1. Test both dark & light theme for both classic & neo interface
2. Open Settings > App Store Settings to see the changes

Fixes #3979

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
