### PR TITLE
Fix ListView search filtering and selection (iOS + Android)

### DIFF
--- a/appinventor/common/src/com/google/appinventor/common/utils/StringUtils.java
+++ b/appinventor/common/src/com/google/appinventor/common/utils/StringUtils.java
@@ -357,4 +357,15 @@ public final class StringUtils {
     int index = qualifiedName.lastIndexOf('.');
     return index < 0 ? "" : qualifiedName.substring(0, index);
   }
+
+  /**
+   * Gets the simple class name from a given fully qualified class name.
+   *
+   * @param qualifiedName  fully qualified class name
+   * @return  simple class name
+   */
+  public static String getSimpleClassName(String qualifiedName) {
+    int index = qualifiedName.lastIndexOf('.');
+    return index < 0 ? qualifiedName : qualifiedName.substring(index + 1);
+  }
 }

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -57,8 +57,6 @@ class ListDataModel {
   var displayCount: Int { filteredIndices.count }
   /// Maps a visible row back to its real position in `elements` / `items`.
   func originalIndex(_ displayRow: Int) -> Int { filteredIndices[displayRow] }
-  /// Whether the row at the given real position is currently shown (i.e. survives the filter).
-  func isVisible(_ originalIndex: Int) -> Bool { filteredIndices.contains(originalIndex) }
 }
 
   open class ListView: ViewComponent, AbstractMethodsForViewComponent,
@@ -1155,15 +1153,22 @@ class ListDataModel {
 
   open func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
     _model.setFilter(searchText)
-    // Keep the selection while the selected item is still on screen, and clear it only when the
-    // filter hides it, so the user never ends up with a selection they cannot see.
-    if _selectionIndex > 0 && !_model.isVisible(Int(_selectionIndex) - 1) {
-      _selectionIndex = 0
-      _selection = ""
-      _selectionDetailText = ""
-    }
     _view.reloadData()
     _collectionView.reloadData()
+    // reloadData drops UIKit's selection state, so the highlight is lost on every filter change.
+    // Selection is stored against the original index, so re-highlight the selected item's new
+    // visible row while it survives the filter, and clear it only when the filter hides it, so the
+    // user never ends up with a selection they cannot see.
+    if _selectionIndex > 0 {
+      if let displayRow = _model.filteredIndices.firstIndex(of: Int(_selectionIndex) - 1) {
+        _view.selectRow(at: IndexPath(row: displayRow, section: 0), animated: false, scrollPosition: .none)
+        _collectionView.selectItem(at: IndexPath(item: displayRow, section: 0), animated: false, scrollPosition: [])
+      } else {
+        _selectionIndex = 0
+        _selection = ""
+        _selectionDetailText = ""
+      }
+    }
   }
 
   open func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -57,6 +57,8 @@ class ListDataModel {
   var displayCount: Int { filteredIndices.count }
   /// Maps a visible row back to its real position in `elements` / `items`.
   func originalIndex(_ displayRow: Int) -> Int { filteredIndices[displayRow] }
+  /// Whether the row at the given real position is currently shown (i.e. survives the filter).
+  func isVisible(_ originalIndex: Int) -> Bool { filteredIndices.contains(originalIndex) }
 }
 
   open class ListView: ViewComponent, AbstractMethodsForViewComponent,
