### PR TITLE
Bring #3958 iOS ListView changes into ucr (ListView.swift only)

### DIFF
--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -5,11 +5,14 @@
 
 import Foundation
 
-fileprivate let kListViewDefaultBackgroundColor = Color.black
-fileprivate let kListViewDefaultSelectionColor = Color.lightGray
-fileprivate let kListViewDefaultTextColor = Color.white
+fileprivate let kListViewDefaultBackgroundColor = Color.black.int32
+fileprivate let kListViewDefaultElementColor = Color.none.int32
+fileprivate let kListViewDefaultSelectionColor = Color.lightGray.int32
+fileprivate let kListViewDefaultTextColor = Color.white.int32
+fileprivate let kListViewDefaultDividerColor = Color.none.int32
 fileprivate let kDefaultTableCell = "UITableViewCell"
 fileprivate let kDefaultTableCellHeight = CGFloat(44.0)
+fileprivate let kDefaultTableCellVerticalPadding = CGFloat(30.0)
 
 let VERTICAL_LAYOUT = 0
 let HORIZONTAL_LAYOUT = 1
@@ -59,25 +62,33 @@ class ListDataModel {
   func originalIndex(_ displayRow: Int) -> Int { filteredIndices[displayRow] }
 }
 
+fileprivate final class ListViewRootView: UIView {
+  var preferredSizeProvider: (() -> CGSize)?
+
+  override var intrinsicContentSize: CGSize {
+    return preferredSizeProvider?() ?? super.intrinsicContentSize
+  }
+}
+
   open class ListView: ViewComponent, AbstractMethodsForViewComponent,
     UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate,
     UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
   fileprivate final var _view: UITableView
-  fileprivate let _rootView = UIView()
+  fileprivate let _rootView = ListViewRootView()
   fileprivate var _collectionView: UICollectionView
   fileprivate let kDefaultItemSize = CGSize(width: 160, height: 56)
     
-  fileprivate var _backgroundColor = Int32(bitPattern: Color.default.rawValue)
+  fileprivate var _backgroundColor = kListViewDefaultBackgroundColor
   fileprivate let _model = ListDataModel()
   fileprivate var _selection = ""
   fileprivate var _selectionDetailText = ""
-  fileprivate var _selectionColor = Int32(bitPattern: Color.default.rawValue)
+  fileprivate var _selectionColor = kListViewDefaultSelectionColor
   fileprivate var _selectionIndex = Int32(0)
   fileprivate var _showFilter = false
-  fileprivate var _textColor = Int32(bitPattern: Color.default.rawValue)
-  fileprivate var _textColorDetail = Int32(bitPattern: Color.default.rawValue)
+  fileprivate var _textColor = kListViewDefaultTextColor
+  fileprivate var _textColorDetail = kListViewDefaultTextColor
   fileprivate var _fontSize = Int32(22)
-  fileprivate var _automaticHeightConstraint: NSLayoutConstraint!
+  fileprivate var _automaticHeightConstraint: NSLayoutConstraint?
   fileprivate var _fontSizeDetail = Int32(16)
   //ListData
   fileprivate var _listViewLayoutMode = Int32(0)
@@ -88,9 +99,9 @@ class ListDataModel {
   fileprivate let _horizontalLayout = UICollectionViewFlowLayout()
   fileprivate let filter = UISearchBar()
   fileprivate var _hint = "Search list..."
-  fileprivate var _dividerColor = Int32(bitPattern: Color.default.rawValue)
+  fileprivate var _dividerColor = kListViewDefaultDividerColor
   fileprivate var _dividerThickness = Int32(0)
-  fileprivate var _elementColor = Int32(bitPattern: Color.default.rawValue)
+  fileprivate var _elementColor = kListViewDefaultElementColor
   fileprivate var _elementCornerRadius = Int32(0)
   fileprivate var _elementMarginsWidth = Int32(0)
   fileprivate var _imageHeight = Int32(200)
@@ -117,12 +128,15 @@ class ListDataModel {
     Width = kLengthFillParent
     _view.tableFooterView = UIView()
     _view.backgroundView = nil
-    _view.backgroundColor = preferredTextColor(parent.form)
+    _view.backgroundColor = argbToColor(_backgroundColor)
 
     // Auto height for the table (existing)
     _automaticHeightConstraint = _view.heightAnchor.constraint(equalToConstant: kDefaultTableCellHeight)
-    _automaticHeightConstraint.priority = UILayoutPriority(1.0)
-    _automaticHeightConstraint.isActive = true
+    _automaticHeightConstraint?.priority = UILayoutPriority(1.0)
+    _automaticHeightConstraint?.isActive = true
+    _rootView.preferredSizeProvider = { [weak self] in
+      return self?.preferredListViewSize ?? CGSize(width: 320, height: kDefaultTableCellHeight)
+    }
 
     // Create horizontal collection view
     let layout = UICollectionViewFlowLayout()
@@ -170,18 +184,24 @@ class ListDataModel {
  
   open override var view: UIView { _rootView }
 
+  @objc open override var Width: Int32 {
+    get {
+      return super.Width
+    }
+    set(width) {
+      super.Width = width == kLengthPreferred ? kLengthFillParent : width
+    }
+  }
+
   // MARK: Properties
   @objc open var BackgroundColor: Int32 {
     get {
       return _backgroundColor
     }
     set(backgroundColor) {
-      if (backgroundColor == Int32(bitPattern: Color.default.rawValue)) {
-        _backgroundColor = Int32(bitPattern: kListViewDefaultBackgroundColor.rawValue)
-      } else {
-        _backgroundColor = backgroundColor
-      }
+      _backgroundColor = backgroundColor
       _view.backgroundColor = argbToColor(_backgroundColor)
+      _collectionView.backgroundColor = argbToColor(_backgroundColor)
     }
   }
 
@@ -206,7 +226,7 @@ class ListDataModel {
       _model.items = []
       _model.elements = []
       guard !elements.isEmpty else {
-        _view.reloadData()
+        elementsCount()
         return
       }
       addElements(elements)
@@ -220,60 +240,61 @@ class ListDataModel {
       "Image": image as AnyObject
     ]
   }
+
+  private func listItem(at index: Int) -> [String: AnyObject]? {
+    guard index >= 0 && index < _model.count else {
+      return nil
+    }
+    if _model.isDataMode {
+      return _model.items[index]
+    }
+    return makeListItem(text1: _model.elements[index])
+  }
+
+  private func normalizedListItem(from item: AnyObject) -> [String: AnyObject] {
+    if let dictionary = item as? [String: AnyObject] {
+      return dictionary
+    }
+    if let dictionary = item as? NSDictionary {
+      return [
+        "Text1": (dictionary["Text1"] as? String ?? "") as AnyObject,
+        "Text2": (dictionary["Text2"] as? String ?? "") as AnyObject,
+        "Image": (dictionary["Image"] as? String ?? "") as AnyObject
+      ]
+    }
+    return makeListItem(text1: toString(item))
+  }
+
+  private func normalizedElements(_ elements: [AnyObject]) -> [AnyObject] {
+    if elements.first is SCMSymbol {
+      return Array(elements.dropFirst())
+    }
+    return elements
+  }
   
     private func addElements(_ elements: [AnyObject]) {
       if !elements.isEmpty {
         let testItemsForDict = _model.items.first(where: { $0 is NSDictionary })
         let testElementsForDict = elements.first(where: { $0 is NSDictionary })
-        //let filteredListElements = elements.filter { $0 is YailList<AnyObject> }
-        
         let otherElements = elements.filter { !($0 is NSDictionary) }
-        
         let useDictFormat = testItemsForDict?["Text1"] != nil || testElementsForDict?["Text1"] != nil
-       
-        
         if useDictFormat {
           _model.items.append(contentsOf: elements.compactMap { $0 as? [String: AnyObject] })
-          
           for item in otherElements {
             // Fall back to simple text item
             if let str = item as? String {
               _model.items.append(makeListItem(text1: str))
             } else if let n = item as? NSNumber {
               _model.items.append(makeListItem(text1: n.stringValue))
-              
             }
           }
-        }/*a else if filteredListElements.count > 0 {
-          var dict: [String: AnyObject] = [:]
-          print("item type is YailList \(dict)")
-          for kvPair in filteredListElements {
-            if let pair = kvPair as? YailList<AnyObject>, pair.count >= 3 {
-              if let key = pair[1] as? String {
-                dict[key] = pair[2] as AnyObject
-              }
-            }
-          }
-          _model.items.append(dict)
-        }*/
+        }
         _model.elements.insert(contentsOf: otherElements.toStringArray(), at: 0)
-        /* don't add to items
-         for item in otherElements {
-            // Fall back to simple text item
-            if let str = item as? String {
-              _model.items.append(makeListItem(text1: str))
-            } else if let n = item as? NSNumber {
-              _model.items.append(makeListItem(text1: n.stringValue))
-
-            }
-        }*/
         elementsCount()
       }
     }
   func elementsCount() {
-    //let rows = max(_model.items.count, _model.items.count)
-    let rows = max(_model.elements.count, _model.items.count)
-    _automaticHeightConstraint.constant = rows == 0 ? kDefaultTableCellHeight : kDefaultTableCellHeight * CGFloat(rows)
+    _automaticHeightConstraint?.constant = preferredTableHeight
     if let searchBar = _view.tableHeaderView as? UISearchBar {
       self.searchBar(searchBar, textDidChange: searchBar.text ?? "")
     } else {
@@ -281,6 +302,7 @@ class ListDataModel {
     }
     _collectionView.reloadData()
     _collectionView.collectionViewLayout.invalidateLayout()
+    invalidateListViewSize()
   }
 
   @objc open var FontTypeface: String {
@@ -289,17 +311,17 @@ class ListDataModel {
     }
     set(fontTypeface) {
       _fontTypeface = fontTypeface
-      _view.reloadData()
+      elementsCount()
     }
   }
 
   @objc open var FontTypefaceDetail: String {
     get {
-      return _fontTypeface
+      return _fontTypefaceDetail
     }
     set(FontTypefaceDetail) {
       _fontTypefaceDetail = FontTypefaceDetail
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -318,11 +340,7 @@ class ListDataModel {
       return _dividerColor
     }
     set(dividerColor) {
-      if (dividerColor == Int32(bitPattern: Color.default.rawValue)) {
-        _dividerColor = Int32(bitPattern: kListViewDefaultBackgroundColor.rawValue)
-      } else {
-        _dividerColor = dividerColor
-      }
+      _dividerColor = dividerColor
     }
   }
 
@@ -342,11 +360,7 @@ class ListDataModel {
       return _elementColor
     }
     set(elementColor) {
-      if (elementColor == Int32(bitPattern: Color.default.rawValue)) {
-        _elementColor = Int32(bitPattern: kListViewDefaultBackgroundColor.rawValue)
-      } else {
-        _elementColor = elementColor
-      }
+      _elementColor = elementColor
     }
   }
 
@@ -406,6 +420,7 @@ class ListDataModel {
     set(jsonString) {
       do {
         if let dictionaries = try getObjectFromJson(jsonString) as? [[String: Any]] {
+          _model.elements.removeAll()
           _model.items = dictionaries.compactMap { dictionary in
             var item: [String: String] = [:]
 
@@ -428,7 +443,7 @@ class ListDataModel {
 
             return nil
           }
-          _view.reloadData()
+          elementsCount()
         }
       } catch {
         print("Error parsing JSON: \(error)")
@@ -444,6 +459,7 @@ class ListDataModel {
     set(listViewLayoutMode) {
       _listViewLayoutMode = listViewLayoutMode
       _view.reloadData()
+      invalidateListViewSize()
     }
   }
 
@@ -452,6 +468,17 @@ class ListDataModel {
     set(orientation) {
       _orientation = orientation
       updateOrientationUI()
+    }
+  }
+
+  @objc open override var Height: Int32 {
+    get {
+      return super.Height
+    }
+    set(height) {
+      super.Height = height
+      _automaticHeightConstraint?.constant = preferredTableHeight
+      invalidateListViewSize()
     }
   }
     
@@ -473,9 +500,7 @@ class ListDataModel {
       }
 
       _collectionView.backgroundColor =
-        (_backgroundColor == Int32(bitPattern: Color.default.rawValue))
-        ? preferredTextColor(_container?.form)
-        : argbToColor(_backgroundColor)
+        argbToColor(_backgroundColor)
 
       // ✅ Correct update order:
       _collectionView.reloadData()
@@ -485,6 +510,7 @@ class ListDataModel {
       _automaticHeightConstraint?.isActive = true
       _view.reloadData()
     }
+    invalidateListViewSize()
 
   }
 
@@ -497,17 +523,20 @@ class ListDataModel {
       if let selectedRow = _view.indexPathForSelectedRow {
         _view.deselectRow(at: selectedRow, animated: false)
       }
-      if let index = _model.elements.firstIndex(of: selection) {
+      if let index = _model.items.firstIndex(where: { $0["Text1"] as? String == selection }) {
         _selectionIndex = Int32(index) + 1
         _selection = selection
+        _selectionDetailText = _model.items[index]["Text2"] as? String ?? ""
         _view.selectRow(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .none)
-      } else if let index = _model.items.firstIndex(where: { $0["Text1"] as? String == selection }) {
+      } else if let index = _model.elements.firstIndex(of: selection) {
         _selectionIndex = Int32(index) + 1
         _selection = selection
+        _selectionDetailText = ""
         _view.selectRow(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .none)
       } else {
         _selectionIndex = 0
         _selection = ""
+        _selectionDetailText = ""
       }
     }
   }
@@ -520,12 +549,14 @@ class ListDataModel {
       if let selectedRow = _view.indexPathForSelectedRow {
         _view.deselectRow(at: selectedRow, animated: false)
       }
-      if let index = _model.items.firstIndex(where: { $0["Text2"] as? String == selectionDetailText as? String }) {
+      if let index = _model.items.firstIndex(where: { $0["Text2"] as? String == selectionDetailText }) {
         _selectionIndex = Int32(index) + 1
+        _selection = _model.items[index]["Text1"] as? String ?? ""
         _selectionDetailText = selectionDetailText
         _view.selectRow(at: IndexPath(item: index, section: 0), animated: true, scrollPosition: .none)
       } else {
         _selectionIndex = 0
+        _selection = ""
         _selectionDetailText = ""
       }
     }
@@ -546,10 +577,11 @@ class ListDataModel {
       return _selectionIndex
     }
     set(selectionIndex) {
-      if selectionIndex > 0 && selectionIndex <= Int32(_model.elements.count) {
+      if selectionIndex > 0 && selectionIndex <= Int32(listItemCount),
+         let item = listItem(at: Int(selectionIndex) - 1) {
         _selectionIndex = selectionIndex
-        _selection = _model.elements[Int(selectionIndex) - 1] as? String ?? ""
-        _selectionDetailText = _model.elements[Int(selectionIndex) - 1] as? String ?? ""
+        _selection = item["Text1"] as? String ?? ""
+        _selectionDetailText = item["Text2"] as? String ?? ""
         _view.selectRow(at: IndexPath(row: Int(_selectionIndex) - 1, section: 0), animated: true, scrollPosition: UITableView.ScrollPosition.middle)
       } else {
         _selectionIndex = 0
@@ -575,6 +607,7 @@ class ListDataModel {
       } else if !_showFilter && _view.tableHeaderView != nil {
         _view.tableHeaderView = nil
       }
+      invalidateListViewSize()
     }
   }
 
@@ -614,7 +647,7 @@ class ListDataModel {
     }
     set(fontSize) {
       _fontSize = fontSize < 0 ? Int32(7) : fontSize
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -625,7 +658,7 @@ class ListDataModel {
     }
     set(fontSizeDetail) {
       _fontSizeDetail = fontSizeDetail < 0 ? Int32(7) : fontSizeDetail
-      _view.reloadData()
+      elementsCount()
     }
   }
 
@@ -704,6 +737,8 @@ class ListDataModel {
 
   @objc open func AddItemAtIndex(_ addIndex: Int32, _ mainText: String, _ detailText: String, _ imageName: String) {
     guard addIndex > 0 && addIndex <= Int32(_model.count) + 1 else {
+      _container?.form?.dispatchErrorOccurredEvent(self, "AddItemAtIndex",
+                                                   ErrorMessage.ERROR_LISTVIEW_INDEX_OUT_OF_BOUNDS, addIndex)
       return
     }
     let index = Int(addIndex - 1)
@@ -724,33 +759,20 @@ class ListDataModel {
 
   /* insert element to ListView as Dictionary or as String */
   @objc open func AddItemsAtIndex(_ addIndex: Int32, _ elements: [AnyObject]) {
+    let elements = normalizedElements(elements)
     if elements.isEmpty {
       return
     }
-    if addIndex < 1 || addIndex - 1 > max(_model.items.count, _model.items.count) {
+    if addIndex < 1 || addIndex > Int32(listItemCount + 1) {
       _container?.form?.dispatchErrorOccurredEvent(self, "AddItemsAtIndex",
                                                    ErrorMessage.ERROR_LISTVIEW_INDEX_OUT_OF_BOUNDS, addIndex)
       return
     }
     
-    if !elements.isEmpty {
-      let index = Int(addIndex - 1)
-      var newItems: [[String: AnyObject]] = []
-      for item in elements {
-        if let rowDict = item as? NSDictionary,
-           let stoDict = rowDict as? [String: AnyObject] {
-          newItems.append(stoDict)
-        } else if let row = item as Optional {
-          newItems.append(["Text1": row as AnyObject])
-        } /*else {
-          _container?.form?.dispatchErrorOccurredEvent(self, "AddItemAtIndex",
-               ErrorMessage.ERROR_LISTVIEW_MISSING_REQUIRED_ITEM, index)
-          return
-        }*/
-        _model.items.insert(contentsOf: newItems, at: index)
-      }
-      elementsCount()
-    }
+    let index = Int(addIndex - 1)
+    let newItems = elements.map { normalizedListItem(from: $0) }
+    _model.items.insert(contentsOf: newItems, at: index)
+    elementsCount()
   }
 
 
@@ -776,10 +798,13 @@ class ListDataModel {
 
   @objc open func Refresh() {
     _view.reloadData()
+    _collectionView.reloadData()
+    _collectionView.collectionViewLayout.invalidateLayout()
+    invalidateListViewSize()
   }
 
   @objc open func RemoveItemAtIndex(_ index: Int32) {
-    if index < 1 || index > max(_model.items.count, _model.elements.count) {
+    if index < 1 || index > Int32(listItemCount) {
       _container?.form?.dispatchErrorOccurredEvent(self, "RemoveItemAtIndex",
            ErrorMessage.ERROR_LISTVIEW_INDEX_OUT_OF_BOUNDS, index)
       return
@@ -790,7 +815,7 @@ class ListDataModel {
     if _model.elements.count >= index {
       _model.elements.remove(at: Int(index - 1))
     }
-    _view.reloadData()
+    elementsCount()
   }
 
   // MARK: Events
@@ -802,23 +827,20 @@ class ListDataModel {
   // MARK: UITableViewDataSource
 
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-      let cell = tableView.dequeueReusableCell(withIdentifier: kDefaultTableCell) ??
-      UITableViewCell(style: .subtitle, reuseIdentifier: kDefaultTableCell)
-      let hasElements = _model.elements.count > 0
-      
+      let layoutReuseIdentifier = "\(kDefaultTableCell)\(_listViewLayoutMode)"
+      let cell = tableView.dequeueReusableCell(withIdentifier: layoutReuseIdentifier) ??
+        UITableViewCell(style: .subtitle, reuseIdentifier: layoutReuseIdentifier)
       // Map the visible row back to its real position so search filtering works.
       let origRow = _model.originalIndex(indexPath.row)
-      if _listViewLayoutMode == 0 { // assume only strings (no dicts]
-        if hasElements {
-          let item = _model.elements[origRow]
-          cell.textLabel?.text = item as? String
-        } else{
-          let item = _model.items[origRow]
-          cell.textLabel?.text = item["Text1"] as? String
-        }
-        
+      let item = listItem(at: origRow) ?? makeListItem()
+      cell.imageView?.image = nil
+      tableView.rowHeight = UITableView.automaticDimension
+
+      if _listViewLayoutMode == 0 {
+        cell.textLabel?.text = item["Text1"] as? String
+        cell.detailTextLabel?.text = ""
+        tableView.estimatedRowHeight = 44
       } else {
-        let item = _model.items[origRow]
         if _listViewLayoutMode == 1 {
           tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 44
@@ -837,14 +859,14 @@ class ListDataModel {
           stackView.alignment = .fill
           stackView.distribution = .fill
           stackView.spacing = 8.0
-          
+
           // Add the labels to the stack view
           stackView.addArrangedSubview(cell.textLabel!)
           stackView.addArrangedSubview(cell.detailTextLabel!)
-          
+
           // Add the stack view to the cell's content view
           cell.contentView.addSubview(stackView)
-          
+
           // Set up constraints
           stackView.translatesAutoresizingMaskIntoConstraints = false
           NSLayoutConstraint.activate([
@@ -859,6 +881,11 @@ class ListDataModel {
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = item["Text2"] as? String
 
+          // Configure the layout
+          cell.layoutMargins = UIEdgeInsets.zero
+          cell.separatorInset = UIEdgeInsets.zero
+          cell.preservesSuperviewLayoutMargins = true
+
           // Create a stack view to hold the labels horizontally. Align by
           // first baseline so the labels' first text lines line up visually
           // regardless of font-size differences (top alignment makes the
@@ -869,7 +896,7 @@ class ListDataModel {
           stackView.alignment = .firstBaseline
           stackView.distribution = .fillEqually
           stackView.spacing = 8.0
-          
+
           // Add the labels to the stack view
           stackView.addArrangedSubview(cell.textLabel!)
           stackView.addArrangedSubview(cell.detailTextLabel!)
@@ -886,36 +913,37 @@ class ListDataModel {
             stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
           ])
         } else if _listViewLayoutMode == 3 {
-          tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 60
-          cell.textLabel?.text = item["Text1"] as? String
+          tableView.estimatedRowHeight = preferredRowHeight
+          cell.textLabel?.text = item["Text1"] as? String ?? ""
+          cell.detailTextLabel?.text = ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
-             let image = AssetManager.shared.imageFromPath(path: imagePath as! String) {
+             let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-            
+
             // Configure the layout
             cell.layoutMargins = UIEdgeInsets.zero
             cell.separatorInset = UIEdgeInsets.zero
             cell.preservesSuperviewLayoutMargins = true
-            
+
             // Create a stack view to hold the labels horizontally
             let stackView = UIStackView()
             stackView.axis = .horizontal
             stackView.alignment = .leading
             stackView.distribution = .fill
             stackView.spacing = 8.0
-            
+
             // Add the labels to the stack view
             stackView.addArrangedSubview(cell.imageView!)
             stackView.addArrangedSubview(cell.textLabel!)
-            
+
             // Add the stack view to the cell's content view
             cell.contentView.addSubview(stackView)
-            
+
             // Set up constraints
             stackView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
+
               stackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
               stackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
               stackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
@@ -925,20 +953,19 @@ class ListDataModel {
             ])
           }
         } else if _listViewLayoutMode == 4 {
-          tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 60
-          cell.textLabel?.text = item["Text1"] as? String
-          cell.detailTextLabel?.text = item["Text2"] as? String
+          cell.textLabel?.text = item["Text1"] as? String ?? ""
+          cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
-             let image = AssetManager.shared.imageFromPath(path: imagePath as! String) {
+             let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-            
+
             // Configure the layout
             cell.layoutMargins = UIEdgeInsets.zero
             cell.separatorInset = UIEdgeInsets.zero
             cell.preservesSuperviewLayoutMargins = true
-            
+
             // Create a horizontal stack view to hold the imageView and a nested vertical stack view
             let horizontalStackView = UIStackView()
             horizontalStackView.axis = .horizontal
@@ -954,18 +981,18 @@ class ListDataModel {
             verticalStackView.alignment = .fill
             verticalStackView.distribution = .fill
             verticalStackView.spacing = 8.0
-            
+
             // Add the imageView and nested vertical stack view to the horizontal stack view
             horizontalStackView.addArrangedSubview(cell.imageView!)
             horizontalStackView.addArrangedSubview(verticalStackView)
-            
+
             // Add the textLabel and detailTextLabel to the vertical stack view
             verticalStackView.addArrangedSubview(cell.textLabel!)
             verticalStackView.addArrangedSubview(cell.detailTextLabel!)
-            
+
             // Add the horizontal stack view to the cell's content view
             cell.contentView.addSubview(horizontalStackView)
-            
+
             // Set up constraints
             horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
@@ -978,20 +1005,19 @@ class ListDataModel {
             ])
           }
         } else if _listViewLayoutMode == 5 {
-          tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 120
-          cell.textLabel?.text = item["Text1"] as? String
-          cell.detailTextLabel?.text = item["Text2"] as? String
+          cell.textLabel?.text = item["Text1"] as? String ?? ""
+          cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
-             let image = AssetManager.shared.imageFromPath(path: imagePath as! String) {
+             let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-            
+
             // Configure the layout
             cell.layoutMargins = UIEdgeInsets.zero
             cell.separatorInset = UIEdgeInsets.zero
             cell.preservesSuperviewLayoutMargins = true
-            
+
             // Inner stack: labels with .fill so they span the full label-stack
             // width, making textAlignment visible regardless of text length.
             let labelsStackView = UIStackView()
@@ -1010,10 +1036,10 @@ class ListDataModel {
             verticalStackView.spacing = 8.0
             verticalStackView.addArrangedSubview(cell.imageView!)
             verticalStackView.addArrangedSubview(labelsStackView)
-            
+
             // Add the outer stack to the cell's content view
             cell.contentView.addSubview(verticalStackView)
-            
+
             // Set up constraints. The labelsStackView width is pinned to the
             // outer stack so labels span full row width while the image stays
             // centered at its intrinsic / explicit size.
@@ -1024,16 +1050,15 @@ class ListDataModel {
               verticalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
               verticalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0),
               cell.imageView!.widthAnchor.constraint(equalToConstant: CGFloat(_imageWidth / 4)),
-              cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4)),
-              labelsStackView.widthAnchor.constraint(equalTo: verticalStackView.widthAnchor)
+              cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4))
             ])
           }
         } else {
-          tableView.rowHeight = UITableView.automaticDimension
           tableView.estimatedRowHeight = 44
           cell.textLabel?.text = item["Text1"] as? String
+          cell.detailTextLabel?.text = ""
         }
-    }
+      }
 
     // Both labels wrap inside their 50% half (matches the Designer mock).
     cell.textLabel?.numberOfLines = 0
@@ -1061,8 +1086,8 @@ class ListDataModel {
     } else {
       tableView.separatorColor =  argbToColor(_dividerColor)
     }
-    
-    
+
+
     if _backgroundColor == Color.default.int32 {
       cell.backgroundColor = preferredTextColor(form)
     } else {
@@ -1079,7 +1104,7 @@ class ListDataModel {
             ? argbToColor(_elementColor)
             : cell.backgroundColor
 
-    
+
     //maintext
     if _textColor == Color.default.int32 {
       cell.textLabel?.textColor = preferredBackgroundColor(form)
@@ -1110,16 +1135,8 @@ class ListDataModel {
       cell.detailTextLabel?.font = UIFont(name: "Courier", size: CGFloat(_fontSizeDetail))
     }
 
-    if cell.selectedBackgroundView == nil {
-      cell.selectedBackgroundView = UIView()
-    }
-
     let selectedBgView = UIView()
-    selectedBgView.backgroundColor =
-    (_selectionColor != Color.none.int32) ?
-      (_selectionColor == Color.default.int32 ? (argbToColor(kListViewDefaultSelectionColor.rawValue))
-        : argbToColor(_selectionColor))
-      :argbToColor(_selectionColor)
+    selectedBgView.backgroundColor = argbToColor(_selectionColor)
     cell.selectedBackgroundView = selectedBgView
 
     cell.textLabel?.textAlignment = nsTextAlignment(for: _textAlignmentMain, in: cell)
@@ -1134,6 +1151,14 @@ class ListDataModel {
     }
 
     // MARK: UITableViewDelegate
+
+    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+      return preferredRowHeight
+    }
+
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+      return preferredRowHeight
+    }
 
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
       // Map the tapped visible row back to its real position, so selection is correct while filtering.
@@ -1176,6 +1201,76 @@ class ListDataModel {
   }
 
   // MARK: Private implementation
+
+  private var preferredListViewSize: CGSize {
+    let width = preferredListViewWidth()
+    if _orientation == HORIZONTAL_LAYOUT {
+      return CGSize(width: width, height: max(kDefaultItemSize.height, 60.0))
+    }
+
+    return CGSize(width: width, height: preferredTableHeight)
+  }
+
+  private var preferredTableHeight: CGFloat {
+    if _lastSetHeight != kLengthPreferred {
+      return max(kDefaultTableCellHeight, _rootView.bounds.height)
+    }
+    let rows = listItemCount
+    let rowHeight = rows == 0 ? kDefaultTableCellHeight : preferredRowHeight * CGFloat(rows)
+    let headerHeight = _view.tableHeaderView?.bounds.height ?? 0
+    return max(kDefaultTableCellHeight, rowHeight + headerHeight)
+  }
+
+  private var preferredRowHeight: CGFloat {
+    let mainTextHeight = ceil(listFont(typeface: _fontTypeface, size: _fontSize).lineHeight)
+    let detailTextHeight = ceil(listFont(typeface: _fontTypefaceDetail, size: _fontSizeDetail).lineHeight)
+    let singleTextHeight = mainTextHeight + kDefaultTableCellVerticalPadding
+    let twoTextVerticalHeight = mainTextHeight + detailTextHeight + kDefaultTableCellVerticalPadding
+    let twoTextHorizontalHeight = max(mainTextHeight, detailTextHeight) + kDefaultTableCellVerticalPadding
+
+    switch _listViewLayoutMode {
+    case 1:
+      return max(kDefaultTableCellHeight, twoTextVerticalHeight)
+    case 2:
+      return max(kDefaultTableCellHeight, twoTextHorizontalHeight)
+    case 3:
+      return max(60.0, singleTextHeight)
+    case 4:
+      return max(60.0, twoTextVerticalHeight)
+    case 5:
+      return max(120.0, twoTextVerticalHeight)
+    default:
+      return max(kDefaultTableCellHeight, singleTextHeight)
+    }
+  }
+
+  private func listFont(typeface: String, size: Int32) -> UIFont {
+    let pointSize = CGFloat(size)
+    if typeface == "1" {
+      return UIFont(name: "Helvetica", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    } else if typeface == "2" {
+      return UIFont(name: "Times New Roman", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    } else if typeface == "3" {
+      return UIFont(name: "Courier", size: pointSize) ?? UIFont.systemFont(ofSize: pointSize)
+    }
+    return UIFont.systemFont(ofSize: pointSize)
+  }
+
+  private func preferredListViewWidth() -> CGFloat {
+    if let formWidth = form?.scaleFrameLayout.bounds.width, formWidth > 0 {
+      return formWidth
+    }
+    if let formWidth = form?.view.bounds.width, formWidth > 0 {
+      return formWidth
+    }
+    return 320
+  }
+
+  private func invalidateListViewSize() {
+    _rootView.invalidateIntrinsicContentSize()
+    _rootView.setNeedsLayout()
+    _rootView.superview?.setNeedsLayout()
+  }
 
   private final class HListCell: UICollectionViewCell {
   static let reuseId = "HListCell"
@@ -1228,7 +1323,10 @@ class ListDataModel {
   required init?(coder: NSCoder) { fatalError() }
   }
 
-    
+  private var listItemCount: Int {
+    return _model.count
+  }
+
   // UICollectionViewDataSource
   public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
     return _model.displayCount
@@ -1250,7 +1348,6 @@ class ListDataModel {
       detailText = item["Text2"] as? String ?? ""
       if let path = item["Image"] as? String,
          !path.isEmpty {
-        print("image path: \(path)")
         image = AssetManager.shared.imageFromPath(path: path)
       }
     } else {
@@ -1266,18 +1363,14 @@ class ListDataModel {
     
     (cell.backgroundView as? UIView)?.backgroundColor =
         (_elementColor != Color.none.int32)
-        ? ((_elementColor == Color.default.int32) ? preferredTextColor(_container?.form) : argbToColor(_elementColor))
-        : ((_backgroundColor == Color.default.int32) ? preferredTextColor(_container?.form) : argbToColor(_backgroundColor))
+        ? argbToColor(_elementColor)
+        : argbToColor(_backgroundColor)
 
     (cell.selectedBackgroundView as? UIView)?.backgroundColor =
-        (_selectionColor == Color.default.int32)
-        ? argbToColor(Int32(bitPattern: kListViewDefaultSelectionColor.rawValue))
-        : argbToColor(_selectionColor)
+        argbToColor(_selectionColor)
     
     _collectionView.backgroundColor =
-        (_backgroundColor == Color.default.int32)
-    ? preferredTextColor(_container?.form)
-        : argbToColor(_backgroundColor)
+        argbToColor(_backgroundColor)
 
     cell.titleLabel.text = mainText
     cell.detailLabel.text = detailText
@@ -1294,8 +1387,8 @@ class ListDataModel {
     else if _fontTypefaceDetail == "3" { cell.detailLabel.font = UIFont(name: "Courier", size: CGFloat(_fontSizeDetail)) ?? cell.detailLabel.font }
 
     // Text colors
-    cell.titleLabel.textColor = (_textColor == Color.default.int32) ? preferredBackgroundColor(_container?.form) : argbToColor(_textColor)
-    cell.detailLabel.textColor = (_textColorDetail == Color.default.int32) ? preferredBackgroundColor(_container?.form) : argbToColor(_textColorDetail)
+    cell.titleLabel.textColor = argbToColor(_textColor)
+    cell.detailLabel.textColor = argbToColor(_textColorDetail)
 
     // Image
     cell.imageView.image = image
@@ -1306,10 +1399,7 @@ class ListDataModel {
 
     let selectedBgView = UIView()
     selectedBgView.backgroundColor =
-    (_selectionColor != Color.none.int32) ?
-      (_selectionColor == Color.default.int32 ? (argbToColor(kListViewDefaultSelectionColor.rawValue))
-        : argbToColor(_selectionColor))
-      :argbToColor(_selectionColor)
+      argbToColor(_selectionColor)
     cell.selectedBackgroundView = selectedBgView
     return cell
   }


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

Merges `master` into `ucr` now that #3958 ("[iOS] UI Discrepancy Fix") landed on
master. Only `ListView.swift` conflicted (23 hunks). Resolved keeping `ucr`'s
`ListDataModel` (`_model`) as the data + filtering foundation, with #3958's
UI/sizing (ListViewRootView, preferredRowHeight/TableHeight, per-mode cell
reuse, color constants) layered on top. Rendering and selection route through
`_model` and are filter-aware. Both sides' work preserved.

*Testing Guidelines*

Build AIComponentKit (⌘B) + run the Companion: filtering on vertical/horizontal
lists (selection stays correct while filtered), all 6 layout modes, text
alignment, colors light/dark.

**Context for the changes**

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

For all other changes:

- [x] I have made no changes that affect the master branch

**General items:**

- [x] My code follows the:
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
