### PR TITLE
Migrate ListView ListData editor rows from CellTable to UiBinder widgets

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -18,11 +18,6 @@ import com.google.appinventor.shared.rpc.project.ProjectNode;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidAssetsFolder;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
 
-import com.google.gwt.cell.client.ButtonCell;
-import com.google.gwt.cell.client.FieldUpdater;
-import com.google.gwt.cell.client.SelectionCell;
-import com.google.gwt.cell.client.TextInputCell;
-
 import com.google.gwt.core.client.GWT;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -37,9 +32,6 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 
-import com.google.gwt.user.cellview.client.CellTable;
-import com.google.gwt.user.cellview.client.Column;
-
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -49,20 +41,21 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
-import com.google.gwt.view.client.ListDataProvider;
-
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * The "Click to Add/Delete Data" dialog for the ListView ListData property.
  *
- * <p>This is the UiBinder migration of the former {@code ClickHandle} inner class. The dialog
- * chrome (title, button bar and the container that holds the data rows) is now declared in
- * {@code ListViewAddDataDialog.ui.xml} and wrapped in the accessible {@link Dialog} widget, which
- * provides the ARIA role, modal semantics, Escape-to-close and focus management. The data grid
- * itself is still the original {@link CellTable}; replacing it with real-widget rows is the next
- * step (PR 1.2).
+ * <p>The dialog chrome (title, button bar and the container that holds the data rows) is declared
+ * in {@code ListViewAddDataDialog.ui.xml} and wrapped in the accessible {@link Dialog} widget, which
+ * provides the ARIA role, modal semantics, Escape-to-close and focus management.
+ *
+ * <p>The data grid is built from real, focusable widgets: each row is a {@link ListViewDataRow}
+ * added to {@code rowsContainer}. The rows are the source of truth, so there is no separate working
+ * copy. Which fields a row exposes ({@code Text1}, {@code Text2}, {@code Image}) is derived from the
+ * current ListView layout and applied by showing/hiding the row's widgets. The saved JSON is
+ * unchanged from the previous {@code CellTable}-based implementation.
  */
 public class ListViewAddDataDialog {
 
@@ -72,7 +65,8 @@ public class ListViewAddDataDialog {
       GWT.create(ListViewAddDataDialogUiBinder.class);
 
   @UiField Dialog dialogBox;
-  @UiField FlowPanel tableContainer;
+  @UiField HorizontalPanel headerRow;
+  @UiField FlowPanel rowsContainer;
   @UiField Button addRow;
   @UiField Button save;
   @UiField Button cancel;
@@ -82,15 +76,19 @@ public class ListViewAddDataDialog {
   private final YoungAndroidListViewAddDataPropertyEditor owner;
   private final int layout;
 
-  /* Working copy of the rows; only written back to the property on SAVE. */
-  private final List<JSONObject> itemsCopy = new ArrayList<JSONObject>();
-  private final CellTable<JSONObject> table = new CellTable<JSONObject>();
-  private final ListDataProvider<JSONObject> model = new ListDataProvider<JSONObject>(itemsCopy);
-  private final JSONArray rows = new JSONArray();
+  /* Which fields apply to the current layout, derived once from the layout mode. */
+  private final boolean showDetail;
+  private final boolean showImage;
+
+  /* Asset names (incl. "None") used to populate each row's image picker. */
+  private final List<String> imageChoices;
 
   ListViewAddDataDialog(YoungAndroidListViewAddDataPropertyEditor owner, int layout) {
     this.owner = owner;
     this.layout = layout;
+    this.showDetail = layoutHasDetail(layout);
+    this.showImage = layoutHasImage(layout);
+    this.imageChoices = buildImageChoices();
     UI_BINDER.createAndBindUi(this);
 
     dialogBox.setCaption(MESSAGES.listDataAddDataTitle());
@@ -99,16 +97,11 @@ public class ListViewAddDataDialog {
     save.setText(MESSAGES.saveButton());
     cancel.setText(MESSAGES.cancelButton());
 
+    buildHeader();
+
     for (JSONObject item : owner.getItems()) {
-      itemsCopy.add(item);
+      rowsContainer.add(new ListViewDataRow(item, showDetail, showImage, imageChoices));
     }
-
-    table.setRowData(itemsCopy);
-    table.setEmptyTableWidget(new Label("No row data available yet!"));
-    model.addDataDisplay(table);
-
-    buildColumns();
-    tableContainer.add(table);
   }
 
   /** Centers and shows the dialog. */
@@ -116,125 +109,60 @@ public class ListViewAddDataDialog {
     dialogBox.center();
   }
 
-  /**
-   * Creates the table columns for the current ListView layout. The set of columns determines which
-   * fields ({@code Text1}, {@code Text2}, {@code Image}) a row exposes for editing.
-   */
-  private void buildColumns() {
-    if (layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
-      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
-      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-      table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
-      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-      table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
-        layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
-      table.addColumn(createTextBoxes("Text1"), MESSAGES.listDataMainTextHeader());
-      table.addColumn(createTextBoxes("Text2"), MESSAGES.listDataDetailTextHeader());
-      table.addColumn(createImageSelectionDropDown("Image"), MESSAGES.listDataImageHeader());
-    }
-
-    table.addColumn(createDeleteButton());
+  /** Whether the given layout shows a detail (second) text field. */
+  private static boolean layoutHasDetail(int layout) {
+    return layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT
+        || layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR
+        || layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT
+        || layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT;
   }
 
-  private Column<JSONObject, String> createDeleteButton() {
-    Column<JSONObject, String> column = new Column<JSONObject, String>(new ButtonCell()) {
-      @Override
-      public String getValue(JSONObject jsonObject) {
-        return "DELETE";
-      }
-    };
-    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-      @Override
-      public void update(int i, JSONObject jsonObject, String s) {
-        itemsCopy.remove(i);
-        model.refresh();
-        table.setRowCount(0);
-        table.setRowData(0, itemsCopy);
-      }
-    });
-    return column;
+  /** Whether the given layout shows an image picker. */
+  private static boolean layoutHasImage(int layout) {
+    return layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT
+        || layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT
+        || layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT;
   }
 
-  private Column<JSONObject, String> createTextBoxes(final String columnKey) {
-    Column<JSONObject, String> column = new Column<JSONObject, String>(new TextInputCell()) {
-      @Override
-      public String getValue(JSONObject jsonObject) {
-        if (jsonObject.containsKey(columnKey)) {
-          JSONString stringVal = (JSONString) jsonObject.get(columnKey);
-          return (stringVal.stringValue());
-        } else {
-          jsonObject.put(columnKey, new JSONString(""));
-          return "";
-        }
-      }
-    };
-    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-      @Override
-      public void update(int i, JSONObject jsonObject, String s) {
-        jsonObject.put(columnKey, new JSONString(s));
-      }
-    });
-    return column;
-  }
-
-  private Column<JSONObject, String> createImageSelectionDropDown(final String columnKey) {
+  /** Builds the list of selectable image assets ("None" plus every project asset). */
+  private List<String> buildImageChoices() {
     Project project = Ode.getInstance().getProjectManager()
         .getProject(owner.getSimpleEditor().getProjectId());
     YoungAndroidAssetsFolder assetsFolder =
         ((YoungAndroidProjectNode) project.getRootNode()).getAssetsFolder();
     List<String> choices = new ArrayList<String>();
-    choices.add(0, "None");
+    choices.add("None");
     if (assetsFolder != null) {
       for (ProjectNode node : assetsFolder.getChildren()) {
         choices.add(node.getName());
       }
     }
-    Column<JSONObject, String> column = new Column<JSONObject, String>(new SelectionCell(choices)) {
-      @Override
-      public String getValue(JSONObject jsonObject) {
-        if (jsonObject.containsKey(columnKey)) {
-          JSONString stringVal = (JSONString) jsonObject.get(columnKey);
-          return (stringVal.stringValue());
-        } else {
-          jsonObject.put(columnKey, new JSONString(""));
-          return "";
-        }
-      }
-    };
-    column.setFieldUpdater(new FieldUpdater<JSONObject, String>() {
-      @Override
-      public void update(int i, JSONObject jsonObject, String s) {
-        jsonObject.put(columnKey, new JSONString(s));
-      }
-    });
-    return column;
+    return choices;
+  }
+
+  /** Adds the column headers that match the visible fields for the current layout. */
+  private void buildHeader() {
+    headerRow.add(new Label(MESSAGES.listDataMainTextHeader()));
+    if (showDetail) {
+      headerRow.add(new Label(MESSAGES.listDataDetailTextHeader()));
+    }
+    if (showImage) {
+      headerRow.add(new Label(MESSAGES.listDataImageHeader()));
+    }
   }
 
   @UiHandler("addRow")
   void onAddRow(ClickEvent event) {
     // creates a row with default data for the corresponding layout type
     JSONObject data = new JSONObject();
-    if (layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT) {
-      data.put("Text1", new JSONString(""));
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) {
-      data.put("Text1", new JSONString(""));
+    data.put("Text1", new JSONString(""));
+    if (showDetail) {
       data.put("Text2", new JSONString(""));
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) {
-      data.put("Text1", new JSONString(""));
-      data.put("Image", new JSONString("None"));
-    } else if (layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TWO_TEXT ||
-        layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT) {
-      data.put("Text1", new JSONString(""));
-      data.put("Text2", new JSONString(""));
+    }
+    if (showImage) {
       data.put("Image", new JSONString("None"));
     }
-    itemsCopy.add(data);
-    table.setRowData(itemsCopy);
+    rowsContainer.add(new ListViewDataRow(data, showDetail, showImage, imageChoices));
   }
 
   @UiHandler("save")
@@ -242,14 +170,15 @@ public class ListViewAddDataDialog {
     // save the data for the corresponding layout type
     List<JSONObject> items = owner.getItems();
     items.clear();
-    for (int i = 0; i < itemsCopy.size(); ++i) {
-      JSONObject obj = itemsCopy.get(i);
-      if ((layout == ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT ||
-          layout == ComponentConstants.LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT) && obj.containsKey("Text2")) {
+    JSONArray rows = new JSONArray();
+    for (int i = 0; i < rowsContainer.getWidgetCount(); ++i) {
+      ListViewDataRow row = (ListViewDataRow) rowsContainer.getWidget(i);
+      JSONObject obj = row.toJsonObject();
+      // null fields that don't belong to the current layout so the saved JSON is unchanged
+      if (!showDetail && obj.containsKey("Text2")) {
         obj.put("Text2", null);
       }
-      if ((layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT ||
-          layout == ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT_LINEAR) && obj.containsKey("Image")) {
+      if (!showImage && obj.containsKey("Image")) {
         obj.put("Image", null);
       }
       rows.set(i, obj);
@@ -269,7 +198,6 @@ public class ListViewAddDataDialog {
     confirm.yes.addClickHandler(new ClickHandler() {
       @Override
       public void onClick(ClickEvent clickEvent) {
-        itemsCopy.clear();
         confirm.hide();
         dialogBox.hide();
       }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -20,6 +20,8 @@ import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjec
 
 import com.google.gwt.core.client.GWT;
 
+import com.google.gwt.dom.client.Style;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
@@ -142,13 +144,27 @@ public class ListViewAddDataDialog {
 
   /** Adds the column headers that match the visible fields for the current layout. */
   private void buildHeader() {
-    headerRow.add(new Label(MESSAGES.listDataMainTextHeader()));
+    headerRow.add(makeHeaderLabel(MESSAGES.listDataMainTextHeader(), ListViewDataRow.COLUMN_TEXT_WIDTH));
     if (showDetail) {
-      headerRow.add(new Label(MESSAGES.listDataDetailTextHeader()));
+      headerRow.add(
+          makeHeaderLabel(MESSAGES.listDataDetailTextHeader(), ListViewDataRow.COLUMN_TEXT_WIDTH));
     }
     if (showImage) {
-      headerRow.add(new Label(MESSAGES.listDataImageHeader()));
+      headerRow.add(makeHeaderLabel(MESSAGES.listDataImageHeader(), ListViewDataRow.COLUMN_IMAGE_WIDTH));
     }
+  }
+
+  /** Creates a header label whose width matches the row field below it so the columns line up. */
+  private static Label makeHeaderLabel(String text, String width) {
+    Label label = new Label(text);
+    label.setWidth(width);
+    // Match the row field's box model so the header lines up: border-box width, no extra left
+    // padding from the dialog stylesheet, and the same right margin the fields use as the gap.
+    Style style = label.getElement().getStyle();
+    style.setProperty("boxSizing", "border-box");
+    style.setPaddingLeft(0, Style.Unit.PX);
+    style.setMarginRight(8, Style.Unit.PX);
+    return label;
   }
 
   @UiHandler("addRow")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
@@ -11,7 +11,8 @@
     <g:VerticalPanel>
       <g:Button ui:field="topInvisible" styleName="FocusTrap" tabIndex="-1"/>
 
-      <g:FlowPanel ui:field="tableContainer"/>
+      <g:HorizontalPanel ui:field="headerRow"/>
+      <g:FlowPanel ui:field="rowsContainer"/>
       <g:Button ui:field="addRow"/>
 
       <g:HorizontalPanel horizontalAlignment="ALIGN_CENTER">

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -1,0 +1,133 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.properties;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.gwt.core.client.GWT;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import com.google.gwt.json.client.JSONValue;
+
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.TextBox;
+
+import java.util.List;
+
+/**
+ * A single editable row in the ListView ListData editor dialog.
+ *
+ * <p>Replaces the virtualized {@code CellTable} cells with real, focusable widgets (a
+ * {@link TextBox} for the main text, an optional {@link TextBox} for the detail text, an optional
+ * {@link ListBox} for the image and a delete {@link Button}). The detail and image widgets are
+ * shown or hidden according to the current ListView layout, mirroring the per-layout column logic
+ * the {@code CellTable} used to perform.
+ *
+ * <p>The row owns its backing {@link JSONObject}: {@link #toJsonObject()} writes the current widget
+ * values back into it and returns it, preserving any keys that belong to other layouts so the saved
+ * JSON stays identical to the previous implementation.
+ */
+public class ListViewDataRow extends Composite {
+
+  interface ListViewDataRowUiBinder extends UiBinder<HorizontalPanel, ListViewDataRow> {}
+
+  private static final ListViewDataRowUiBinder UI_BINDER =
+      GWT.create(ListViewDataRowUiBinder.class);
+
+  @UiField TextBox mainText;
+  @UiField TextBox detailText;
+  @UiField ListBox imagePicker;
+  @UiField Button delete;
+
+  private final JSONObject item;
+  private final boolean showDetail;
+  private final boolean showImage;
+
+  /**
+   * @param item the backing data for this row (mutated in place by {@link #toJsonObject()})
+   * @param showDetail whether the detail text field applies to the current layout
+   * @param showImage whether the image picker applies to the current layout
+   * @param imageChoices the asset names (including "None") to populate the image picker with
+   */
+  ListViewDataRow(JSONObject item, boolean showDetail, boolean showImage,
+      List<String> imageChoices) {
+    this.item = item;
+    this.showDetail = showDetail;
+    this.showImage = showImage;
+    initWidget(UI_BINDER.createAndBindUi(this));
+
+    delete.setText(MESSAGES.deleteButton());
+
+    mainText.setText(getString("Text1"));
+
+    if (showDetail) {
+      detailText.setText(getString("Text2"));
+    } else {
+      detailText.setVisible(false);
+    }
+
+    if (showImage) {
+      for (String choice : imageChoices) {
+        imagePicker.addItem(choice);
+      }
+      selectImage(getString("Image"));
+    } else {
+      imagePicker.setVisible(false);
+    }
+  }
+
+  /** Writes the current widget values back into the backing item and returns it. */
+  JSONObject toJsonObject() {
+    item.put("Text1", new JSONString(mainText.getText()));
+    if (showDetail) {
+      item.put("Text2", new JSONString(detailText.getText()));
+    }
+    if (showImage) {
+      int selected = imagePicker.getSelectedIndex();
+      String image = selected >= 0 ? imagePicker.getItemText(selected) : "None";
+      item.put("Image", new JSONString(image));
+    }
+    return item;
+  }
+
+  /** Returns the string value for {@code key}, or "" if absent or not a string. */
+  private String getString(String key) {
+    if (item.containsKey(key)) {
+      JSONValue value = item.get(key);
+      JSONString stringValue = value.isString();
+      if (stringValue != null) {
+        return stringValue.stringValue();
+      }
+    }
+    return "";
+  }
+
+  /** Selects the image-picker entry matching {@code value}, falling back to the first ("None"). */
+  private void selectImage(String value) {
+    for (int i = 0; i < imagePicker.getItemCount(); i++) {
+      if (imagePicker.getItemText(i).equals(value)) {
+        imagePicker.setSelectedIndex(i);
+        return;
+      }
+    }
+    imagePicker.setSelectedIndex(0);
+  }
+
+  @UiHandler("delete")
+  void onDelete(ClickEvent event) {
+    removeFromParent();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -9,6 +9,8 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.gwt.core.client.GWT;
 
+import com.google.gwt.dom.client.Style.Unit;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 
 import com.google.gwt.json.client.JSONObject;
@@ -47,6 +49,12 @@ public class ListViewDataRow extends Composite {
   private static final ListViewDataRowUiBinder UI_BINDER =
       GWT.create(ListViewDataRowUiBinder.class);
 
+  // Column widths, shared with the dialog header (ListViewAddDataDialog) so the header labels line
+  // up with the fields below them. Combined with box-sizing: border-box on the fields, the rendered
+  // widths match these values exactly.
+  static final String COLUMN_TEXT_WIDTH = "150px";
+  static final String COLUMN_IMAGE_WIDTH = "130px";
+
   @UiField TextBox mainText;
   @UiField TextBox detailText;
   @UiField ListBox imagePicker;
@@ -69,7 +77,14 @@ public class ListViewDataRow extends Composite {
     this.showImage = showImage;
     initWidget(UI_BINDER.createAndBindUi(this));
 
+    mainText.setWidth(COLUMN_TEXT_WIDTH);
+    detailText.setWidth(COLUMN_TEXT_WIDTH);
+    imagePicker.setWidth(COLUMN_IMAGE_WIDTH);
+
     delete.setText(MESSAGES.deleteButton());
+    // The dialog stylesheet puts a 10px margin on every button; remove it for the in-row delete
+    // button so the rows stay compact.
+    delete.getElement().getStyle().setMargin(0, Unit.PX);
 
     mainText.setText(getString("Text1"));
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
@@ -1,0 +1,30 @@
+<!-- Copyright 2025 MIT, All rights reserved -->
+<!-- Released under the Apache License, Version 2.0 -->
+<!-- http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+    xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+  <ui:style>
+    .row {
+      padding: 2px 0;
+    }
+    .field {
+      margin-right: 8px;
+    }
+    .text {
+      width: 150px;
+    }
+    .image {
+      width: 130px;
+    }
+  </ui:style>
+
+  <g:HorizontalPanel ui:field="container" styleName="{style.row}"
+      verticalAlignment="ALIGN_MIDDLE">
+    <g:TextBox ui:field="mainText" addStyleNames="{style.text} {style.field}"/>
+    <g:TextBox ui:field="detailText" addStyleNames="{style.text} {style.field}"/>
+    <g:ListBox ui:field="imagePicker" addStyleNames="{style.image} {style.field}"/>
+    <g:Button ui:field="delete"/>
+  </g:HorizontalPanel>
+</ui:UiBinder>

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.ui.xml
@@ -9,22 +9,19 @@
     .row {
       padding: 2px 0;
     }
+    /* border-box so a field's rendered width equals the width set in Java, which is the same value
+       the dialog uses for the matching header label, keeping the header and columns aligned. */
     .field {
+      box-sizing: border-box;
       margin-right: 8px;
-    }
-    .text {
-      width: 150px;
-    }
-    .image {
-      width: 130px;
     }
   </ui:style>
 
   <g:HorizontalPanel ui:field="container" styleName="{style.row}"
       verticalAlignment="ALIGN_MIDDLE">
-    <g:TextBox ui:field="mainText" addStyleNames="{style.text} {style.field}"/>
-    <g:TextBox ui:field="detailText" addStyleNames="{style.text} {style.field}"/>
-    <g:ListBox ui:field="imagePicker" addStyleNames="{style.image} {style.field}"/>
+    <g:TextBox ui:field="mainText" addStyleNames="{style.field}"/>
+    <g:TextBox ui:field="detailText" addStyleNames="{style.field}"/>
+    <g:ListBox ui:field="imagePicker" addStyleNames="{style.field}"/>
     <g:Button ui:field="delete"/>
   </g:HorizontalPanel>
 </ui:UiBinder>


### PR DESCRIPTION


> **This is a follow-up to #3990** ("Migrate ListView ListData editor dialog chrome to UiBinder"). That PR converted the dialog *chrome* to UiBinder while leaving the `CellTable` inside; this PR is the second and final step of that migration.

**What does this PR accomplish?**

*Description*

Follow-up to #3990, which migrated the ListView **ListData** editor's dialog *chrome* to UiBinder but kept the original `CellTable` inside. This PR completes the migration by replacing the `CellTable` itself with real, focusable widgets.

**What changed:**
- **New `ListViewDataRow.{java,ui.xml}`** — one editable row as a UiBinder `Composite` (`initWidget`, mirroring the existing `ProjectListItem` pattern) containing real widgets: a `TextBox` for the main text, an optional `TextBox` for the detail text, an optional `ListBox` image picker, and a delete `Button`. `toJsonObject()` writes the widget values back into the row's backing item; the delete button removes the row via `removeFromParent()`.
- **`ListViewAddDataDialog.{java,ui.xml}`** — the `CellTable` (and its `ListDataProvider` model, working-copy list, and column-building/cell-factory methods) is removed. The dialog now holds the rows in a `FlowPanel` (`rowsContainer`) with a lightweight header row. Whether a row exposes the detail field and/or the image picker is derived from the current `ListViewLayout` and applied by **showing/hiding** the row's widgets, instead of adding/removing columns. The rows are the source of truth (no separate working copy): load builds one `ListViewDataRow` per item, Add appends a blank row, and Save iterates the rows to rebuild the JSON array.

The accessible `Dialog` wrapper, focus-trap behavior, and Cancel-confirm dialog from #3990 are unchanged. The saved `ListData` JSON contract is **identical** to before (same keys, same per-layout null-ing).


**Context for the changes**

This changes only the Designer/appengine UI of a property editor (GWT client code). It does **not** change anything that runs on the device, so it does not affect the companion — branched from `master` with `master` as the base.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

*(No blocks/designer API change — this is an internal refactor of an existing property editor's UI. No new property, no version bump, no upgrader, and the saved data format is unchanged.)*

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine

