### PR TITLE
Add keyboard navigation to the ListView ListData editor

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5283,6 +5283,8 @@ public interface OdeMessages extends Messages, ComponentTranslations {
     "<tr><td>Reset Connection</td><td>Alt + Shift + R</td></tr>" +
     "<tr><td>Refresh Companion Screen</td><td>Alt + R</td></tr>" +
     "<tr><td>Navigate Components in components tree</td><td>↑/↓</td></tr>" +
+    "<tr><td>Add a row in the ListView data editor</td><td>Enter</td></tr>" +
+    "<tr><td>Navigate rows in the ListView data editor</td><td>↑/↓</td></tr>" +
     "<tr><td>Open this dialog</td><td>Alt + ?</td></tr>" +
     "</tbody>" +
     "</table>")

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -5285,6 +5285,7 @@ public interface OdeMessages extends Messages, ComponentTranslations {
     "<tr><td>Navigate Components in components tree</td><td>↑/↓</td></tr>" +
     "<tr><td>Add a row in the ListView data editor</td><td>Enter</td></tr>" +
     "<tr><td>Navigate rows in the ListView data editor</td><td>↑/↓</td></tr>" +
+    "<tr><td>Move to the next / previous field in the ListView data editor</td><td>Tab / Shift+Tab</td></tr>" +
     "<tr><td>Open this dialog</td><td>Alt + ?</td></tr>" +
     "</tbody>" +
     "</table>")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -111,13 +111,26 @@ public class ListViewAddDataDialog {
     updateCount();
   }
 
-  /** Creates a data row wired to refresh the item count when it deletes itself. */
+  /** Creates a data row wired to the dialog's count refresh and keyboard navigation. */
   private ListViewDataRow newRow(JSONObject item) {
     return new ListViewDataRow(item, showDetail, showImage, imageChoices, imageUrls,
-        new Runnable() {
+        new ListViewDataRow.Callbacks() {
           @Override
-          public void run() {
+          public void onRowDeleted() {
             updateCount();
+          }
+
+          @Override
+          public void onEnterAddRow() {
+            addBlankRow().focusColumn(ListViewDataRow.COL_MAIN);
+          }
+
+          @Override
+          public void onMoveFocus(ListViewDataRow from, int deltaRows, int column) {
+            int index = rowsContainer.getWidgetIndex(from) + deltaRows;
+            if (index >= 0 && index < rowsContainer.getWidgetCount()) {
+              ((ListViewDataRow) rowsContainer.getWidget(index)).focusColumn(column);
+            }
           }
         });
   }
@@ -174,6 +187,11 @@ public class ListViewAddDataDialog {
 
   @UiHandler("addRow")
   void onAddRow(ClickEvent event) {
+    addBlankRow().focusColumn(ListViewDataRow.COL_MAIN);
+  }
+
+  /** Appends a blank row for the current layout, refreshes the count, and returns it. */
+  private ListViewDataRow addBlankRow() {
     // creates a row with default data for the corresponding layout type
     JSONObject data = new JSONObject();
     data.put("Text1", new JSONString(""));
@@ -183,8 +201,10 @@ public class ListViewAddDataDialog {
     if (showImage) {
       data.put("Image", new JSONString("None"));
     }
-    rowsContainer.add(newRow(data));
+    ListViewDataRow row = newRow(data);
+    rowsContainer.add(row);
     updateCount();
+    return row;
   }
 
   @UiHandler("save")

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.java
@@ -122,7 +122,7 @@ public class ListViewAddDataDialog {
 
           @Override
           public void onEnterAddRow() {
-            addBlankRow().focusColumn(ListViewDataRow.COL_MAIN);
+            addBlankRow().focusFirstCell();
           }
 
           @Override
@@ -187,7 +187,7 @@ public class ListViewAddDataDialog {
 
   @UiHandler("addRow")
   void onAddRow(ClickEvent event) {
-    addBlankRow().focusColumn(ListViewDataRow.COL_MAIN);
+    addBlankRow().focusFirstCell();
   }
 
   /** Appends a blank row for the current layout, refreshes the count, and returns it. */

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewAddDataDialog.ui.xml
@@ -19,8 +19,8 @@
       </g:FlowPanel>
 
       <g:FlowPanel styleName="lie-foot">
-        <g:Button ui:field="cancel" styleName="lie-btn" addStyleNames="lie-btn-ghost"/>
-        <g:Button ui:field="save" styleName="lie-btn" addStyleNames="lie-btn-primary"/>
+        <g:Button ui:field="cancel" styleName="ode-TextButton"/>
+        <g:Button ui:field="save" styleName="ode-TextButton"/>
       </g:FlowPanel>
 
       <g:Button ui:field="bottomInvisible" styleName="FocusTrap" tabIndex="-1"/>

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -59,6 +59,23 @@ public class ListViewDataRow extends Composite {
   /** Sentinel value used by the ListData JSON for "no image". */
   private static final String NO_IMAGE = "None";
 
+  /** Column identifiers used for column-preserving Up/Down navigation between rows. */
+  static final int COL_THUMB = 0;
+  static final int COL_MAIN = 1;
+  static final int COL_DETAIL = 2;
+
+  /** Lets the dialog react to per-row keyboard actions (delete, Enter-to-add, Up/Down navigation). */
+  interface Callbacks {
+    /** The row deleted itself; the dialog should refresh its item count. */
+    void onRowDeleted();
+
+    /** Enter was pressed in a text field: append a new row and focus its first field. */
+    void onEnterAddRow();
+
+    /** Up/Down was pressed: move focus {@code deltaRows} away from {@code from}, same {@code column}. */
+    void onMoveFocus(ListViewDataRow from, int deltaRows, int column);
+  }
+
   @UiField FlowPanel container;
   @UiField FlowPanel thumbColumn;
   @UiField FocusPanel thumbTile;
@@ -72,7 +89,7 @@ public class ListViewDataRow extends Composite {
   private final boolean showImage;
   private final List<String> imageChoices;
   private final Map<String, String> imageUrls;
-  private final Runnable onDelete;
+  private final Callbacks callbacks;
 
   /** The currently selected image asset name (or {@link #NO_IMAGE}). */
   private String selectedImage = NO_IMAGE;
@@ -83,16 +100,16 @@ public class ListViewDataRow extends Composite {
    * @param showImage whether the image picker applies to the current layout
    * @param imageChoices the asset names (including "None") offered by the picker
    * @param imageUrls map from asset name to a previewable URL (no entry for "None")
-   * @param onDelete callback invoked after this row removes itself (lets the dialog update its count)
+   * @param callbacks hooks the dialog uses to react to this row's keyboard actions
    */
   ListViewDataRow(JSONObject item, boolean showDetail, boolean showImage,
-      List<String> imageChoices, Map<String, String> imageUrls, Runnable onDelete) {
+      List<String> imageChoices, Map<String, String> imageUrls, Callbacks callbacks) {
     this.item = item;
     this.showDetail = showDetail;
     this.showImage = showImage;
     this.imageChoices = imageChoices;
     this.imageUrls = imageUrls;
-    this.onDelete = onDelete;
+    this.callbacks = callbacks;
     initWidget(UI_BINDER.createAndBindUi(this));
 
     delete.setText("×");  // multiplication sign, used as a compact close/delete glyph
@@ -101,9 +118,11 @@ public class ListViewDataRow extends Composite {
     delete.setTitle(MESSAGES.deleteButton());
 
     mainText.setText(getString("Text1"));
+    addKeyNav(mainText, COL_MAIN);
 
     if (showDetail) {
       detailText.setText(getString("Text2"));
+      addKeyNav(detailText, COL_DETAIL);
     } else {
       detailText.setVisible(false);
     }
@@ -126,6 +145,12 @@ public class ListViewDataRow extends Composite {
           if (key == KeyCodes.KEY_ENTER || key == KeyCodes.KEY_SPACE) {
             event.preventDefault();
             openImagePicker();
+          } else if (key == KeyCodes.KEY_UP) {
+            event.preventDefault();
+            callbacks.onMoveFocus(ListViewDataRow.this, -1, COL_THUMB);
+          } else if (key == KeyCodes.KEY_DOWN) {
+            event.preventDefault();
+            callbacks.onMoveFocus(ListViewDataRow.this, 1, COL_THUMB);
           }
         }
       });
@@ -196,8 +221,47 @@ public class ListViewDataRow extends Composite {
   @UiHandler("delete")
   void onDeleteClicked(ClickEvent event) {
     removeFromParent();
-    if (onDelete != null) {
-      onDelete.run();
+    if (callbacks != null) {
+      callbacks.onRowDeleted();
+    }
+  }
+
+  /**
+   * Wires Enter (append a new row) and Up/Down (column-preserving row navigation) on {@code box}, so
+   * data can be entered without the mouse. Tab/Shift-Tab still move between fields natively.
+   */
+  private void addKeyNav(TextBox box, final int column) {
+    box.addKeyDownHandler(new KeyDownHandler() {
+      @Override
+      public void onKeyDown(KeyDownEvent event) {
+        switch (event.getNativeKeyCode()) {
+          case KeyCodes.KEY_ENTER:
+            event.preventDefault();
+            callbacks.onEnterAddRow();
+            break;
+          case KeyCodes.KEY_UP:
+            event.preventDefault();
+            callbacks.onMoveFocus(ListViewDataRow.this, -1, column);
+            break;
+          case KeyCodes.KEY_DOWN:
+            event.preventDefault();
+            callbacks.onMoveFocus(ListViewDataRow.this, 1, column);
+            break;
+          default:
+            break;
+        }
+      }
+    });
+  }
+
+  /** Moves keyboard focus to the given column of this row, falling back to the main text field. */
+  void focusColumn(int column) {
+    if (column == COL_THUMB && showImage) {
+      thumbTile.setFocus(true);
+    } else if (column == COL_DETAIL && showDetail) {
+      detailText.setFocus(true);
+    } else {
+      mainText.setFocus(true);
     }
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -269,6 +269,11 @@ public class ListViewDataRow extends Composite {
     }
   }
 
+  /** Focuses the first cell of the row: the image tile if the layout has one, else the main text. */
+  void focusFirstCell() {
+    focusColumn(COL_THUMB);  // COL_THUMB falls back to the main text field when there is no image
+  }
+
   /**
    * A small popup that lists "None" plus every project image asset (with a preview swatch) and
    * reports the chosen asset name back through {@link Callback}. This realizes Susan's preferred

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/ListViewDataRow.java
@@ -8,6 +8,7 @@ package com.google.appinventor.client.editor.youngandroid.properties;
 import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -33,6 +34,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.TextBox;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -213,9 +215,11 @@ public class ListViewDataRow extends Composite {
           public void onImageSelected(String name) {
             selectedImage = name;
             updateThumbnail();
+            thumbTile.setFocus(true);  // return focus to the tile after choosing
           }
         });
     picker.showRelativeTo(thumbTile);
+    picker.focusSelected();
   }
 
   @UiHandler("delete")
@@ -276,6 +280,12 @@ public class ListViewDataRow extends Composite {
       void onImageSelected(String name);
     }
 
+    /** The focusable choice tiles, in display order, for arrow-key navigation. */
+    private final List<FocusPanel> items = new ArrayList<FocusPanel>();
+
+    /** Index of the tile to focus when the picker opens (the current selection, else the first). */
+    private int selectedIndex = 0;
+
     AssetImagePicker(List<String> choices, Map<String, String> urls, String current,
         final Callback callback) {
       super(true, false);  // autoHide, non-modal
@@ -285,10 +295,11 @@ public class ListViewDataRow extends Composite {
       list.setStyleName("lie-picker");
 
       for (final String name : choices) {
-        FocusPanel item = new FocusPanel();
+        final FocusPanel item = new FocusPanel();
         item.setStyleName("lie-picker-item");
         if (name.equals(current)) {
           item.addStyleName("lie-picker-selected");
+          selectedIndex = items.size();
         }
         item.getElement().setTabIndex(0);
 
@@ -318,18 +329,54 @@ public class ListViewDataRow extends Composite {
         item.addKeyDownHandler(new KeyDownHandler() {
           @Override
           public void onKeyDown(KeyDownEvent event) {
-            int key = event.getNativeKeyCode();
-            if (key == KeyCodes.KEY_ENTER || key == KeyCodes.KEY_SPACE) {
-              event.preventDefault();
-              callback.onImageSelected(name);
-              hide();
+            switch (event.getNativeKeyCode()) {
+              case KeyCodes.KEY_ENTER:
+              case KeyCodes.KEY_SPACE:
+                event.preventDefault();
+                callback.onImageSelected(name);
+                hide();
+                break;
+              case KeyCodes.KEY_UP:
+                event.preventDefault();
+                focusItem(items.indexOf(item) - 1);
+                break;
+              case KeyCodes.KEY_DOWN:
+                event.preventDefault();
+                focusItem(items.indexOf(item) + 1);
+                break;
+              case KeyCodes.KEY_ESCAPE:
+                event.preventDefault();
+                hide();
+                break;
+              default:
+                break;
             }
           }
         });
+        items.add(item);
         list.add(item);
       }
 
       setWidget(list);
+    }
+
+    /** Focuses the choice tile at {@code index}, clamped to the valid range. */
+    private void focusItem(int index) {
+      if (items.isEmpty()) {
+        return;
+      }
+      int clamped = Math.max(0, Math.min(index, items.size() - 1));
+      items.get(clamped).setFocus(true);
+    }
+
+    /** Moves keyboard focus into the picker (the current selection). Call after showing. */
+    void focusSelected() {
+      Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+        @Override
+        public void execute() {
+          focusItem(selectedIndex);
+        }
+      });
     }
   }
 }

--- a/appinventor/appengine/war/static/css/Ya.css
+++ b/appinventor/appengine/war/static/css/Ya.css
@@ -3832,31 +3832,6 @@ div.dropdiv p {
   border-top: 1px solid #eee;
   background: #fafafa;
 }
-.lie-btn {
-  border: none;
-  border-radius: 4px;
-  font: 500 13px 'Roboto', sans-serif;
-  cursor: pointer;
-  margin: 0;
-}
-.lie-btn-ghost {
-  padding: 8px 16px;
-  background: none;
-  color: #888888;
-}
-.lie-btn-ghost:hover {
-  background: #ededed;
-  color: #555555;
-}
-.lie-btn-primary {
-  padding: 8px 22px;
-  background: #a5cf47;
-  color: #33401a;
-}
-.lie-btn-primary:hover {
-  background: #98c23a;
-}
-
 /* ---- Image picker popup (Susan's click-the-thumbnail option) ------ */
 .lie-picker {
   max-height: 280px;


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Adds full keyboard navigation to the ListView **ListData** editor — the pop-up
opened by the *Click to Add/Delete Data* button on a ListView's `ListData`
property — so item data can be entered and moved through entirely from the
keyboard, with no mouse.

This builds on the earlier migration of the editor's rows from a virtualized
`CellTable` to real focusable widgets (`TextBox`/`FocusPanel`/`Button`). With
real widgets in place, this PR wires up the key handling:

| Key | Where | Action |
|---|---|---|
| Tab | any control | next control (forward) |
| Shift+Tab | any control | previous control (back) |
| Enter | main / detail text field | append a new blank row + focus its main field |
| ↓ Arrow Down | text field or thumbnail tile | same column, next row |
| ↑ Arrow Up | text field or thumbnail tile | same column, previous row |
| ← / → | text field | move caret in the field |
| Enter / Space | thumbnail tile | open image picker |
| Enter / Space | delete button | delete the row |
| Esc | anywhere in dialog | close dialog |

Notes:
- Tab/Shift+Tab already worked once the rows became real widgets; this PR adds
  Enter (append + focus), Up/Down (column-preserving row navigation), and makes
  the **Add Row** button also focus the new row.
- Up/Down are safe to repurpose because the fields are single-line text boxes,
  where those keys are otherwise unused; Left/Right are left to move the caret.
- The logic lives in the two files that own the widgets — no new files.
  `ListViewDataRow` detects the keys on its own widgets and reports them through
  a small `Callbacks` interface; `ListViewAddDataDialog` makes the cross-row
  decisions (append a row, focus a sibling).
- **No data-contract change:** the saved `ListData` JSON (`[{Text1, Text2,
  Image}]`) is byte-for-byte identical. Designer/appengine only — no companion
  or runtime impact.

**Context for the changes**

Designer/appengine-only change to a property editor. It does not touch the
components runtime or the companion, and adds no new blocks/designer API (no
`SimpleProperty`, so no `YaVersion`/upgrader/`versioning.js` changes). Branched
from `master`, base `master`.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
