### PR TITLE
Fix runtime crash when custom font asset is deleted

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidFontTypefaceChoicePropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidFontTypefaceChoicePropertyEditor.java
@@ -233,13 +233,13 @@ public final class YoungAndroidFontTypefaceChoicePropertyEditor extends Addition
   public void onProjectNodeRemoved(Project project, ProjectNode node) {
     if (node instanceof YoungAndroidAssetNode) {
       String assetName = node.getName();
-      
-      // Check whether our asset was removed.
       String currentValue = property.getValue();
-      if (node.getName().equals(currentValue)) {
-        // Our asset was removed.
-        choices.selectValue(MESSAGES.defaultFontTypeface());
-        property.setValue(MESSAGES.defaultFontTypeface());
+
+      // Check whether our asset was removed.
+      if (assetName.equals(currentValue)) {
+        // Our asset was removed, fallback to default.
+        choices.selectValue("0");
+        property.setValue("0");
       }
       
       // Remove the asset from the list.


### PR DESCRIPTION
**What does this PR accomplish?**
When a font asset was removed, FontTypeface was reset to the display string "default" instead of its internal value "0", causing the component (e.g. Label) to retain a stale asset path and crash at runtime.

_after font deletion_
<img width="1818" height="906" alt="should be 0" src="https://github.com/user-attachments/assets/ae87c754-4e4e-44a7-89d0-1ecc082884f6" />

*Testing Guidelines*
1. Add a Label, upload a font (.ttf) and set the FontTypeface of this Label to this new font
2. Connect your companion, No issue yet!
3. Disconnect the companion and delete the font now
4. Connect your companion again and this time you should not have a runtime error like this

<img width="442" height="440" alt="Screenshot 2026-06-27 at 10 25 01 PM" src="https://github.com/user-attachments/assets/781081c1-b3a0-4c38-a859-ff5a30e668ba" />

Fixes #3058 

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion (I'm not sure here)

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
