### PR TITLE
Migrate ListView ListData editor dialog chrome to UiBinder

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -1124,6 +1124,10 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Confirm cancel from ListData property editor without saving data.")
   String listDataConcelConfirm();
 
+  @DefaultMessage("Click to Add Row Data")
+  @Description("Button to add a new blank row in the ListData property editor")
+  String listDataAddRowButton();
+
 
   // Used in boxes/ViewerBox.java
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -1,0 +1,322 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2024 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.properties;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.simple.SimpleEditor;
+import com.google.appinventor.client.explorer.project.Project;
+import com.google.appinventor.client.wizards.Dialog;
+
+import com.google.appinventor.components.common.ComponentConstants;
+
+import com.google.appinventor.shared.rpc.project.ProjectNode;
+import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
+import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+
+import com.google.gwt.cell.client.ButtonCell;
+import com.google.gwt.cell.client.FieldUpdater;
+import com.google.gwt.cell.client.SelectionCell;
+import com.google.gwt.cell.client.TextInputCell;
+
+import com.google.gwt.core.client.GWT;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
+
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.cellview.client.Column;
+
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+import com.google.gwt.view.client.ListDataProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The "Click to Add/Delete Data" dialog for the ListView ListData property.
+ *
+ * <p>This is the UiBinder migration of the former {@code ClickHandle} inner class. The dialog
+ * chrome (title, button bar and the container that holds the data rows) is now declared in
+ * {@code ListViewAddDataDialog.ui.xml} and wrapped in the accessible {@link Dialog} widget, which
+ * provides the ARIA role, modal semantics, Escape-to-close and focus management. The data grid
+ * itself is still the original {@link CellTable}; replacing it with real-widget rows is the next
+ * step (PR 1.2).
+ */
+public class ListViewAddDataDialog {
+
+  interface ListViewAddDataDialogUiBinder extends UiBinder<Widget, ListViewAddDataDialog> {}
+
+  private static final ListViewAddDataDialogUiBinder UI_BINDER =
+      GWT.create(ListViewAddDataDialogUiBinder.class);
+
+  @UiField Dialog dialogBox;
+  @UiField FlowPanel tableContainer;
+  @UiField Button addRow;
+  @UiField Button save;
+  @UiField Button cancel;
+  @UiField Button topInvisible;
+  @UiField Button bottomInvisible;
+
+  private final YoungAndroidListViewAddDataPropertyEditor owner;
+  private final int layout;
+
+  /* Working copy of the rows; only written back to the property on SAVE. */
+  private final List<JSONObject> itemsCopy = new ArrayList<JSONObject>();
+  private final CellTable<JSONObject> table = new CellTable<JSONObject>();
+  private final ListDataProvider<JSONObject> model = new ListDataProvider<JSONObject>(itemsCopy);
+  private final JSONArray rows = new JSONArray();
+
+  ListViewAddDataDialog(YoungAndroidListViewAddDataPropertyEditor owner, int layout) {
+    this.owner = owner;
+    this.layout = layout;
+    UI_BINDER.createAndBindUi(this);
+
+    dialogBox.setCaption(MESSAGES.listDataAddDataTitle());
+    dialogBox.setAriaLabel(MESSAGES.listDataAddDataTitle());
+    addRow.setText(MESSAGES.listDataAddRowButton());
+    save.setText(MESSAGES.saveButton());
+    cancel.setText(MESSAGES.cancelButton());
+
+    for (JSONObject item : owner.getItems()) {
+      itemsCopy.add(item);
+    }
+
+    table.setRowData(itemsCopy);
+    table.setEmptyTableWidget(new Label("No row data available yet!"));
+    model.addDataDisplay(table);
+
+    buildColumns();
+    tableContainer.add(table);
+  }
+
+  /** Centers and shows the dialog. */
+  void show() {
+    dialogBox.center();
+  }
+
+  /**
+   * Creates the table columns for the current ListView layout. The set of columns determines which
+   * fields ({@code Text1}, {@code Text2}, {@code Image}) a row exposes for editing.
+   */
+  private void buildColumns() {
+    if (layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
+      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
+          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
+      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
+      table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
+      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
+      table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
+        layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
+      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
+      table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
+      table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
+    }
+
+    table.addColumn(createDeleteButton());
+  }
+
+  private Column<JSONObject, String> createDeleteButton() {
+    Column<JSONObject, String> column = new Column<JSONObject, String>(new ButtonCell()) {
+      @Override
+      public String getValue(JSONObject jsonObject) {
+        return "DELETE";
+      }
+    };
+    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
+      @Override
+      public void update(int i, JSONObject jsonObject, String s) {
+        itemsCopy.remove(i);
+        model.refresh();
+        table.setRowCount(0);
+        table.setRowData(0, itemsCopy);
+      }
+    });
+    return column;
+  }
+
+  private Column<JSONObject, String> createTextBoxes(final String columnKey) {
+    Column<JSONObject, String> column = new Column<JSONObject, String>(new TextInputCell()) {
+      @Override
+      public String getValue(JSONObject jsonObject) {
+        if (jsonObject.containsKey(columnKey)) {
+          JSONString stringVal = (JSONString) jsonObject.get(columnKey);
+          return (stringVal.stringValue());
+        } else {
+          jsonObject.put(columnKey, new JSONString(""));
+          return "";
+        }
+      }
+    };
+    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
+      @Override
+      public void update(int i, JSONObject jsonObject, String s) {
+        jsonObject.put(columnKey, new JSONString(s));
+      }
+    });
+    return column;
+  }
+
+  private Column<JSONObject, String> createImageSelectionDropDown(final String columnKey) {
+    Project project = Ode.getInstance().getProjectManager()
+        .getProject(owner.getSimpleEditor().getProjectId());
+    YoungAndroidAssetsFolder assetsFolder =
+        ((YoungAndroidProjectNode) project.getRootNode()).getAssetsFolder();
+    List<String> choices = new ArrayList<String>();
+    choices.add(0, "None");
+    if (assetsFolder != null) {
+      for (ProjectNode node : assetsFolder.getChildren()) {
+        choices.add(node.getName());
+      }
+    }
+    Column<JSONObject, String> column = new Column<JSONObject, String>(new SelectionCell(choices)) {
+      @Override
+      public String getValue(JSONObject jsonObject) {
+        if (jsonObject.containsKey(columnKey)) {
+          JSONString stringVal = (JSONString) jsonObject.get(columnKey);
+          return (stringVal.stringValue());
+        } else {
+          jsonObject.put(columnKey, new JSONString(""));
+          return "";
+        }
+      }
+    };
+    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
+      @Override
+      public void update(int i, JSONObject jsonObject, String s) {
+        jsonObject.put(columnKey, new JSONString(s));
+      }
+    });
+    return column;
+  }
+
+  @UiHandler("addRow")
+  void onAddRow(ClickEvent event) {
+    // creates a row with default data for the corresponding layout type
+    JSONObject data = new JSONObject();
+    if (layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
+      data.put("Text1", new JSONString(""));
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
+          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
+      data.put("Text1", new JSONString(""));
+      data.put("Text2", new JSONString(""));
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
+      data.put("Text1", new JSONString(""));
+      data.put("Image", new JSONString("None"));
+    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
+        layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
+      data.put("Text1", new JSONString(""));
+      data.put("Text2", new JSONString(""));
+      data.put("Image", new JSONString("None"));
+    }
+    itemsCopy.add(data);
+    table.setRowData(itemsCopy);
+  }
+
+  @UiHandler("save")
+  void onSave(ClickEvent event) {
+    // save the data for the corresponding layout type
+    List<JSONObject> items = owner.getItems();
+    items.clear();
+    for (int i = 0; i < itemsCopy.size(); ++i) {
+      JSONObject obj = itemsCopy.get(i);
+      if ((layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT ||
+          layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) && obj.containsKey("Text2")) {
+        obj.put("Text2", null);
+      }
+      if ((layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
+          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) && obj.containsKey("Image")) {
+        obj.put("Image", null);
+      }
+      rows.set(i, obj);
+      items.add(i, obj);
+    }
+    owner.commitListData(rows.toString());
+    dialogBox.hide();
+  }
+
+  @UiHandler("cancel")
+  void onCancel(ClickEvent event) {
+    // discards changes in the data for the corresponding layout type
+    final Cancel confirm = new Cancel();
+    confirm.center();
+    confirm.setStylePrimaryName("ode-DialogBox");
+    confirm.show();
+    confirm.yes.addClickHandler(new ClickHandler() {
+      @Override
+      public void onClick(ClickEvent clickEvent) {
+        itemsCopy.clear();
+        confirm.hide();
+        dialogBox.hide();
+      }
+    });
+    confirm.no.addClickHandler(new ClickHandler() {
+      @Override
+      public void onClick(ClickEvent clickEvent) {
+        confirm.hide();
+      }
+    });
+  }
+
+  /*
+   * The invisible "FocusTrap" buttons at the top and bottom of the dialog keep keyboard focus
+   * contained within the popup: tabbing past the last control wraps to the first, and vice versa.
+   */
+  @UiHandler("topInvisible")
+  void focusLast(FocusEvent event) {
+    cancel.setFocus(true);
+  }
+
+  @UiHandler("bottomInvisible")
+  void focusFirst(FocusEvent event) {
+    addRow.setFocus(true);
+  }
+
+  /**
+   * Confirmation dialog shown when the user clicks CANCEL, asking whether to discard unsaved data.
+   */
+  static class Cancel extends DialogBox {
+    VerticalPanel verticalPanel;
+    HorizontalPanel buttonPanel;
+    Button yes;
+    Button no;
+
+    Cancel() {
+      verticalPanel = new VerticalPanel();
+      buttonPanel = new HorizontalPanel();
+      setText(MESSAGES.cancelButton());
+      verticalPanel.add(new Label(MESSAGES.listDataConcelConfirm()));
+      yes = new Button(MESSAGES.okButton());
+      no = new Button(MESSAGES.cancelButton());
+      buttonPanel.add(yes);
+      buttonPanel.add(no);
+      buttonPanel.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_CENTER);
+      verticalPanel.add(buttonPanel);
+      setWidget(verticalPanel);
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
@@ -1,0 +1,25 @@
+<!-- Copyright 2024 MIT, All rights reserved -->
+<!-- Released under the Apache License, Version 2.0 -->
+<!-- http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+    xmlns:g="urn:import:com.google.gwt.user.client.ui"
+    xmlns:wiz="urn:import:com.google.appinventor.client.wizards">
+
+  <wiz:Dialog ui:field="dialogBox" role="dialog" ariaModal="true"
+              styleName="ode-DialogBox">
+    <g:VerticalPanel>
+      <g:Button ui:field="topInvisible" styleName="FocusTrap" tabIndex="-1"/>
+
+      <g:FlowPanel ui:field="tableContainer"/>
+      <g:Button ui:field="addRow"/>
+
+      <g:HorizontalPanel horizontalAlignment="ALIGN_CENTER">
+        <g:Button ui:field="save"/>
+        <g:Button ui:field="cancel"/>
+      </g:HorizontalPanel>
+
+      <g:Button ui:field="bottomInvisible" styleName="FocusTrap" tabIndex="-1"/>
+    </g:VerticalPanel>
+  </wiz:Dialog>
+</ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidListViewAddDataPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidListViewAddDataPropertyEditor.java
@@ -5,27 +5,9 @@
 
 package com.google.appinventor.client.editor.youngandroid.properties;
 
-import static com.google.appinventor.client.Ode.MESSAGES;
-
-import com.google.appinventor.client.Ode;
-
 import com.google.appinventor.client.editor.simple.SimpleEditor;
 
-import com.google.appinventor.client.explorer.project.Project;
-
 import com.google.appinventor.client.widgets.properties.PropertyEditor;
-
-import com.google.appinventor.components.common.ComponentConstants;
-
-import com.google.appinventor.shared.rpc.project.ProjectNode;
-
-import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
-import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
-
-import com.google.gwt.cell.client.ButtonCell;
-import com.google.gwt.cell.client.FieldUpdater;
-import com.google.gwt.cell.client.SelectionCell;
-import com.google.gwt.cell.client.TextInputCell;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -33,20 +15,9 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
-import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 
-import com.google.gwt.user.cellview.client.CellTable;
-import com.google.gwt.user.cellview.client.Column;
-
 import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.DialogBox;
-import com.google.gwt.user.client.ui.HasHorizontalAlignment;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.VerticalPanel;
-
-import com.google.gwt.view.client.ListDataProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +25,10 @@ import java.util.List;
 /**
  * AddData property in the ListView component. It is used to add/delete data
  * for different layout types of ListView.
+ *
+ * <p>The button opens {@link ListViewAddDataDialog}, which holds the editing grid. This editor
+ * keeps the data layer (the JSON {@code <-> List<JSONObject>} load/save) and hands the dialog the
+ * items to edit and a callback to persist them.
  */
 
 public class YoungAndroidListViewAddDataPropertyEditor extends PropertyEditor {
@@ -62,13 +37,11 @@ public class YoungAndroidListViewAddDataPropertyEditor extends PropertyEditor {
 
   private int layout;
   private List<JSONObject> items;
-  private List<JSONObject> itemsCopy;
 
   private final SimpleEditor editor;
 
   public YoungAndroidListViewAddDataPropertyEditor(final SimpleEditor editor) {
     items = new ArrayList<JSONObject>();
-    itemsCopy = new ArrayList<JSONObject>();
     addData = new Button("Click to Add/Delete Data");
     this.editor = editor;
 
@@ -92,10 +65,7 @@ public class YoungAndroidListViewAddDataPropertyEditor extends PropertyEditor {
     addData.addClickHandler(new ClickHandler() {
       @Override
       public void onClick(ClickEvent clickEvent) {
-        ClickHandle ch = new ClickHandle(layout);
-        ch.center();
-        ch.setStylePrimaryName("ode-DialogBox");
-        ch.show();
+        new ListViewAddDataDialog(YoungAndroidListViewAddDataPropertyEditor.this, layout).show();
       }
     });
     initWidget(addData);
@@ -108,239 +78,18 @@ public class YoungAndroidListViewAddDataPropertyEditor extends PropertyEditor {
     this.layout = layout;
   }
 
-  /**
-   * class to display data table and add/delete data for AddData property
-   */
-  class ClickHandle extends DialogBox {
-    VerticalPanel verticalPanel;
-    HorizontalPanel actionButtons;
-    Button add, save, cancel;
-    CellTable<JSONObject> table;
-    JSONArray rows;
-
-    ListDataProvider<JSONObject> model;
-
-    Column<JSONObject, String> createDeleteButton() {
-      Column<JSONObject, String> column = new Column<JSONObject, String>(new ButtonCell()) {
-        @Override
-        public String getValue(JSONObject jsonObject) {
-          return "DELETE";
-        }
-      };
-      column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-        @Override
-        public void update(int i, JSONObject jsonObject, String s) {
-          itemsCopy.remove(i);
-          model.refresh();
-          table.setRowCount(0);
-          table.setRowData(0, itemsCopy);
-        }
-      });
-      return column;
-    }
-
-    Column<JSONObject, String> createTextBoxes(final String columnKey) {
-      Column<JSONObject, String> column = new Column<JSONObject, String>(new TextInputCell()) {
-        @Override
-        public String getValue(JSONObject jsonObject) {
-          if (jsonObject.containsKey(columnKey)) {
-            JSONString stringVal = (JSONString)jsonObject.get(columnKey);
-            return (stringVal.stringValue());
-          } else {
-            jsonObject.put(columnKey, new JSONString(""));
-            return "";
-          }
-        }
-      };
-      column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-        @Override
-        public void update(int i, JSONObject jsonObject, String s) {
-          jsonObject.put(columnKey, new JSONString(s));
-        }
-      });
-      return column;
-    }
-
-    Column<JSONObject, String> createImageSelectionDropDown(final String columnKey) {
-      Project project = Ode.getInstance().getProjectManager().getProject(editor.getProjectId());
-      YoungAndroidAssetsFolder assetsFolder = ((YoungAndroidProjectNode) project.getRootNode()).getAssetsFolder();
-      List<String> choices = new ArrayList<String>();
-      choices.add(0, "None");
-      if (assetsFolder != null) {
-        for (ProjectNode node : assetsFolder.getChildren()) {
-          choices.add(node.getName());
-        }
-      }
-      Column<JSONObject, String> column = new Column<JSONObject, String>(new SelectionCell(choices)) {
-        @Override
-        public String getValue(JSONObject jsonObject) {
-          if (jsonObject.containsKey(columnKey)) {
-            JSONString stringVal = (JSONString)jsonObject.get(columnKey);
-            return (stringVal.stringValue());
-          } else {
-            jsonObject.put(columnKey, new JSONString(""));
-            return "";
-          }
-        }
-      };
-      column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-        @Override
-        public void update(int i, JSONObject jsonObject, String s) {
-          jsonObject.put(columnKey, new JSONString(s));
-        }
-      });
-      return column;
-    }
-
-    ClickHandle(final int layoutValue) {
-
-      verticalPanel = new VerticalPanel();
-      actionButtons = new HorizontalPanel();
-      itemsCopy = new ArrayList<JSONObject>();
-      model = new ListDataProvider(itemsCopy);
-      table = new CellTable<JSONObject>();
-      rows = new JSONArray();
-      add  = new Button("Click to Add Row Data");
-      save = new Button("SAVE");
-      cancel = new Button("CANCEL");
-
-      setText(MESSAGES.listDataAddDataTitle());
-
-      for (int i = 0; i < items.size(); ++i) {
-        itemsCopy.add(i, items.get(i));
-      }
-
-      table.setRowData(itemsCopy);
-      table.setEmptyTableWidget(new Label("No row data available yet!"));
-      model.addDataDisplay(table);
-
-      /*
-       * create table columns and type of each column according to the type of ListView layout
-       */
-      if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
-        table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-      } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-            layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
-        table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-        table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
-      } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
-        table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-        table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
-      } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
-          layoutValue ==ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
-        table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-        table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
-        table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
-      }
-
-      table.addColumn(createDeleteButton());
-
-      add.addClickHandler(new ClickHandler() {
-        @Override
-        public void onClick(ClickEvent clickEvent) {
-          /*
-           * creates a row with default data for the corresponding layout type
-           */
-          JSONObject data = new JSONObject();
-          if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
-            data.put("Text1", new JSONString(""));
-          } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-                layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
-            data.put("Text1", new JSONString(""));
-            data.put("Text2", new JSONString(""));
-          } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
-            data.put("Text1", new JSONString(""));
-            data.put("Image", new JSONString("None"));
-          } else if (layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
-              layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
-            data.put("Text1", new JSONString(""));
-            data.put("Text2", new JSONString(""));
-            data.put("Image", new JSONString("None"));
-          }
-          itemsCopy.add(data);
-          table.setRowData(itemsCopy);
-        }
-      });
-
-      /*
-       * save the data for the corresponding layout type
-       */
-      save.addClickHandler(new ClickHandler() {
-        @Override
-        public void onClick(ClickEvent clickEvent) {
-          items.clear();
-          for (int i = 0; i < itemsCopy.size(); ++i) {
-            JSONObject obj = itemsCopy.get(i);
-            if ((layoutValue == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT ||
-                layoutValue == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) && obj.containsKey("Text2")) {
-              obj.put("Text2", null);
-            }
-            if ((layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-                layoutValue == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) && obj.containsKey("Image")) {
-              obj.put("Image", null);
-            }
-            rows.set(i, obj);
-            items.add(i, obj);
-          }
-          property.setValue(rows.toString());
-          ClickHandle.this.hide();
-        }
-      });
-
-      /*
-       * discards changes in the data for the corresponding layout type
-       */
-      cancel.addClickHandler(new ClickHandler() {
-        @Override
-        public void onClick(ClickEvent clickEvent) {
-          final Cancel cancel = new Cancel();
-          cancel.center();
-          cancel.setStylePrimaryName("ode-DialogBox");
-          cancel.show();
-          cancel.yes.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-              itemsCopy.clear();
-              cancel.hide();
-              ClickHandle.this.hide();
-            }
-          });
-          cancel.no.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-              cancel.hide();
-            }
-          });
-        }
-      });
-
-      verticalPanel.add(table);
-      verticalPanel.add(add);
-      actionButtons.add(save);
-      actionButtons.add(cancel);
-      actionButtons.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_CENTER);
-      verticalPanel.add(actionButtons);
-      setWidget(verticalPanel);
-    }
+  /** Returns the editable items list shared with the open dialog. */
+  List<JSONObject> getItems() {
+    return items;
   }
 
