### PR TITLE
Fix incorrect Tooltip for Colors blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/colors.js
+++ b/appinventor/blocklyeditor/src/blocks/colors.js
@@ -35,7 +35,7 @@ Blockly.Blocks['color_white'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ffffff'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_WHITE }]
 };
@@ -48,7 +48,7 @@ Blockly.Blocks['color_red'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ff0000'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_RED }]
 };
@@ -61,7 +61,7 @@ Blockly.Blocks['color_pink'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ffafaf'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_PINK }]
 };
@@ -74,7 +74,7 @@ Blockly.Blocks['color_orange'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ffc800'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_ORANGE }]
 };
@@ -87,7 +87,7 @@ Blockly.Blocks['color_yellow'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ffff00'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_YELLOW }]
 };
@@ -100,7 +100,7 @@ Blockly.Blocks['color_green'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#00ff00'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_GREEN }]
 };
@@ -113,7 +113,7 @@ Blockly.Blocks['color_cyan'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#00ffff'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_CYAN }]
 };
@@ -126,7 +126,7 @@ Blockly.Blocks['color_blue'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#0000ff'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_BLUE }]
 };
@@ -139,7 +139,7 @@ Blockly.Blocks['color_magenta'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#ff00ff'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_MAGENTA }]
 };
@@ -152,7 +152,7 @@ Blockly.Blocks['color_light_gray'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#cccccc'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_LIGHT_GRAY }]
 };
@@ -165,7 +165,7 @@ Blockly.Blocks['color_gray'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#888888'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_GRAY }]
 };
@@ -179,7 +179,7 @@ Blockly.Blocks['color_dark_gray'] = {
     this.setColour(Blockly.COLOR_CATEGORY_HUE);
     this.appendDummyInput().appendField(new Blockly.FieldColour('#444444'), 'COLOR');
     this.setOutput(true, AI.BlockUtils.YailTypeToBlocklyType("number",AI.BlockUtils.OUTPUT));
-    this.setTooltip(Blockly.Msg.LANG_COLOUR_MAKE_COLOUR_TOOLTIP);
+    this.setTooltip(Blockly.Msg.LANG_COLOUR_PICKER_TOOLTIP);
   },
   typeblock: [{ translatedName: Blockly.Msg.LANG_COLOUR_DARK_GRAY }]
 };


### PR DESCRIPTION
**What does this PR accomplish?**
Replace `Tooltip` for affected Colors blocks described in linked issue

_Fixed now_
<img width="292" height="107" alt="image" src="https://github.com/user-attachments/assets/ee19a9df-da66-492e-982d-bd98817db5fe" />

*Testing Guidelines*
1. Open Colors blocks
2. Hover your mouse on any square color block (Color picker)

Fixes #3991 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
