### PR TITLE
Fix broken automutation

### DIFF
--- a/appinventor/blocklyeditor/src/mixins/dynamic_connections.js
+++ b/appinventor/blocklyeditor/src/mixins/dynamic_connections.js
@@ -68,20 +68,23 @@ AI.Blockly.Mixins.DynamicConnections = {
     if (!this.tempinput) {
       return;  // No pending connection.
     }
-    if (this.tempinput.connection.targetConnection) {
-      var repeatingInputName = this.repeatingInputName;
-      this.inputList.forEach(function (input, i) {
-        input.name = repeatingInputName + i;
-      });
-    } else if (this.tempinput) {
-      this.removeInput('TEMPINSERT');
-    }
-    this.tempinput = undefined;
+    // 1. Remove inputs with no targetConnection.
     for (var i = this.inputList.length - 1; i >= 0; i--) {
-      if (!this.inputList[i].connection.targetConnection) {
-        this.inputList.splice(i, 1);
+      var input = this.inputList[i];
+      if (!input.connection.targetConnection) {
+        // If 1st input is removed, call appendField to restore block TITLE.
+        var blockTitle;
+        if (i === 0) blockTitle = input.fieldRow[0].getValue();
+        this.removeInput(input.name);
+        if (i === 0) this.inputList[0].appendField(blockTitle);
       }
     }
+    // 2. Rename inputs name.
+    var repeatingInputName = this.repeatingInputName;
+    this.inputList.forEach(function (input, i) {
+      input.name = repeatingInputName + i;
+    });
+    this.tempinput = undefined;
     this.itemCount_ = this.inputList.length;
   }
 }


### PR DESCRIPTION
**What does this PR accomplish?**
This PR aims to FIX 2 issues:
1. Fix broken automutation in 'text_join' and 'lists_create_with' blocks.
2. Fix block TITLE disappearance on 1st input removal due to automutation.

*Description*
**Issue 1**: `finalizeConnections` handles the automutation, so when an input is added using automutation, it creates a tempinput 'TEMPINSERT'.

<img width="400" height="211" alt="REC-20260625142111-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/b3a849b8-6ef9-4a35-84d1-e581793bbaf5" />

**The Problem**: current order of execution of this function is `'rename all inputs then remove empty inputs'`

<img width="445" height="322" alt="Screenshot 2026-06-24 at 1 48 44 PM" src="https://github.com/user-attachments/assets/97d02101-6e70-4aa0-a9aa-016cc68d9bc2" />

This create errors when we open the mutator, inputs are missing + not in their correct positions (the whole workspace is broken now)

<img width="297" height="188" alt="image" src="https://github.com/user-attachments/assets/65837df8-882c-43ef-a842-1a7bd57733ee" />

**The Fix**: reverse the order of execution to `'remove empty inputs then rename all inputs'`

<img width="445" height="306" alt="Screenshot 2026-06-24 at 1 53 39 PM" src="https://github.com/user-attachments/assets/a47580d0-7c83-419b-a980-297e35204b22" />

✅ No missing input + inputs are in their correct positions

**Issue 2**: if the removed input is the 1st input of the block, it also removes the 'TITLE' of the block, e.g. `'join'`, `'make a list'`

<img width="400" height="188" alt="REC-20260625143735-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/fb51b2f7-9233-48de-83fe-d4422b7d9361" />

**The Fix**: code is refactored to add the field back to the new 1st input

*Testing Guidelines*
Please follow steps shown in GIFs attached

Fixes #3360 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
