### PR TITLE
Fix Block Editor issue

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -130,6 +130,8 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
 
   private String defaultCloudDBToken = null;
 
+  private final Set<String> loadedBlocksEditors = new HashSet<>();
+
   /**
    * Opens the project property dialog
    */
@@ -230,6 +232,11 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   }
 
   private void loadBlocksEditor(String formName) {
+    if (loadedBlocksEditors.contains(formName)) {
+      return;
+    }
+    loadedBlocksEditors.add(formName);
+
     final BlocksEditor<?, DesignerEditor<?, ?, ?, ?, ?>> newBlocksEditor =
         (BlocksEditor) editorMap.get(formName).blocksEditor;
     newBlocksEditor.loadFile(new Command() {
@@ -656,6 +663,7 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
         editors.blocksEditor = null;
       }
     }
+    loadedBlocksEditors.remove(formName);
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaProjectEditor.java
@@ -130,8 +130,6 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
 
   private String defaultCloudDBToken = null;
 
-  private final Set<String> loadedBlocksEditors = new HashSet<>();
-
   /**
    * Opens the project property dialog
    */
@@ -232,11 +230,6 @@ public final class YaProjectEditor extends ProjectEditor implements ProjectChang
   }
 
   private void loadBlocksEditor(String formName) {
-    if (loadedBlocksEditors.contains(formName)) {
-      return;
-    }
-    loadedBlocksEditors.add(formName);
-
     final BlocksEditor<?, DesignerEditor<?, ?, ?, ?, ?>> newBlocksEditor =
         (BlocksEditor) editorMap.get(formName).blocksEditor;
     newBlocksEditor.loadFile(new Command() {


### PR DESCRIPTION
**What does this PR accomplish?**

This PR aims to fix the internal error shown in the linked issue, and it solves 2 problems at once

1. Users can now recreate the screen with the same name and work on it seamlessly
2. After screen recreation, the new screen opens automatically

The only culprit here is the `loadedBlocksEditors` Set:

1. This was causing `IndexOutOfBoundsException` in `selectFileEditor` method of `ProjectEditor.java`
2. The error is at `showWidget(index)` as the `index` here is `-1`
3. `Index` is `-1` because widget doesn't exist (`screen-name.bky`)
4. Widget doesn't exist because it was never created in `loadBlocksEditor` method of `YaProjectEditor.java`
5. Why it was not created? because `formName` exist in `loadedBlocksEditors` Set & was never removed when the old screen with the same name was deleted
6. Since, the `formName` already exist, it exits the method without calling `addBlocksEditor` method

_Fixed now_

https://github.com/user-attachments/assets/e83777c5-3203-4498-a548-fbfda79bfb11

*Testing Guidelines*
Follow steps shown in screen recording

Fixes #3986 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