-  class Cancel extends DialogBox {
-    VerticalPanel verticalPanel;
-    HorizontalPanel buttonPanel;
-    Button yes, no;
+  /** Returns the editor that owns this property, used to resolve project assets. */
+  SimpleEditor getSimpleEditor() {
+    return editor;
+  }
 
-    Cancel(){
-      verticalPanel = new VerticalPanel();
-      buttonPanel = new HorizontalPanel();
-      setText(MESSAGES.cancelButton());
-      verticalPanel.add(new Label(MESSAGES.listDataConcelConfirm()));
-      yes = new Button(MESSAGES.okButton());
-      no = new Button(MESSAGES.cancelButton());
-      buttonPanel.add(yes);
-      buttonPanel.add(no);
-      buttonPanel.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_CENTER);
-      verticalPanel.add(buttonPanel);
-      setWidget(verticalPanel);
-    }
+  /** Persists the edited rows (a JSON array string) back to the ListData property. */
+  void commitListData(String value) {
+    property.setValue(value);
   }
 }


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Migrates the ListView **ListData** property editor's popup (the "Click to Add/Delete Data" dialog) from hand-built imperative GWT to UiBinder. This is the first step of the editor refactor: only the dialog **chrome** is converted; the existing `CellTable` data grid is kept inside unchanged, so there is no change to editing behavior or to the saved JSON data format.

Changes:
- Drops the `ClickHandle` and `Cancel` inner classes from `YoungAndroidListViewAddDataPropertyEditor` and moves the dialog into a new UiBinder pair, `ListViewAddDataDialog.{java,ui.xml}` (imports relocated accordingly; the property editor keeps the JSON load/save logic).
- Wraps the dialog in the accessible `wizards.Dialog` widget, so it gains the ARIA dialog role, focus trap, Escape-to-close, auto-focus on open and focus restore on close — accessibility the old `DialogBox` did not have.
- Replaces hardcoded button strings with `OdeMessages`. Adds a new key `listDataAddRowButton` ("Click to Add Row Data") for the add button rather than reusing `addButton()`, whose text is "Upload File ..." and is inappropriate here; Save/Cancel reuse the existing `saveButton()`/`cancelButton()`.


- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
