### PR TITLE
fix p shortcut after a11y changes

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -742,7 +742,7 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
     } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.isTextboxFocused()) {
       SourceStructureBox.getSourceStructureBox().getSourceStructureExplorer().getTree().setFocus(true);
     } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.isTextboxFocused()) {
-      PropertiesBox.getPropertiesBox().getElement().getElementsByTagName("a").getItem(0).focus();
+      designProperties.focusFirstCategory();
     } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.isTextboxFocused()) {
       AssetListBox.getAssetListBox().getAssetList().getTree().setFocus(true);
     }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/designer/DesignerEditor.java
@@ -739,11 +739,11 @@ public abstract class DesignerEditor<S extends SourceNode, T extends MockDesigne
           }
         }
       }
-    } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.isTextboxFocused()) {
+    } else if (event.getNativeKeyCode() == KeyCodes.KEY_T && !palettePanel.shouldSuppressShortcuts()) {
       SourceStructureBox.getSourceStructureBox().getSourceStructureExplorer().getTree().setFocus(true);
-    } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.isTextboxFocused()) {
+    } else if (event.getNativeKeyCode() == KeyCodes.KEY_P && !palettePanel.shouldSuppressShortcuts()) {
       designProperties.focusFirstCategory();
-    } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.isTextboxFocused()) {
+    } else if (event.getNativeKeyCode() == KeyCodes.KEY_M && !palettePanel.shouldSuppressShortcuts()) {
       AssetListBox.getAssetListBox().getAssetList().getTree().setFocus(true);
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
@@ -180,7 +180,7 @@ public abstract class AbstractPalettePanel<
       public void onKeyDown(KeyDownEvent event) {
         DesignToolbar designToolbar = Ode.getInstance().getDesignToolbar();
         if (designToolbar.currentView == DesignToolbar.View.DESIGNER && event.getNativeKeyCode() == 191
-                && !isTextboxFocused() && !event.isAltKeyDown()) {
+                && !shouldSuppressShortcuts() && !event.isAltKeyDown()) {
           {
             event.preventDefault();
             searchText.setFocus(true);
@@ -537,6 +537,14 @@ public abstract class AbstractPalettePanel<
     var element = $doc.activeElement;
     return element.tagName === 'INPUT' && element.type === 'text' || element.tagName === 'TEXTAREA';
   }-*/;
+
+  public native boolean isMenuOpen()/*-{
+    return $doc.querySelector('[aria-haspopup="menu"][aria-expanded="true"]') !== null;
+  }-*/;
+
+  public boolean shouldSuppressShortcuts() {
+    return isTextboxFocused() || isMenuOpen();
+  }
 
   private void requestRebuildList() {
     if (rebuild != null) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/SimplePalettePanel.java
@@ -44,4 +44,8 @@ public interface SimplePalettePanel {
   MockComponent createMockComponent(String name, String type);
 
   boolean isTextboxFocused();
+
+  boolean isMenuOpen();
+
+  boolean shouldSuppressShortcuts();
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaFormEditor.java
@@ -522,7 +522,7 @@ public final class YaFormEditor extends DesignerEditor<YoungAndroidFormNode, Moc
     if (!isActiveEditor()) {
       return;  // Not the active editor
     }
-    if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.isTextboxFocused()
+    if (event.getNativeKeyCode() == KeyCodes.KEY_V && !palettePanel.shouldSuppressShortcuts()
         && !(event.isControlKeyDown() || event.isMetaKeyDown())) {
       getVisibleComponentsPanel().focusCheckbox();
     } else {

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/AbstractCollapsiblePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/AbstractCollapsiblePanel.java
@@ -95,6 +95,13 @@ public abstract class AbstractCollapsiblePanel extends FlowPanel {
   }
 
   /**
+   * Focuses the header element of this panel (which has tabindex="0").
+   */
+  public void focus() {
+    header.getElement().focus();
+  }
+
+  /**
    * Adds a widget to the content area.
    *
    * @param widget the widget to add

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/ContextMenu.java
@@ -7,6 +7,9 @@
 package com.google.appinventor.client.widgets;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
@@ -149,6 +152,10 @@ public final class ContextMenu {
    */
   public void hide() {
     popupPanel.hide();
+  }
+
+  public HandlerRegistration addCloseHandler(CloseHandler<PopupPanel> handler) {
+    return popupPanel.addCloseHandler(handler);
   }
 
   /* Returns if the context menu is showing */

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/DropDownButton.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/DropDownButton.java
@@ -17,11 +17,14 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.uibinder.client.ElementParserToUse;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.MenuItem;
+import com.google.gwt.user.client.ui.PopupPanel;
 
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.UIObject;
@@ -140,6 +143,13 @@ public class DropDownButton extends TextButton {
           menu.moveSelectionDown();
           menu.focus();
         }
+      }
+    });
+
+    menu.addCloseHandler(new CloseHandler<PopupPanel>() {
+      @Override
+      public void onClose(CloseEvent<PopupPanel> event) {
+        updateAriaExpanded(false);
       }
     });
 

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PropertiesPanel.java
@@ -169,6 +169,15 @@ public class PropertiesPanel extends Composite implements ComponentDatabaseChang
   }
 
   /**
+   * Focuses the first category header in the panel, if one exists.
+   */
+  public void focusFirstCategory() {
+    if (panel.getWidgetCount() > 0) {
+      ((CollapsibleCategoryPanel) panel.getWidget(0)).focus();
+    }
+  }
+
+  /**
    * Set the label at the top of the properties panel. Note that you have
    * to do this after calling setProperties because it clears the label!
    * @param name


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
The p shortcut crashes the app cause it looks for the first a tag and it won't find it after a11y changes.
[EDIT] The second commit also fixes type ahead lookups when menus are open.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

Click on p with an open project and it will crash. Build this branch and then try m, p, v or other shortcuts, it should actually focus the properties panel with p.
[EDIT] for the second fix, open the 'Projects menu' and type m, it will focus the Media panel instead of focusing the 'Move To Trash' menu item. After the fix, all shortcuts should be disabled when a menu is open, so type ahead lookups (using the first letter of a menu item) should focus the menu item instead.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine


NOTE: These are two different fixes and can be merged as two different commits instead of squashing, but they are related enough to squash also, so whatever works.