### PR TITLE
Google Classroom integration for App Inventor (design branch)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -804,6 +804,7 @@ public class Ode implements EntryPoint {
         })
         .then0(this::retrieveTemplateData)
         .then0(this::maybeOpenLastProject)
+        .then0(this::maybeShowLmsConnectStatus)
         .error(caught -> {
           if (caught == null) {
             // previous step rejected without an actual error
@@ -841,6 +842,25 @@ public class Ode implements EntryPoint {
     // The following line causes problems with GWT debugging, and commenting
     // it out doesn't seem to break things.
     //History.fireCurrentHistoryState();
+  }
+
+  /**
+   * Shows a banner when the Google Classroom connect flow redirects back to the
+   * IDE with an {@code lmsConnect} status parameter. Fully guarded so a status
+   * banner can never affect startup.
+   */
+  private Promise<Object> maybeShowLmsConnectStatus() {
+    try {
+      String status = Window.Location.getParameter("lmsConnect");
+      if ("success".equals(status)) {
+        ErrorReporter.reportInfo(MESSAGES.classroomConnectSuccess());
+      } else if ("error".equals(status)) {
+        ErrorReporter.reportError(MESSAGES.classroomConnectError());
+      }
+    } catch (Exception e) {
+      // A status banner must never affect startup.
+    }
+    return resolve(null);
   }
 
   private Promise<Object> handleGalleryId() {

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -658,6 +658,34 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Menu item for connecting the user's account to Google Classroom.")
   String connectGoogleClassroomMenuItem();
 
+  @DefaultMessage("Submit to Google Classroom")
+  @Description("Menu item for exporting the current project to the user's Google Drive for a Google Classroom submission.")
+  String submitToGoogleClassroomMenuItem();
+
+  @DefaultMessage("Uploaded <b>{0}</b> to your Google Drive. {1} to confirm, then attach this file to your assignment in Google Classroom and turn it in.")
+  @Description("Shown after a project is uploaded to Drive for Google Classroom. {0} is the uploaded file name, {1} is a link that opens the file.")
+  String classroomSubmitSuccess(String fileName, String openLink);
+
+  @DefaultMessage("Open it")
+  @Description("Link text in the Google Classroom upload-success banner that opens the uploaded file in Google Drive.")
+  String classroomOpenInDrive();
+
+  @DefaultMessage("Connect your Google account to Google Classroom first, then try again.")
+  @Description("Shown when a Google Classroom submit is attempted before the user has connected their Google account.")
+  String classroomNotConnected();
+
+  @DefaultMessage("Connected to Google Classroom.")
+  @Description("Banner shown after the user successfully connects their Google account to Google Classroom.")
+  String classroomConnectSuccess();
+
+  @DefaultMessage("Could not connect to Google Classroom. Please try again.")
+  @Description("Banner shown after the Google Classroom connection flow fails.")
+  String classroomConnectError();
+
+  @DefaultMessage("Could not submit to Google Classroom. Please try again.")
+  @Description("Shown when exporting a project to Google Drive for Google Classroom fails for a reason other than a missing connection.")
+  String classroomSubmitError();
+
   @DefaultMessage("Chromebook")
   @Description("Menu item for initiating a connection to the companion running on a Chromebook.")
   String chromebookMenuItem();

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -654,6 +654,10 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Message providing details about starting the wireless connection.")
   String AICompanionMenuItem();
 
+  @DefaultMessage("Connect Google Classroom")
+  @Description("Menu item for connecting the user's account to Google Classroom.")
+  String connectGoogleClassroomMenuItem();
+
   @DefaultMessage("Chromebook")
   @Description("Menu item for initiating a connection to the companion running on a Chromebook.")
   String chromebookMenuItem();

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -130,6 +130,13 @@ public class TopToolbar extends Composite {
       settingsDropDown.removeItem(WIDGET_NAME_APP_STORE_SETTINGS);
     }
 
+    // Show the Google Classroom item only when the server has the LMS OAuth client
+    // configured. removeUnneededSeparators then drops the hidden item plus, in the
+    // classic menu, the separator that would otherwise dangle at the menu's end.
+    connectDropDown.setItemVisible(MESSAGES.connectGoogleClassroomMenuItem(),
+        Ode.getSystemConfig().getLmsEnabled());
+    connectDropDown.removeUnneededSeparators();
+
     fileDropDown.removeUnneededSeparators();
 
     // Second Buildserver Menu Items

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -137,6 +137,11 @@ public class TopToolbar extends Composite {
         Ode.getSystemConfig().getLmsEnabled());
     connectDropDown.removeUnneededSeparators();
 
+    // Show the Submit to Google Classroom item only when the LMS integration is
+    // configured, the same gate as the connect item.
+    fileDropDown.setItemVisible(MESSAGES.submitToGoogleClassroomMenuItem(),
+        Ode.getSystemConfig().getLmsEnabled());
+
     fileDropDown.removeUnneededSeparators();
 
     // Second Buildserver Menu Items

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
@@ -52,6 +52,9 @@
       <ai:DropDownItem name="ExportProject" caption="{messages.exportProjectMenuItem}">
         <actions:ExportProjectAction/>
       </ai:DropDownItem>
+      <ai:DropDownItem name="SubmitToGoogleClassroom" caption="{messages.submitToGoogleClassroomMenuItem}">
+        <actions:SubmitToGoogleClassroomAction/>
+      </ai:DropDownItem>
       <ai:DropDownItem name="ExportAllProjects" caption="{messages.exportAllProjectsMenuItem}">
         <actions:ExportAllProjectsAction/>
       </ai:DropDownItem>

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
@@ -103,6 +103,10 @@
       <ai:DropDownItem name="SaveProjectToCompanion" caption="{messages.saveProjectToCompanionMenuItem}">
         <yaactions:SaveProjectToCompanionAction/>
       </ai:DropDownItem>
+      <hr/>
+      <ai:DropDownItem name="ConnectGoogleClassroom" caption="{messages.connectGoogleClassroomMenuItem}">
+        <actions:ConnectGoogleClassroomAction/>
+      </ai:DropDownItem>
     </ai:DropDownButton>
 
     <!-- Build Menu -->

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/ConnectGoogleClassroomAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/ConnectGoogleClassroomAction.java
@@ -1,0 +1,26 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.actions;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Window;
+
+/**
+ * Starts the Google Classroom sign-in flow by navigating the browser to the
+ * server's {@code /lms/connect} endpoint. That endpoint runs behind the
+ * authentication filter, mints the OAuth state for the signed-in user, and
+ * redirects on to Google's consent screen; the callback returns to App Inventor.
+ */
+public class ConnectGoogleClassroomAction implements Command {
+  private static final String CONNECT_URL = "/lms/connect";
+
+  @Override
+  public void execute() {
+    // assign, not replace, so the user can press Back to return to the IDE if
+    // they cancel Google's consent.
+    Window.Location.assign(CONNECT_URL);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToGoogleClassroomAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToGoogleClassroomAction.java
@@ -1,0 +1,103 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.actions;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.appinventor.client.ErrorReporter;
+import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.OdeAsyncCallback;
+import com.google.appinventor.client.boxes.ProjectListBox;
+import com.google.appinventor.client.explorer.project.Project;
+import com.google.appinventor.shared.rpc.RpcResult;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.safehtml.shared.UriUtils;
+import com.google.gwt.user.client.Command;
+
+import java.util.List;
+
+/**
+ * Exports the current project to the signed-in user's Google Drive for the
+ * Google Classroom integration, then shows a banner with a link to the new file
+ * and a reminder to attach it to the Classroom assignment. This is Route C, where
+ * the student attaches the file by hand; the server endpoint confirms the user
+ * owns the project before exporting.
+ */
+public class SubmitToGoogleClassroomAction implements Command {
+
+  // Guards against a double-click starting a second upload (which would create a
+  // duplicate Drive file) while the first request is still in flight.
+  private static volatile boolean submitting = false;
+
+  @Override
+  public void execute() {
+    long projectId;
+    if (Ode.getInstance().getCurrentView() == Ode.PROJECTS) {
+      List<Project> selectedProjects =
+          ProjectListBox.getProjectListBox().getProjectList().getSelectedProjects();
+      if (selectedProjects.size() != 1) {
+        ErrorReporter.reportInfo(MESSAGES.selectOnlyOneProject());
+        return;
+      }
+      projectId = selectedProjects.get(0).getProjectId();
+    } else {
+      projectId = Ode.getCurrentProject().getProjectId();
+    }
+    exportToDrive(projectId);
+  }
+
+  private void exportToDrive(long projectId) {
+    if (submitting) {
+      return;
+    }
+    submitting = true;
+    final String fileName = driveFileName(projectId);
+    Ode.getInstance().getProjectService().exportProjectToDrive(projectId,
+        new OdeAsyncCallback<RpcResult>(MESSAGES.classroomSubmitError()) {
+          @Override
+          public void onSuccess(RpcResult result) {
+            submitting = false;
+            if (result.succeeded()) {
+              // The banner renders HTML, so it carries a clickable link to the new
+              // file (replacing an auto-opened tab, which browsers commonly block
+              // from an asynchronous callback). The URL is sanitized with UriUtils,
+              // the file name is HTML-escaped, and the link is opened without access
+              // to this window.
+              String href = UriUtils.fromString(result.getOutput()).asString();
+              String openLink = "<a href=\"" + href
+                  + "\" target=\"_blank\" rel=\"noopener noreferrer\">"
+                  + MESSAGES.classroomOpenInDrive() + "</a>";
+              ErrorReporter.reportInfo(MESSAGES.classroomSubmitSuccess(
+                  SafeHtmlUtils.htmlEscape(fileName), openLink));
+            } else if ("NOT_CONNECTED".equals(result.getError())) {
+              ErrorReporter.reportError(MESSAGES.classroomNotConnected());
+            } else {
+              ErrorReporter.reportError(MESSAGES.classroomSubmitError());
+            }
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+            submitting = false;
+            super.onFailure(t);
+          }
+        });
+  }
+
+  /**
+   * Returns the name the exported file will have in Drive. The server forms it as
+   * the project name plus {@code .aia}. Falls back to a generic label if the
+   * project is not loaded, so the banner never shows a broken name.
+   */
+  private static String driveFileName(long projectId) {
+    Project project = Ode.getInstance().getProjectManager().getProject(projectId);
+    if (project == null || project.getProjectName() == null
+        || project.getProjectName().isEmpty()) {
+      return "your project";
+    }
+    return project.getProjectName() + ".aia";
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/local/LocalProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/local/LocalProjectService.java
@@ -285,6 +285,11 @@ public class LocalProjectService implements ProjectServiceAsync {
   }
 
   @Override
+  public void exportProjectToDrive(long projectId, AsyncCallback<RpcResult> callback) {
+
+  }
+
+  @Override
   public void loadFromGallery(String galleryId, AsyncCallback<UserProject> callback) {
 
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
@@ -88,6 +88,9 @@
       <ai:DropDownItem name="CompanionUpdate" caption="{messages.companionUpdate}">
         <actions:CompanionUpdateAction/>
       </ai:DropDownItem>
+      <ai:DropDownItem name="ConnectGoogleClassroom" caption="{messages.connectGoogleClassroomMenuItem}">
+        <actions:ConnectGoogleClassroomAction/>
+      </ai:DropDownItem>
     </ai:DropDownButton>
 
     <!-- Build Menu -->

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
@@ -47,6 +47,9 @@
       <ai:DropDownItem name="ExportProject" caption="{messages.exportButton}">
         <actions:ExportProjectAction/>
       </ai:DropDownItem>
+      <ai:DropDownItem name="SubmitToGoogleClassroom" caption="{messages.submitToGoogleClassroomMenuItem}">
+        <actions:SubmitToGoogleClassroomAction/>
+      </ai:DropDownItem>
       <ai:DropDownItem name="ExportAllProjects" caption="{messages.exportAllProjectsMenuItem}"
                        visible="false">
         <actions:ExportAllProjectsAction/>

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporter.java
@@ -39,6 +39,24 @@ public interface FileExporter {
       @Nullable String extension) throws IOException;
 
   /**
+   * Exports the project source files as a zip, excluding the project history,
+   * keystore, Yail, and screenshots. This suits callers that only need the
+   * project's .aia archive.
+   *
+   * <p>This method applies no access control. Like the other export methods it
+   * returns the project that belongs to {@code userId}, so any caller that
+   * exposes it to a request must first confirm that the requesting user owns
+   * the project or is an administrator.
+   *
+   * @param userId the userId
+   * @param projectId the project id belonging to the userId
+   * @return the source files as a zip
+   * @throws IllegalArgumentException if there are no source files
+   * @throws IOException if files cannot be written
+   */
+  ProjectSourceZip exportProjectSourceZip(String userId, long projectId) throws IOException;
+
+  /**
    * Exports the project source files as a zip.
    *
    * @param userId                 the userId

--- a/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/FileExporterImpl.java
@@ -66,6 +66,13 @@ public final class FileExporterImpl implements FileExporter {
   }
 
   @Override
+  public ProjectSourceZip exportProjectSourceZip(String userId, long projectId)
+      throws IOException {
+    return exportProjectSourceZip(userId, projectId, false, false, null, false, false, false,
+        false, false, false);
+  }
+
+  @Override
   public ProjectSourceZip exportProjectSourceZip(String userId, long projectId,
       boolean includeProjectHistory,
       boolean includeAndroidKeystore,

--- a/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/ProjectServiceImpl.java
@@ -8,7 +8,9 @@ package com.google.appinventor.server;
 
 import com.google.appinventor.common.version.AppInventorFeatures;
 
+import com.google.appinventor.server.encryption.EncryptionException;
 import com.google.appinventor.server.flags.Flag;
+import com.google.appinventor.server.lms.GoogleDriveProjectExporter;
 import com.google.appinventor.server.project.CommonProjectService;
 import com.google.appinventor.server.project.youngandroid.YoungAndroidProjectService;
 import com.google.appinventor.server.storage.StorageIo;
@@ -249,6 +251,32 @@ public class ProjectServiceImpl extends OdeRemoteServiceServlet implements Proje
   public RpcResult sendToGallery(long projectId) {
     final String userId = userInfoProvider.getUserId();
     return getProjectRpcImpl(userId, projectId).sendToGallery(userId, projectId);
+  }
+
+  @Override
+  public RpcResult exportProjectToDrive(long projectId) {
+    final String userId = userInfoProvider.getUserId();
+    // Entry-point owner check: confirm the signed-in user owns this project
+    // before the unguarded exporter building block runs, the same guarantee the
+    // download path relies on.
+    storageIo.assertUserHasProject(userId, projectId);
+    try {
+      String driveLink = new GoogleDriveProjectExporter().exportProjectToDrive(userId, projectId);
+      return RpcResult.createSuccessfulRpcResult(driveLink, "");
+    } catch (IllegalStateException e) {
+      // No stored Google credential: the user must connect to Google first. The
+      // error code lets the client show a distinct, actionable message rather
+      // than a generic failure.
+      return RpcResult.createFailingRpcResult("", "NOT_CONNECTED");
+    } catch (IOException | EncryptionException | IllegalArgumentException e) {
+      // The full cause (for example a disabled Drive API, a revoked credential,
+      // or a project with no source files) is logged for the administrator while
+      // the client shows a generic upload-failed message. IllegalArgumentException
+      // is safe to catch here because the ownership check above throws
+      // SecurityException, which is deliberately left to propagate.
+      LOG.log(Level.WARNING, "Drive export failed for user " + userId, e);
+      return RpcResult.createFailingRpcResult("", "UPLOAD_FAILED");
+    }
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/UserInfoServiceImpl.java
@@ -11,6 +11,7 @@ import static com.google.appinventor.shared.storage.StorageUtil.APPSTORE_CREDENT
 import com.google.appinventor.common.version.AppInventorFeatures;
 import com.google.appinventor.server.flags.Flag;
 import com.google.appinventor.server.ios.CredentialsEncryptor;
+import com.google.appinventor.server.lms.LmsOAuthConfig;
 import com.google.appinventor.server.storage.StorageIo;
 import com.google.appinventor.server.storage.StorageIoInstanceHolder;
 import com.google.appinventor.server.survey.Survey;
@@ -93,6 +94,7 @@ public class UserInfoServiceImpl extends OdeRemoteServiceServlet implements User
     config.setGalleryEnabled(Flag.createFlag("gallery.enabled", false).get());
     config.setGalleryReadOnly(Flag.createFlag("gallery.readonly", false).get());
     config.setGalleryLocation(Flag.createFlag("gallery.location", "").get());
+    config.setLmsEnabled(LmsOAuthConfig.isConfigured());
     config.setDeleteAccountAllowed(deleteAccountAllowed);
     config.setIosExtensions(storageIo.getIosExtensionsConfig());
     config.setSurveyUrl(surveyUrl);

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleDriveProjectExporter.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleDriveProjectExporter.java
@@ -1,0 +1,77 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.FileExporter;
+import com.google.appinventor.server.FileExporterImpl;
+import com.google.appinventor.server.encryption.EncryptionException;
+import com.google.appinventor.shared.rpc.project.ProjectSourceZip;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+
+/**
+ * Exports a user's App Inventor project to their own Google Drive, wiring
+ * together pieces that already exist: the source-zip export
+ * ({@link FileExporter}), the stored Google credential
+ * ({@link LmsCredentialStore}), a refresh of that credential into a short-lived
+ * access token ({@link GoogleOAuthClient}), and the Drive upload
+ * ({@link GoogleDriveUploader}).
+ *
+ * <p>This is a building block with a documented contract and no inline access
+ * control. It trusts that its caller has already confirmed the requesting user
+ * may export the project, the same arrangement the export helper relies on for
+ * the download path. The owner check belongs in the calling endpoint, not here.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public final class GoogleDriveProjectExporter {
+
+  private final FileExporter fileExporter;
+  private final LmsCredentialStore credentialStore;
+
+  /** Creates an exporter backed by the default file exporter and credential store. */
+  public GoogleDriveProjectExporter() {
+    this(new FileExporterImpl(), new LmsCredentialStore());
+  }
+
+  @VisibleForTesting
+  GoogleDriveProjectExporter(FileExporter fileExporter, LmsCredentialStore credentialStore) {
+    this.fileExporter = fileExporter;
+    this.credentialStore = credentialStore;
+  }
+
+  /**
+   * Exports the given project to the user's Google Drive and returns a browser
+   * link to the new file. The caller must have already confirmed that the user
+   * owns the project.
+   *
+   * @param userId the App Inventor user id, also the owner of the target Drive
+   * @param projectId the project to export
+   * @return a browser link (the Drive {@code webViewLink}) to the newly created file
+   * @throws IllegalStateException if the user has no stored Google credential, so
+   *     the caller should route them through the connect flow first
+   * @throws IOException if the token refresh, the export, or the upload fails,
+   *     including an {@code invalid_grant} error when the stored credential has
+   *     been revoked or has expired
+   * @throws EncryptionException if the stored credential cannot be decrypted
+   */
+  public String exportProjectToDrive(String userId, long projectId)
+      throws IOException, EncryptionException {
+    String refreshToken = credentialStore.getGoogleRefreshToken(userId);
+    if (refreshToken == null) {
+      throw new IllegalStateException("No stored Google credential for the user");
+    }
+    String tokenJson = GoogleOAuthClient.refreshAccessToken(
+        LmsOAuthConfig.clientId(), LmsOAuthConfig.clientSecret(), refreshToken);
+    String accessToken = LmsHttp.jsonField(tokenJson, "access_token");
+    if (accessToken == null) {
+      throw new IOException("The Google token refresh returned no access token");
+    }
+    ProjectSourceZip zip = fileExporter.exportProjectSourceZip(userId, projectId);
+    return GoogleDriveUploader.uploadFile(accessToken, zip.getFileName(), zip.getContent());
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleDriveUploader.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleDriveUploader.java
@@ -1,0 +1,131 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+
+import org.json.JSONObject;
+
+/**
+ * Uploads a file to a user's Google Drive through the Drive REST API, matching
+ * the prototype's {@link HttpURLConnection} pattern and avoiding a new
+ * client-library dependency. Used by the Google Classroom integration to place a
+ * student's exported project into their Drive.
+ *
+ * <p>A resumable upload is used rather than a multipart upload because an
+ * App Inventor project with media assets routinely exceeds the five megabyte
+ * ceiling of a multipart request. A resumable upload carries no such limit: a
+ * session is opened with the file metadata, then the bytes are sent in a single
+ * follow-up request to the session URI.
+ *
+ * <p>The caller supplies an access token granted the {@code drive.file} scope, so
+ * this class has no dependency on configuration or storage.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public final class GoogleDriveUploader {
+
+  /**
+   * Endpoint that opens a resumable upload session. The {@code fields} query
+   * parameter is carried through to the final response, so the completed upload
+   * returns the new file's id and its browser link.
+   */
+  private static final String INITIATE_ENDPOINT =
+      "https://www.googleapis.com/upload/drive/v3/files"
+          + "?uploadType=resumable&fields=id,webViewLink";
+
+  private static final String OCTET_STREAM = "application/octet-stream";
+
+  private GoogleDriveUploader() {}
+
+  /**
+   * Uploads {@code content} to the authenticated user's Drive and returns a
+   * browser link to the new file.
+   *
+   * @param accessToken an OAuth access token with the drive.file scope
+   * @param fileName the name to give the file in Drive
+   * @param content the raw file bytes
+   * @return the {@code webViewLink} for opening the new file in a browser
+   * @throws IOException if the upload fails or no link is returned
+   */
+  public static String uploadFile(String accessToken, String fileName, byte[] content)
+      throws IOException {
+    String sessionUri = openSession(accessToken, fileName, content.length);
+    return uploadContent(sessionUri, accessToken, content);
+  }
+
+  /**
+   * Opens a resumable upload session for a file of the given name and size, and
+   * returns the session URI taken from the response {@code Location} header.
+   */
+  private static String openSession(String accessToken, String fileName, int contentLength)
+      throws IOException {
+    HttpURLConnection conn = LmsHttp.open(INITIATE_ENDPOINT);
+    try {
+      LmsHttp.applyTimeouts(conn);
+      conn.setRequestMethod("POST");
+      conn.setDoOutput(true);
+      conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+      conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+      conn.setRequestProperty("X-Upload-Content-Type", OCTET_STREAM);
+      conn.setRequestProperty("X-Upload-Content-Length", Integer.toString(contentLength));
+      // One-shot call: do not reuse a pooled keep-alive socket, which can surface
+      // as an "Unexpected end of file from server" once the socket has gone stale.
+      conn.setRequestProperty("Connection", "close");
+      byte[] metadata =
+          ("{\"name\":" + JSONObject.quote(fileName) + "}").getBytes(StandardCharsets.UTF_8);
+      conn.setFixedLengthStreamingMode(metadata.length);
+      try (OutputStream os = conn.getOutputStream()) {
+        os.write(metadata);
+      }
+      int status = conn.getResponseCode();
+      if (status != HttpURLConnection.HTTP_OK) {
+        throw new IOException(
+            "Drive upload could not start (HTTP " + status + "): " + LmsHttp.errorBody(conn));
+      }
+      String sessionUri = conn.getHeaderField("Location");
+      if (sessionUri == null) {
+        throw new IOException("Drive resumable session init returned no session URI");
+      }
+      return sessionUri;
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  /**
+   * Uploads the file bytes to the resumable session URI and returns the new
+   * file's browser link from the final response.
+   */
+  private static String uploadContent(String sessionUri, String accessToken, byte[] content)
+      throws IOException {
+    HttpURLConnection conn = LmsHttp.open(sessionUri);
+    try {
+      LmsHttp.applyTimeouts(conn);
+      conn.setRequestMethod("PUT");
+      conn.setDoOutput(true);
+      conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+      conn.setRequestProperty("Content-Type", OCTET_STREAM);
+      // One-shot call: do not reuse a pooled keep-alive socket (see openSession).
+      conn.setRequestProperty("Connection", "close");
+      conn.setFixedLengthStreamingMode(content.length);
+      try (OutputStream os = conn.getOutputStream()) {
+        os.write(content);
+      }
+      String json = LmsHttp.readBody(conn, "Drive upload");
+      String webViewLink = LmsHttp.jsonField(json, "webViewLink");
+      if (webViewLink == null) {
+        throw new IOException("Drive upload returned no file link");
+      }
+      return webViewLink;
+    } finally {
+      conn.disconnect();
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleOAuthClient.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleOAuthClient.java
@@ -8,7 +8,6 @@ package com.google.appinventor.server.lms;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -52,16 +51,44 @@ public final class GoogleOAuthClient {
     return postForm(body, "code exchange");
   }
 
+  /**
+   * Exchanges a stored refresh token for a fresh token response JSON, which
+   * includes a short-lived access token. Used when a Google API call needs an
+   * access token but only the long-lived refresh token is stored.
+   *
+   * @param clientId the OAuth client id
+   * @param clientSecret the OAuth client secret
+   * @param refreshToken the stored Google OAuth refresh token
+   * @return the raw token response JSON, including the {@code access_token} field
+   * @throws IOException if the request fails, including an {@code invalid_grant}
+   *     error when the refresh token has been revoked or has expired
+   */
+  public static String refreshAccessToken(
+      String clientId, String clientSecret, String refreshToken) throws IOException {
+    String body = "grant_type=refresh_token"
+        + "&client_id=" + LmsHttp.urlEncode(clientId)
+        + "&client_secret=" + LmsHttp.urlEncode(clientSecret)
+        + "&refresh_token=" + LmsHttp.urlEncode(refreshToken);
+    return postForm(body, "token refresh");
+  }
+
   private static String postForm(String body, String label) throws IOException {
-    HttpURLConnection conn = (HttpURLConnection) new URL(TOKEN_ENDPOINT).openConnection();
-    LmsHttp.applyTimeouts(conn);
-    conn.setRequestMethod("POST");
-    conn.setDoOutput(true);
-    conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-    conn.setRequestProperty("Accept", "application/json");
-    try (OutputStream os = conn.getOutputStream()) {
-      os.write(body.getBytes(StandardCharsets.UTF_8));
+    HttpURLConnection conn = LmsHttp.open(TOKEN_ENDPOINT);
+    try {
+      LmsHttp.applyTimeouts(conn);
+      conn.setRequestMethod("POST");
+      conn.setDoOutput(true);
+      conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+      conn.setRequestProperty("Accept", "application/json");
+      // Do not reuse a pooled keep-alive connection, which can surface as an
+      // "Unexpected end of file from server" once the socket has gone stale.
+      conn.setRequestProperty("Connection", "close");
+      try (OutputStream os = conn.getOutputStream()) {
+        os.write(body.getBytes(StandardCharsets.UTF_8));
+      }
+      return LmsHttp.readBody(conn, label);
+    } finally {
+      conn.disconnect();
     }
-    return LmsHttp.readBody(conn, label);
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleOAuthClient.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/GoogleOAuthClient.java
@@ -1,0 +1,67 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Minimal client for the Google OAuth 2.0 token endpoint, used by the Google
+ * Classroom integration. Uses {@link HttpURLConnection} directly, matching the
+ * prototype servlet and avoiding a new client-library dependency.
+ *
+ * <p>The client id, client secret, and authorization code are passed in as
+ * arguments rather than read from configuration, so this client depends on
+ * neither flags nor storage.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public final class GoogleOAuthClient {
+
+  private static final String TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+  private GoogleOAuthClient() {}
+
+  /**
+   * Exchanges an authorization code for the token response JSON, which includes
+   * the refresh token on the first consent. Used by the OAuth callback.
+   *
+   * @param clientId the OAuth client id
+   * @param clientSecret the OAuth client secret
+   * @param code the authorization code from Google's redirect
+   * @param redirectUri the redirect uri registered for the client
+   * @param codeVerifier the PKCE code verifier whose challenge was sent at authorization
+   * @return the raw token response JSON
+   * @throws IOException if the request fails
+   */
+  public static String exchangeAuthorizationCode(
+      String clientId, String clientSecret, String code, String redirectUri, String codeVerifier)
+      throws IOException {
+    String body = "grant_type=authorization_code"
+        + "&client_id=" + LmsHttp.urlEncode(clientId)
+        + "&client_secret=" + LmsHttp.urlEncode(clientSecret)
+        + "&code=" + LmsHttp.urlEncode(code)
+        + "&redirect_uri=" + LmsHttp.urlEncode(redirectUri)
+        + "&code_verifier=" + LmsHttp.urlEncode(codeVerifier);
+    return postForm(body, "code exchange");
+  }
+
+  private static String postForm(String body, String label) throws IOException {
+    HttpURLConnection conn = (HttpURLConnection) new URL(TOKEN_ENDPOINT).openConnection();
+    LmsHttp.applyTimeouts(conn);
+    conn.setRequestMethod("POST");
+    conn.setDoOutput(true);
+    conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+    conn.setRequestProperty("Accept", "application/json");
+    try (OutputStream os = conn.getOutputStream()) {
+      os.write(body.getBytes(StandardCharsets.UTF_8));
+    }
+    return LmsHttp.readBody(conn, label);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsAuthCallbackServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsAuthCallbackServlet.java
@@ -35,15 +35,20 @@ public class LmsAuthCallbackServlet extends HttpServlet {
   private static final Logger LOG =
       Logger.getLogger(LmsAuthCallbackServlet.class.getName());
 
-  /** Where to send the browser after the flow completes. */
-  private static final String RETURN_URL = "/";
+  /** Where to send the browser after a successful connection (the IDE shows a banner). */
+  private static final String CONNECTED_URL = "/?lmsConnect=success";
+
+  /** Where to send the browser after a failed connection (the IDE shows a banner). */
+  private static final String ERROR_URL = "/?lmsConnect=error";
 
   private final LmsCredentialStore credentialStore = new LmsCredentialStore();
 
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     if (req.getParameter("error") != null) {
-      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Google sign in did not complete.");
+      // The user declined consent or Google reported an error: send them back to
+      // the IDE with a failure banner rather than a dead-end error page.
+      resp.sendRedirect(ERROR_URL);
       return;
     }
     String code = req.getParameter("code");
@@ -70,12 +75,11 @@ public class LmsAuthCallbackServlet extends HttpServlet {
     } catch (IOException e) {
       // A redeemed or expired authorization code (for example when the user hits
       // Back or refreshes the callback) or a transient failure reaching Google: the
-      // user should retry, so this is a bad request, not a server crash. The request
-      // is not handed to the logger because its query string carries the single-use
-      // code and state.
+      // user should retry, so send them back to the IDE with a failure banner. The
+      // request is not handed to the logger because its query string carries the
+      // single-use code and state.
       LOG.log(Level.WARNING, "Google token exchange failed for user " + userId, e);
-      resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
-          "Google sign in could not be completed. Please try again.");
+      resp.sendRedirect(ERROR_URL);
       return;
     } catch (EncryptionException e) {
       // Encrypting the refresh token failed: a genuine server-side fault.
@@ -86,11 +90,9 @@ public class LmsAuthCallbackServlet extends HttpServlet {
     // connection did not complete, so do not report success.
     if (!credentialStore.hasGoogleCredential(userId)) {
       LOG.warning("No Google refresh token stored for user " + userId);
-      resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
-          "Google did not return a long-term credential. If this account is already "
-          + "connected, remove App Inventor's access in your Google Account and try again.");
+      resp.sendRedirect(ERROR_URL);
       return;
     }
-    resp.sendRedirect(RETURN_URL);
+    resp.sendRedirect(CONNECTED_URL);
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsAuthCallbackServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsAuthCallbackServlet.java
@@ -1,0 +1,96 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.CrashReport;
+import com.google.appinventor.server.encryption.EncryptionException;
+
+import java.io.IOException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Completes the Google Classroom OAuth 2.0 flow.
+ *
+ * <p>Google redirects here after the user consents. The request is cross-origin
+ * and carries no App Inventor session, so this servlet is intentionally NOT
+ * behind {@code odeAuthFilter}. It recovers the user id from the encrypted
+ * {@link LmsOAuthState}, exchanges the authorization code for tokens via
+ * {@link GoogleOAuthClient}, stores the refresh token encrypted via
+ * {@link LmsCredentialStore}, and redirects the browser back into App Inventor.
+ * No token is ever written to the response.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsAuthCallbackServlet extends HttpServlet {
+
+  private static final Logger LOG =
+      Logger.getLogger(LmsAuthCallbackServlet.class.getName());
+
+  /** Where to send the browser after the flow completes. */
+  private static final String RETURN_URL = "/";
+
+  private final LmsCredentialStore credentialStore = new LmsCredentialStore();
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    if (req.getParameter("error") != null) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Google sign in did not complete.");
+      return;
+    }
+    String code = req.getParameter("code");
+    String state = req.getParameter("state");
+    if (code == null || state == null) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing required parameters.");
+      return;
+    }
+    LmsOAuthState.Payload payload = LmsOAuthState.verify(state);
+    if (payload == null) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "Invalid or expired sign in. Please try again.");
+      return;
+    }
+    String userId = payload.userId();
+    try {
+      String tokenJson = GoogleOAuthClient.exchangeAuthorizationCode(
+          LmsOAuthConfig.clientId(), LmsOAuthConfig.clientSecret(), code,
+          LmsOAuthConfig.redirectUri(), payload.codeVerifier());
+      String refreshToken = LmsHttp.jsonField(tokenJson, "refresh_token");
+      if (refreshToken != null) {
+        credentialStore.saveGoogleRefreshToken(userId, refreshToken);
+      }
+    } catch (IOException e) {
+      // A redeemed or expired authorization code (for example when the user hits
+      // Back or refreshes the callback) or a transient failure reaching Google: the
+      // user should retry, so this is a bad request, not a server crash. The request
+      // is not handed to the logger because its query string carries the single-use
+      // code and state.
+      LOG.log(Level.WARNING, "Google token exchange failed for user " + userId, e);
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "Google sign in could not be completed. Please try again.");
+      return;
+    } catch (EncryptionException e) {
+      // Encrypting the refresh token failed: a genuine server-side fault.
+      throw CrashReport.createAndLogError(LOG, null, "user=" + userId, e);
+    }
+    // Google returns a refresh token only when one is newly granted; prompt=consent
+    // should force that. If nothing is stored (and none was stored before), the
+    // connection did not complete, so do not report success.
+    if (!credentialStore.hasGoogleCredential(userId)) {
+      LOG.warning("No Google refresh token stored for user " + userId);
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "Google did not return a long-term credential. If this account is already "
+          + "connected, remove App Inventor's access in your Google Account and try again.");
+      return;
+    }
+    resp.sendRedirect(RETURN_URL);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsConnectServlet.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsConnectServlet.java
@@ -1,0 +1,54 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.CrashReport;
+import com.google.appinventor.server.OdeServlet;
+import com.google.appinventor.server.encryption.EncryptionException;
+
+import java.io.IOException;
+
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Starts the Google Classroom OAuth 2.0 flow for the signed-in user.
+ *
+ * <p>This servlet runs behind {@code odeAuthFilter}, so the user id is taken from
+ * the authenticated session via {@link #userInfoProvider} (never from a request
+ * parameter). The id is sealed into the OAuth {@code state} by
+ * {@link LmsOAuthState} so that the unauthenticated {@link LmsAuthCallbackServlet}
+ * can recover it after Google's cross-origin redirect. The browser is then
+ * redirected to Google's consent screen.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsConnectServlet extends OdeServlet {
+
+  private static final Logger LOG = Logger.getLogger(LmsConnectServlet.class.getName());
+
+  @Override
+  public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    if (!LmsOAuthConfig.isConfigured()) {
+      LOG.warning("Rejecting /lms/connect: Google Classroom OAuth is not configured.");
+      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Google Classroom integration is not configured.");
+      return;
+    }
+    // odeAuthFilter guarantees an authenticated user before this servlet runs.
+    String userId = userInfoProvider.getUserId();
+    try {
+      String codeVerifier = Pkce.newCodeVerifier();
+      String state = LmsOAuthState.create(userId, codeVerifier);
+      resp.sendRedirect(
+          LmsOAuthConfig.buildAuthorizationUrl(state, Pkce.codeChallenge(codeVerifier)));
+    } catch (EncryptionException e) {
+      throw CrashReport.createAndLogError(LOG, req, "user=" + userId, e);
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsCredentialStore.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsCredentialStore.java
@@ -1,0 +1,86 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.encryption.EncryptionException;
+import com.google.appinventor.server.encryption.EncryptionStrategy;
+import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.shared.storage.StorageUtil;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Stores and retrieves a user's Google OAuth refresh token for the Google
+ * Classroom integration.
+ *
+ * <p>The refresh token is encrypted at rest with {@link EncryptionStrategy#WRITE}
+ * (Keyczar, keyed from {@code WEB-INF/keystore}) and persisted as a per-user file
+ * through {@link StorageIo}, the same mechanism that stores the Android keystore
+ * and the App Store credentials. The plaintext token is never written to storage.
+ *
+ * <p>Because it uses the existing {@link StorageIo} user-file methods, this store
+ * adds nothing to the StorageIo interface and works unchanged on any storage
+ * backend that implements it.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsCredentialStore {
+
+  private final StorageIo storageIo = StorageIoInstanceHolder.getInstance();
+
+  /**
+   * Encrypts and stores the Google refresh token for a user, replacing any
+   * existing value.
+   *
+   * @param userId the App Inventor user id
+   * @param refreshToken the plaintext Google OAuth refresh token
+   * @throws EncryptionException if the token cannot be encrypted
+   */
+  public void saveGoogleRefreshToken(String userId, String refreshToken)
+      throws EncryptionException {
+    if (userId == null || userId.isEmpty()) {
+      throw new IllegalArgumentException("userId must not be empty");
+    }
+    if (refreshToken == null || refreshToken.isEmpty()) {
+      throw new IllegalArgumentException("refreshToken must not be empty");
+    }
+    byte[] encrypted =
+        EncryptionStrategy.WRITE.encrypt(refreshToken.getBytes(StandardCharsets.UTF_8));
+    storageIo.uploadRawUserFile(
+        userId, StorageUtil.LMS_GOOGLE_REFRESH_TOKEN_FILENAME, encrypted);
+  }
+
+  /**
+   * Loads and decrypts the Google refresh token for a user.
+   *
+   * @param userId the App Inventor user id
+   * @return the plaintext refresh token, or {@code null} if none is stored
+   * @throws EncryptionException if the stored token cannot be decrypted
+   */
+  public String getGoogleRefreshToken(String userId) throws EncryptionException {
+    if (!hasGoogleCredential(userId)) {
+      return null;
+    }
+    byte[] encrypted =
+        storageIo.downloadRawUserFile(userId, StorageUtil.LMS_GOOGLE_REFRESH_TOKEN_FILENAME);
+    return new String(EncryptionStrategy.WRITE.decrypt(encrypted), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Returns whether a Google refresh token is stored for the given user.
+   *
+   * @param userId the App Inventor user id
+   * @return {@code true} if a token is stored for the user
+   */
+  public boolean hasGoogleCredential(String userId) {
+    if (userId == null || userId.isEmpty()) {
+      return false;
+    }
+    return storageIo.getUserFiles(userId).contains(
+        StorageUtil.LMS_GOOGLE_REFRESH_TOKEN_FILENAME);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsHttp.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsHttp.java
@@ -5,11 +5,16 @@
 
 package com.google.appinventor.server.lms;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -42,6 +47,34 @@ final class LmsHttp {
   static void applyTimeouts(HttpURLConnection conn) {
     conn.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
     conn.setReadTimeout(READ_TIMEOUT_MILLIS);
+  }
+
+  /**
+   * Opens a connection to {@code urlString} through the optional outbound proxy
+   * named by the {@code lms.proxy.host}, {@code lms.proxy.port}, and
+   * {@code lms.proxy.type} system properties. Production on App Engine reaches
+   * Google directly, so these are unset there and the connection is direct. They
+   * exist for restricted networks and local development behind a proxy, and they
+   * bypass any host-level proxy the platform might otherwise impose.
+   *
+   * @param urlString the absolute URL to open
+   * @return an unconnected {@link HttpURLConnection} using the configured proxy
+   * @throws IOException if the URL is malformed or the connection cannot open
+   */
+  static HttpURLConnection open(String urlString) throws IOException {
+    return (HttpURLConnection) new URL(urlString).openConnection(proxy());
+  }
+
+  @VisibleForTesting
+  static Proxy proxy() {
+    String host = System.getProperty("lms.proxy.host", "");
+    if (host.isEmpty()) {
+      return Proxy.NO_PROXY;
+    }
+    int port = Integer.parseInt(System.getProperty("lms.proxy.port", "0"));
+    Proxy.Type type = "socks".equalsIgnoreCase(System.getProperty("lms.proxy.type", "http"))
+        ? Proxy.Type.SOCKS : Proxy.Type.HTTP;
+    return new Proxy(type, new InetSocketAddress(host, port));
   }
 
   /**
@@ -87,6 +120,33 @@ final class LmsHttp {
     } finally {
       conn.disconnect();
     }
+  }
+
+  /**
+   * Reads a failed connection's error stream as UTF-8 for diagnostics, returning
+   * an empty string when there is none. Used to surface a Google API error body
+   * (for example a disabled-API or insufficient-scope message) in the thrown
+   * exception so the cause is visible in the logs.
+   *
+   * @param conn an already-sent connection whose status is 4xx or 5xx
+   * @return the error body, or an empty string
+   */
+  static String errorBody(HttpURLConnection conn) {
+    InputStream stream = conn.getErrorStream();
+    if (stream == null) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        sb.append(line);
+      }
+    } catch (IOException e) {
+      // Best effort: return whatever was read before the failure.
+    }
+    return sb.toString();
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsHttp.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsHttp.java
@@ -1,0 +1,109 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Small HTTP and JSON helpers shared by the LMS Google API clients. Uses
+ * {@link HttpURLConnection} for requests and the {@code org.json} parser already
+ * on the server classpath for responses.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+final class LmsHttp {
+
+  /** Connect timeout for the Google API calls, in milliseconds. */
+  private static final int CONNECT_TIMEOUT_MILLIS = 15000;
+
+  /** Read timeout for the Google API calls, in milliseconds. */
+  private static final int READ_TIMEOUT_MILLIS = 30000;
+
+  private LmsHttp() {}
+
+  /**
+   * Applies connect and read timeouts so a slow or hung Google response cannot
+   * pin a server request thread indefinitely.
+   *
+   * @param conn the connection to configure
+   */
+  static void applyTimeouts(HttpURLConnection conn) {
+    conn.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+    conn.setReadTimeout(READ_TIMEOUT_MILLIS);
+  }
+
+  /**
+   * URL-encodes a value for an application/x-www-form-urlencoded body.
+   *
+   * @param value the value to encode
+   * @return the URL-encoded value
+   */
+  static String urlEncode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads the response body as UTF-8, or throws on a 4xx/5xx response. On an
+   * error the thrown message includes the response body for diagnosis, so this
+   * must not be used for an endpoint whose error body could carry a secret
+   * (Google's token and Drive error bodies do not).
+   *
+   * @param conn an already-sent connection
+   * @param label a short label for error messages
+   * @return the response body as a string
+   * @throws IOException on a 4xx or 5xx response, or on a read error
+   */
+  static String readBody(HttpURLConnection conn, String label) throws IOException {
+    try {
+      int status = conn.getResponseCode();
+      InputStream stream =
+          (status >= 200 && status < 400) ? conn.getInputStream() : conn.getErrorStream();
+      StringBuilder sb = new StringBuilder();
+      if (stream != null) {
+        try (BufferedReader reader =
+            new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+          String line;
+          while ((line = reader.readLine()) != null) {
+            sb.append(line);
+          }
+        }
+      }
+      if (status >= 400) {
+        throw new IOException(label + " returned HTTP " + status + ": " + sb);
+      }
+      return sb.toString();
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  /**
+   * Returns the value of a top-level field as a non-empty string, or
+   * {@code null} if the field is absent or empty.
+   *
+   * @param json a JSON object body
+   * @param key the field name
+   * @return the field value, or {@code null} if the field is absent or empty
+   * @throws IOException if {@code json} is not valid JSON
+   */
+  static String jsonField(String json, String key) throws IOException {
+    try {
+      String value = new JSONObject(json).optString(key, null);
+      return (value == null || value.isEmpty()) ? null : value;
+    } catch (JSONException e) {
+      throw new IOException("Could not parse the JSON response", e);
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthConfig.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthConfig.java
@@ -32,13 +32,15 @@ public final class LmsOAuthConfig {
       "https://accounts.google.com/o/oauth2/v2/auth";
 
   /**
-   * OAuth scope requested at sign-in: read-only access to the user's Classroom
-   * courses. The {@code drive.file} scope for exporting a project to the user's
-   * Drive is added by the later Drive-upload work, so this sign-in PR requests
-   * only the Classroom scope and keeps the stored token least privilege.
+   * OAuth scopes requested at sign-in: read-only access to the user's Classroom
+   * courses, and the per-file {@code drive.file} scope so the integration can
+   * upload an exported project to the user's own Drive. {@code drive.file} grants
+   * access only to files this app creates, so the stored token stays least
+   * privilege. Scopes are space-separated per the OAuth 2.0 spec.
    */
   private static final String SCOPE =
-      "https://www.googleapis.com/auth/classroom.courses.readonly";
+      "https://www.googleapis.com/auth/classroom.courses.readonly"
+          + " https://www.googleapis.com/auth/drive.file";
 
   private LmsOAuthConfig() {}
 

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthConfig.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthConfig.java
@@ -1,0 +1,88 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.flags.Flag;
+import com.google.appinventor.server.util.UriBuilder;
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Configuration and authorization-URL construction for the Google Classroom
+ * OAuth 2.0 flow, shared by {@link LmsConnectServlet} (start) and
+ * {@link LmsAuthCallbackServlet} (callback). Values come from the
+ * {@code <system-properties>} section of appengine-web.xml via {@link Flag}; no
+ * secret is hard coded.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public final class LmsOAuthConfig {
+
+  private static final Flag<String> CLIENT_ID_FLAG =
+      Flag.createFlag("lms.google.classroom.client_id", "");
+  private static final Flag<String> CLIENT_SECRET_FLAG =
+      Flag.createFlag("lms.google.classroom.client_secret", "");
+  private static final Flag<String> REDIRECT_URI_FLAG =
+      Flag.createFlag("lms.google.classroom.redirect_uri", "");
+
+  /** Google OAuth 2.0 authorization endpoint. */
+  private static final String AUTHORIZATION_ENDPOINT =
+      "https://accounts.google.com/o/oauth2/v2/auth";
+
+  /**
+   * OAuth scope requested at sign-in: read-only access to the user's Classroom
+   * courses. The {@code drive.file} scope for exporting a project to the user's
+   * Drive is added by the later Drive-upload work, so this sign-in PR requests
+   * only the Classroom scope and keeps the stored token least privilege.
+   */
+  private static final String SCOPE =
+      "https://www.googleapis.com/auth/classroom.courses.readonly";
+
+  private LmsOAuthConfig() {}
+
+  /** Returns whether the client id, secret, and redirect URI are all configured. */
+  public static boolean isConfigured() {
+    return !CLIENT_ID_FLAG.get().isEmpty()
+        && !CLIENT_SECRET_FLAG.get().isEmpty()
+        && !REDIRECT_URI_FLAG.get().isEmpty();
+  }
+
+  static String clientId() {
+    return CLIENT_ID_FLAG.get();
+  }
+
+  static String clientSecret() {
+    return CLIENT_SECRET_FLAG.get();
+  }
+
+  static String redirectUri() {
+    return REDIRECT_URI_FLAG.get();
+  }
+
+  /**
+   * Builds the Google authorization URL carrying {@code state} and the PKCE
+   * {@code codeChallenge}.
+   */
+  static String buildAuthorizationUrl(String state, String codeChallenge) {
+    return buildAuthorizationUrl(CLIENT_ID_FLAG.get(), REDIRECT_URI_FLAG.get(), state,
+        codeChallenge);
+  }
+
+  @VisibleForTesting
+  static String buildAuthorizationUrl(String clientId, String redirectUri, String state,
+      String codeChallenge) {
+    return new UriBuilder(AUTHORIZATION_ENDPOINT)
+        .add("client_id", clientId)
+        .add("redirect_uri", redirectUri)
+        .add("response_type", "code")
+        .add("scope", SCOPE)
+        .add("access_type", "offline")
+        .add("prompt", "consent")
+        .add("code_challenge", codeChallenge)
+        .add("code_challenge_method", "S256")
+        .add("state", state)
+        .build();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthState.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/LmsOAuthState.java
@@ -1,0 +1,152 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.server.encryption.EncryptionException;
+import com.google.appinventor.server.encryption.EncryptionStrategy;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Mints and verifies the opaque {@code state} value carried through the Google
+ * Classroom OAuth redirect.
+ *
+ * <p>Google's callback arrives without an App Inventor session: it is a
+ * cross-origin redirect from Google, so the session cookie cannot be relied on.
+ * The id of the user who began the flow, and the PKCE code verifier minted for
+ * it, are therefore carried inside this state rather than read from a cookie.
+ *
+ * <p>The state is the issue timestamp, the PKCE code verifier, and the user id,
+ * encrypted with the symmetric {@link EncryptionStrategy#WRITE} key (the same key
+ * that protects the stored refresh token). Encryption makes the state both
+ * unreadable and tamper evident, so the callback can trust what it recovers, and
+ * a short time to live bounds how long a captured state stays usable. The state
+ * is not single use, but a replay is harmless: sealing the verifier here binds
+ * the authorization code to the transaction that started the flow (see
+ * {@link Pkce}), and Google's authorization code is itself single use.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public final class LmsOAuthState {
+
+  /** How long a freshly minted state remains valid. */
+  private static final long TTL_MILLIS = TimeUnit.MINUTES.toMillis(10);
+
+  /**
+   * Tolerance for clock skew between the instance that mints the state and the one
+   * that verifies it; a state dated slightly in the future is still accepted.
+   */
+  private static final long CLOCK_SKEW_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
+  /**
+   * Field separator. A space never occurs in the timestamp (digits) or the
+   * URL-safe Base64 code verifier, the two fields that precede the user id. The
+   * user id is the unambiguous remainder of the payload, so it may contain any
+   * character.
+   */
+  private static final String SEPARATOR = " ";
+
+  private LmsOAuthState() {}
+
+  /** The data sealed in a state: the user id and the PKCE code verifier. */
+  public static final class Payload {
+    private final String userId;
+    private final String codeVerifier;
+
+    Payload(String userId, String codeVerifier) {
+      this.userId = userId;
+      this.codeVerifier = codeVerifier;
+    }
+
+    public String userId() {
+      return userId;
+    }
+
+    public String codeVerifier() {
+      return codeVerifier;
+    }
+  }
+
+  /**
+   * Mints a state sealing {@code userId} and {@code codeVerifier}, valid for the
+   * next ten minutes.
+   *
+   * @param userId the id of the user beginning the OAuth flow
+   * @param codeVerifier the PKCE code verifier minted for this flow
+   * @return a URL-safe opaque state string
+   * @throws EncryptionException if the state cannot be encrypted
+   * @throws IllegalArgumentException if either argument is null or empty
+   */
+  public static String create(String userId, String codeVerifier) throws EncryptionException {
+    return create(userId, codeVerifier, System.currentTimeMillis());
+  }
+
+  @VisibleForTesting
+  static String create(String userId, String codeVerifier, long issuedAtMillis)
+      throws EncryptionException {
+    if (userId == null || userId.isEmpty()) {
+      throw new IllegalArgumentException("userId must not be null or empty");
+    }
+    if (codeVerifier == null || codeVerifier.isEmpty()) {
+      throw new IllegalArgumentException("codeVerifier must not be null or empty");
+    }
+    // The user id is placed last so it is the unambiguous remainder on verify; the
+    // verifier precedes it and is URL-safe Base64, so it never holds the separator.
+    String payload = issuedAtMillis + SEPARATOR + codeVerifier + SEPARATOR + userId;
+    byte[] encrypted = EncryptionStrategy.WRITE.encrypt(payload.getBytes(StandardCharsets.UTF_8));
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(encrypted);
+  }
+
+  /**
+   * Recovers the {@link Payload} from a state minted by {@link #create}, or
+   * returns {@code null} if the state is malformed, tampered with, or expired.
+   *
+   * @param state a state string produced by {@link #create}
+   * @return the sealed payload, or {@code null} if the state is not valid
+   */
+  public static Payload verify(String state) {
+    return verify(state, System.currentTimeMillis());
+  }
+
+  @VisibleForTesting
+  static Payload verify(String state, long nowMillis) {
+    if (state == null || state.isEmpty()) {
+      return null;
+    }
+    String payload;
+    try {
+      byte[] decrypted = EncryptionStrategy.WRITE.decrypt(Base64.getUrlDecoder().decode(state));
+      payload = new String(decrypted, StandardCharsets.UTF_8);
+    } catch (EncryptionException | IllegalArgumentException e) {
+      // Decryption failure (tampered or wrong key) or invalid Base64.
+      return null;
+    }
+    int firstSep = payload.indexOf(SEPARATOR);
+    int secondSep = (firstSep < 0) ? -1 : payload.indexOf(SEPARATOR, firstSep + 1);
+    if (firstSep <= 0 || secondSep < 0) {
+      return null;
+    }
+    long issuedAtMillis;
+    try {
+      issuedAtMillis = Long.parseLong(payload.substring(0, firstSep));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+    long age = nowMillis - issuedAtMillis;
+    if (age < -CLOCK_SKEW_MILLIS || age > TTL_MILLIS) {
+      return null;
+    }
+    String codeVerifier = payload.substring(firstSep + 1, secondSep);
+    String userId = payload.substring(secondSep + 1);
+    if (codeVerifier.isEmpty() || userId.isEmpty()) {
+      return null;
+    }
+    return new Payload(userId, codeVerifier);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/Pkce.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/Pkce.java
@@ -1,0 +1,72 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Proof Key for Code Exchange (PKCE, RFC 7636) helpers for the Google Classroom
+ * OAuth 2.0 flow.
+ *
+ * <p>The connect servlet generates a random {@link #newCodeVerifier() verifier},
+ * seals it into the OAuth state, and sends its {@link #codeChallenge(String)
+ * S256 challenge} to Google. The callback recovers the verifier from the state
+ * and presents it on the token exchange. Because the verifier is carried only
+ * inside the encrypted, tamper-evident state, an attacker who replays a captured
+ * state cannot pair it with an authorization code minted for a different
+ * transaction: the code's challenge would not match the sealed verifier. This
+ * closes the authorization-code-injection gap that a session-less callback would
+ * otherwise have (RFC 9700 section 2.1).
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+final class Pkce {
+
+  /**
+   * Number of random bytes in a verifier. URL-safe Base64 of 32 bytes is 43
+   * characters, the minimum length RFC 7636 section 4.1 allows (43 to 128).
+   */
+  private static final int VERIFIER_BYTES = 32;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private Pkce() {}
+
+  /**
+   * Returns a new high-entropy code verifier, a URL-safe string suitable for
+   * both the {@code code_verifier} parameter and storage inside the state.
+   *
+   * @return a fresh PKCE code verifier
+   */
+  static String newCodeVerifier() {
+    byte[] bytes = new byte[VERIFIER_BYTES];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  /**
+   * Returns the S256 code challenge for {@code codeVerifier}, that is the
+   * URL-safe Base64 of its SHA-256 digest (RFC 7636 section 4.2).
+   *
+   * @param codeVerifier a code verifier from {@link #newCodeVerifier()}
+   * @return the S256 code challenge to send to the authorization endpoint
+   */
+  static String codeChallenge(String codeVerifier) {
+    byte[] digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256")
+          .digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+    } catch (NoSuchAlgorithmException e) {
+      // Every conforming JVM ships SHA-256, so this cannot happen.
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/package-info.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/package-info.java
@@ -1,0 +1,40 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+/**
+ * Learning Management System (LMS) integrations for App Inventor.
+ *
+ * <p>This package is the server-side root for App Inventor's LMS integrations.
+ * The first provider is Google Classroom; additional providers (Canvas and
+ * Moodle via LTI 1.3) can be added later behind the same storage and servlet
+ * layers.
+ *
+ * <p>It currently implements the Google Classroom sign-in flow, which connects a
+ * user's account and stores the resulting refresh token:
+ * <ul>
+ *   <li>{@link com.google.appinventor.server.lms.LmsConnectServlet} starts the
+ *       flow for the signed-in user, sealing the user id into an encrypted
+ *       {@link com.google.appinventor.server.lms.LmsOAuthState} and redirecting
+ *       to Google's consent screen.</li>
+ *   <li>{@link com.google.appinventor.server.lms.LmsAuthCallbackServlet}
+ *       completes the flow after Google's session-less redirect, recovering the
+ *       user id from the state and exchanging the authorization code through
+ *       {@link com.google.appinventor.server.lms.GoogleOAuthClient}.</li>
+ *   <li>{@link com.google.appinventor.server.lms.LmsCredentialStore} encrypts the
+ *       refresh token with Keyczar and persists it as a per-user file through
+ *       {@code StorageIo}, the same mechanism used for the Android keystore and
+ *       the App Store credentials. The plaintext token is never written to
+ *       storage.</li>
+ *   <li>{@link com.google.appinventor.server.lms.LmsOAuthConfig} reads the OAuth
+ *       client configuration from flags and builds the authorization URL.</li>
+ *   <li>{@link com.google.appinventor.server.lms.LmsHttp} holds the small HTTP
+ *       and JSON helpers shared by the Google API clients.</li>
+ * </ul>
+ *
+ * <p>Planned additions: the teacher and student designer UI, and the assignment
+ * lifecycle (list courses, distribute a template project, collect submissions,
+ * set a grade), including uploading an exported project to the student's Drive.
+ */
+package com.google.appinventor.server.lms;

--- a/appinventor/appengine/src/com/google/appinventor/server/lms/package-info.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/lms/package-info.java
@@ -33,8 +33,20 @@
  *       and JSON helpers shared by the Google API clients.</li>
  * </ul>
  *
- * <p>Planned additions: the teacher and student designer UI, and the assignment
- * lifecycle (list courses, distribute a template project, collect submissions,
- * set a grade), including uploading an exported project to the student's Drive.
+ * <p>It also provides the building blocks for exporting a project to the user's
+ * own Drive, ahead of the endpoint that will call them:
+ * <ul>
+ *   <li>{@link com.google.appinventor.server.lms.GoogleDriveUploader} uploads file
+ *       bytes to the user's Drive under the {@code drive.file} scope, and
+ *       {@link com.google.appinventor.server.lms.GoogleOAuthClient} refreshes the
+ *       stored credential into the access token that upload needs.</li>
+ *   <li>{@link com.google.appinventor.server.lms.GoogleDriveProjectExporter} ties
+ *       the export helper, the credential store, the refresh, and the upload into
+ *       a single building block.</li>
+ * </ul>
+ *
+ * <p>Planned additions: the teacher and student designer UI, and the rest of the
+ * assignment lifecycle (list courses, distribute a template project, collect
+ * submissions, set a grade).
  */
 package com.google.appinventor.server.lms;

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectService.java
@@ -107,6 +107,16 @@ public interface ProjectService extends RemoteService {
   public RpcResult sendToGallery(long projectId);
 
   /**
+   * Exports the given project to the signed-in user's Google Drive for the
+   * Google Classroom integration.
+   *
+   * @param projectId the project to export
+   * @return an {@link RpcResult} whose output, on success, is a link to the new
+   *     Drive file; on failure the error describes what went wrong
+   */
+  public RpcResult exportProjectToDrive(long projectId);
+
+  /**
    * Load a project from the new Gallery
    * @param galleryId  The gallery's unique ID for this project
    * @return UserProject information object for newly loaded project

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectServiceAsync.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/project/ProjectServiceAsync.java
@@ -64,6 +64,12 @@ public interface ProjectServiceAsync {
    * @see ProjectService#sendToGallery(long)
    */
   void sendToGallery(long projectId, AsyncCallback<RpcResult> callback);
+
+  /**
+   * @see ProjectService#exportProjectToDrive(long)
+   */
+  void exportProjectToDrive(long projectId, AsyncCallback<RpcResult> callback);
+
   /**
    * @see ProjectService#loadFromGallery(String)
    */

--- a/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/rpc/user/Config.java
@@ -42,6 +42,7 @@ public class Config implements IsSerializable, Serializable {
   private boolean galleryEnabled;
   private String galleryLocation;
   private boolean galleryReadOnly;
+  private boolean lmsEnabled;
   private List<String> tutorialUrlAllowed;
   private boolean serverExpired;
   private boolean deleteAccountAllowed;
@@ -226,6 +227,14 @@ public class Config implements IsSerializable, Serializable {
 
   public void setGalleryReadOnly(boolean value) {
     galleryReadOnly = value;
+  }
+
+  public boolean getLmsEnabled() {
+    return lmsEnabled;
+  }
+
+  public void setLmsEnabled(boolean value) {
+    lmsEnabled = value;
   }
 
   public void setTutorialUrlAllowed(List<String> value) {

--- a/appinventor/appengine/src/com/google/appinventor/shared/storage/StorageUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/storage/StorageUtil.java
@@ -28,6 +28,7 @@ public class StorageUtil {
   public static final String ANDROID_KEYSTORE_FILENAME = "android.keystore";
   public static final String APPSTORE_CREDENTIALS_FILENAME = "appstore_credentials.der";
   public static final String USER_BACKPACK_FILENAME = "backpack.xml";
+  public static final String LMS_GOOGLE_REFRESH_TOKEN_FILENAME = "lms_google_refresh_token.dat";
 
   /**
    * Gets the final component from a path.  This assumes that path components

--- a/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/FileExporterImplTest.java
@@ -134,6 +134,25 @@ public class FileExporterImplTest extends LocalDatastoreTestCase {
     }
   }
 
+  public void testExportProjectSourceZipWithDefaults() throws IOException {
+    ProjectSourceZip project = exporter.exportProjectSourceZip(USER_ID, projectId);
+    Map<String, byte[]> content = testExportProjectSourceZipHelper(project);
+    assertEquals(2, content.size());
+    /* The two-argument overload exports the same source-only zip as the full
+     * method with all flags false: the two source files and no remix history. */
+    assertFalse(content.containsKey(FileExporter.REMIX_INFORMATION_FILE_PATH));
+  }
+
+  public void testExportProjectSourceZipWithDefaultsNonExistingProject() throws IOException {
+    try {
+      exporter.exportProjectSourceZip(USER_ID, projectId + 1);
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException ||
+                 e.getCause() instanceof IllegalArgumentException);
+    }
+  }
+
   public void testExportProjectOutputFileWithTarget() throws IOException {
     RawFile file = exporter.exportProjectOutputFile(USER_ID, projectId, "target1");
     assertEquals(TARGET1_NAME, file.getFileName());

--- a/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceExportToDriveTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/ProjectServiceExportToDriveTest.java
@@ -1,0 +1,71 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server;
+
+import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.server.encryption.KeyczarEncryptor;
+import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.shared.rpc.RpcResult;
+import com.google.appinventor.shared.rpc.project.youngandroid.NewYoungAndroidProjectParameters;
+import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
+
+/**
+ * Tests for {@link ProjectServiceImpl#exportProjectToDrive(long)}, the Route C
+ * submit-to-Google-Classroom endpoint. These cover the two branches that need no
+ * live Google call: the entry-point ownership check, and the graceful failure
+ * when the user has not connected a Google account. The successful upload path
+ * drives live Google calls and is left to the integration tests.
+ *
+ * <p>This test sets the current user directly through {@link LocalUser} rather
+ * than mocking it, so it runs without PowerMock.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class ProjectServiceExportToDriveTest extends LocalDatastoreTestCase {
+
+  private static final String KEYSTORE_ROOT_PATH =
+      TestUtils.APP_INVENTOR_ROOT_DIR + "/appengine/build/war/";  // must end with a slash
+
+  private static final String USER_ID = "1";
+  private static final String USER_EMAIL = "user@example.com";
+  private static final String PACKAGE_NAME = "com.example.App";
+  private static final String PROJECT_NAME = "App";
+
+  private StorageIo storageIo;
+  private ProjectServiceImpl projectService;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    KeyczarEncryptor.rootPath.setForTest(KEYSTORE_ROOT_PATH);
+    storageIo = StorageIoInstanceHolder.getInstance();
+    LocalUser.getInstance().set(storageIo.getUser(USER_ID, USER_EMAIL));
+    projectService = new ProjectServiceImpl();
+  }
+
+  public void testExportProjectToDriveRejectsProjectNotOwned() {
+    // A project id the signed-in user does not own must be rejected by the
+    // entry-point ownership check, before any export work happens.
+    try {
+      projectService.exportProjectToDrive(999999L);
+      fail("expected a SecurityException for a project the user does not own");
+    } catch (SecurityException expected) {
+      // expected
+    }
+  }
+
+  public void testExportProjectToDriveWithoutCredentialFails() {
+    long projectId = projectService.newProject(
+        YoungAndroidProjectNode.YOUNG_ANDROID_PROJECT_TYPE, PROJECT_NAME,
+        new NewYoungAndroidProjectParameters(PACKAGE_NAME)).getProjectId();
+    // The user owns the project but has not connected a Google account, so the
+    // export must fail gracefully with a failing RpcResult rather than throw.
+    RpcResult result = projectService.exportProjectToDrive(projectId);
+    assertFalse(result.succeeded());
+    assertEquals("NOT_CONNECTED", result.getError());
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/GoogleDriveProjectExporterTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/GoogleDriveProjectExporterTest.java
@@ -1,0 +1,51 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.server.FileExporterImpl;
+import com.google.appinventor.server.LocalDatastoreTestCase;
+import com.google.appinventor.server.encryption.KeyczarEncryptor;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+
+/**
+ * Tests for {@link GoogleDriveProjectExporter}. Its happy path drives live Google
+ * token-refresh and Drive-upload calls, so that path is covered by the
+ * integration tests with mocked Google responses rather than here. This unit test
+ * pins the one branch that needs no network: the guard for a user who has not
+ * connected a Google credential.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class GoogleDriveProjectExporterTest extends LocalDatastoreTestCase {
+
+  private static final String KEYSTORE_ROOT_PATH =
+      TestUtils.APP_INVENTOR_ROOT_DIR + "/appengine/build/war/";  // must end with a slash
+
+  private static final String USER_ID = "1";
+  private static final String USER_EMAIL = "user@example.com";
+
+  private GoogleDriveProjectExporter exporter;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    KeyczarEncryptor.rootPath.setForTest(KEYSTORE_ROOT_PATH);
+    StorageIoInstanceHolder.getInstance().getUser(USER_ID, USER_EMAIL);
+    exporter = new GoogleDriveProjectExporter(new FileExporterImpl(), new LmsCredentialStore());
+  }
+
+  public void testExportWithoutStoredCredentialThrows() throws Exception {
+    // The user has not connected to Google, so there is no refresh token to mint
+    // an access token from, and the export must not proceed.
+    try {
+      exporter.exportProjectToDrive(USER_ID, 1L);
+      fail("expected an IllegalStateException when no Google credential is stored");
+    } catch (IllegalStateException expected) {
+      // expected
+    }
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsCredentialStoreTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsCredentialStoreTest.java
@@ -1,0 +1,80 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.server.LocalDatastoreTestCase;
+import com.google.appinventor.server.encryption.KeyczarEncryptor;
+import com.google.appinventor.server.storage.StorageIo;
+import com.google.appinventor.server.storage.StorageIoInstanceHolder;
+import com.google.appinventor.shared.storage.StorageUtil;
+
+/**
+ * Tests for {@link LmsCredentialStore}.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsCredentialStoreTest extends LocalDatastoreTestCase {
+
+  private static final String KEYSTORE_ROOT_PATH =
+      TestUtils.APP_INVENTOR_ROOT_DIR + "/appengine/build/war/";  // must end with a slash
+
+  private static final String USER_ID = "1";
+  private static final String USER_EMAIL = "user@example.com";
+  private static final String REFRESH_TOKEN = "1//0gRefreshTokenValueExample";
+
+  private LmsCredentialStore store;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    KeyczarEncryptor.rootPath.setForTest(KEYSTORE_ROOT_PATH);
+    StorageIoInstanceHolder.getInstance().getUser(USER_ID, USER_EMAIL);
+    store = new LmsCredentialStore();
+  }
+
+  public void testNoCredentialInitially() throws Exception {
+    assertFalse(store.hasGoogleCredential(USER_ID));
+    assertNull(store.getGoogleRefreshToken(USER_ID));
+  }
+
+  public void testSaveThenGetReturnsSameToken() throws Exception {
+    store.saveGoogleRefreshToken(USER_ID, REFRESH_TOKEN);
+    assertTrue(store.hasGoogleCredential(USER_ID));
+    assertEquals(REFRESH_TOKEN, store.getGoogleRefreshToken(USER_ID));
+  }
+
+  public void testSaveReplacesExistingToken() throws Exception {
+    store.saveGoogleRefreshToken(USER_ID, REFRESH_TOKEN);
+    String second = "1//0gSecondTokenValue";
+    store.saveGoogleRefreshToken(USER_ID, second);
+    assertEquals(second, store.getGoogleRefreshToken(USER_ID));
+  }
+
+  public void testStoredBytesDoNotContainPlaintext() throws Exception {
+    store.saveGoogleRefreshToken(USER_ID, REFRESH_TOKEN);
+    StorageIo storageIo = StorageIoInstanceHolder.getInstance();
+    byte[] stored =
+        storageIo.downloadRawUserFile(USER_ID, StorageUtil.LMS_GOOGLE_REFRESH_TOKEN_FILENAME);
+    String storedAsString = new String(stored, StorageUtil.DEFAULT_CHARSET);
+    assertFalse(storedAsString.contains(REFRESH_TOKEN));
+  }
+
+  public void testEmptyArgumentsRejected() {
+    try {
+      store.saveGoogleRefreshToken("", REFRESH_TOKEN);
+      fail();
+    } catch (Exception e) {
+      // expected
+    }
+    try {
+      store.saveGoogleRefreshToken(USER_ID, "");
+      fail();
+    } catch (Exception e) {
+      // expected
+    }
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsHttpTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsHttpTest.java
@@ -1,0 +1,42 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import java.io.IOException;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link LmsHttp}. Only the pure {@code jsonField} parser is unit
+ * tested here; the networked methods are exercised by the live handshake.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsHttpTest extends TestCase {
+
+  public void testJsonFieldReturnsValue() throws Exception {
+    assertEquals("ya29.abc",
+        LmsHttp.jsonField("{\"access_token\":\"ya29.abc\",\"expires_in\":3599}", "access_token"));
+  }
+
+  public void testJsonFieldAbsentReturnsNull() throws Exception {
+    assertNull(LmsHttp.jsonField("{\"access_token\":\"ya29.abc\"}", "refresh_token"));
+  }
+
+  public void testJsonFieldEmptyReturnsNull() throws Exception {
+    // optString yields "" for a present-but-empty field; jsonField normalizes that to null.
+    assertNull(LmsHttp.jsonField("{\"id\":\"\"}", "id"));
+  }
+
+  public void testJsonFieldMalformedThrows() {
+    try {
+      LmsHttp.jsonField("not json", "id");
+      fail();
+    } catch (IOException e) {
+      // expected
+    }
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsHttpTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsHttpTest.java
@@ -6,12 +6,15 @@
 package com.google.appinventor.server.lms;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 
 import junit.framework.TestCase;
 
 /**
- * Tests for {@link LmsHttp}. Only the pure {@code jsonField} parser is unit
- * tested here; the networked methods are exercised by the live handshake.
+ * Tests for {@link LmsHttp}. The pure {@code jsonField} parser and the
+ * {@code proxy()} selection are unit tested here; the networked methods are
+ * exercised by the live handshake.
  *
  * @author zikun@stanford.edu (Zikun Zhu)
  */
@@ -38,5 +41,42 @@ public class LmsHttpTest extends TestCase {
     } catch (IOException e) {
       // expected
     }
+  }
+
+  public void testProxyDefaultsToNoProxyWhenHostUnset() {
+    System.clearProperty("lms.proxy.host");
+    assertEquals(Proxy.NO_PROXY, LmsHttp.proxy());
+  }
+
+  public void testProxyUsesSocksWhenConfigured() {
+    System.setProperty("lms.proxy.host", "127.0.0.1");
+    System.setProperty("lms.proxy.port", "33211");
+    System.setProperty("lms.proxy.type", "socks");
+    try {
+      Proxy p = LmsHttp.proxy();
+      assertEquals(Proxy.Type.SOCKS, p.type());
+      InetSocketAddress address = (InetSocketAddress) p.address();
+      assertEquals("127.0.0.1", address.getHostString());
+      assertEquals(33211, address.getPort());
+    } finally {
+      clearProxyProps();
+    }
+  }
+
+  public void testProxyDefaultsToHttpTypeWhenTypeUnset() {
+    System.setProperty("lms.proxy.host", "127.0.0.1");
+    System.setProperty("lms.proxy.port", "8080");
+    System.clearProperty("lms.proxy.type");
+    try {
+      assertEquals(Proxy.Type.HTTP, LmsHttp.proxy().type());
+    } finally {
+      clearProxyProps();
+    }
+  }
+
+  private static void clearProxyProps() {
+    System.clearProperty("lms.proxy.host");
+    System.clearProperty("lms.proxy.port");
+    System.clearProperty("lms.proxy.type");
   }
 }

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthConfigTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthConfigTest.java
@@ -1,0 +1,43 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link LmsOAuthConfig}'s authorization-URL construction.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsOAuthConfigTest extends TestCase {
+
+  public void testBuildAuthorizationUrlHasAllRequiredParams() {
+    String url = LmsOAuthConfig.buildAuthorizationUrl(
+        "the-client-id", "http://localhost:8888/lms/auth/callback", "STATE-123", "CHALLENGE-xyz");
+    assertTrue(url.startsWith("https://accounts.google.com/o/oauth2/v2/auth"));
+    assertTrue(url.contains("client_id=the-client-id"));
+    assertTrue(url.contains("redirect_uri="));
+    assertTrue(url.contains("response_type=code"));
+    assertTrue(url.contains("access_type=offline"));  // needed to receive a refresh token
+    assertTrue(url.contains("prompt=consent"));        // forces a refresh token each consent
+    assertTrue(url.contains("code_challenge=CHALLENGE-xyz"));  // PKCE challenge
+    assertTrue(url.contains("code_challenge_method=S256"));    // PKCE method
+    assertTrue(url.contains("state=STATE-123"));
+  }
+
+  public void testBuildAuthorizationUrlRequestsOnlyClassroomScope() {
+    String url = LmsOAuthConfig.buildAuthorizationUrl("cid", "http://localhost/cb", "s", "ch");
+    assertTrue(url.contains("classroom.courses.readonly"));
+    // The Drive scope is deferred to the Drive-upload PR, so the sign-in PR stays least privilege.
+    assertFalse(url.contains("drive.file"));
+  }
+
+  public void testIsConfiguredFalseWhenSecretsUnset() {
+    // With no system properties set, the client id and secret default to empty,
+    // so the connect servlet's configuration gate is closed.
+    assertFalse(LmsOAuthConfig.isConfigured());
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthConfigTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthConfigTest.java
@@ -28,11 +28,11 @@ public class LmsOAuthConfigTest extends TestCase {
     assertTrue(url.contains("state=STATE-123"));
   }
 
-  public void testBuildAuthorizationUrlRequestsOnlyClassroomScope() {
+  public void testBuildAuthorizationUrlRequestsClassroomAndDriveScopes() {
     String url = LmsOAuthConfig.buildAuthorizationUrl("cid", "http://localhost/cb", "s", "ch");
     assertTrue(url.contains("classroom.courses.readonly"));
-    // The Drive scope is deferred to the Drive-upload PR, so the sign-in PR stays least privilege.
-    assertFalse(url.contains("drive.file"));
+    // The Drive upload needs the per-file drive.file scope, requested at sign-in.
+    assertTrue(url.contains("drive.file"));
   }
 
   public void testIsConfiguredFalseWhenSecretsUnset() {

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthStateTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/LmsOAuthStateTest.java
@@ -1,0 +1,130 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import com.google.appinventor.common.testutils.TestUtils;
+import com.google.appinventor.server.encryption.KeyczarEncryptor;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link LmsOAuthState}. This state helper only uses the symmetric
+ * encryption key, not the datastore, so the test extends {@link TestCase}
+ * directly rather than the heavier datastore test base.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class LmsOAuthStateTest extends TestCase {
+
+  private static final String KEYSTORE_ROOT_PATH =
+      TestUtils.APP_INVENTOR_ROOT_DIR + "/appengine/build/war/";  // must end with a slash
+
+  private static final String USER_ID = "1234-user-uuid";
+  private static final String VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+  // A fixed reference time so the time-to-live tests do not depend on the clock.
+  private static final long ISSUED_AT = 1_000_000_000_000L;
+  private static final long ONE_MINUTE = 60 * 1000L;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    KeyczarEncryptor.rootPath.setForTest(KEYSTORE_ROOT_PATH);
+  }
+
+  public void testRoundTripReturnsUserIdAndVerifier() throws Exception {
+    String state = LmsOAuthState.create(USER_ID, VERIFIER);
+    LmsOAuthState.Payload payload = LmsOAuthState.verify(state);
+    assertNotNull(payload);
+    assertEquals(USER_ID, payload.userId());
+    assertEquals(VERIFIER, payload.codeVerifier());
+  }
+
+  public void testFreshStateWithinTtlAccepted() throws Exception {
+    String state = LmsOAuthState.create(USER_ID, VERIFIER, ISSUED_AT);
+    LmsOAuthState.Payload payload = LmsOAuthState.verify(state, ISSUED_AT + 9 * ONE_MINUTE);
+    assertNotNull(payload);
+    assertEquals(USER_ID, payload.userId());
+  }
+
+  public void testExpiredStateRejected() throws Exception {
+    String state = LmsOAuthState.create(USER_ID, VERIFIER, ISSUED_AT);
+    assertNull(LmsOAuthState.verify(state, ISSUED_AT + 11 * ONE_MINUTE));
+  }
+
+  public void testTamperedStateRejected() throws Exception {
+    String state = LmsOAuthState.create(USER_ID, VERIFIER);
+    char[] chars = state.toCharArray();
+    int mid = chars.length / 2;
+    chars[mid] = (chars[mid] == 'A') ? 'B' : 'A';  // flip one ciphertext character
+    assertNull(LmsOAuthState.verify(new String(chars)));
+  }
+
+  public void testGarbageStateReturnsNull() {
+    assertNull(LmsOAuthState.verify("not a valid state"));
+    assertNull(LmsOAuthState.verify(""));
+    assertNull(LmsOAuthState.verify(null));
+  }
+
+  public void testEmptyUserIdRejected() {
+    try {
+      LmsOAuthState.create("", VERIFIER);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    } catch (Exception e) {
+      fail("expected IllegalArgumentException, got " + e);
+    }
+  }
+
+  public void testEmptyVerifierRejected() {
+    try {
+      LmsOAuthState.create(USER_ID, "");
+      fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    } catch (Exception e) {
+      fail("expected IllegalArgumentException, got " + e);
+    }
+  }
+
+  public void testDistinctStatesForSameInputs() throws Exception {
+    // Even with identical inputs the ciphertext differs, because the encryption
+    // uses a random initialization vector; two flows never produce the same state.
+    String first = LmsOAuthState.create(USER_ID, VERIFIER);
+    String second = LmsOAuthState.create(USER_ID, VERIFIER);
+    assertFalse(first.equals(second));
+  }
+
+  public void testUserIdWithSpaceRoundTrips() throws Exception {
+    // The user id is the unambiguous remainder of the payload, so even a value
+    // containing the separator survives the round trip.
+    String userIdWithSpace = "user id with spaces";
+    String state = LmsOAuthState.create(userIdWithSpace, VERIFIER);
+    LmsOAuthState.Payload payload = LmsOAuthState.verify(state);
+    assertNotNull(payload);
+    assertEquals(userIdWithSpace, payload.userId());
+    assertEquals(VERIFIER, payload.codeVerifier());
+  }
+
+  public void testStateAtExactTtlBoundaryAccepted() throws Exception {
+    // age == TTL is still valid; the check rejects only age > TTL.
+    String state = LmsOAuthState.create(USER_ID, VERIFIER, ISSUED_AT);
+    assertNotNull(LmsOAuthState.verify(state, ISSUED_AT + 10 * ONE_MINUTE));
+  }
+
+  public void testFutureDatedStateRejected() throws Exception {
+    // A state dated further in the future than the clock-skew tolerance is rejected.
+    String state = LmsOAuthState.create(USER_ID, VERIFIER, ISSUED_AT);
+    assertNull(LmsOAuthState.verify(state, ISSUED_AT - ONE_MINUTE));  // 60s exceeds the tolerance
+  }
+
+  public void testStateWithinClockSkewToleranceAccepted() throws Exception {
+    // A state dated slightly in the future, as cross-instance clock skew can cause, is accepted.
+    String state = LmsOAuthState.create(USER_ID, VERIFIER, ISSUED_AT);
+    assertNotNull(LmsOAuthState.verify(state, ISSUED_AT - 5000));  // 5s of skew, within tolerance
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/server/lms/PkceTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/lms/PkceTest.java
@@ -1,0 +1,43 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.server.lms;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link Pkce}.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class PkceTest extends TestCase {
+
+  public void testCodeChallengeMatchesRfc7636Vector() {
+    // The worked S256 example from RFC 7636 Appendix B: a fixed verifier and the
+    // exact challenge it must produce. This pins the SHA-256 + URL-safe Base64.
+    assertEquals("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        Pkce.codeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"));
+  }
+
+  public void testNewCodeVerifierIsUrlSafeAndLongEnough() {
+    String verifier = Pkce.newCodeVerifier();
+    // RFC 7636 section 4.1 allows 43 to 128 characters from the unreserved set.
+    assertTrue("unexpected length " + verifier.length(),
+        verifier.length() >= 43 && verifier.length() <= 128);
+    assertTrue(verifier.matches("[A-Za-z0-9_-]+"));
+  }
+
+  public void testNewCodeVerifierIsDistinctEachCall() {
+    assertFalse(Pkce.newCodeVerifier().equals(Pkce.newCodeVerifier()));
+  }
+
+  public void testCodeChallengeIsUrlSafeWithoutPadding() {
+    // S256 of any verifier is a 32-byte digest, 43 URL-safe Base64 characters with
+    // no '=' padding and no '+' or '/'.
+    String challenge = Pkce.codeChallenge(Pkce.newCodeVerifier());
+    assertEquals(43, challenge.length());
+    assertTrue(challenge.matches("[A-Za-z0-9_-]+"));
+  }
+}

--- a/appinventor/appengine/war/WEB-INF/web.xml
+++ b/appinventor/appengine/war/WEB-INF/web.xml
@@ -70,6 +70,35 @@
     <servlet-name>RestServlet</servlet-name>
     <url-pattern>/rest/*</url-pattern>
   </servlet-mapping>
+
+  <!-- LMS Google Classroom OAuth 2.0 sign-in.
+       lmsConnectServlet (start) runs behind odeAuthFilter, so the user id comes
+       from the authenticated session and is sealed into the OAuth state.
+       lmsAuthCallbackServlet (callback) is intentionally NOT behind the filter,
+       so Google's cross-origin redirect can complete without an App Inventor
+       session; it recovers the user id from the encrypted state. -->
+  <servlet>
+    <servlet-name>lmsConnectServlet</servlet-name>
+    <servlet-class>com.google.appinventor.server.lms.LmsConnectServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>lmsConnectServlet</servlet-name>
+    <url-pattern>/lms/connect</url-pattern>
+  </servlet-mapping>
+  <filter-mapping>
+    <filter-name>odeAuthFilter</filter-name>
+    <servlet-name>lmsConnectServlet</servlet-name>
+  </filter-mapping>
+
+  <servlet>
+    <servlet-name>lmsAuthCallbackServlet</servlet-name>
+    <servlet-class>com.google.appinventor.server.lms.LmsAuthCallbackServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>lmsAuthCallbackServlet</servlet-name>
+    <url-pattern>/lms/auth/callback</url-pattern>
+  </servlet-mapping>
+
   <!-- Nonce based APK download -->
 
   <servlet>


### PR DESCRIPTION
**Status. Design branch, not yet ready for review or merge.**

This is an exploratory branch for the full Google Classroom integration. It is intentionally one evolving branch rather than a finished change. It now holds three steps. The Google sign in with the encrypted token storage, a convenience overload for exporting a project source archive, and the Drive upload with a Submit to Google Classroom item built on it. A few decisions are still open and being discussed, such as where the entry point should live. The description below covers the first step, and the update at the end covers the rest.

**What does this PR accomplish?**

*Description*

This pull request adds the first step of a Learning Management System integration for App Inventor. It lets a user connect their Google account so that App Inventor can later work with that user's Google Classroom on their behalf.

A new "Connect Google Classroom" item is added to the Connect menu. Choosing it starts a server side OAuth 2.0 authorization code flow with PKCE against Google, requests read access to the user's Classroom courses along with the per file Drive scope the upload step uses, and on success stores the resulting refresh token encrypted at rest. App Inventor then holds a long lived credential for the Classroom features built on it.

A few notes that should help the review.

- The feature is off by default. The menu item appears only when the server has a Google OAuth client configured through three system properties (a client id, a client secret, and a redirect URI). A deployment without those properties is unaffected and the item stays hidden.
- The flow uses PKCE (RFC 7636) on top of the client secret. The state carried through Google's redirect is encrypted and tamper evident with the existing Keyczar write key, so the callback, which carries no session of its own, can trust what it recovers, and a replayed state cannot be paired with an authorization code minted for a different transaction (RFC 9700 section 2.1).
- Two scopes are requested. The read only Classroom courses scope, and the per file drive.file scope the upload step uses, which reaches only files this application creates. The broad Drive scope is never requested, so the stored token cannot read the rest of a user's Drive.
- The refresh token is encrypted with the same write key and stored as a per user file through the existing StorageIo, the same mechanism that already stores the Android keystore and the App Store credentials. It adds nothing to the StorageIo interface and needs no schema change.
- No token is ever written to a response.

The first step is deliberately limited to sign in and credential storage. It reads no Classroom data. Nothing on the branch changes any on device or blocks behavior.

 1. the Connect menu showing the new "Connect Google Classroom" item

<img width="1512" height="424" alt="Screenshot 2026-06-22 at 6 24 35 AM" src="https://github.com/user-attachments/assets/a36c3234-d88e-4c25-aad0-112bc01fe3ba" />
<img width="1512" height="446" alt="Screenshot 2026-06-22 at 6 24 49 AM" src="https://github.com/user-attachments/assets/88bc35bf-1e0b-40f0-9101-fa8bd5a1c0c3" />

 2. Google's consent screen as recorded for the first step, showing the read only Classroom scope. The branch now also requests the per file drive.file scope for the upload step, so the current consent screen lists both.
<img width="1512" height="694" alt="Screenshot 2026-06-22 at 6 25 00 AM" src="https://github.com/user-attachments/assets/de56c5a2-3faa-4d48-b976-5f3423658900" />

<img width="1512" height="811" alt="Screenshot 2026-06-22 at 6 25 10 AM" src="https://github.com/user-attachments/assets/130fa96a-f570-48fe-a151-6b2907b05086" />

Afterwards, it returns to App Inventor after approval.


*Testing Guidelines*

To exercise the whole flow you need a Google OAuth client and the three system properties, then a running development server.

1. In the Google Cloud console create an OAuth 2.0 client of type Web application, enable the Google Classroom API, and register the callback as an authorized redirect URI. For a local server that callback is http://localhost:8888/lms/auth/callback
2. In appengine-web.xml set the three system properties lms.google.classroom.client_id, lms.google.classroom.client_secret, and lms.google.classroom.redirect_uri. Real secrets should not be committed.
3. Build, run the development server, and open any project. The Connect menu now shows "Connect Google Classroom".
4. Choose it. The browser is sent to Google's consent screen, which requests the read only Classroom scope and the per file drive.file scope. Approve it. The browser returns to App Inventor and the encrypted refresh token is stored for that user.
5. With the three properties unset, the menu item does not appear and the connect endpoint reports that the integration is not configured, which confirms the feature stays off by default.

The change also adds unit tests for the PKCE helper, the encrypted state, the configuration and authorization URL, the credential store, and the HTTP and JSON helpers.

**Update, August 2026**

Two more steps now sit on the branch. A convenience overload for exporting a project source archive, which also stands on its own against the main repository as mit-cml/appinventor-sources#4002. And the Drive upload behind a Submit to Google Classroom item in the Project menu, which exports the project source archive, uploads it to the user's Drive through the per file drive.file scope, and then points the user at the new file with a reminder to attach it to the Classroom assignment, with unit tests around the exporter, the uploader, and the helpers. The wider work then pivoted to the LTI 1.3 standard, which reaches most major Learning Management Systems with one implementation, and the standing reference for that is mit-cml/appinventor-sources#4031. Classroom itself does not speak LTI, so the building blocks on this branch remain the path for a Classroom school.

**Context for the changes**

These changes are limited to the appengine server and the GWT client. They do not affect the companion or any on device behavior, so this pull request is based on master.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine