### PR TITLE
Chart iOS: pass en_US_POSIX to DateFormatters and fix hh -> HH (#3894)

### DIFF
--- a/appinventor/components-ios/src/AxisChartView.swift
+++ b/appinventor/components-ios/src/AxisChartView.swift
@@ -155,13 +155,15 @@ open class AxisChartView : ChartView {
       } else if _vType == CHART_VALUE_DATE {
         
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let date = Date(timeIntervalSince1970: value)
         let test = dateFormatter.string(from: date)
         return test
       } else if _vType == CHART_VALUE_TIME {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "hh:mm:ss"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "HH:mm:ss"
         let date = Date(timeIntervalSince1970: value)
         return dateFormatter.string(from: date)
       }

--- a/appinventor/components-ios/src/BarChartDataModel.swift
+++ b/appinventor/components-ios/src/BarChartDataModel.swift
@@ -46,6 +46,7 @@ open class BarChartDataModel: Chart2DDataModel {
   public func formatDateTime(_ value: String) -> Double? {
     
     let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     dateFormatter.dateFormat = "yyyy-MM-dd"
     let date = dateFormatter.date(from: value)
     if date == nil {

--- a/appinventor/components-ios/src/PointChartDataModel.swift
+++ b/appinventor/components-ios/src/PointChartDataModel.swift
@@ -53,9 +53,11 @@ open class PointChartDataModel: Chart2DDataModel {
     } else if let value = o as? String {
       let retVal = Double(value)
       if retVal == nil {
+        self.dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         self.dateFormatter.dateFormat = "yyyy-MM-dd"
         let date = self.dateFormatter.date(from: value)
         if date == nil {
+          self.timeFormatter.locale = Locale(identifier: "en_US_POSIX")
           self.timeFormatter.dateFormat = "HH:mm:ss"
           return self.timeFormatter.date(from: value)?.timeIntervalSince1970
         }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

*Description*

Closes #3894 — the iOS counterpart to #3891.

The six `DateFormatter` instances in `AxisChartView.swift`, `BarChartDataModel.swift` and `PointChartDataModel.swift` are created without an explicit `locale`, so iOS resolves them against `Locale.current`. On a Thai-locale device the default calendar is Buddhist, so the `yyyy` pattern produces `2569` instead of `2026`; on locales with non-Western digit shaping (Arabic, Persian, Myanmar) the numeric pattern characters render in the local script.

This PR sets `dateFormatter.locale = Locale(identifier: "en_US_POSIX")` on every affected formatter, and fixes the second issue from the bug report: `AxisChartView.swift` used `"hh:mm:ss"` (12-hour) for the time axis while every other site (and Android) uses `"HH:mm:ss"` (24-hour). It is now `"HH:mm:ss"`.

**Why `en_US_POSIX` and not `Locale.US`:** Apple Technical Q&A [QA1480](https://developer.apple.com/library/archive/qa/qa1480/_index.html) recommends `en_US_POSIX` for fixed-format date code — it is guaranteed Gregorian, Latin-digit, and invariant across user settings and OS versions, whereas `en_US` can still pick up user regional overrides. Because the format strings (`yyyy-MM-dd`, `HH:mm:ss`) fully specify component order, the locale only affects calendar and digit script — it does **not** impose US `mm/dd/yy` layout on anyone. This directly addresses @ewpatton's concern on #3891 that `Locale.US` might make dates appear "wrong" for `dd/mm/yy` users.

*Testing Guidelines*

1. Set an iOS device/simulator locale to Thai.
2. In Designer, create a Bar chart and a Point chart with date-type X values.
3. Run in the iOS Companion.
4. **Before this PR:** axis date labels show Buddhist-year numbers (e.g. `2569-04-17`); time axis shows 12-hour values.
5. **After this PR:** axis labels show Gregorian-year Western digits, time axis is 24-hour, regardless of device locale.
6. Regression on a US-locale device: date labels unchanged; time-axis labels are now 24-hour (matching Android).

Closes #3894.

**Context for the changes**

This is iOS Companion runtime code, so it targets the `ucr` branch per the contributing guidelines.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine