### PR TITLE
Use class instead of tag for Swift OptionHelper generation

### DIFF
--- a/appinventor/common/src/com/google/appinventor/common/utils/StringUtils.java
+++ b/appinventor/common/src/com/google/appinventor/common/utils/StringUtils.java
@@ -357,4 +357,15 @@ public final class StringUtils {
     int index = qualifiedName.lastIndexOf('.');
     return index < 0 ? "" : qualifiedName.substring(0, index);
   }
+
+  /**
+   * Gets the simple class name from a given fully qualified class name.
+   *
+   * @param qualifiedName  fully qualified class name
+   * @return  simple class name
+   */
+  public static String getSimpleClassName(String qualifiedName) {
+    int index = qualifiedName.lastIndexOf('.');
+    return index < 0 ? qualifiedName : qualifiedName.substring(index + 1);
+  }
 }

--- a/appinventor/components-ios/src/OptionHelper.swift
+++ b/appinventor/components-ios/src/OptionHelper.swift
@@ -97,7 +97,7 @@ import Foundation
       "Sensitivity": Sensitivity.fromUnderlyingValue(_:)
     ],
     "Button": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Canvas": [
@@ -111,18 +111,18 @@ import Foundation
       "PointShape": PointStyle.fromUnderlyingValue(_:)
     ],
     "ContactPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "DatePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "EmailPicker": [
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "FilePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Form": [
@@ -138,14 +138,14 @@ import Foundation
       "AlignVertical": VerticalAlignment.fromUnderlyingValue(_:)
     ],
     "ImagePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Label": [
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "ListPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "ListView": [
@@ -167,7 +167,7 @@ import Foundation
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "PhoneNumberPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Spinner": [
@@ -180,7 +180,7 @@ import Foundation
       "ReceivingEnabled": ReceivingState.fromUnderlyingValue(_:)
     ],
     "TimePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Trendline": [

--- a/appinventor/components/src/com/google/appinventor/components/scripts/SwiftOptionHelperGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/SwiftOptionHelperGenerator.java
@@ -5,6 +5,7 @@
 
 package com.google.appinventor.components.scripts;
 
+import com.google.appinventor.common.utils.StringUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -131,7 +132,7 @@ public class SwiftOptionHelperGenerator extends ComponentProcessor {
     pw.print(functionName);
     pw.print("\": ");
     OptionList items = optionLists.get((String) helperKey.getKey());
-    pw.print(items.getTagName());
+    pw.print(StringUtils.getSimpleClassName(items.getClassName()));
     pw.print(".fromUnderlyingValue(_:)");
   }
 


### PR DESCRIPTION
Change-Id: I4f7b689d2191267695893c252c70b226041be981

**What does this PR accomplish?**

*Description*

This PR fixes an issue where the OptionHelper object for Swift fails to compile after d30b79f. We had been using tag name, which always matched the simple class name, until that change was made. However, the Swift code actually needs the class name. This PR switches to using the class name and regenerates the OptionHelper.swift file.

**Context for the changes**

- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
