### PR TITLE
Clock iOS: use en_US_POSIX for date parsing and pattern formatting

### DIFF
--- a/appinventor/components-ios/src/Clock.swift
+++ b/appinventor/components-ios/src/Clock.swift
@@ -9,11 +9,14 @@ import Foundation
  * Creates a `DateFormatter` object for the given `str`.
  *
  * @param str The date format string
+ * @param locale The locale used to resolve pattern symbols. Defaults to
+ *     en_US_POSIX so parsing and pattern formatting are deterministic
+ *     across device locales (see #3984).
  * @returns A new DateFormatter object configured with the given string
  */
-fileprivate func makeFormat(_ str: String) -> DateFormatter {
+fileprivate func makeFormat(_ str: String, locale: Locale = Locale(identifier: "en_US_POSIX")) -> DateFormatter {
   let date = DateFormatter()
-  date.locale = Locale.preferredLanguage
+  date.locale = locale
   date.dateFormat = str
   return date
 }
@@ -243,7 +246,7 @@ open class Clock: NonvisibleComponent, LifecycleDelegate {
   }
   
   @objc open func WeekdayName(_ instant: Date) -> String {
-    let dayName = makeFormat("EEEE")
+    let dayName = makeFormat("EEEE", locale: Locale.preferredLanguage)
     return dayName.string(from: instant)
   }
   
@@ -252,7 +255,7 @@ open class Clock: NonvisibleComponent, LifecycleDelegate {
   }
   
   @objc open func MonthName(_ instant: Date) -> String {
-    let dayName = makeFormat("LLLL")
+    let dayName = makeFormat("LLLL", locale: Locale.preferredLanguage)
     return dayName.string(from: instant)
   }
   
@@ -271,7 +274,7 @@ open class Clock: NonvisibleComponent, LifecycleDelegate {
   }
   
   @objc open func FormatTime(_ instant: Date) -> String {
-    let dateFormatter = makeFormat("h:mm:ss a")
+    let dateFormatter = makeFormat("h:mm:ss a", locale: Locale.preferredLanguage)
     return dateFormatter.string(from: instant)
   }
   


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

*Description*

iOS half of #3984. The Android half is #3988.

`Clock.swift`'s `makeFormat` helper set every `DateFormatter`'s locale to the user's preferred language. For the `DATE_FORMATTERS` parsing array that backs `MakeInstant`, this means a Thai-language iPhone resolves `yyyy` against the Buddhist calendar: `MakeInstant("06/10/2026")` reads 2026 as a Buddhist Era year and returns Gregorian year 1483. Any app that parses a saved or hardcoded date string silently gets an instant about 543 years in the past. `FormatDate`/`FormatDateTime` have the mirror problem, which also breaks round-trips (format a date, store it, parse it later).

The fix: `makeFormat` now takes a `locale` parameter defaulting to `en_US_POSIX`, which is Apple's documented locale for fixed-format date code ([Technical Q&A QA1480](https://developer.apple.com/library/archive/qa/qa1480/_index.html)) and consistent with the Chart fix in #3982. Parsing and pattern-based formatting pick up the deterministic default with no call-site changes.

Three functions intentionally keep the device language, now passed explicitly: `WeekdayName`, `MonthName`, and `FormatTime`. These are localized display functions, and the Android fix (#3988) also left their Android counterparts untouched. Their behavior is unchanged by this PR.

Because the format strings fully specify component order, `en_US_POSIX` only pins the calendar and digit script. It does not impose US date layout on anyone.

*Testing Guidelines*

1. Set an iPhone or simulator language to Thai.
2. In a test app, call `Clock.MakeInstant("06/10/2026")` then `Clock.Year(...)` on the result.
3. Before this PR: 1483. After this PR: 2026.
4. Round-trip check: `Clock.FormatDate` an instant, parse it back with `Clock.MakeInstant`, confirm the same instant on any locale.
5. Confirm `WeekdayName` and `MonthName` still return Thai names on a Thai device (unchanged behavior).
6. Regression on a US-locale device: all Clock blocks behave identically to before.

Addresses the iOS portion of #3984.

**Context for the changes**

This is iOS Companion runtime code, so it targets the `ucr` branch per the contributing guidelines.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine