### PR TITLE
Fix MockCircularProgress sizing

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircularProgress.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockCircularProgress.java
@@ -7,33 +7,63 @@
 package com.google.appinventor.client.editor.simple.components;
 
 import com.google.appinventor.client.editor.simple.SimpleEditor;
-import com.google.gwt.user.client.ui.InlineHTML;
+import com.google.appinventor.client.editor.simple.components.utils.SVGPanel;
+import com.google.gwt.user.client.ui.SimplePanel;
 
 
 public final class MockCircularProgress extends MockVisibleComponent {
-
-
   public static final String TYPE = "CircularProgress";
   private static final String PROPERTY_NAME_COLOR = "Color";
-  private InlineHTML progressBarWidget;
+  private static final String DEFAULT_COLOR = "&HFF0000FF"; // Blue.
+  private static final int DEFAULT_SIZE = 40;
+
+  private final SimplePanel panel; // Root panel that holds svgpanel.
+  private final SVGPanel svgpanel;
 
   public MockCircularProgress(SimpleEditor editor) {
     super(editor, TYPE, images.circularProgress());
 
-    progressBarWidget = new InlineHTML();
-    progressBarWidget.setStylePrimaryName("ode-SimpleMockComponent");
-    progressBarWidget.setText("\u25ef");
-    MockComponentsUtil.setWidgetFontSize(progressBarWidget, "35");
-    MockComponentsUtil.setWidgetTextAlign(progressBarWidget, "1");
-    MockComponentsUtil.setWidgetFontBold(progressBarWidget, "bold");
-    initComponent(progressBarWidget);
+    panel = new SimplePanel();
+    panel.setStylePrimaryName("ode-SimpleMockComponent");
+
+    svgpanel = new SVGPanel();
+    svgpanel.getElement().setAttribute("viewBox", "0 0 40 40");
+
+    panel.setWidget(svgpanel);
+    updateProgressSize(DEFAULT_SIZE, DEFAULT_SIZE);
+
+    initComponent(panel);
+    setIndeterminateColorProperty(DEFAULT_COLOR);
+  }
+
+  private void updateProgressSize(int width, int height) {
+    panel.setPixelSize(width, height);
+    svgpanel.setPixelSize(width, height);
   }
 
   private void setIndeterminateColorProperty(String text) {
     if (MockComponentsUtil.isDefaultColor(text)) {
-      text = "&HFFFFFFFF";  //white
+      text = DEFAULT_COLOR;
     }
-    MockComponentsUtil.setWidgetTextColor(progressBarWidget, text);
+    String color = MockComponentsUtil.getColor(text).toString();
+    svgpanel.setInnerSVG("<circle cx=\"20\" cy=\"20\" r=\"16\" fill=\"none\" "
+        + "stroke=\"" + color + "\" stroke-width=\"4\"/>");
+  }
+
+  @Override
+  public int getPreferredWidth() {
+    return DEFAULT_SIZE;
+  }
+
+  @Override
+  public int getPreferredHeight() {
+    return DEFAULT_SIZE;
+  }
+
+  @Override
+  public void setPixelSize(int width, int height) {
+    super.setPixelSize(width, height);
+    updateProgressSize(width, height);
   }
 
   @Override


### PR DESCRIPTION
**What does this PR accomplish?**
This PR aims to fix a sizing issue in `MockCircularProgress`: the `progressBarWidget` does not size correctly when the height/width of the component is changed.

*Description*
1. Replace `InlineHTML` with an `SVGPanel` containing the circle, so it resizes correctly when the height/width properties change.
2. Wrap the `SVGPanel` in a `SimplePanel`.
3. Add `updateProgressSize` to update the size of both the `panel` and the `svgpanel`.

_Fixed now_

https://github.com/user-attachments/assets/42a86138-a3e2-4d7c-ae97-0b4259588a66

*Testing Guidelines*
Follow steps shown in screen recording.

Fixes #4022

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
