### PR TITLE
Fix cancel redirect and top toolbar dropdowns

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -675,7 +675,7 @@ public class Ode implements EntryPoint {
       assetManager.loadAssets(project.getProjectId());
       assetListBox.getAssetList().refreshAssetList(project.getProjectId());
     }
-    getTopToolbar().updateFileMenuButtons(1);
+    getTopToolbar().updateFileMenuButtons(Ode.DESIGNER);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -324,7 +324,7 @@ public class TopToolbar extends Composite {
     // TODO: This code will work only so long as these menu items stay located in the file/build
     // menus as expected. It should be refactored.
     int projectCount = ProjectListBox.getProjectListBox().getProjectList().getMyProjectsCount();
-    if (view == 0) {  // We are in the Projects view
+    if (view == Ode.PROJECTS) {  // We are in the Projects view
       if ("ProjectDesignOnly".equals(fileDropDown.getName())) {
         fileDropDown.setVisible(false);
       }

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/DeleteAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/DeleteAction.java
@@ -42,6 +42,7 @@ public class DeleteAction implements Command {
               Ode.getInstance().getFolderManager().moveItemsToFolder(selectedProjects, selectedFolders,
                   Ode.getInstance().getFolderManager().getTrashFolder());
               Ode.getInstance().getFolderManager().saveAllFolders();
+              Ode.getInstance().switchToProjectsView();
             }
           } else {
             // The user can select a project to resolve the
@@ -55,10 +56,10 @@ public class DeleteAction implements Command {
           if (deleteConfirmation(true, selectedProjects, Collections.emptyList())) {
             Ode.getInstance().getFolderManager().moveItemsToFolder(selectedProjects, Collections.emptyList(),
                 Ode.getInstance().getFolderManager().getTrashFolder());
+            Ode.getInstance().switchToProjectsView();
             //Add the command to stop this current project from saving
           }
         }
-        Ode.getInstance().switchToProjectsView();
       }
     });
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/SwitchToProjectAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/SwitchToProjectAction.java
@@ -13,6 +13,6 @@ public class SwitchToProjectAction implements Command {
   @Override
   public void execute() {
     Ode.getInstance().switchToProjectsView();
-    Ode.getInstance().getTopToolbar().updateFileMenuButtons(0);
+    Ode.getInstance().getTopToolbar().updateFileMenuButtons(Ode.PROJECTS);
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/DesignToolbar.java
@@ -180,7 +180,7 @@ public class DesignToolbar extends Toolbar {
 
     // Gray out the Designer button and enable the blocks button
     toggleEditor(false);
-    Ode.getInstance().getTopToolbar().updateFileMenuButtons(0);
+    Ode.getInstance().getTopToolbar().updateFileMenuButtons(Ode.DESIGNER);
     toggleView();
   }
 
@@ -243,7 +243,7 @@ public class DesignToolbar extends Toolbar {
       projectEditor.selectFileEditor(screen.blocksEditor);
       toggleEditor(true);
     }
-    Ode.getInstance().getTopToolbar().updateFileMenuButtons(1);
+    Ode.getInstance().getTopToolbar().updateFileMenuButtons(Ode.DESIGNER);
     // Inform the Blockly Panel which project/screen (aka form) we are working on
     BlocklyPanel.setCurrentForm(projectId + "_" + newScreenName);
     screen.blocksEditor.makeActiveWorkspace();

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/SwitchToBlocksEditorAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/SwitchToBlocksEditorAction.java
@@ -26,7 +26,7 @@ public class SwitchToBlocksEditorAction implements Command {
       long projectId = Ode.getInstance().getCurrentYoungAndroidProjectRootNode().getProjectId();
       toolbar.switchToScreen(projectId, toolbar.getCurrentProject().currentScreen, DesignToolbar.View.BLOCKS);
       toolbar.toggleEditor(true);       // Gray out the blocks button and enable the designer button
-      Ode.getInstance().getTopToolbar().updateFileMenuButtons(1);
+      Ode.getInstance().getTopToolbar().updateFileMenuButtons(Ode.DESIGNER);
     }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/SwitchToFormEditorAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/actions/SwitchToFormEditorAction.java
@@ -31,7 +31,7 @@ public class SwitchToFormEditorAction implements Command {
           long projectId = Ode.getInstance().getCurrentYoungAndroidProjectRootNode().getProjectId();
           toolbar.switchToScreen(projectId, toolbar.getCurrentProject().currentScreen, View.DESIGNER);
           toolbar.toggleEditor(false);      // Gray out the Designer button and enable the blocks button
-          Ode.getInstance().getTopToolbar().updateFileMenuButtons(1);
+          Ode.getInstance().getTopToolbar().updateFileMenuButtons(Ode.DESIGNER);
         }
       }, false);
     }


### PR DESCRIPTION
Fixes #3983 

_Fixed now : cancel redirect_
Now, `DeleteAction` switch to `Projects` view only when the delete confirmation is true, this prevents the unnecessary redirect.

https://github.com/user-attachments/assets/16c0a0c1-c357-4ce7-8fc8-9a57775dffc2

_Fixed now: top toolbar dropdowns_
The weird behavior as shown here https://github.com/mit-cml/appinventor-sources/issues/3983#issuecomment-4678315976 is fixed, I've updated the `updateFileMenuButtons` method with all references + tested all cases
Also, I have replaced integers with constants defined in `Ode.java` for cleaner code: `Ode.PROJECTS & Ode.DESIGNER`

https://github.com/user-attachments/assets/61cb2d79-c2b1-49eb-b2b5-f001002a69de

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine