### PR TITLE
Add native Padding/Margin properties to visible components

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/LayoutInfo.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/LayoutInfo.java
@@ -41,6 +41,23 @@ abstract class LayoutInfo {
     }
   }
 
+
+  public int getLayoutWidth() {
+    if (component instanceof MockVisibleComponent && width >= 0) {
+      MockVisibleComponent visibleComp = (MockVisibleComponent) component;
+      return width + visibleComp.getPaddingSumWidth() + visibleComp.getMarginSumWidth();
+    }
+    return width;
+  }
+
+  public int getLayoutHeight() {
+    if (component instanceof MockVisibleComponent && height >= 0) {
+      MockVisibleComponent visibleComp = (MockVisibleComponent) component;
+      return height + visibleComp.getPaddingSumHeight() + visibleComp.getMarginSumHeight();
+    }
+    return height;
+  }
+
   protected void prepareToGatherDimensions() {
   }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockHVLayoutBase.java
@@ -270,7 +270,7 @@ abstract class MockHVLayoutBase extends MockLayout {
     for (MockComponent child : containerLayoutInfo.visibleChildren) {
       LayoutInfo childLayoutInfo = containerLayoutInfo.layoutInfoMap.get(child);
       if (childLayoutInfo.width != MockVisibleComponent.LENGTH_FILL_PARENT) {
-        width = Math.max(width, childLayoutInfo.width + BORDER_SIZE);
+        width = Math.max(width, childLayoutInfo.getLayoutWidth() + BORDER_SIZE);
         allFillParent = false;
       }
     }
@@ -298,6 +298,9 @@ abstract class MockHVLayoutBase extends MockLayout {
         childHeight = childLayoutInfo.calculateAutomaticHeight();
       } else if (childHeight <= MockVisibleComponent.LENGTH_PERCENT_TAG) {
         childHeight = convertFromPercent(childHeight, Dim.HEIGHT);
+      }else {
+        // Fetch the inflated footprint if it is an absolute metric size
+        childHeight = childLayoutInfo.getLayoutHeight();
       }
       height += childHeight + BORDER_SIZE;
     }
@@ -399,8 +402,8 @@ abstract class MockHVLayoutBase extends MockLayout {
       topY += COMPONENT_SPACING;
 
       LayoutInfo childLayoutInfo = containerLayoutInfo.layoutInfoMap.get(child);
-      int childWidthWithBorder = childLayoutInfo.width + BORDER_SIZE;
-      int childHeightWithBorder = childLayoutInfo.height + BORDER_SIZE;
+      int childWidthWithBorder = childLayoutInfo.getLayoutWidth() + BORDER_SIZE;
+      int childHeightWithBorder = childLayoutInfo.getLayoutHeight() + BORDER_SIZE;
 
       // leftX is where the left edge of the child should be.  For a vertical alignment
       // it's either zero (left align) or set so the center of child is at the centered
@@ -437,8 +440,8 @@ abstract class MockHVLayoutBase extends MockLayout {
     int height = 0;
     for (MockComponent child : containerLayoutInfo.visibleChildren) {
       LayoutInfo childLayoutInfo = containerLayoutInfo.layoutInfoMap.get(child);
-      if (childLayoutInfo.height != MockVisibleComponent.LENGTH_FILL_PARENT) {
-        height = Math.max(height, childLayoutInfo.height + BORDER_SIZE);
+      if (childLayoutInfo.getLayoutHeight() != MockVisibleComponent.LENGTH_FILL_PARENT) {
+        height = Math.max(height, childLayoutInfo.getLayoutHeight() + BORDER_SIZE);
         allFillParent = false;
       }
     }
@@ -593,8 +596,8 @@ abstract class MockHVLayoutBase extends MockLayout {
       }
       dividerLocations[index] = leftX;
       LayoutInfo childLayoutInfo = containerLayoutInfo.layoutInfoMap.get(child);
-      int childWidthWithBorder = childLayoutInfo.width + BORDER_SIZE;
-      int childHeightWithBorder = childLayoutInfo.height + BORDER_SIZE;
+      int childWidthWithBorder = childLayoutInfo.getLayoutWidth() + BORDER_SIZE;
+      int childHeightWithBorder = childLayoutInfo.getLayoutHeight() + BORDER_SIZE;
 
       // topY is where the top of each component goes.  It starts out either at zero, or offset
       // so the entire stack is vertically centered in the arrangement (i.e., offset by

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -72,7 +72,8 @@ public abstract class MockVisibleComponent extends MockComponent {
   protected static final String PROPERTY_NAME_LISTVIEW_LAYOUT = "ListViewLayout";
   protected static final String PROPERTY_NAME_TEXT_ALIGNMENT_MAIN = "TextAlignmentMain";
   protected static final String PROPERTY_NAME_TEXT_ALIGNMENT_DETAIL = "TextAlignmentDetail";
-
+  protected static final String PROPERTY_NAME_PADDING = "Padding";
+  protected static final String PROPERTY_NAME_MARGIN = "Margin";
   // Note: the values below are duplicated in Component.java
   // If you change them here, change them there!
 
@@ -202,11 +203,89 @@ public abstract class MockVisibleComponent extends MockComponent {
       refreshForm();
     } else if (propertyName.equals(PROPERTY_NAME_TOP)) {
       refreshForm();
+    } else if (propertyName.equals(PROPERTY_NAME_PADDING)) {
+      applyMockPadding(newValue);
+      refreshForm();
+    } else if (propertyName.equals(PROPERTY_NAME_MARGIN)) {
+      applyMockMargin(newValue);
+      refreshForm();
     }
   }
   
   public SimpleNonVisibleComponentsPanel getNonVisibleComponentsPanel() {
     return editor.getNonVisibleComponentsPanel();
+  }
+
+  private void applyMockPadding(String paddingValues) {
+    if (paddingValues != null && paddingValues.contains(",")) {
+      String[] sides = paddingValues.split(",");
+      if (sides.length == 4) {
+        try {
+          Widget w = getWidget();
+          if (w != null && w.getElement() != null) {
+            com.google.gwt.dom.client.Style style = w.getElement().getStyle();
+            style.setProperty("paddingTop", Integer.parseInt(sides[0].trim()) + "px");
+            style.setProperty("paddingLeft", Integer.parseInt(sides[1].trim()) + "px");
+            style.setProperty("paddingRight", Integer.parseInt(sides[2].trim()) + "px");
+            style.setProperty("paddingBottom", Integer.parseInt(sides[3].trim()) + "px");
+          }
+        } catch (NumberFormatException e) {
+          // Graceful catch
+        }
+      }
+    }
+  }
+
+  private void applyMockMargin(String marginValues) {
+    if (marginValues != null && marginValues.contains(",")) {
+      String[] sides = marginValues.split(",");
+      if (sides.length == 4) {
+        try {
+          Widget w = getWidget();
+          if (w != null && w.getElement() != null) {
+            com.google.gwt.dom.client.Style style = w.getElement().getStyle();
+            style.setProperty("marginTop", Integer.parseInt(sides[0].trim()) + "px");
+            style.setProperty("marginLeft", Integer.parseInt(sides[1].trim()) + "px");
+            style.setProperty("marginRight", Integer.parseInt(sides[2].trim()) + "px");
+            style.setProperty("marginBottom", Integer.parseInt(sides[3].trim()) + "px");
+          }
+        } catch (NumberFormatException e) {
+          // Graceful catch
+        }
+      }
+    }
+  }
+
+  public int getPaddingSumHeight() {
+    return getSideValueSum(properties.getProperty(PROPERTY_NAME_PADDING), true);
+  }
+
+  public int getPaddingSumWidth() {
+    return getSideValueSum(properties.getProperty(PROPERTY_NAME_PADDING), false);
+  }
+
+  public int getMarginSumHeight() {
+    return getSideValueSum(properties.getProperty(PROPERTY_NAME_MARGIN), true);
+  }
+
+  public int getMarginSumWidth() {
+    return getSideValueSum(properties.getProperty(PROPERTY_NAME_MARGIN), false);
+  }
+
+  private int getSideValueSum(EditableProperty prop, boolean vertical) {
+    if (prop != null && prop.getValue().contains(",")) {
+      String[] sides = prop.getValue().split(",");
+      if (sides.length == 4) {
+        try {
+          if (vertical) {
+            return Integer.parseInt(sides[0].trim()) + Integer.parseInt(sides[3].trim()); // Top + Bottom
+          } else {
+            return Integer.parseInt(sides[1].trim()) + Integer.parseInt(sides[2].trim()); // Left + Right
+          }
+        } catch (NumberFormatException ignored) {}
+      }
+    }
+    return 0;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/MockVisibleComponent.java
@@ -19,6 +19,11 @@ import com.google.appinventor.shared.settings.SettingsConstants;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.json.client.JSONException;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONValue;
 
 /**
  * Abstract superclass for components with a visual representation.
@@ -217,42 +222,32 @@ public abstract class MockVisibleComponent extends MockComponent {
   }
 
   private void applyMockPadding(String paddingValues) {
-    if (paddingValues != null && paddingValues.contains(",")) {
-      String[] sides = paddingValues.split(",");
-      if (sides.length == 4) {
-        try {
-          Widget w = getWidget();
-          if (w != null && w.getElement() != null) {
-            com.google.gwt.dom.client.Style style = w.getElement().getStyle();
-            style.setProperty("paddingTop", Integer.parseInt(sides[0].trim()) + "px");
-            style.setProperty("paddingLeft", Integer.parseInt(sides[1].trim()) + "px");
-            style.setProperty("paddingRight", Integer.parseInt(sides[2].trim()) + "px");
-            style.setProperty("paddingBottom", Integer.parseInt(sides[3].trim()) + "px");
-          }
-        } catch (NumberFormatException e) {
-          // Graceful catch
-        }
-      }
+    int[] sides = parseJsonSides(paddingValues);
+    if (sides == null) {
+      return;
+    }
+    Widget w = getWidget();
+    if (w != null && w.getElement() != null) {
+      com.google.gwt.dom.client.Style style = w.getElement().getStyle();
+      style.setProperty("paddingTop", sides[0] + "px");
+      style.setProperty("paddingLeft", sides[1] + "px");
+      style.setProperty("paddingRight", sides[2] + "px");
+      style.setProperty("paddingBottom", sides[3] + "px");
     }
   }
 
   private void applyMockMargin(String marginValues) {
-    if (marginValues != null && marginValues.contains(",")) {
-      String[] sides = marginValues.split(",");
-      if (sides.length == 4) {
-        try {
-          Widget w = getWidget();
-          if (w != null && w.getElement() != null) {
-            com.google.gwt.dom.client.Style style = w.getElement().getStyle();
-            style.setProperty("marginTop", Integer.parseInt(sides[0].trim()) + "px");
-            style.setProperty("marginLeft", Integer.parseInt(sides[1].trim()) + "px");
-            style.setProperty("marginRight", Integer.parseInt(sides[2].trim()) + "px");
-            style.setProperty("marginBottom", Integer.parseInt(sides[3].trim()) + "px");
-          }
-        } catch (NumberFormatException e) {
-          // Graceful catch
-        }
-      }
+    int[] sides = parseJsonSides(marginValues);
+    if (sides == null) {
+      return;
+    }
+    Widget w = getWidget();
+    if (w != null && w.getElement() != null) {
+      com.google.gwt.dom.client.Style style = w.getElement().getStyle();
+      style.setProperty("marginTop", sides[0] + "px");
+      style.setProperty("marginLeft", sides[1] + "px");
+      style.setProperty("marginRight", sides[2] + "px");
+      style.setProperty("marginBottom", sides[3] + "px");
     }
   }
 
@@ -273,19 +268,52 @@ public abstract class MockVisibleComponent extends MockComponent {
   }
 
   private int getSideValueSum(EditableProperty prop, boolean vertical) {
-    if (prop != null && prop.getValue().contains(",")) {
-      String[] sides = prop.getValue().split(",");
-      if (sides.length == 4) {
-        try {
-          if (vertical) {
-            return Integer.parseInt(sides[0].trim()) + Integer.parseInt(sides[3].trim()); // Top + Bottom
-          } else {
-            return Integer.parseInt(sides[1].trim()) + Integer.parseInt(sides[2].trim()); // Left + Right
-          }
-        } catch (NumberFormatException ignored) {}
-      }
+    if (prop == null) {
+      return 0;
     }
-    return 0;
+    int[] sides = parseJsonSides(prop.getValue());
+    if (sides == null) {
+      return 0;
+    }
+    if (vertical) {
+      return sides[0] + sides[3]; // Top + Bottom
+    } else {
+      return sides[1] + sides[2]; // Left + Right
+    }
+  }
+
+  /**
+   * Parses a JSON string of the form {"top":T,"left":L,"right":R,"bottom":B}
+   * into a 4-element int[] {top, left, right, bottom}. Returns null if the
+   * input is null, empty, or malformed in any way.
+   */
+  private int[] parseJsonSides(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      JSONValue parsed = JSONParser.parseStrict(value);
+      JSONObject obj = parsed.isObject();
+      if (obj == null) {
+        return null;
+      }
+      int t = getIntOrZero(obj, "top");
+      int l = getIntOrZero(obj, "left");
+      int r = getIntOrZero(obj, "right");
+      int b = getIntOrZero(obj, "bottom");
+      return new int[]{t, l, r, b};
+    } catch (JSONException | IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private int getIntOrZero(JSONObject obj, String key) {
+    JSONValue v = obj.get(key);
+    if (v == null) {
+      return 0;
+    }
+    JSONNumber num = v.isNumber();
+    return num != null ? (int) num.doubleValue() : 0;
   }
 
   /**

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/simple/components/utils/PropertiesUtil.java
@@ -79,6 +79,7 @@ import com.google.appinventor.client.widgets.properties.StringPropertyEditor;
 import com.google.appinventor.client.widgets.properties.SubsetJSONPropertyEditor;
 import com.google.appinventor.client.widgets.properties.TextAreaPropertyEditor;
 import com.google.appinventor.client.widgets.properties.TextPropertyEditor;
+import com.google.appinventor.client.widgets.properties.PaddingMarginPropertyEditor;
 
 import com.google.appinventor.components.common.PropertyTypeConstants;
 
@@ -216,6 +217,10 @@ public class PropertiesUtil {
   public static PropertyEditor createPropertyEditor(String editorType, String defaultValue, DesignerEditor editor, String[] editorArgs) {
     if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT)) {
       return new YoungAndroidHorizontalAlignmentChoicePropertyEditor();
+    } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_PADDING)) {
+      return new PaddingMarginPropertyEditor();
+    } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_MARGIN)) {
+      return new PaddingMarginPropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT)) {
       return new YoungAndroidVerticalAlignmentChoicePropertyEditor();
     } else if (editorType.equals(PropertyTypeConstants.PROPERTY_TYPE_ASSET)) {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidPaddingMarginPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/properties/YoungAndroidPaddingMarginPropertyEditor.java
@@ -1,0 +1,18 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor.youngandroid.properties;
+
+import com.google.appinventor.client.widgets.properties.PaddingMarginPropertyEditor;
+
+/**
+ * Young Android designer wrapper for the native Padding and Margin cross editor.
+ */
+public class YoungAndroidPaddingMarginPropertyEditor extends PaddingMarginPropertyEditor {
+
+  public YoungAndroidPaddingMarginPropertyEditor() {
+    super(); // Inherits the 3x3 Grid, textboxes, and validation logic automatically
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PaddingMarginPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PaddingMarginPropertyEditor.java
@@ -13,6 +13,11 @@ import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.json.client.JSONException;
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.TextBox;
@@ -20,8 +25,16 @@ import com.google.gwt.user.client.ui.TextBox;
 /**
  * Property editor for native Padding and Margin structural bounds.
  * Displays a compact, space-saving "+" directional cross layout.
+ *
+ * Values are stored/round-tripped as a JSON string of the form:
+ *   {"top":T,"left":L,"right":R,"bottom":B}
  */
 public class PaddingMarginPropertyEditor extends PropertyEditor {
+
+  private static final String KEY_TOP = "top";
+  private static final String KEY_LEFT = "left";
+  private static final String KEY_RIGHT = "right";
+  private static final String KEY_BOTTOM = "bottom";
 
   private final Grid crossGrid;
   private final TextBox topBox;
@@ -95,15 +108,13 @@ public class PaddingMarginPropertyEditor extends PropertyEditor {
   @Override
   protected void updateValue() {
     String value = property.getValue();
-    if (value != null && value.contains(",")) {
-      String[] parts = value.split(",");
-      if (parts.length == 4) {
-        topBox.setText(parts[0].trim());
-        leftBox.setText(parts[1].trim());
-        rightBox.setText(parts[2].trim());
-        bottomBox.setText(parts[3].trim());
-        return;
-      }
+    int[] sides = parseJsonSides(value);
+    if (sides != null) {
+      topBox.setText(String.valueOf(sides[0]));
+      leftBox.setText(String.valueOf(sides[1]));
+      rightBox.setText(String.valueOf(sides[2]));
+      bottomBox.setText(String.valueOf(sides[3]));
+      return;
     }
     // Reliable system defaults
     topBox.setText("0");
@@ -113,35 +124,79 @@ public class PaddingMarginPropertyEditor extends PropertyEditor {
   }
 
   /**
+   * Parses a JSON string of the form {"top":T,"left":L,"right":R,"bottom":B}
+   * into a 4-element int[] {top, left, right, bottom}. Returns null if the
+   * input is null, empty, or malformed in any way.
+   */
+  private int[] parseJsonSides(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    try {
+      JSONValue parsed = JSONParser.parseStrict(value);
+      JSONObject obj = parsed.isObject();
+      if (obj == null) {
+        return null;
+      }
+      int t = getIntOrZero(obj, KEY_TOP);
+      int l = getIntOrZero(obj, KEY_LEFT);
+      int r = getIntOrZero(obj, KEY_RIGHT);
+      int b = getIntOrZero(obj, KEY_BOTTOM);
+      return new int[]{t, l, r, b};
+    } catch (JSONException | IllegalArgumentException e) {
+      // Malformed JSON — treat as absent, caller falls back to defaults
+      return null;
+    }
+  }
+
+  private int getIntOrZero(JSONObject obj, String key) {
+    JSONValue v = obj.get(key);
+    if (v == null) {
+      return 0;
+    }
+    JSONNumber num = v.isNumber();
+    return num != null ? (int) num.doubleValue() : 0;
+  }
+
+  /**
    * Evaluates input layout integrity, handles text parsing safely,
    * and normalizes malformed inputs instantly without infinite focus alert loops.
    */
   private void validateAndSetValues() {
-    String t = parseNumericInput(topBox.getText());
-    String l = parseNumericInput(leftBox.getText());
-    String r = parseNumericInput(rightBox.getText());
-    String b = parseNumericInput(bottomBox.getText());
+    int t = parseNumericInput(topBox.getText());
+    int l = parseNumericInput(leftBox.getText());
+    int r = parseNumericInput(rightBox.getText());
+    int b = parseNumericInput(bottomBox.getText());
 
-    String csvValue = t + "," + l + "," + r + "," + b;
+    // Reflect any silently-cleaned values back into the text boxes
+    topBox.setText(String.valueOf(t));
+    leftBox.setText(String.valueOf(l));
+    rightBox.setText(String.valueOf(r));
+    bottomBox.setText(String.valueOf(b));
+
+    JSONObject json = new JSONObject();
+    json.put(KEY_TOP, new JSONNumber(t));
+    json.put(KEY_LEFT, new JSONNumber(l));
+    json.put(KEY_RIGHT, new JSONNumber(r));
+    json.put(KEY_BOTTOM, new JSONNumber(b));
+    String jsonValue = json.toString();
 
     // Only update and trigger a property change event if the values actually changed
-    if (!csvValue.equals(property.getValue())) {
-      property.setValue(csvValue);
+    if (!jsonValue.equals(property.getValue())) {
+      property.setValue(jsonValue);
     }
   }
 
-  private String parseNumericInput(String text) {
+  private int parseNumericInput(String text) {
     String cleanStr = text.trim();
     if (cleanStr.isEmpty()) {
-      return "0";
+      return 0;
     }
     try {
-      // If it's valid code bytecode representation, keep it intact
-      Integer.parseInt(cleanStr);
-      return cleanStr;
+      return Integer.parseInt(cleanStr);
     } catch (NumberFormatException e) {
       // Silently clean bad data to prevent UI lockup loops
-      return "0";
+      return 0;
     }
   }
 }

--- a/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PaddingMarginPropertyEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/widgets/properties/PaddingMarginPropertyEditor.java
@@ -1,0 +1,147 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.widgets.properties;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.appinventor.client.widgets.properties.PropertyEditor;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.user.client.ui.Grid;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.TextBox;
+
+/**
+ * Property editor for native Padding and Margin structural bounds.
+ * Displays a compact, space-saving "+" directional cross layout.
+ */
+public class PaddingMarginPropertyEditor extends PropertyEditor {
+
+  private final Grid crossGrid;
+  private final TextBox topBox;
+  private final TextBox leftBox;
+  private final TextBox rightBox;
+  private final TextBox bottomBox;
+
+  public PaddingMarginPropertyEditor() {
+    crossGrid = new Grid(3, 3);
+    // Add styling class to handle clean rendering in the side-panel wrapper
+    crossGrid.addStyleName("ode-PaddingMarginGrid");
+
+    topBox = new TextBox();
+    leftBox = new TextBox();
+    rightBox = new TextBox();
+    bottomBox = new TextBox();
+
+    // Enforce clean styling rules
+    String boxWidth = "38px";
+    topBox.setWidth(boxWidth);
+    leftBox.setWidth(boxWidth);
+    rightBox.setWidth(boxWidth);
+    bottomBox.setWidth(boxWidth);
+
+    // Arrange within the 3x3 structural visual layout grid
+    crossGrid.setWidget(0, 1, topBox);
+    crossGrid.setWidget(1, 0, leftBox);
+    crossGrid.setWidget(1, 1, new HTML("<div style='text-align:center; font-weight:bold; line-height:25px; color:#5a5a5a;'>+</div>"));
+    crossGrid.setWidget(1, 2, rightBox);
+    crossGrid.setWidget(2, 1, bottomBox);
+
+    // Event handler to capture keystrokes and handle escape cancellations
+    KeyUpHandler keyHandler = new KeyUpHandler() {
+      @Override
+      public void onKeyUp(KeyUpEvent event) {
+        int keyCode = event.getNativeKeyCode();
+        if (keyCode == KeyCodes.KEY_ESCAPE) {
+          updateValue(); // Reset fields back to last valid state
+          ((TextBox) event.getSource()).setFocus(false);
+        } else if (keyCode == KeyCodes.KEY_ENTER) {
+          validateAndSetValues();
+          ((TextBox) event.getSource()).setFocus(false);
+        }
+      }
+    };
+
+    // Standard BlurHandler tracking ensures values save when a user clicks away
+    BlurHandler blurHandler = new BlurHandler() {
+      @Override
+      public void onBlur(BlurEvent event) {
+        validateAndSetValues();
+      }
+    };
+
+    // Wire up events across all four boxes
+    TextBox[] boxes = {topBox, leftBox, rightBox, bottomBox};
+    for (TextBox box : boxes) {
+      box.addKeyUpHandler(keyHandler);
+      box.addBlurHandler(blurHandler);
+    }
+
+    initWidget(crossGrid);
+  }
+
+  @Override
+  protected void onUnload() {
+    validateAndSetValues();
+    super.onUnload();
+  }
+
+  @Override
+  protected void updateValue() {
+    String value = property.getValue();
+    if (value != null && value.contains(",")) {
+      String[] parts = value.split(",");
+      if (parts.length == 4) {
+        topBox.setText(parts[0].trim());
+        leftBox.setText(parts[1].trim());
+        rightBox.setText(parts[2].trim());
+        bottomBox.setText(parts[3].trim());
+        return;
+      }
+    }
+    // Reliable system defaults
+    topBox.setText("0");
+    leftBox.setText("0");
+    rightBox.setText("0");
+    bottomBox.setText("0");
+  }
+
+  /**
+   * Evaluates input layout integrity, handles text parsing safely,
+   * and normalizes malformed inputs instantly without infinite focus alert loops.
+   */
+  private void validateAndSetValues() {
+    String t = parseNumericInput(topBox.getText());
+    String l = parseNumericInput(leftBox.getText());
+    String r = parseNumericInput(rightBox.getText());
+    String b = parseNumericInput(bottomBox.getText());
+
+    String csvValue = t + "," + l + "," + r + "," + b;
+
+    // Only update and trigger a property change event if the values actually changed
+    if (!csvValue.equals(property.getValue())) {
+      property.setValue(csvValue);
+    }
+  }
+
+  private String parseNumericInput(String text) {
+    String cleanStr = text.trim();
+    if (cleanStr.isEmpty()) {
+      return "0";
+    }
+    try {
+      // If it's valid code bytecode representation, keep it intact
+      Integer.parseInt(cleanStr);
+      return cleanStr;
+    } catch (NumberFormatException e) {
+      // Silently clean bad data to prevent UI lockup loops
+      return "0";
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -440,6 +440,16 @@ public final class YoungAndroidFormUpgrader {
         srcCompVersion = upgradeEv3UltrasonicSensorProperties(componentProperties, srcCompVersion);
       } else if (componentType.equals("NxtDirectCommands")) {
         srcCompVersion = upgradeNxtDirectCommandsProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("AbsoluteArrangement")) {
+        srcCompVersion = upgradeAbsoluteArrangementProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("CircularProgress")) {
+        srcCompVersion = upgradeCircularProgressProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("LinearProgress")) {
+        srcCompVersion = upgradeLinearProgressProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("Switch")) {
+        srcCompVersion = upgradeSwitchProperties(componentProperties, srcCompVersion);
+      } else if (componentType.equals("TableArrangement")) {
+        srcCompVersion = upgradeTableArrangementProperties(componentProperties, srcCompVersion);
       }
 
       if (srcCompVersion < sysCompVersion) {
@@ -701,6 +711,11 @@ public final class YoungAndroidFormUpgrader {
       // Added the NumberOfSteps property, TouchDown and TouchUp events
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // Margin property were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 
@@ -765,6 +780,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 7) {
       // Assets helper block was added.
       srcCompVersion = 7;
+    }
+    if (srcCompVersion < 8) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 8;
     }
     return srcCompVersion;
   }
@@ -880,6 +900,11 @@ public final class YoungAndroidFormUpgrader {
       // The ValueFormat property was added.
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Margin property were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -920,6 +945,11 @@ public final class YoungAndroidFormUpgrader {
       handlePropertyRename(componentProperties, "Value", "Checked");
       // Properties related to this component have now been upgraded to version 2.
       srcCompVersion = 2;
+    }
+    if (srcCompVersion < 3) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 3;
     }
     return srcCompVersion;
   }
@@ -965,6 +995,11 @@ public final class YoungAndroidFormUpgrader {
       // No properties need to be modified to upgrade to version 6.
       srcCompVersion = 6;
     }
+    if (srcCompVersion < 7) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 7;
+    }
     return srcCompVersion;
   }
 
@@ -984,6 +1019,11 @@ public final class YoungAndroidFormUpgrader {
       // Assets helper block was added.
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -1002,6 +1042,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 7) {
       // TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
       srcCompVersion = 7;
+    }
+    if (srcCompVersion < 8) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 8;
     }
     return srcCompVersion;
   }
@@ -1300,6 +1345,11 @@ public final class YoungAndroidFormUpgrader {
       // Assets helper block was added.
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -1310,6 +1360,11 @@ public final class YoungAndroidFormUpgrader {
       // Add HorizontalAlignment and VerticalAlignment dropdown blocks.
       // Assets helper block was added.
       srcCompVersion = 2;
+    }
+    if (srcCompVersion < 3) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 3;
     }
     return srcCompVersion;
   }
@@ -1346,6 +1401,11 @@ public final class YoungAndroidFormUpgrader {
       // Assets helper block was added.
       srcCompVersion = 6;
     }
+    if (srcCompVersion < 7) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 7;
+    }
     return srcCompVersion;
   }
 
@@ -1380,6 +1440,11 @@ public final class YoungAndroidFormUpgrader {
       handlePropertyRename(componentProperties, "ImagePath", "Selection");
       // Properties related to this component have now been upgraded to version 2.
       srcCompVersion = 5;
+    }
+    if (srcCompVersion < 6) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 6;
     }
     return srcCompVersion;
   }
@@ -1474,6 +1539,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 5) {
       srcCompVersion = 5;
     }
+    if (srcCompVersion < 6) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 6;
+    }
     return srcCompVersion;
   }
 
@@ -1515,6 +1585,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 9) {
       // Added ItemTextColor, ItemBackgroundColor
       srcCompVersion = 9;
+    }
+    if (srcCompVersion < 10) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 10;
     }
     return srcCompVersion;
   }
@@ -1577,6 +1652,11 @@ public final class YoungAndroidFormUpgrader {
       // Added TextAlignmentDetail property (default: 0 = left).
       srcCompVersion = 11;
     }
+    if (srcCompVersion < 12) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 12;
+    }
     return srcCompVersion;
   }
 
@@ -1633,6 +1713,11 @@ public final class YoungAndroidFormUpgrader {
       // TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
       srcCompVersion = 7;
     }
+    if (srcCompVersion < 8) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 8;
+    }
     return srcCompVersion;
   }
 
@@ -1667,6 +1752,11 @@ public final class YoungAndroidFormUpgrader {
       // The Shape property was added.
       // No properties need to be modified to upgrade to version 4.
       srcCompVersion = 4;
+    }
+    if (srcCompVersion < 5) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
     }
     return srcCompVersion;
   }
@@ -1779,6 +1869,11 @@ public final class YoungAndroidFormUpgrader {
       // TextColor properties were added.
       srcCompVersion = 2;
     }
+    if (srcCompVersion < 3) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 3;
+    }
     return srcCompVersion;
   }
 
@@ -1814,6 +1909,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 4) {
       // Assets helper block was added.
       srcCompVersion = 4;
+    }
+    if (srcCompVersion < 5) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
     }
     return srcCompVersion;
   }
@@ -1858,6 +1958,11 @@ public final class YoungAndroidFormUpgrader {
       // Assets helper block was added.
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 5;
+    }
     return srcCompVersion;
   }
 
@@ -1868,6 +1973,11 @@ public final class YoungAndroidFormUpgrader {
       // Add HorizontalAlignment and VerticalAlignment dropdown blocks.
       // Assets helper block was added.
       srcCompVersion = 2;
+    }
+    if (srcCompVersion < 3) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 3;
     }
     return srcCompVersion;
   }
@@ -2020,6 +2130,11 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 14) {
       // TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
       srcCompVersion = 14;
+    }
+    if (srcCompVersion < 15) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 15;
     }
     return srcCompVersion;
   }
@@ -2287,6 +2402,65 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 2;
     }
     return srcCompVersion;
+  }
+
+  private static int upgradeAbsoluteArrangementProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeCircularProgressProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeLinearProgressProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeSwitchProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeTableArrangementProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
+    }
+    return srcCompVersion;
+  }
+
+  private static void handlePaddingMarginDefaultProperty(Map<String, JSONValue> componentProperties) {
+    if (!componentProperties.containsKey("Padding")) {
+      componentProperties.put("Padding", new ClientJsonString("0,0,0,0"));
+    }
+    if (!componentProperties.containsKey("Margin")) {
+      componentProperties.put("Margin", new ClientJsonString("0,0,0,0"));
+    }
   }
 
   private static void handlePropertyRename(Map<String, JSONValue> componentProperties,

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -301,6 +301,9 @@ public final class YoungAndroidFormUpgrader {
       } else if (componentType.equals("File")) {
         srcCompVersion = upgradeFileProperties(componentProperties, srcCompVersion);
 
+      } else if (componentType.equals("FilePicker")) {
+        srcCompVersion = upgradeFilePickerProperties(componentProperties, srcCompVersion);
+
       } else if (componentType.equals("Form")) {
         srcCompVersion = upgradeFormProperties(componentProperties, srcCompVersion);
 
@@ -1073,6 +1076,16 @@ public final class YoungAndroidFormUpgrader {
         componentProperties.put("DefaultScope", new ClientJsonString("Legacy"));
       }
       srcCompVersion = 4;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeFilePickerProperties(
+          Map<String, JSONValue> componentProperties, int srcCompVersion) {
+    if (srcCompVersion < 2) {
+      // Padding and Margin properties were added.
+      handlePaddingMarginDefaultProperty(componentProperties);
+      srcCompVersion = 2;
     }
     return srcCompVersion;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -2456,10 +2456,10 @@ public final class YoungAndroidFormUpgrader {
 
   private static void handlePaddingMarginDefaultProperty(Map<String, JSONValue> componentProperties) {
     if (!componentProperties.containsKey("Padding")) {
-      componentProperties.put("Padding", new ClientJsonString("0,0,0,0"));
+      componentProperties.put("Padding", new ClientJsonString("{\"top\":0,\"left\":0,\"right\":0,\"bottom\":0}"));
     }
     if (!componentProperties.containsKey("Margin")) {
-      componentProperties.put("Margin", new ClientJsonString("0,0,0,0"));
+      componentProperties.put("Margin", new ClientJsonString("{\"top\":0,\"left\":0,\"right\":0,\"bottom\":0}"));
     }
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1751,7 +1751,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // Assets helper block was added.
     7: Blockly.Versioning.makeSetterUseHelper(
-        'Button', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets)
+        'Button', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets),
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    8: "noUpgrade"
 
   }, // End BarcodeScanner upgraders
 
@@ -1861,7 +1864,9 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2: The ExtendDomainToInclude and ExtendRangeToInclude methods were added.
     3: "noUpgrade",
     // AI2: The property axesTextColor and method setAxesTextColor were added.
-    4: "noUpgrade"
+    4: "noUpgrade",
+    // Added Margin property. No block manipulation necessary.
+    5: "noUpgrade"
 
   }, // End Chart upgraders
 
@@ -1888,7 +1893,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "CheckBox": {
 
     // AI2: The Value property was renamed to Checked.
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    3: "noUpgrade"
 
   }, // End CheckBox upgraders
 
@@ -1950,7 +1958,10 @@ Blockly.Versioning.AllUpgradeMaps =
     5: "noUpgrade",
 
     // AI2:  Added ContactUri
-    6: "noUpgrade"
+    6: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    7: "noUpgrade"
 
   }, // End ContactPicker upgraders
 
@@ -1973,7 +1984,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // Assets helper block was added.
     4: Blockly.Versioning.makeSetterUseHelper(
-        'DatePicker', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets)
+        'DatePicker', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets),
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    5: "noUpgrade"
 
   }, // End DatePicker upgraders
 
@@ -1998,7 +2012,10 @@ Blockly.Versioning.AllUpgradeMaps =
     7: [
       Blockly.Versioning.changeMethodName("EmailPicker", "SetCursorAt", "MoveCursorTo"),
       Blockly.Versioning.changeMethodName("EmailPicker", "SetCursorAtEnd", "MoveCursorToEnd"),
-      Blockly.Versioning.changeEventName("EmailPicker", "OnTextChanged", "TextChanged")]
+      Blockly.Versioning.changeEventName("EmailPicker", "OnTextChanged", "TextChanged")],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    8: "noUpgrade"
 
   }, // End EmailPicker upgraders
 
@@ -2093,7 +2110,10 @@ Blockly.Versioning.AllUpgradeMaps =
         Blockly.Versioning.makeSetterUseDropdown(
            'HorizontalArrangement', 'AlignVertical', 'VerticalAlignment'),
         Blockly.Versioning.makeSetterUseHelper(
-           'HorizontalArrangement', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets)]
+           'HorizontalArrangement', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets)],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    5: "noUpgrade"
 
   }, // End HorizontalArrangement upgraders
 
@@ -2110,7 +2130,10 @@ Blockly.Versioning.AllUpgradeMaps =
         Blockly.Versioning.makeSetterUseDropdown(
            'HorizontalScrollArrangement', 'AlignVertical', 'VerticalAlignment'),
         Blockly.Versioning.makeSetterUseHelper('HorizontalScrollArrangement', 'Image',
-           Blockly.Versioning.tryReplaceBlockWithAssets)]
+           Blockly.Versioning.tryReplaceBlockWithAssets)],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    3: "noUpgrade"
 
   }, // End HorizontalScrollArrangement upgraders
 
@@ -2135,8 +2158,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // Assets helper block was added.
     6: Blockly.Versioning.makeSetterUseHelper(
-        'Image', 'Picture', Blockly.Versioning.tryReplaceBlockWithAssets)
+        'Image', 'Picture', Blockly.Versioning.tryReplaceBlockWithAssets),
 
+    // Added Padding and Margin properties. No block manipulation necessary.
+    7: "noUpgrade"
   }, // End Image upgraders
 
   "ImageBot": {
@@ -2168,7 +2193,10 @@ Blockly.Versioning.AllUpgradeMaps =
     /* From BlockSaveFile.java:
       handlePropertyRename(componentName, "ImagePath", "Selection");
     */
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    6: "noUpgrade"
 
   }, // End ImagePicker upgraders
 
@@ -2236,7 +2264,10 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2: Add HTMLFormat property
     4: "noUpgrade",
 
-    5: "noUpgrade"
+    5: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    6: "noUpgrade"
 
   }, // End Label upgraders
 
@@ -2448,7 +2479,10 @@ Blockly.Versioning.AllUpgradeMaps =
     8: "noUpgrade",
 
     // AI2: Added  ItemTextColor and ItemBackgroundColor
-    9: "noUpgrade"
+    9: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    10: "noUpgrade"
 
   }, // End ListPicker upgraders
 
@@ -2482,11 +2516,12 @@ Blockly.Versioning.AllUpgradeMaps =
     // - Changed TextSize property to FontSize
     // - Add new layout
     10: "noUpgrade",
-
     // AI2:
     // - Added TextAlignmentMain property
     // - Added TextAlignmentDetail property
-    11: "noUpgrade"
+    11: "noUpgrade",
+    // Added Padding and Margin properties. No block manipulation necessary.
+    12: "noUpgrade"
 
   }, // End ListView upgraders
 
@@ -2853,7 +2888,10 @@ Blockly.Versioning.AllUpgradeMaps =
     7: [
       Blockly.Versioning.changeMethodName("PasswordTextBox", "SetCursorAt", "MoveCursorTo"),
       Blockly.Versioning.changeMethodName("PasswordTextBox", "SetCursorAtEnd", "MoveCursorToEnd"),
-      Blockly.Versioning.changeEventName("PasswordTextBox", "OnTextChanged", "TextChanged")]
+      Blockly.Versioning.changeEventName("PasswordTextBox", "OnTextChanged", "TextChanged")],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    8: "noUpgrade"
 
   }, // End PasswordTextBox upgraders
 
@@ -2896,7 +2934,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI1: The Shape property was added.
     // No blocks need to be modified to upgrade to version 4.
-    4: "noUpgrade"
+    4: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    5: "noUpgrade"
 
   }, // End PhoneNumberPicker upgraders
 
@@ -3125,7 +3166,10 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // Added the NumberOfSteps and ColorThumb property, TouchDown and TouchUp events, 
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // Added Margin property. No block manipulation necessary.
+    4: "noUpgrade"
 
   }, // End Slider upgraders
 
@@ -3181,7 +3225,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI2: The BackgroundColor, Enabled, FontBold, FontSize, Height, Image, ShowFeedback, TextAlignment, and
     // TextColor properties were added.
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    3: "noUpgrade"
 
 
   }, // End Spinner upgraders
@@ -3210,7 +3257,10 @@ Blockly.Versioning.AllUpgradeMaps =
   "TableArrangement": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    2: "noUpgrade"
 
   }, // End TableArrangementupgraders
 
@@ -3253,7 +3303,10 @@ Blockly.Versioning.AllUpgradeMaps =
     14: [
       Blockly.Versioning.changeMethodName("TextBox", "SetCursorAt", "MoveCursorTo"),
       Blockly.Versioning.changeMethodName("TextBox", "SetCursorAtEnd", "MoveCursorToEnd"),
-      Blockly.Versioning.changeEventName("TextBox", "OnTextChanged", "TextChanged")]
+      Blockly.Versioning.changeEventName("TextBox", "OnTextChanged", "TextChanged")],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    15: "noUpgrade"
 
   }, // End TextBox upgraders
 
@@ -3314,7 +3367,10 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // Assets helper block was added.
     4: Blockly.Versioning.makeSetterUseHelper(
-        'TimePicker', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets)
+        'TimePicker', 'Image', Blockly.Versioning.tryReplaceBlockWithAssets),
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    5: "noUpgrade"
 
   }, // End TimePicker upgraders
 
@@ -3406,7 +3462,10 @@ Blockly.Versioning.AllUpgradeMaps =
         Blockly.Versioning.makeSetterUseDropdown(
            'VerticalArrangement', 'AlignVertical', 'VerticalAlignment'),
         Blockly.Versioning.makeSetterUseHelper('VerticalArrangement', 'Image',
-           Blockly.Versioning.tryReplaceBlockWithAssets)]
+           Blockly.Versioning.tryReplaceBlockWithAssets)],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    5: "noUpgrade"
   }, // End VerticalArrangement upgraders
 
   "VerticalScrollArrangement": {
@@ -3422,7 +3481,10 @@ Blockly.Versioning.AllUpgradeMaps =
         Blockly.Versioning.makeSetterUseDropdown(
            'VerticalScrollArrangement', 'AlignVertical', 'VerticalAlignment'),
         Blockly.Versioning.makeSetterUseHelper('VerticalScrollArrangement', 'Image',
-           Blockly.Versioning.tryReplaceBlockWithAssets)]
+           Blockly.Versioning.tryReplaceBlockWithAssets)],
+
+    // Added Padding and Margin properties. No block manipulation necessary.
+    3: "noUpgrade"
   }, // End VerticalScrollArrangement upgraders
 
   "VideoPlayer": {

--- a/appinventor/components/src/com/google/appinventor/components/common/BoxSide.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/BoxSide.java
@@ -1,0 +1,44 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a LayoutDimension type used by padding and margin helper blocks.
+ */
+public enum BoxSide implements OptionList<String> {
+  All("all"),
+  Top("top"),
+  Bottom("bottom"),
+  Left("left"),
+  Right("right"),
+  Leading("leading"),
+  Trailing("trailing");
+
+  private final String value;
+
+  BoxSide(String value) {
+    this.value = value;
+  }
+
+  public String toUnderlyingValue() {
+    return value;
+  }
+
+  private static final Map<String, BoxSide> lookup = new HashMap<>();
+
+  static {
+    for (BoxSide dim : BoxSide.values()) {
+      lookup.put(dim.toUnderlyingValue(), dim);
+    }
+  }
+
+  public static BoxSide fromUnderlyingValue(String dim) {
+    return lookup.get(dim);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -21,6 +21,12 @@ public class ComponentConstants {
   public static final int APP_INVENTOR_MIN_SDK = 14;
 
   /**
+   * Default value for padding and margin (top,left,right,bottom)
+   */
+  public static final String DEFAULT_PADDING_VALUE = "0,0,0,0";
+  public static final String DEFAULT_MARGIN_VALUE = "0,0,0,0";
+
+  /**
    * Layout constants.
    */
   public static final int LAYOUT_ORIENTATION_HORIZONTAL = 1;

--- a/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ComponentConstants.java
@@ -23,8 +23,8 @@ public class ComponentConstants {
   /**
    * Default value for padding and margin (top,left,right,bottom)
    */
-  public static final String DEFAULT_PADDING_VALUE = "0,0,0,0";
-  public static final String DEFAULT_MARGIN_VALUE = "0,0,0,0";
+  public static final String DEFAULT_PADDING_VALUE = "{\"top\":0,\"left\":0,\"right\":0,\"bottom\":0}";
+  public static final String DEFAULT_MARGIN_VALUE = "{\"top\":0,\"left\":0,\"right\":0,\"bottom\":0}";
 
   /**
    * Layout constants.

--- a/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/PropertyTypeConstants.java
@@ -299,6 +299,18 @@ public class PropertyTypeConstants {
   public static final String PROPERTY_TYPE_VISIBILITY = "visibility";
 
   /**
+   * Padding values (Top,Left,Right,Bottom) for visible components.
+   * @see com.google.appinventor.client.editor.youngandroid.properties.PaddingMarginPropertyEditor
+   */
+  public static final String PROPERTY_TYPE_PADDING = "padding";
+
+  /**
+   * Margin values (Top,Left,Right,Bottom) for visible components.
+   * @see com.google.appinventor.client.editor.youngandroid.properties.PaddingMarginPropertyEditor
+   */
+  public static final String PROPERTY_TYPE_MARGIN = "margin";
+
+  /**
    * Choices of Text Receiving options. {@link
    * com.google.appinventor.client.editor.youngandroid.properties.YoungAndroidTextReceivingPropertyEditor}.
    */

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -787,7 +787,7 @@ public class YaVersion {
   // - AbsoluteArrangement component was added.
   // For ABSOLUTEARRANGEMENT_COMPONENT_VERSION 2:
   // - Padding and Margin properties was added.
-  public static final int ABSOLUTEARRANGEMENT_COMPONENT_VERSION = 1;
+  public static final int ABSOLUTEARRANGEMENT_COMPONENT_VERSION = 2;
 
   //For ACCELEROMETERSENSOR_COMPONENT_VERSION 2:
   // - AccelerometerSensor.MinimumInterval property was added.

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -612,7 +612,35 @@ public class YaVersion {
   // - CHATBOT_COMPONENT_VERSION was incremented to 4
   // For YOUNG_ANDROID_VERSION 234:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 39.
-  public static final int YOUNG_ANDROID_VERSION = 234;
+  // For YOUNG_ANDROID_VERSION 235:
+  // - ABSOLUTEARRANGEMENT_COMPONENT_VERSION was incremented to 2
+  // - BUTTON_COMPONENT_VERSION was incremented to 8
+  // - CHART_COMPONENT_VERSION was incremented to 5
+  // - CHECKBOX_COMPONENT_VERSION was incremented to 3
+  // - CIRCULAR_PROGRESS_COMPONENT_VERSION was incremented to 2
+  // - CONTACTPICKER_COMPONENT_VERSION was incremented to 7
+  // - DATEPICKER_COMPONENT_VERSION was incremented to 5
+  // - EMAILPICKER_COMPONENT_VERSION was incremented to 8
+  // - FILEPICKER_COMPONENT_VERSION was incremented to 2
+  // - HORIZONTALARRANGEMENT_COMPONENT_VERSION was incremented to 5
+  // - HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION was incremented to 3
+  // - IMAGE_COMPONENT_VERSION was incremented to 7
+  // - IMAGEPICKER_COMPONENT_VERSION was incremented to 6
+  // - LABEL_COMPONENT_VERSION was incremented to 6
+  // - LINEAR_PROGRESS_COMPONENT_VERSION was incremented to 2
+  // - LISTPICKER_COMPONENT_VERSION was incremented to 10
+  // - LISTVIEW_COMPONENT_VERSION was incremented to 12
+  // - PASSWORDTEXTBOX_COMPONENT_VERSION was incremented to 8
+  // - PHONENUMBERPICKER_COMPONENT_VERSION was incremented to 5
+  // - SLIDER_COMPONENT_VERSION was incremented to 4
+  // - SPINNER_COMPONENT_VERSION was incremented to 3
+  // - SWITCH_COMPONENT_VERSION was incremented to 2
+  // - TABLEARRANGEMENT_COMPONENT_VERSION was incremented to 2
+  // - TEXTBOX_COMPONENT_VERSION was incremented to 15
+  // - TIMEPICKER_COMPONENT_VERSION was incremented to 5
+  // - VERTICALARRANGEMENT_COMPONENT_VERSION was incremented to 5
+  // - VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION was incremented to 3
+  public static final int YOUNG_ANDROID_VERSION = 235;
 
   // ............................... Blocks Language Version Number ...............................
 
@@ -757,6 +785,8 @@ public class YaVersion {
 
   // For ABSOLUTEARRANGEMENT_COMPONENT_VERSION 1:
   // - AbsoluteArrangement component was added.
+  // For ABSOLUTEARRANGEMENT_COMPONENT_VERSION 2:
+  // - Padding and Margin properties was added.
   public static final int ABSOLUTEARRANGEMENT_COMPONENT_VERSION = 1;
 
   //For ACCELEROMETERSENSOR_COMPONENT_VERSION 2:
@@ -851,7 +881,9 @@ public class YaVersion {
   // - FontSize, FontBold, FontItalic properties made visible in block editor
   // For BUTTON_COMPONENT_VERSION 7:
   // - Assets helper block was added.
-  public static final int BUTTON_COMPONENT_VERSION = 7;
+  // For BUTTON_COMPONENT_VERSION 8:
+  //- Padding and Margin properties was added.
+  public static final int BUTTON_COMPONENT_VERSION = 8;
 
   public static final int CAMCORDER_COMPONENT_VERSION = 1;
 
@@ -909,7 +941,9 @@ public class YaVersion {
   // - The axesTextColor property was added
   // - The setAxesTextColor method was added
   // - The ValueFormat property was added
-  public static final int CHART_COMPONENT_VERSION = 4;
+  // For CHART_COMPONENT_VERSION 5:
+  // - Margin property was added.
+  public static final int CHART_COMPONENT_VERSION = 5;
 
   // For CHART_DATA_2D_COMPONENT_VERSION 2:
   // - The dataLabelColor property was added
@@ -930,7 +964,9 @@ public class YaVersion {
 
   // For CHECKBOX_COMPONENT_VERSION 2:
   // - The Value property was renamed to Checked.
-  public static final int CHECKBOX_COMPONENT_VERSION = 2;
+  // For CHECKBOX_COMPONENT_VERSION 3:
+  // - Padding and Margin properties was added.
+  public static final int CHECKBOX_COMPONENT_VERSION = 3;
 
   // For CIRCLE_COMPONENT_VERSION 1:
   // - Initial implementation of Circle for Maps
@@ -958,7 +994,9 @@ public class YaVersion {
   // - For Eclair and up, we now use ContactsContract instead of the deprecated Contacts.
   // For CONTACTPICKER_COMPONENT_VERSION 6:
   // - The ContactUri property was added
-  public static final int CONTACTPICKER_COMPONENT_VERSION = 6;
+  // For CONTACTPICKER_COMPONENT_VERSION 7:
+  // - Padding and Margin properties was added.
+  public static final int CONTACTPICKER_COMPONENT_VERSION = 7;
 
   public static final int DATA_FILE_COMPONENT_VERSION = 1;
 
@@ -972,7 +1010,9 @@ public class YaVersion {
   // - SetDateToDisplayFromInstant, and Instant property are added.
   // For DATEPICKER_COMPONENT_VERSION 3:
   // - Assets helper block was added.
-  public static final int DATEPICKER_COMPONENT_VERSION = 4;
+  // For DATEPICKER_COMPONENT_VERSION 5:
+  // - Padding and Margin properties was added.
+  public static final int DATEPICKER_COMPONENT_VERSION = 5;
 
   // For EMAILPICKER_COMPONENT_VERSION 2:
   // - The Alignment property was renamed to TextAlignment.
@@ -981,7 +1021,9 @@ public class YaVersion {
   // For EMAILPICKER_COMPONENT_VERSION 7:
   // - Bumped up to be strictly greater than Kodular's EmailPicker (6).
   // - TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
-  public static final int EMAILPICKER_COMPONENT_VERSION = 7;
+  // For EMAILPICKER_COMPONENT_VERSION 8:
+  // - Padding and Margin properties was added.
+  public static final int EMAILPICKER_COMPONENT_VERSION = 8;
 
   // For FEATURE_COLLECTION_COMPONENT_VERSION 1:
   // - Initial FeatureCollection implementation for Maps
@@ -1003,7 +1045,9 @@ public class YaVersion {
   // - The LegacyMode property was removed. Use DefaultScope instead.
   public static final int FILE_COMPONENT_VERSION = 4;
 
-  public static final int FILEPICKER_COMPONENT_VERSION = 1;
+  // For FILEPICKER_COMPONENT_VERSION 2:
+  // - Padding and Margin properties was added.
+  public static final int FILEPICKER_COMPONENT_VERSION = 2;
 
   // For FORM_COMPONENT_VERSION 2:
   // - The Screen.Scrollable property was added.
@@ -1104,12 +1148,16 @@ public class YaVersion {
   // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 4:
   // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
   // - Assets helper block was added.
-  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 4;
+  // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 5:
+  // - Padding and Margin properties was added.
+  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 5;
 
   // For HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
   // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
   // - Assets helper block was added.
-  public static final int HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION = 2;
+  // For HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION 3:
+  // - Padding and Margin properties was added.
+  public static final int HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION = 3;
 
   // For IMAGE_COMPONENT_VERSION 2:
   // - The RotationAngle property was added.
@@ -1122,7 +1170,9 @@ public class YaVersion {
   // - The AlternateText property was added.
   // For IMAGE_COMPONENT_VERSION 6:
   // - Assets helper block was added.
-  public static final int IMAGE_COMPONENT_VERSION = 6;
+  // For IMAGE_COMPONENT_VERSION 7:
+  // - Padding and Margin properties was added.
+  public static final int IMAGE_COMPONENT_VERSION = 7;
 
   // For IMAGEBOT_COMPONENT_VERSION 2:
   // - The ApiKey property was made available in the designer
@@ -1137,8 +1187,9 @@ public class YaVersion {
   // For IMAGEPICKER_COMPONENT_VERSION 5:
   // - The ImagePath property was changed to Selection, and now returns a file path to
   //   external storage
-
-  public static final int IMAGEPICKER_COMPONENT_VERSION = 5;
+  // For IMAGEPICKER_COMPONENT_VERSION 6:
+  // - Padding and Margin properties was added.
+  public static final int IMAGEPICKER_COMPONENT_VERSION = 6;
 
   // For IMAGESPRITE_COMPONENT_VERSION 2:
   // - The Rotates property was added.
@@ -1170,8 +1221,9 @@ public class YaVersion {
   // - The HTML format is defined.
   // For LABEL_COMPONENT_VERSION 5:
   // - The HTMLContent property is defined.
-
-  public static final int LABEL_COMPONENT_VERSION = 5;
+  // For LABEL_COMPONENT_VERSION 6:
+  // - Padding and Margin properties was added.
+  public static final int LABEL_COMPONENT_VERSION = 6;
 
   // For LINESTRING_COMPONENT_VERSION 1:
   // - Initial LineString implementation for Maps
@@ -1196,7 +1248,9 @@ public class YaVersion {
   // - Added title property
   // For LISTPICKER_COMPONENT_VERSION 9:
   // - Added ItemTextColor, ItemBackgroundColor
-  public static final int LISTPICKER_COMPONENT_VERSION = 9;
+  // For LISTPICKER_COMPONENT_VERSION 10:
+  // - Padding and Margin properties was added.
+  public static final int LISTPICKER_COMPONENT_VERSION = 10;
 
   // For LISTVIEW_COMPONENT_VERSION 1:
   // - Initial version.
@@ -1223,7 +1277,12 @@ public class YaVersion {
   // For LISTVIEW_COMPONENT_VERSION 11:
   // - Added TextAlignmentMain property
   // - Added TextAlignmentDetail property
-  public static final int LISTVIEW_COMPONENT_VERSION = 11;
+  // For LISTVIEW_COMPONENT_VERSION 11:
+  // - Added TextAlignmentMain property
+  // - Added TextAlignmentDetail property
+  // For LISTVIEW_COMPONENT_VERSION 12:
+  // - Padding and Margin properties was added.
+  public static final int LISTVIEW_COMPONENT_VERSION = 12;
 
   // For LOCATIONSENSOR_COMPONENT_VERSION 2:
   // - The TimeInterval and DistanceInterval properties were added.
@@ -1342,7 +1401,9 @@ public class YaVersion {
   // For PASSWORDTEXTBOX_COMPONENT_VERSION 7:
   // - Bumped up to be strictly greater than Kodular's PasswordTextBox (6).
   // - TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
-  public static final int PASSWORDTEXTBOX_COMPONENT_VERSION = 7;
+  // For PASSWORDTEXTBOX_COMPONENT_VERSION 8:
+  // - Padding and Margin properties was added.
+  public static final int PASSWORDTEXTBOX_COMPONENT_VERSION = 8;
 
   // For PEDOMETER_COMPONENT_VERSION 2:
   // - The step sensing algorithm was updated to be more accurate.
@@ -1366,7 +1427,9 @@ public class YaVersion {
   // - The method Open was added.
   // For PHONENUMBERPICKER_COMPONENT_VERSION 4:
   // - The Shape property was added.
-  public static final int PHONENUMBERPICKER_COMPONENT_VERSION = 4;
+  // For PHONENUMBERPICKER_COMPONENT_VERSION 5:
+  // - Padding and Margin properties was added.
+  public static final int PHONENUMBERPICKER_COMPONENT_VERSION = 5;
 
   public static final int PHONESTATUS_COMPONENT_VERSION = 1;
 
@@ -1412,7 +1475,9 @@ public class YaVersion {
   // - Added the property to allow for the removal of the Thumb Slider
   // For SLIDER_COMPONENT_VERSION 3:
   // - Added the NumberOfStepsand ThumbColor property, TouchDown and TouchUp events
-  public static final int SLIDER_COMPONENT_VERSION = 3;
+  // For SLIDER_COMPONENT_VERSION 4:
+  // - Margin property was added.
+  public static final int SLIDER_COMPONENT_VERSION = 4;
 
   // For SPINNER_COMPONENT_VERSION 1:
   // - Initial version.
@@ -1420,7 +1485,9 @@ public class YaVersion {
   // - Added BackgroundColor, Enabled, Image, ShowFeedback properties
   // - Added TextSize, TextColor, TextAlignment, TextBold, TextItalic, TextTypeface properties
   // - Added TouchUp and TouchDown events
-  public static final int SPINNER_COMPONENT_VERSION = 2;
+  // For SPINNER_COMPONENT_VERSION 3:
+  // - Padding and Margin properties was added.
+  public static final int SPINNER_COMPONENT_VERSION = 3;
 
   // For SOUND_COMPONENT_VERSION 2:
   // - The Sound.SoundError event was added.
@@ -1463,9 +1530,13 @@ public class YaVersion {
 
   // For SWITCH_COMPONENT_VERSION 1
   //  - Initial Version
-  public static final int SWITCH_COMPONENT_VERSION = 1;
+  // For SWITCH_COMPONENT_VERSION 2
+  // - Padding and Margin properties was added.
+  public static final int SWITCH_COMPONENT_VERSION = 2;
 
-  public static final int TABLEARRANGEMENT_COMPONENT_VERSION = 1;
+  // For TABLEARRANGEMENT_COMPONENT_VERSION 2
+  // - Padding and Margin properties was added.
+  public static final int TABLEARRANGEMENT_COMPONENT_VERSION = 2;
 
   // For TEXTBOX_COMPONENT_VERSION 2:
   // - The TextBox.NumbersOnly property was added.
@@ -1481,7 +1552,9 @@ public class YaVersion {
   // For TEXTBOX_COMPONENT_VERSION 14:
   // - Bumped up to be strictly greater than Kodular's TextBox (13).
   // - TextChanged event, HintColor property, MoveCursorTo, MoveCursorToEnd and MoveCursorToStart methods were added.
-  public static final int TEXTBOX_COMPONENT_VERSION = 14;
+  // For TEXTBOX_COMPONENT_VERSION 15:
+  // - Padding and Margin properties was added.
+  public static final int TEXTBOX_COMPONENT_VERSION = 15;
 
   // For TEXTING_COMPONENT_VERSION 2:
   // Texting over Wifi was implemented using Google Voice
@@ -1524,7 +1597,9 @@ public class YaVersion {
   // - SetTimeToDisplayFromInstant, and Instant property are added.
   // For TIMEPICKER_COMPONENT_VERSION 4:
   // - Assets helper block was added.
-  public static final int TIMEPICKER_COMPONENT_VERSION = 4;
+  // For TIMEPICKER_COMPONENT_VERSION 5:
+  // - Padding and Margin properties was added.
+  public static final int TIMEPICKER_COMPONENT_VERSION = 5;
 
   // For TINYDB_COMPONENT_VERSION 2:
   // - Added Property: Namespace
@@ -1592,12 +1667,16 @@ public class YaVersion {
   // For VERTICALARRANGEMENT_COMPONENT_VERSION 4:
   // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
   // - Assets helper block was added.
-  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 4;
+  // For VERTICALARRANGEMENT_COMPONENT_VERSION 5:
+  // - Padding and Margin properties was added.
+  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 5;
 
   // For VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
   // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
   // - Assets helper block was added.
-  public static final int VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION = 2;
+  // For VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION 3:
+  // - Padding and Margin properties was added.
+  public static final int VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION = 3;
 
   // For VIDEOPLAYER_COMPONENT_VERSION 2:
   // - The VideoPlayer.VideoPlayerError event was added.
@@ -1710,11 +1789,15 @@ public class YaVersion {
 
   // For CIRCULAR_PROGRESS_COMPONENT_VERSION 1:
   // - Initial version
-  public static final int CIRCULAR_PROGRESS_COMPONENT_VERSION = 1;
+  // For CIRCULAR_PROGRESS_COMPONENT_VERSION 2:
+  // - Margin property was added.
+  public static final int CIRCULAR_PROGRESS_COMPONENT_VERSION = 2;
 
   // For LINEAR_PROGRESS_COMPONENT_VERSION 1:
   // - Initial version
-  public static final int LINEAR_PROGRESS_COMPONENT_VERSION = 1;
+  // For LINEAR_PROGRESS_COMPONENT_VERSION 2:
+  // - Margin property was added.
+  public static final int LINEAR_PROGRESS_COMPONENT_VERSION = 2;
 
   // Companion Versions and Update Information
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
@@ -39,6 +39,10 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   private int left = ComponentConstants.DEFAULT_X_Y;
   private int top = ComponentConstants.DEFAULT_X_Y;
 
+  private String paddingString = ComponentConstants.DEFAULT_PADDING_VALUE;
+  private String marginString = ComponentConstants.DEFAULT_MARGIN_VALUE;
+
+
   /**
    * Creates a new AndroidViewComponent.
    *
@@ -319,6 +323,104 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   public void Top(int y) {
     this.top = y;
     container.setChildNeedsLayout(this);
+  }
+
+  /**
+   * Returns the padding space inside the component's bounds (Top,Left,Right,Bottom).
+   */
+  @SimpleProperty(
+          category = PropertyCategory.APPEARANCE,
+          userVisible = false)
+  public String Padding() {
+    return paddingString;
+  }
+
+  /**
+   * Specifies the padding space inside the component's bounds (Top,Left,Right,Bottom).
+   *
+   * @param padding comma-separated "top,left,right,bottom" values in pixels
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_PADDING,
+          defaultValue = "0,0,0,0")
+  @SimpleProperty(
+          category = PropertyCategory.APPEARANCE,
+          description = "The padding space inside the component bounds (Top,Left,Right,Bottom).")
+  public void Padding(String padding) {
+    this.paddingString = padding;
+    applyPadding();
+  }
+
+  /**
+   * Applies the current paddingString to the underlying view. Subclasses whose
+   * appearance logic resets padding as a side effect (e.g. background drawable
+   * reassignment) should call this again after that logic runs.
+   */
+  protected void applyPadding() {
+    if (paddingString != null && paddingString.contains(",")) {
+      String[] sides = paddingString.split(",");
+      if (sides.length == 4) {
+        try {
+          int t = Integer.parseInt(sides[0].trim());
+          int l = Integer.parseInt(sides[1].trim());
+          int r = Integer.parseInt(sides[2].trim());
+          int b = Integer.parseInt(sides[3].trim());
+          getView().setPadding(l, t, r, b);
+        } catch (NumberFormatException e) {
+          // Ignore malformed input safely
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the margin space outside the %type%'s bounds (Top,Left,Right,Bottom).
+   */
+  @SimpleProperty(
+          category = PropertyCategory.APPEARANCE,
+          userVisible = false)
+  public String Margin() {
+    return marginString;
+  }
+
+  /**
+   * Specifies the margin space outside the component's bounds (Top,Left,Right,Bottom).
+   *
+   * @param margin comma-separated "top,left,right,bottom" values in pixels
+   */
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_MARGIN,
+          defaultValue = "0,0,0,0")
+  @SimpleProperty(
+          category = PropertyCategory.APPEARANCE,
+          description = "The margin space outside the component bounds (Top,Left,Right,Bottom).")
+  public void Margin(String margin) {
+    this.marginString = margin;
+    applyMargin();
+  }
+
+  /**
+   * Applies the current marginString to the underlying view's LayoutParams,
+   * if the parent container's LayoutParams subtype supports margins.
+   */
+  protected void applyMargin() {
+    if (marginString != null && marginString.contains(",")) {
+      String[] sides = marginString.split(",");
+      if (sides.length == 4) {
+        try {
+          final int t = Integer.parseInt(sides[0].trim());
+          final int l = Integer.parseInt(sides[1].trim());
+          final int r = Integer.parseInt(sides[2].trim());
+          final int b = Integer.parseInt(sides[3].trim());
+
+          android.view.ViewGroup.LayoutParams lp = getView().getLayoutParams();
+          if (lp instanceof android.view.ViewGroup.MarginLayoutParams) {
+            ((android.view.ViewGroup.MarginLayoutParams) lp).setMargins(l, t, r, b);
+            getView().requestLayout();
+          }
+        } catch (NumberFormatException e) {
+          // Ignore malformed input safely
+        }
+      }
+    }
   }
 
   // Component implementation

--- a/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/AndroidViewComponent.java
@@ -7,15 +7,19 @@
 package com.google.appinventor.components.runtime;
 
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.google.appinventor.components.annotations.DesignerProperty;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.SimplePropertyCopier;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.BoxSide;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 /**
  * Underlying base class for all components with views; not accessible to Simple programmers.
@@ -42,6 +46,8 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   private String paddingString = ComponentConstants.DEFAULT_PADDING_VALUE;
   private String marginString = ComponentConstants.DEFAULT_MARGIN_VALUE;
 
+  protected YailDictionary paddingSource;
+  protected YailDictionary marginSource;
 
   /**
    * Creates a new AndroidViewComponent.
@@ -326,100 +332,162 @@ public abstract class AndroidViewComponent extends VisibleComponent {
   }
 
   /**
-   * Returns the padding space inside the component's bounds (Top,Left,Right,Bottom).
+   * This hidden property is used solely to force the App Inventor compiler
+   * to generate the helper dropdown blocks for LayoutDimension.
+   * It is not intended to be used by the end-user.
    */
   @SimpleProperty(
-          category = PropertyCategory.APPEARANCE,
-          userVisible = false)
-  public String Padding() {
-    return paddingString;
+          userVisible = false,
+          description = "Internal helper to expose LayoutDimension blocks."
+  )
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Dummy setter; no implementation needed as this is just a compiler hook.
   }
 
-  /**
-   * Specifies the padding space inside the component's bounds (Top,Left,Right,Bottom).
-   *
-   * @param padding comma-separated "top,left,right,bottom" values in pixels
-   */
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_PADDING,
-          defaultValue = "0,0,0,0")
+          defaultValue = ComponentConstants.DEFAULT_PADDING_VALUE)
   @SimpleProperty(
           category = PropertyCategory.APPEARANCE,
-          description = "The padding space inside the component bounds (Top,Left,Right,Bottom).")
-  public void Padding(String padding) {
-    this.paddingString = padding;
+          description = "The padding space inside the component bounds. Accepts a Dictionary in blocks."
+  )
+  public void Padding(YailDictionary padding) {
+    this.paddingSource = padding;
     applyPadding();
   }
 
   /**
-   * Applies the current paddingString to the underlying view. Subclasses whose
-   * appearance logic resets padding as a side effect (e.g. background drawable
-   * reassignment) should call this again after that logic runs.
+   * Re-applies the last known padding input to the view. Safe to call with
+   * no arguments any time the view's padding may have been reset as a side
+   * effect of other logic (e.g. background drawable reassignment).
    */
   protected void applyPadding() {
-    if (paddingString != null && paddingString.contains(",")) {
-      String[] sides = paddingString.split(",");
-      if (sides.length == 4) {
-        try {
-          int t = Integer.parseInt(sides[0].trim());
-          int l = Integer.parseInt(sides[1].trim());
-          int r = Integer.parseInt(sides[2].trim());
-          int b = Integer.parseInt(sides[3].trim());
-          getView().setPadding(l, t, r, b);
-        } catch (NumberFormatException e) {
-          // Ignore malformed input safely
-        }
+    applyPadding(paddingSource);
+  }
+
+  protected void applyPadding(YailDictionary input) {
+    View view = getView();
+    float density = container.$form().deviceDensity();
+
+    int t = (int) (view.getPaddingTop() / density);
+    int l = (int) (view.getPaddingLeft() / density);
+    int r = (int) (view.getPaddingRight() / density);
+    int b = (int) (view.getPaddingBottom() / density);
+
+    int[] merged = mergeSides(input, t, l, r, b); // merged is in dp
+    if (merged != null) {
+      view.setPadding(
+              Math.round(merged[1] * density),
+              Math.round(merged[0] * density),
+              Math.round(merged[2] * density),
+              Math.round(merged[3] * density)
+      ); // l, t, r, b
+    }
+  }
+
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_MARGIN,
+          defaultValue = ComponentConstants.DEFAULT_MARGIN_VALUE)
+  @SimpleProperty(
+          category = PropertyCategory.APPEARANCE,
+          description = "The margin space outside the component bounds. Accepts a Dictionary in blocks."
+  )
+  public void Margin(YailDictionary margin) {
+    this.marginSource = margin;
+    applyMargin();
+  }
+
+  /**
+   * Re-applies the last known margin input to the view's LayoutParams. Safe
+   * to call with no arguments any time margins may need to be reasserted.
+   */
+  protected void applyMargin() {
+    applyMargin(marginSource);
+  }
+
+  protected void applyMargin(YailDictionary input) {
+    View view = getView();
+    ViewGroup.LayoutParams lp = view.getLayoutParams();
+
+    if (lp instanceof ViewGroup.MarginLayoutParams) {
+      ViewGroup.MarginLayoutParams marginLp = (ViewGroup.MarginLayoutParams) lp;
+      float density = container.$form().deviceDensity();
+
+      int t = (int) (marginLp.topMargin / density);
+      int l = (int) (marginLp.leftMargin / density);
+      int r = (int) (marginLp.rightMargin / density);
+      int b = (int) (marginLp.bottomMargin / density);
+
+      int[] merged = mergeSides(input, t, l, r, b); // merged is in dp
+      if (merged != null) {
+        marginLp.setMargins(
+                Math.round(merged[1] * density),
+                Math.round(merged[0] * density),
+                Math.round(merged[2] * density),
+                Math.round(merged[3] * density)
+        ); // l, t, r, b
+        view.requestLayout();
       }
     }
   }
 
   /**
-   * Returns the margin space outside the %type%'s bounds (Top,Left,Right,Bottom).
+   * Resolves a Padding/Margin YailDictionary against the view's current
+   * side values, returning a merged [top, left, right, bottom] array.
+   * "all" overrides every side if present and valid; otherwise each side
+   * is read individually, with "leading"/"trailing" as fallbacks for
+   * "left"/"right". Any side not specified (or invalid) keeps its current
+   * value. Returns null if the input is null.
    */
-  @SimpleProperty(
-          category = PropertyCategory.APPEARANCE,
-          userVisible = false)
-  public String Margin() {
-    return marginString;
+  private int[] mergeSides(YailDictionary dict, int curT, int curL, int curR, int curB) {
+    if (dict == null) {
+      return null;
+    }
+
+    int t = curT, l = curL, r = curR, b = curB;
+
+    int allVal = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.All));
+    if (allVal >= 0) {
+      return new int[]{allVal, allVal, allVal, allVal};
+    }
+
+    int dictTop = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Top));
+    if (dictTop >= 0) t = dictTop;
+
+    int dictLeft = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Left));
+    if (dictLeft < 0) dictLeft = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Leading));
+    if (dictLeft >= 0) l = dictLeft;
+
+    int dictRight = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Right));
+    if (dictRight < 0) dictRight = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Trailing));
+    if (dictRight >= 0) r = dictRight;
+
+    int dictBottom = parsePositiveIntOrMinusOne(getSide(dict, BoxSide.Bottom));
+    if (dictBottom >= 0) b = dictBottom;
+
+    return new int[]{t, l, r, b};
   }
 
   /**
-   * Specifies the margin space outside the component's bounds (Top,Left,Right,Bottom).
-   *
-   * @param margin comma-separated "top,left,right,bottom" values in pixels
+   * Looks up a side's value in the dictionary, accepting either the
+   * BoxSide enum constant itself as a key, or its underlying String
+   * value (e.g. "top") — the latter being what blocks-built
+   * dictionaries will actually contain, since OptionList blocks
+   * evaluate to their underlying value at runtime.
    */
-  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_MARGIN,
-          defaultValue = "0,0,0,0")
-  @SimpleProperty(
-          category = PropertyCategory.APPEARANCE,
-          description = "The margin space outside the component bounds (Top,Left,Right,Bottom).")
-  public void Margin(String margin) {
-    this.marginString = margin;
-    applyMargin();
+  private Object getSide(YailDictionary dict, BoxSide side) {
+    Object val = dict.get(side.toUnderlyingValue());
+    if (val == null) {
+      val = dict.get(side);
+    }
+    return val;
   }
 
-  /**
-   * Applies the current marginString to the underlying view's LayoutParams,
-   * if the parent container's LayoutParams subtype supports margins.
-   */
-  protected void applyMargin() {
-    if (marginString != null && marginString.contains(",")) {
-      String[] sides = marginString.split(",");
-      if (sides.length == 4) {
-        try {
-          final int t = Integer.parseInt(sides[0].trim());
-          final int l = Integer.parseInt(sides[1].trim());
-          final int r = Integer.parseInt(sides[2].trim());
-          final int b = Integer.parseInt(sides[3].trim());
-
-          android.view.ViewGroup.LayoutParams lp = getView().getLayoutParams();
-          if (lp instanceof android.view.ViewGroup.MarginLayoutParams) {
-            ((android.view.ViewGroup.MarginLayoutParams) lp).setMargins(l, t, r, b);
-            getView().requestLayout();
-          }
-        } catch (NumberFormatException e) {
-          // Ignore malformed input safely
-        }
-      }
+  private int parsePositiveIntOrMinusOne(Object val) {
+    if (val == null) return -1;
+    try {
+      int parsed = (val instanceof Number) ? ((Number) val).intValue() : Integer.parseInt(val.toString().trim());
+      return (parsed >= 0) ? parsed : -1;
+    } catch (NumberFormatException e) {
+      return -1;
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ButtonBase.java
@@ -317,6 +317,7 @@ public abstract class ButtonBase extends TouchComponent<android.widget.Button>
         ViewUtil.setBackgroundImage(view, new BitmapDrawable(result));
       }
     }
+    applyPadding();
   }
 
   private Drawable getSafeBackgroundDrawable() {
@@ -649,6 +650,7 @@ public abstract class ButtonBase extends TouchComponent<android.widget.Button>
         TextViewUtil.setTextColors(view, defaultColorStateList);
       }
     }
+    applyPadding();
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
@@ -46,12 +46,14 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
+import com.google.appinventor.components.annotations.Options;
 
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.FileScope;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.common.BoxSide;
 
 import com.google.appinventor.components.runtime.collect.Sets;
 
@@ -68,6 +70,7 @@ import com.google.appinventor.components.runtime.util.ScopedFile;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.Synchronizer;
 import com.google.appinventor.components.runtime.util.YailList;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -1278,13 +1281,18 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 
   @Override
-  public void Margin(String margin) {
+  public void Margin(YailDictionary margin) {
     // Not supported for this component type
+  }
+
+  @Override
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Ignored
   }
 
   // Methods supporting event handling

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Canvas.java
@@ -1277,6 +1277,16 @@ public final class Canvas extends AndroidViewComponent implements ComponentConta
     extendMovesOutsideCanvas = extend;   
   }
 
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
+  public void Margin(String margin) {
+    // Not supported for this component type
+  }
+
   // Methods supporting event handling
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
@@ -554,6 +554,11 @@ public class Chart extends AndroidViewComponent
     return this.zeroY;
   }
 
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
   /**
    * Extends the domain of the chart to include the provided x value. If x is already within the
    * bounds of the domain, this method has no effect.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Chart.java
@@ -26,6 +26,7 @@ import com.google.appinventor.components.common.YaVersion;
 
 import com.google.appinventor.components.runtime.util.ElementsUtil;
 import com.google.appinventor.components.runtime.util.OnInitializeListener;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 import com.google.appinventor.components.runtime.util.YailList;
 
 import java.util.ArrayList;
@@ -555,7 +556,7 @@ public class Chart extends AndroidViewComponent
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/CircularProgress.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/CircularProgress.java
@@ -24,6 +24,7 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 
 @DesignerComponent(
@@ -82,7 +83,7 @@ public final class CircularProgress extends AndroidViewComponent {
 
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/CircularProgress.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/CircularProgress.java
@@ -79,4 +79,11 @@ public final class CircularProgress extends AndroidViewComponent {
   public int Color() {
     return this.indeterminateColor;
   }
+
+
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
@@ -122,6 +122,18 @@ public class FeatureCollection extends MapFeatureContainerBase implements MapFea
     getMap().getController().setFeatureCollectionVisible(this, visibility);
   }
 
+
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
+  public void Margin(String margin) {
+    // Not supported for this component type
+  }
+
+
   @Override
   public View getView() {
     // Even though we are an AndroidViewComponent, we don't actually have a view because the view

--- a/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/FeatureCollection.java
@@ -11,12 +11,15 @@ import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.BoxSide;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.MapFactory;
 import com.google.appinventor.components.runtime.util.MapFactory.MapFeatureCollection;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 import com.google.appinventor.components.runtime.util.YailList;
 
 import android.view.View;
@@ -124,13 +127,18 @@ public class FeatureCollection extends MapFeatureContainerBase implements MapFea
 
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 
   @Override
-  public void Margin(String margin) {
+  public void Margin(YailDictionary margin) {
     // Not supported for this component type
+  }
+
+  @Override
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Ignored
   }
 
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/LinearProgress.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LinearProgress.java
@@ -193,4 +193,10 @@ public final class LinearProgress extends AndroidViewComponent {
   public void ProgressChanged(int progress) {
     EventDispatcher.dispatchEvent(this, "ProgressChanged", progress);
   }
+
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/LinearProgress.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LinearProgress.java
@@ -25,6 +25,7 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 
 @DesignerComponent(
@@ -195,7 +196,7 @@ public final class LinearProgress extends AndroidViewComponent {
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -30,6 +30,7 @@ import com.google.appinventor.components.common.MapType;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.ScaleUnits;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.common.BoxSide;
 
 import com.google.appinventor.components.runtime.LocationSensor.LocationSensorListener;
 
@@ -50,6 +51,7 @@ import com.google.appinventor.components.runtime.util.MapFactory.MapPolygon;
 import com.google.appinventor.components.runtime.util.MapFactory.MapRectangle;
 import com.google.appinventor.components.runtime.util.ScopedFile;
 import com.google.appinventor.components.runtime.util.YailList;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 import java.io.IOException;
 
@@ -611,13 +613,18 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 
   @Override
-  public void Margin(String margin) {
+  public void Margin(YailDictionary margin) {
     // Not supported for this component type
+  }
+
+  @Override
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Ignored
   }
 
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Map.java
@@ -610,6 +610,17 @@ public class Map extends MapFeatureContainerBase implements MapEventListener {
     return sensor == null ? -999 : sensor.Longitude();
   }
 
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
+  public void Margin(String margin) {
+    // Not supported for this component type
+  }
+
+
   @SimpleFunction(description = "Pans the map center to the given latitude and longitude and " +
       "adjust the zoom level to the specified zoom.")
   public void PanTo(double latitude, double longitude, int zoom) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
@@ -472,6 +472,11 @@ public class Slider extends AndroidViewComponent implements SeekBar.OnSeekBarCha
   }
 
   @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
   public View getView() {
     return seekbar;
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Slider.java
@@ -24,6 +24,7 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 /**
  * This class is used to display a `Slider`.
@@ -472,7 +473,7 @@ public class Slider extends AndroidViewComponent implements SeekBar.OnSeekBarCha
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -301,6 +301,15 @@ public final class VideoPlayer extends AndroidViewComponent implements
     }
   }
 
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
+  public void Margin(String margin) {
+    // Not supported for this component type
+  }
 
   /**
    * Method for starting the VideoPlayer once the media has been loaded.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/VideoPlayer.java
@@ -29,9 +29,11 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.BoxSide;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.PermissionException;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
@@ -39,6 +41,7 @@ import com.google.appinventor.components.runtime.util.FullScreenVideoUtil;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.TiramisuUtil;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 import java.io.IOException;
 
 /**
@@ -302,13 +305,18 @@ public final class VideoPlayer extends AndroidViewComponent implements
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 
   @Override
-  public void Margin(String margin) {
+  public void Margin(YailDictionary margin) {
     // Not supported for this component type
+  }
+
+  @Override
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Ignored
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -393,6 +393,16 @@ public final class WebViewer extends AndroidViewComponent {
     resetWebViewClient();
   }
 
+  @Override
+  public void Padding(String padding) {
+    // Not supported for this component type
+  }
+
+  @Override
+  public void Margin(String margin) {
+    // Not supported for this component type
+  }
+
   /**
    * Loads the  page from the home URL.  This happens automatically when
    * home URL is changed.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/WebViewer.java
@@ -25,7 +25,9 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.BoxSide;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 
@@ -35,6 +37,7 @@ import com.google.appinventor.components.runtime.util.FroyoWebViewClient;
 import com.google.appinventor.components.runtime.util.HoneycombWebViewClient;
 import com.google.appinventor.components.runtime.util.MediaUtil;
 import com.google.appinventor.components.runtime.util.SdkLevel;
+import com.google.appinventor.components.runtime.util.YailDictionary;
 
 
 /**
@@ -394,13 +397,18 @@ public final class WebViewer extends AndroidViewComponent {
   }
 
   @Override
-  public void Padding(String padding) {
+  public void Padding(YailDictionary padding) {
     // Not supported for this component type
   }
 
   @Override
-  public void Margin(String margin) {
+  public void Margin(YailDictionary margin) {
     // Not supported for this component type
+  }
+
+  @Override
+  public void LayoutDimensionHelper(@Options(BoxSide.class) String dimension) {
+    // Ignored
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*

Adds `Padding` and `Margin` properties to `AndroidViewComponent`, so components can specify inner/outer spacing directly without workarounds. Values are set via a `YailDictionary` from blocks (supporting individual sides, an all shortcut, and `leading/trailing` aliases for `left/right`), with unspecified sides preserving their current value rather than resetting to 0. Persisted in .scm as JSON. Includes a `BoxSide` OptionList block for use with the standard "make a dictionary"/"make a pair" blocks, dp-to-px density scaling consistent with Width/Height, and a Designer-side cross-layout property editor for visual editing.

<img width="152" height="257" alt="Screenshot 2026-07-05 at 13 18 59" src="https://github.com/user-attachments/assets/bb098a2d-51fa-46f1-946f-c4d865531654" />

<img width="882" height="471" alt="Screenshot 2026-07-09 at 14 14 12" src="https://github.com/user-attachments/assets/290a155a-7c91-4593-b711-4718b3f6c76a" />

https://github.com/user-attachments/assets/186666ab-371f-43ff-95f7-89046d6afbdb




<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*
1. Drag a component supporting `Padding/Margin` (e.g. Button) onto the Designer canvas; set values via the cross-layout property editor and confirm they render and persist across reload.
2. Export as .aia and confirm .scm contains valid JSON for Padding/Margin.
3. In Blocks, use make a dictionary + make a pair with the BoxSide dropdown as keys. confirm the correct sides update on a real device/Companion.
4. Confirm density scaling is correct (padding/margin size matches expected dp value across different device densities).
5. Confirm components that don't support Padding/Margin (Canvas, Chart, Map, etc.) don't error when the properties are set.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #4019 .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
