### PR TITLE
Apply text changes to all DropDownButton faces

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/TextButton.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/TextButton.java
@@ -63,6 +63,17 @@ public class TextButton extends PushButton {
     });
   }
 
+  @Override
+  public void setText(String text) {
+    // Because there is no good way to iterate over all the combinations...
+    getUpFace().setText(text);
+    getDownFace().setText(text);
+    getUpDisabledFace().setText(text);
+    getDownDisabledFace().setText(text);
+    getUpHoveringFace().setText(text);
+    getDownHoveringFace().setText(text);
+  }
+
   protected String makeText(String caption, Icon icon) {
     String text = "";
     if (icon != null) {


### PR DESCRIPTION
Change-Id: I82bf16633ba41bbe783b5bd3c88063840c3fecc6

**What does this PR accomplish?**

This PR fixes a small issue where occasionally the screen dropdown shows the wrong screen name when hovered. The reason being is that `setText(String)` only modifies the current state of the button and there are 6 possible states. Rather than relying on the current face, which could be the hover state, we just change all 6 options simultaneously.

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [ ] Indentation has been doubled checked
    - [ ] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
