### PR TITLE
fix keyboard trap for / search shortcut and click

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/palette/AbstractPalettePanel.java
@@ -19,6 +19,7 @@ import com.google.appinventor.shared.simple.ComponentDatabaseChangeListener;
 import com.google.appinventor.shared.simple.ComponentDatabaseInterface;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -84,6 +85,7 @@ public abstract class AbstractPalettePanel<
 
   private final TextBox searchText;
   private final FlowPanel searchResults;
+  private Element previousFocus;
   private JsArrayString arrayString = (JsArrayString) JsArrayString.createArray();
   private String lastSearch = "";
   private Map<String, SimplePaletteItem> searchSimplePaletteItems = new HashMap<String, SimplePaletteItem>();
@@ -183,6 +185,7 @@ public abstract class AbstractPalettePanel<
                 && !shouldSuppressShortcuts() && !event.isAltKeyDown()) {
           {
             event.preventDefault();
+            previousFocus = getActiveElement();
             searchText.setFocus(true);
           }
         }
@@ -256,8 +259,17 @@ public abstract class AbstractPalettePanel<
     @Override
     public void onKeyDown(KeyDownEvent event) {
       if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE) {
+        event.preventDefault();
+        event.stopPropagation();
         searchResults.clear();
         searchText.setText("");
+        lastSearch = "";
+        doSearch();
+        if (previousFocus != null && canReceiveFocus(previousFocus)) {
+          previousFocus.focus();
+        } else {
+          searchText.getElement().blur();
+        }
       }
     }
   }
@@ -545,6 +557,14 @@ public abstract class AbstractPalettePanel<
   public boolean shouldSuppressShortcuts() {
     return isTextboxFocused() || isMenuOpen();
   }
+
+  private native boolean canReceiveFocus(Element el)/*-{
+    return $doc.body.contains(el) && el.offsetParent != null;
+  }-*/;
+
+  private native Element getActiveElement()/*-{
+    return $doc.activeElement;
+  }-*/;
 
   private void requestRebuildList() {
     if (rebuild != null) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
There is a keyboard trap either using the '/' shortcut or clicking in the search bar on top of the components; once you are there, there is no way to get out of it with the keyboard alone. This adds 'esc' to go back to previous focus (if any) or just blur out of the box if no previous focus or click into the box was used.

<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
Click on the search box for components; there is no way to 'esc' out of it and this is a keyboard trap in accessibility.
After building this branch you should be able to 'esc' out of the box.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
