### PR TITLE
Pass Locale.US to Clock date parsing and formatting in Dates.java

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
@@ -10,6 +10,7 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 
 import java.util.Date;
+import java.util.Locale;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -143,12 +144,16 @@ public final class Dates {
       "hh:mm a",
       "HH:mm"
     };
+    ParseException lastException = null;
     for (String format : formats) {
       try {
-        return new SimpleDateFormat(format).parse(value);
-      } catch (ParseException e) {}
+        return new SimpleDateFormat(format, Locale.US).parse(value);
+      } catch (ParseException e) {
+        lastException = e;
+      }
     }
-    throw new IllegalArgumentException("illegal date/time format in function DateValue()");
+    throw new IllegalArgumentException(
+        "illegal date/time format in function DateValue(): " + value, lastException);
   }
 
   /**
@@ -199,7 +204,7 @@ public final class Dates {
    */
   @SimpleFunction
   public static String FormatDateTime(Calendar date, String pattern) {
-    SimpleDateFormat formatdate = new SimpleDateFormat();
+    SimpleDateFormat formatdate = new SimpleDateFormat("", Locale.US);
     if (pattern.length() == 0) {
       formatdate.applyPattern("MMM d, yyyy hh:mm:ss a");
     } else {
@@ -219,7 +224,7 @@ public final class Dates {
    */
   @SimpleFunction
   public static String FormatDate(Calendar date, String pattern) {
-    SimpleDateFormat formatdate = new SimpleDateFormat();
+    SimpleDateFormat formatdate = new SimpleDateFormat("", Locale.US);
     if (pattern.length() == 0) {
       formatdate.applyPattern("MMM d, yyyy");
     } else {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

*Description*

Android half of #3984. The iOS half is #3989.

`Dates.java` creates `SimpleDateFormat` instances without a `Locale` in three places: `tryParseDate` (which backs `Clock.MakeInstant`), `FormatDateTime`, and `FormatDate`. On a Thai-locale device, `SimpleDateFormat` resolves against the Buddhist calendar, so `Clock.MakeInstant("06/10/2026")` reads 2026 as a Buddhist Era year and returns Gregorian year 1483. Any app that parses a saved or hardcoded date string silently gets an instant about 543 years in the past. Formatting has the mirror problem, which also breaks round-trips (format a date, store it, parse it later).

This PR passes `Locale.US` to all three, the same approach approved and merged in #3891 for the Chart components. The documented format strings (`MM/dd/yyyy`, `HH:mm`, etc.) fully specify component order, so the locale only pins the calendar and digit script. It does not change date layout for anyone.

It also fixes a debuggability problem in the same function: `tryParseDate` swallowed `ParseException` with an empty catch, so a failed parse threw `IllegalArgumentException` with no detail. The exception now includes the input value and carries the last parse error as its cause.

`WeekdayName`/`MonthName` style functions are intentionally untouched. They use locale display names by design and should keep doing so.

*Testing Guidelines*

1. Set an Android device or emulator to Thai (Settings > System > Languages > Thai).
2. In a test app, call `Clock.MakeInstant("06/10/2026")` then `Clock.Year(...)` on the result.
3. Before this PR: `1483`. After this PR: `2026`.
4. Round-trip check: `Clock.FormatDate` an instant, parse it back with `Clock.MakeInstant`, confirm the same instant on any locale.
5. Regression on a US-locale device: all Clock blocks behave identically to before.

Addresses the Android portion of #3984.

**Context for the changes**

This is Android Companion runtime code, so it targets the `ucr` branch per the contributing guidelines.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine