### PR TITLE
Fix/listview image scroll lag

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -5,6 +5,12 @@
 
 package com.google.appinventor.components.runtime;
 
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import android.util.LruCache;
+
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -17,7 +23,10 @@ import androidx.core.view.ViewCompat;
 
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
+
+import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +46,12 @@ public abstract class ListAdapterWithRecyclerView
   protected ComponentContainer container;
   protected List<Integer> selectedItems = new ArrayList<>();
   protected String lastQuery = "";
+
+  // Cache of decoded image drawables keyed by image name. Lazily created the first time an image is
+  // loaded, so text-only list layouts never allocate it. Without it, onBindViewHolder re-decodes
+  // (and re-scales) each image from disk on the UI thread every time a row scrolls into view, which
+  // makes image lists scroll jerkily. Sized to a fraction of the app's available memory.
+  private LruCache<String, Drawable> imageCache;
 
   protected final Filter filter = new Filter() {
     @Override
@@ -95,6 +110,47 @@ public abstract class ListAdapterWithRecyclerView
     this.selectionColor = selectionColor;
     updateData(data);
 }
+
+  /**
+   * Returns the drawable for the given image name, decoding it via MediaUtil on first use and
+   * caching the result. Subsequent binds while scrolling reuse the cached drawable instead of
+   * re-decoding the image from disk on the UI thread, which is what made image lists scroll
+   * jerkily.
+   *
+   * @param imageName the asset/image name from the list item, or empty when there is no image
+   * @return the cached or freshly decoded drawable, or null when imageName is empty
+   * @throws IOException if the image cannot be loaded
+   */
+  protected Drawable getImageDrawable(String imageName) throws IOException {
+    if (imageName == null || imageName.isEmpty()) {
+      return null;
+    }
+    if (imageCache == null) {
+      // Use up to 1/8 of the available memory for the decoded-image cache.
+      final int cacheSizeKb = (int) (Runtime.getRuntime().maxMemory() / 1024 / 8);
+      imageCache = new LruCache<String, Drawable>(cacheSizeKb) {
+        @Override
+        protected int sizeOf(String key, Drawable drawable) {
+          if (drawable instanceof BitmapDrawable) {
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if (bitmap != null) {
+              return bitmap.getByteCount() / 1024;
+            }
+          }
+          return 1;
+        }
+      };
+    }
+    Drawable cached = imageCache.get(imageName);
+    if (cached != null) {
+      return cached;
+    }
+    Drawable drawable = MediaUtil.getBitmapDrawable(container.$form(), imageName);
+    if (drawable != null) {
+      imageCache.put(imageName, drawable);
+    }
+    return drawable;
+  }
 
   public void updateData(List<Object> newItems) {
     this.originalItems = newItems;

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
@@ -16,7 +16,6 @@ import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 import android.util.Log;
 
-import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
@@ -106,7 +105,7 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     }
     imageSingleTextHolder.textViewFirst.setText(first);
     try {
-      Drawable drawable = MediaUtil.getBitmapDrawable(container.$form(), imageName);
+      Drawable drawable = getImageDrawable(imageName);
       ViewUtil.setImage(imageSingleTextHolder.imageView, drawable);
     } catch (IOException ioe) {
       Log.e(LOG_TAG, "onBindViewHolder Unable to load image " + imageName + ": " + ioe.getMessage());

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
@@ -15,7 +15,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
-import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
@@ -157,7 +156,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     imageTwoTextHolder.textViewFirst.setText(first);
     imageTwoTextHolder.textViewSecond.setText(second);
     try {
-      Drawable drawable = MediaUtil.getBitmapDrawable(container.$form(), imageName);
+      Drawable drawable = getImageDrawable(imageName);
       ViewUtil.setImage(imageTwoTextHolder.imageView, drawable);
     } catch (IOException ioe) {
       Log.e(

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
@@ -16,7 +16,6 @@ import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 import android.util.Log;
 
-import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
@@ -141,7 +140,7 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     imageTwoTextHolder.textViewFirst.setText(first);
     imageTwoTextHolder.textViewSecond.setText(second);
     try {
-      Drawable drawable = MediaUtil.getBitmapDrawable(container.$form(), imageName);
+      Drawable drawable = getImageDrawable(imageName);
       ViewUtil.setImage(imageTwoTextHolder.imageView, drawable);
     } catch (IOException ioe) {
       Log.e(LOG_TAG, "onBindViewHolder Unable to load image " + imageName + ": " + ioe.getMessage());


### PR DESCRIPTION

**What does this PR accomplish?**

*Description*

Reduces the jerky/laggy scrolling reported for `ListView` rows that use an image layout.

**Root cause:** the image ListView adapters load each row's image inside `onBindViewHolder` via the **synchronous** `MediaUtil.getBitmapDrawable`. This caused lag because every time a row appeared on the screen, the image was loaded, decoded, and resized again from storage. Since this happens on the UI thread, fast scrolling makes the RecyclerView do a lot of heavy work repeatedly, leading to dropped frames and a less smooth experience.

**Fix:** I added an LruCache<String, Drawable> in the shared ListAdapterWithRecyclerView class along with a getImageDrawable(imageName) helper method.

Now, when an image is loaded for the first time, it is stored in the cache. If the same image is needed again while scrolling, it is fetched directly from the cache instead of being decoded from storage again.

The cache is created only when an image-based ListView is used, so text-only ListViews do not use extra memory.


> **Validation note:** I was **not able to reproduce the original jank on my own device** — it scrolled smoothly even with the stock (unmodified) companion and heavy images. The report is on a **Pixel 8a / Android 16**, and the symptom looks device/OS-specific . So I can't provide a measured before/after myself. Per discussion with the maintainer, this change is being put on a **test server** so the **original reporters can try it on the device that actually reproduces the issue**. The change is low-risk and a sound optimization regardless of whether it fully resolves that specific device's symptom.

Reported at: https://community.appinventor.mit.edu/t/listview-with-images-jerky-lagging-on-swipe-scroll/173790

**Context for the changes**

This changes code that runs on the device (the ListView runtime adapters), so it affects the companion 

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

*(No blocks/designer API change — internal runtime optimization only, so no version bump or upgrader is needed.)*

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
