### PR TITLE
Fix NewFolderWizard UI

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/wizards/NewFolderWizard.ui.xml
@@ -11,7 +11,7 @@
              ui:generatedKeys="com.google.gwt.i18n.server.keygen.MethodNameKeyGenerator"
              ui:generateLocales="default">
   <ui:with field="messages" type="com.google.appinventor.client.OdeMessages" />
-  <wiz:Dialog ui:field="addDialog" caption="{messages.newProjectFolderMenuItem}" styleName="ode-DialogBox">
+  <wiz:Dialog ui:field="addDialog" caption="{messages.newProjectFolderMenuItem}" styleName="ode-DialogBox" width="350px">
     <g:FlowPanel>
       <g:Button ui:field='topInvisible' styleName="FocusTrap"/>
         <w:LabeledTextBox ui:field="input" caption="{messages.newFolderWizardName}"


### PR DESCRIPTION
**What does this PR accomplish?**
Adds width of `350px` in `NewFolderWizard`

_Before_

https://github.com/user-attachments/assets/1a28d85b-0e2a-404d-b7f3-b0f6860e9d1c

_After_

https://github.com/user-attachments/assets/46b7d957-28f6-4774-9063-6ddcc634c706

*Testing Guidelines*
Follow steps shown in screen recording

Fixes #3346 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