@@ -1153,6 +1155,13 @@ class ListDataModel {
 
   open func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
     _model.setFilter(searchText)
+    // Keep the selection while the selected item is still on screen, and clear it only when the
+    // filter hides it, so the user never ends up with a selection they cannot see.
+    if _selectionIndex > 0 && !_model.isVisible(Int(_selectionIndex) - 1) {
+      _selectionIndex = 0
+      _selection = ""
+      _selectionDetailText = ""
+    }
     _view.reloadData()
     _collectionView.reloadData()
   }

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -681,15 +681,38 @@ class ListDataModel {
 
   // MARK: Methods
 
+  /// True when the list currently holds plain string rows rather than Text1/Text2/Image rows.
+  /// For an empty list this falls back to the configured layout, matching the Android behavior.
+  private var usesPlainStrings: Bool {
+    if !_model.items.isEmpty {
+      return false
+    }
+    if !_model.elements.isEmpty {
+      return true
+    }
+    return _listViewLayoutMode == 0
+  }
+
   @objc open func AddItem(_ mainText: String, _ detailText: String, _ imageName: String) {
-    _model.items.append(["Text1": mainText as AnyObject, "Text2": detailText as AnyObject, "Image": imageName as AnyObject])
+    if usesPlainStrings {
+      _model.elements.append(mainText)
+    } else {
+      _model.items.append(makeListItem(text1: mainText, text2: detailText, image: imageName))
+    }
+    elementsCount()
   }
 
   @objc open func AddItemAtIndex(_ addIndex: Int32, _ mainText: String, _ detailText: String, _ imageName: String) {
-    guard addIndex > 0 && addIndex <= _model.items.count + 1 else {
+    guard addIndex > 0 && addIndex <= Int32(_model.count) + 1 else {
       return
     }
-    _model.items.insert(["Text1": mainText as AnyObject, "Text2": detailText as AnyObject, "Image": imageName as AnyObject], at: Int(addIndex - 1))
+    let index = Int(addIndex - 1)
+    if usesPlainStrings {
+      _model.elements.insert(mainText, at: index)
+    } else {
+      _model.items.insert(makeListItem(text1: mainText, text2: detailText, image: imageName), at: index)
+    }
+    elementsCount()
   }
 
   @objc open func AddItems(_ items: [AnyObject]) {

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -24,8 +24,39 @@ class ListDataModel {
   var elements = [String]()
   /// Rich rows: Text1 / Text2 / Image (populated for ListData / image layouts).
   var items: [[String: AnyObject]] = []
-  /// The current filtered view of `elements` (nil when no filter is active).
-  var results: [String]? = nil
+
+  // ---- Filtering (makes the search box actually filter the list, for both string and rich rows) ----
+  private var query = ""
+
+  /// true when the list holds rich rows (dicts); false for a plain string list.
+  var isDataMode: Bool { !items.isEmpty }
+  /// Total number of rows before filtering.
+  var count: Int { isDataMode ? items.count : elements.count }
+
+  /// Original-index positions of the rows matching the current search (identity when no search).
+  /// Recomputed on demand — fine for realistic list sizes; cache if huge lists ever matter.
+  var filteredIndices: [Int] {
+    guard !query.isEmpty else { return Array(0..<count) }
+    let q = query.lowercased()
+    return (0..<count).filter { i in
+      if isDataMode {
+        let row = items[i]
+        let t1 = (row["Text1"] as? String ?? "").lowercased()
+        let t2 = (row["Text2"] as? String ?? "").lowercased()
+        return t1.contains(q) || t2.contains(q)
+      } else {
+        return elements[i].lowercased().contains(q)
+      }
+    }
+  }
+
+  func setFilter(_ text: String) { query = text }
+
+  // ---- What the table / collection actually draws (filter-aware) ----
+  /// Number of rows currently visible (after filtering).
+  var displayCount: Int { filteredIndices.count }
+  /// Maps a visible row back to its real position in `elements` / `items`.
+  func originalIndex(_ displayRow: Int) -> Int { filteredIndices[displayRow] }
 }
 
   open class ListView: ViewComponent, AbstractMethodsForViewComponent,
@@ -752,18 +783,19 @@ class ListDataModel {
       UITableViewCell(style: .subtitle, reuseIdentifier: kDefaultTableCell)
       let hasElements = _model.elements.count > 0
       
-      let listDataIndex = indexPath.row - _model.items.count
+      // Map the visible row back to its real position so search filtering works.
+      let origRow = _model.originalIndex(indexPath.row)
       if _listViewLayoutMode == 0 { // assume only strings (no dicts]
         if hasElements {
-          let item = _model.elements[indexPath.row]
+          let item = _model.elements[origRow]
           cell.textLabel?.text = item as? String
         } else{
-          let item = _model.items[indexPath.row]
+          let item = _model.items[origRow]
           cell.textLabel?.text = item["Text1"] as? String
         }
         
       } else {
-        let item = _model.items[indexPath.row]
+        let item = _model.items[origRow]
         if _listViewLayoutMode == 1 {
           tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 44
@@ -976,7 +1008,7 @@ class ListDataModel {
         } else {
           tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 44
-          cell.textLabel?.text = _model.items[listDataIndex]["Text1"] as? String
+          cell.textLabel?.text = item["Text1"] as? String
         }
     }
 
@@ -1075,21 +1107,21 @@ class ListDataModel {
 
   
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-      return _model.items.isEmpty ? _model.elements.count : _model.items.count
+      return _model.displayCount
     }
 
     // MARK: UITableViewDelegate
 
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-      if indexPath.row < _model.elements.count {
-        _selectionIndex = Int32(indexPath.row) + 1
-        _selection = _model.elements[indexPath.row]
+      // Map the tapped visible row back to its real position, so selection is correct while filtering.
+      let origRow = _model.originalIndex(indexPath.row)
+      _selectionIndex = Int32(origRow) + 1
+      if _model.isDataMode {
+        _selection = _model.items[origRow]["Text1"] as? String ?? ""
+        _selectionDetailText = _model.items[origRow]["Text2"] as? String ?? ""
+      } else {
+        _selection = _model.elements[origRow]
         _selectionDetailText = ""
-      } else if indexPath.row < _model.elements.count + _model.items.count {
-        let listDataIndex = indexPath.row - _model.elements.count
-        _selectionIndex = Int32(indexPath.row) + 1
-        _selection = _model.items[listDataIndex]["Text1"] as! String
-        _selectionDetailText = _model.items[listDataIndex]["Text2"] as! String
       }
       AfterPicking()
     }
@@ -1097,16 +1129,9 @@ class ListDataModel {
   // MARK: UISearchBarDelegate
 
   open func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-    _model.results = nil
-    if !searchText.isEmpty  {
-      _model.results = [String]()
-      for item in _model.elements {
-        if item.starts(with: searchText) {
-          _model.results?.append(item)
-        }
-      }
-    }
+    _model.setFilter(searchText)
     _view.reloadData()
+    _collectionView.reloadData()
   }
 
   open func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
@@ -1166,25 +1191,24 @@ class ListDataModel {
   required init?(coder: NSCoder) { fatalError() }
   }
 
-  var elements: [String] {
-      return _model.results ?? _model.elements
-    }
     
   // UICollectionViewDataSource
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return _model.items.isEmpty ? _model.elements.count : _model.items.count
+    return _model.displayCount
   }
 
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HListCell.reuseId, for: indexPath) as! HListCell
 
-    let isData = !_model.items.isEmpty
+    let isData = _model.isDataMode
+    // Map the visible item back to its real position so search filtering works here too.
+    let origRow = _model.originalIndex(indexPath.item)
     let mainText: String
     let detailText: String
     var image: UIImage? = nil
 
     if isData {
-      let item = _model.items[indexPath.item]
+      let item = _model.items[origRow]
       mainText = item["Text1"] as? String ?? ""
       detailText = item["Text2"] as? String ?? ""
       if let path = item["Image"] as? String,
@@ -1193,7 +1217,7 @@ class ListDataModel {
         image = AssetManager.shared.imageFromPath(path: path)
       }
     } else {
-      mainText = _model.elements[indexPath.item] //_model.items[indexPath.item] as? String ?? ""
+      mainText = _model.elements[origRow]
       detailText = ""
     }
 
@@ -1255,16 +1279,17 @@ class ListDataModel {
 
   // UICollectionViewDelegate (selection → AfterPicking)
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    if !_model.items.isEmpty {
-      let item = _model.items[indexPath.item]
-      _selectionIndex = Int32(indexPath.item) + 1
+    // Map the tapped visible item back to its real position, so selection is correct while filtering.
+    let origRow = _model.originalIndex(indexPath.item)
+    _selectionIndex = Int32(origRow) + 1
+    if _model.isDataMode {
+      let item = _model.items[origRow]
       _selection = item["Text1"] as? String ?? ""
       _selectionDetailText = item["Text2"] as? String ?? ""
-    } /*else {
-      _selectionIndex = Int32(indexPath.item) + 1
-      _selection = elements[indexPath.item] as? String ?? ""
+    } else {
+      _selection = _model.elements[origRow]
       _selectionDetailText = ""
-    } */
+    }
     AfterPicking()
   }
 

--- a/appinventor/components-ios/src/OptionHelper.swift
+++ b/appinventor/components-ios/src/OptionHelper.swift
@@ -97,7 +97,7 @@ import Foundation
       "Sensitivity": Sensitivity.fromUnderlyingValue(_:)
     ],
     "Button": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Canvas": [
@@ -111,18 +111,18 @@ import Foundation
       "PointShape": PointStyle.fromUnderlyingValue(_:)
     ],
     "ContactPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "DatePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "EmailPicker": [
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "FilePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Form": [
@@ -138,14 +138,14 @@ import Foundation
       "AlignVertical": VerticalAlignment.fromUnderlyingValue(_:)
     ],
     "ImagePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Label": [
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "ListPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "ListView": [
@@ -167,7 +167,7 @@ import Foundation
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "PhoneNumberPicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Spinner": [
@@ -180,7 +180,7 @@ import Foundation
       "ReceivingEnabled": ReceivingState.fromUnderlyingValue(_:)
     ],
     "TimePicker": [
-      "Shape": Shape.fromUnderlyingValue(_:),
+      "Shape": ButtonShape.fromUnderlyingValue(_:),
       "TextAlignment": TextAlignment.fromUnderlyingValue(_:)
     ],
     "Trendline": [

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -79,7 +79,9 @@ public abstract class ListAdapterWithRecyclerView
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
       items = new ArrayList<>((List<Object>) filterResults.values);
-      clearSelections();
+      // Filtering changes what is visible, not what the user picked, so the selection is left
+      // alone here. Selection is stored against original item indexes, so it stays correct
+      // whether or not the selected item is currently shown.
       notifyDataSetChanged();
       // We store the original data in the originalItems variable
       // We store the original item indexes in the originalPositions variable
@@ -126,8 +128,34 @@ public abstract class ListAdapterWithRecyclerView
     return cardView;
   }
 
+  /**
+   * Returns the display row showing the given original item index, or -1 when that item is
+   * currently filtered out.
+   */
+  protected int toDisplayPosition(int originalPosition) {
+    return originalPositions.isEmpty() ? originalPosition : originalPositions.indexOf(originalPosition);
+  }
+
+  /**
+   * Returns the original item index behind the given display row.
+   */
+  protected int toOriginalPosition(int displayPosition) {
+    return originalPositions.isEmpty() ? displayPosition : originalPositions.get(displayPosition);
+  }
+
+  /**
+   * Refreshes the row showing the given original item index, if it is currently visible.
+   */
+  private void notifyOriginalChanged(int originalPosition) {
+    int displayPosition = toDisplayPosition(originalPosition);
+    if (displayPosition >= 0) {
+      notifyItemChanged(displayPosition);
+    }
+  }
+
   protected void updateCardViewColor(CardView cardView, int position) {
-    if (selectedItems.contains(position)) {
+    // Selection is stored against original item indexes, so map the display row first.
+    if (selectedItems.contains(toOriginalPosition(position))) {
       cardView.setCardBackgroundColor(selectionColor);
     } else {
       cardView.setCardBackgroundColor(backgroundColor);
@@ -139,32 +167,32 @@ public abstract class ListAdapterWithRecyclerView
     return items.size();
   }
 
+  /**
+   * Selects the item at the given original index, replacing any previous selection.
+   */
   public void toggleSelection(int position) {
-    if (!originalPositions.isEmpty()) {
-      position = originalPositions.indexOf(position);
-    }
     if (selectedItems.contains(position)) {
       return;
     }
     if (!selectedItems.isEmpty()) {
       int oldPosition = selectedItems.get(0);
       selectedItems.clear();
-      notifyItemChanged(oldPosition);
+      notifyOriginalChanged(oldPosition);
     }
     selectedItems.add(position);
-    notifyItemChanged(position);
+    notifyOriginalChanged(position);
   }
 
+  /**
+   * Toggles the item at the given original index, used when MultiSelect is enabled.
+   */
   public void changeSelections(int position) {
-    if (!originalPositions.isEmpty()) {
-      position = originalPositions.indexOf(position);
-    }
     if (selectedItems.contains(position)) {
       selectedItems.remove(Integer.valueOf(position));
     } else {
       selectedItems.add(position);
     }
-    notifyItemChanged(position);
+    notifyOriginalChanged(position);
   }
 
   public void clearSelections() {
@@ -179,12 +207,7 @@ public abstract class ListAdapterWithRecyclerView
 
     @Override
     public void onClick(View v) {
-      int position = getAdapterPosition();
-      
-      if (!originalPositions.isEmpty()) {
-        position = originalPositions.get(position);
-      }
-      clickListener.onItemClick(position, v);
+      clickListener.onItemClick(toOriginalPosition(getAdapterPosition()), v);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -79,9 +79,12 @@ public abstract class ListAdapterWithRecyclerView
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
       items = new ArrayList<>((List<Object>) filterResults.values);
-      // Filtering changes what is visible, not what the user picked, so the selection is left
-      // alone here. Selection is stored against original item indexes, so it stays correct
-      // whether or not the selected item is currently shown.
+      // Keep the selection while the selected item is still on screen, and drop it only when the
+      // filter hides it, so the user never ends up with a selection they cannot see. Selection is
+      // stored against original item indexes, so it survives filtering otherwise.
+      if (!lastQuery.isEmpty()) {
+        selectedItems.retainAll(originalPositions);
+      }
       notifyDataSetChanged();
       // We store the original data in the originalItems variable
       // We store the original item indexes in the originalPositions variable
@@ -133,14 +136,22 @@ public abstract class ListAdapterWithRecyclerView
    * currently filtered out.
    */
   protected int toDisplayPosition(int originalPosition) {
-    return originalPositions.isEmpty() ? originalPosition : originalPositions.indexOf(originalPosition);
+    return lastQuery.isEmpty() ? originalPosition : originalPositions.indexOf(originalPosition);
   }
 
   /**
    * Returns the original item index behind the given display row.
    */
   protected int toOriginalPosition(int displayPosition) {
-    return originalPositions.isEmpty() ? displayPosition : originalPositions.get(displayPosition);
+    return lastQuery.isEmpty() ? displayPosition : originalPositions.get(displayPosition);
+  }
+
+  /**
+   * Returns whether the item at the given original index is currently shown, that is, whether it
+   * survives the active filter. With no filter every item is shown.
+   */
+  public boolean isVisible(int originalPosition) {
+    return lastQuery.isEmpty() || originalPositions.contains(originalPosition);
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.Filter;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView.LayoutParams;
@@ -194,7 +195,16 @@ public final class ListView extends AndroidViewComponent {
       @Override
       public void onTextChanged(CharSequence cs, int arg1, int arg2, int arg3) {
         // When user changed the Text
-        listAdapterWithRecyclerView.getFilter().filter(cs);
+        listAdapterWithRecyclerView.getFilter().filter(cs, new Filter.FilterListener() {
+          @Override
+          public void onFilterComplete(int count) {
+            // Keep the selection while the selected item is still on screen, and clear it only
+            // when the filter hides it, so the user never has a selection they cannot see.
+            if (selectionIndex > 0 && !listAdapterWithRecyclerView.isVisible(selectionIndex - 1)) {
+              SelectionIndex(0);
+            }
+          }
+        });
       }
 
       @Override

--- a/appinventor/components/src/com/google/appinventor/components/scripts/SwiftOptionHelperGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/SwiftOptionHelperGenerator.java
@@ -5,6 +5,7 @@
 
 package com.google.appinventor.components.scripts;
 
+import com.google.appinventor.common.utils.StringUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -131,7 +132,7 @@ public class SwiftOptionHelperGenerator extends ComponentProcessor {
     pw.print(functionName);
     pw.print("\": ");
     OptionList items = optionLists.get((String) helperKey.getKey());
-    pw.print(items.getTagName());
+    pw.print(StringUtils.getSimpleClassName(items.getClassName()));
     pw.print(".fromUnderlyingValue(_:)");
   }
 


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Fixes ListView search-filtering and selection bugs on both platforms.

**iOS** (`components-ios/src/ListView.swift`)
- The search box now actually filters the list. Previously the filtered results
  were computed but never read by `numberOfRows`/`cellForRowAt`, so typing had no
  effect on the vertical list. Matching is now case-insensitive and matches
  anywhere in the text (was prefix-only + case-sensitive) and covers both the
  main and detail text.
- Selection now maps the tapped visible row back to its real position, so
  selecting while filtered picks the correct item — on both the table and the
  horizontal collection view.
- Also enables tapping plain-text items in the horizontal list (previously
  commented out) and fixes a fallback layout branch that indexed with a value
  that could go negative.

**Android** (`components/src/.../ListAdapterWithRecyclerView.java`)
- Filtering no longer clears the current selection — it changes what is visible,
  not what the user picked. Selection is stored against original item indexes, so
  it survives filtering and stays correct whether or not the selected item is
  currently shown. A small pair of helpers (`toDisplayPosition` /
  `toOriginalPosition`) handles the display↔original mapping in one place.

**Selection-on-filter policy:** filtering keeps the selection (does not clear it),
matching the common data-table pattern where selection is tracked independently
and survives filtering. Applied consistently on both platforms. (Out of scope:
data changes — add/remove/set Elements — still clear selection on Android via
`updateData`; unchanged here.)

No user-facing designer/blocks API changed (no new properties or blocks), so no
version bump or upgrader is required.

*Testing Guidelines*

- **iOS:** build the `AIComponentKit` scheme, run the Companion in the simulator
  with a ListView. Type in the search box → the vertical list filters
  (case-insensitive, substring); filter then tap → the correct item is selected;
  repeat with horizontal `Orientation`. Manually verified.
- **Android:** run the Companion on an emulator with a ListView (ShowFilterBar
  on). Select an item → type in the search box → the selection stays; filter then
  tap → correct item selected; clear the filter → selection still highlighted.
  Manually verified. `ant tests -Dskip.ios=true` passes (including `ListViewTest`).

**Context for the changes**

Both changes are to the ListView component runtime that runs on the device (the
companion), so this targets the `ucr` branch.

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
