### PR TITLE
Add convenience overload for exporting a project's source zip

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
@@ -43,6 +43,11 @@ public interface FileExporter {
    * keystore, Yail, and screenshots. This suits callers that only need the
    * project's .aia archive.
    *
+   * <p>This method applies no access control. Like the other export methods it
+   * returns the project that belongs to {@code userId}, so any caller that
+   * exposes it to a request must first confirm that the requesting user owns
+   * the project or is an administrator.
+   *
    * @param userId the userId
    * @param projectId the project id belonging to the userId
    * @return the source files as a zip

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
@@ -39,6 +39,19 @@ public interface FileExporter {
       @Nullable String extension) throws IOException;
 
   /**
+   * Exports the project source files as a zip, excluding the project history,
+   * keystore, Yail, and screenshots. This suits callers that only need the
+   * project's .aia archive.
+   *
+   * @param userId the userId
+   * @param projectId the project id belonging to the userId
+   * @return the source files as a zip
+   * @throws IllegalArgumentException if there are no source files
+   * @throws IOException if files cannot be written
+   */
+  ProjectSourceZip exportProjectSourceZip(String userId, long projectId) throws IOException;
+
+  /**
    * Exports the project source files as a zip.
    *
    * @param userId                 the userId

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -66,6 +66,13 @@ public final class FileExporterImpl implements FileExporter {
   }
 
   @Override
+  public ProjectSourceZip exportProjectSourceZip(String userId, long projectId)
+      throws IOException {
+    return exportProjectSourceZip(userId, projectId, false, false, null, false, false, false,
+        false, false, false);
+  }
+
+  @Override
   public ProjectSourceZip exportProjectSourceZip(String userId, long projectId,
       boolean includeProjectHistory,
       boolean includeAndroidKeystore,

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -103,8 +103,7 @@ public final class FileExporterImpl implements FileExporter {
     String metadata = "";
     for (Long projectId : projectIds) {
       try {
-        ProjectSourceZip projectSourceZip =
-            exportProjectSourceZip(userId, projectId, false, false, null, false, false, false, false, false, false);
+        ProjectSourceZip projectSourceZip = exportProjectSourceZip(userId, projectId);
         byte[] data = projectSourceZip.getContent();
         String name = projectSourceZip.getFileName();
 
@@ -174,8 +173,7 @@ public final class FileExporterImpl implements FileExporter {
         // Note: We never include Yail files when exporting all source projects
         // even for Admins. If you are an admin and want to debug a project, download
         // it explicitly.
-        ProjectSourceZip projectSourceZip =
-          exportProjectSourceZip(userId, projectId, false, false, null, false, false, false, false, false, false);
+        ProjectSourceZip projectSourceZip = exportProjectSourceZip(userId, projectId);
         byte[] data = projectSourceZip.getContent();
         String name = projectSourceZip.getFileName();
 

--- a/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
@@ -143,6 +143,16 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
     assertFalse(content.containsKey(FileExporter.REMIX_INFORMATION_FILE_PATH));
   }
 
+  public void testExportProjectSourceZipWithDefaultsNonExistingProject() throws IOException {
+    try {
+      exporter.exportProjectSourceZip(USER_ID, projectId + 1);
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException ||
+                 e.getCause() instanceof IllegalArgumentException);
+    }
+  }
+
   public void testExportProjectOutputFileWithTarget() throws IOException {
     RawFile file = exporter.exportProjectOutputFile(USER_ID, projectId, "target1");
     assertEquals(TARGET1_NAME, file.getFileName());

--- a/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
@@ -134,6 +134,15 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
     }
   }
 
+  public void testExportProjectSourceZipWithDefaults() throws IOException {
+    ProjectSourceZip project = exporter.exportProjectSourceZip(USER_ID, projectId);
+    Map<String, byte[]> content = testExportProjectSourceZipHelper(project);
+    assertEquals(2, content.size());
+    /* The two-argument overload exports the same source-only zip as the full
+     * method with all flags false: the two source files and no remix history. */
+    assertFalse(content.containsKey(FileExporter.REMIX_INFORMATION_FILE_PATH));
+  }
+
   public void testExportProjectOutputFileWithTarget() throws IOException {
     RawFile file = exporter.exportProjectOutputFile(USER_ID, projectId, "target1");
     assertEquals(TARGET1_NAME, file.getFileName());

--- a/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
@@ -134,22 +134,24 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
     }
   }
 
+  /** The two argument overload exports the standard source only archive. */
   public void testExportProjectSourceZipWithDefaults() throws IOException {
     ProjectSourceZip project = exporter.exportProjectSourceZip(USER_ID, projectId);
     Map<String, byte[]> content = testExportProjectSourceZipHelper(project);
     assertEquals(2, content.size());
-    /* The two-argument overload exports the same source-only zip as the full
-     * method with all flags false: the two source files and no remix history. */
+    // The overload matches the full method with every flag off, so the archive
+    // holds the two source files and no remix history.
     assertFalse(content.containsKey(FileExporter.REMIX_INFORMATION_FILE_PATH));
   }
 
+  /** The overload reports a project that does not exist rather than returning an archive. */
   public void testExportProjectSourceZipWithDefaultsNonExistingProject() throws IOException {
     try {
       exporter.exportProjectSourceZip(USER_ID, projectId + 1);
       fail();
     } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException ||
-                 e.getCause() instanceof IllegalArgumentException);
+      assertTrue(e instanceof IllegalArgumentException
+          || e.getCause() instanceof IllegalArgumentException);
     }
   }
 


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

This adds a two argument exportProjectSourceZip(userId, projectId) overload to FileExporter and FileExporterImpl. It performs the standard source only export and returns the project's .aia archive, delegating to the existing exportProjectSourceZip with the defaults the bulk exporters already use. The two bulk exporters, exportSelectedProjectsSourceZip and exportAllProjectsSourceZip, which spelled the same eleven argument call out inline, now route through the overload as its first callers in the tree. The goal is to give callers that only need a project's .aia a single entry point, rather than repeating the full set of export flags. The new method follows the existing exportProjectOutputFile overload pattern, and the only existing call sites it touches are the two bulk exporters, whose behavior does not change.

*Testing Guidelines*

A new unit test, testExportProjectSourceZipWithDefaults in FileExporterImplTest, builds a project with source and output files, calls the new two argument overload, and asserts that the returned zip contains only the two source files and no remix history. This mirrors the existing testExportProjectSourceZipWithoutHistory test. A second test, testExportProjectSourceZipWithDefaultsNonExistingProject, calls the overload for a project that does not exist and asserts that it throws, mirroring the existing testExportProjectSourceZipWithNonExistingProject test. It can be run with the AiServerLibTests target, for example ant AiServerLibTests with test_name set to com.google.appinventor.server.FileExporterImplTest.

**Context for the changes**

This is a server side change to the appengine module. It does not affect the companion or the device, and it does not change any blocks or designer API. It branches from master.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine

**Update, August 2026**

This branch now sits on master. The rebase applied with no conflicts, the three files it touches have not changed upstream since the branch was created, and the full server suite passes on the result, including the two tests this change adds. A small tidy commit brings the two new tests in line with the project checkstyle rules, so the files carry no warnings beyond what master already has. A follow up commit then routes the two bulk exporters through the overload, which removes two argument lists that ran past the line length limit and gives the overload its callers in the tree, and the server suite passes again after that change.