### PR TITLE
Move Android ListView filtering and selection into ListDataModel

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -17,98 +17,46 @@ import androidx.core.view.ViewCompat;
 
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.google.appinventor.components.runtime.util.YailDictionary;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public abstract class ListAdapterWithRecyclerView
     extends RecyclerView.Adapter<ListAdapterWithRecyclerView.RvViewHolder> implements Filterable {
   protected static final String LOG_TAG = ListView.LOG_TAG;
-  
+
   protected ClickListener clickListener;
 
   protected int backgroundColor;
   protected int selectionColor;
   protected float radius;
-  protected List<Object> items = new ArrayList<>();
-  protected List<Object> originalItems = new ArrayList<>();
-  protected List<Integer> originalPositions = new ArrayList<>();
+  // The model owns the data, the filter, and the selection; this adapter is only a view over it.
+  protected final ListDataModel model;
   protected ComponentContainer container;
-  protected List<Integer> selectedItems = new ArrayList<>();
-  protected String lastQuery = "";
 
   protected final Filter filter = new Filter() {
     @Override
     protected FilterResults performFiltering(CharSequence charSequence) {
-      lastQuery = charSequence.toString().toLowerCase();
+      // Background thread: compute the filtered view without touching state the UI thread reads.
+      ListDataModel.FilterResult computed = model.computeFilter(charSequence.toString());
       FilterResults results = new FilterResults();
-      List<Object> filteredList = new ArrayList<>();
-      originalPositions = new ArrayList<>();
-      if (lastQuery == null || lastQuery.length() == 0) {
-        filteredList = new ArrayList<>(originalItems);
-        items = new ArrayList<>(originalItems);
-      } else {
-        for (int index = 0; index < originalItems.size(); index++) {
-          Object item = originalItems.get(index);
-          String filterString;
-          if (item instanceof YailDictionary) {
-            if (((YailDictionary) item).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {
-              Object o = ((YailDictionary) item).get(Component.LISTVIEW_KEY_DESCRIPTION);
-              filterString = ((YailDictionary) item).get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
-              if (o != null) {
-                filterString += " " + o.toString();
-              }
-            } else {
-              filterString = item.toString();
-            }
-          } else {
-            filterString = item.toString();
-          }
-          if (filterString.toLowerCase().contains(lastQuery)) {
-            filteredList.add(item);
-            originalPositions.add(index);
-          }
-        }
-      }
-      results.count = filteredList.size();
-      results.values = filteredList;
+      results.values = computed;
+      results.count = computed.size();
       return results;
     }
 
     @Override
     protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
-      items = new ArrayList<>((List<Object>) filterResults.values);
-      // Keep the selection while the selected item is still on screen, and drop it only when the
-      // filter hides it, so the user never ends up with a selection they cannot see. Selection is
-      // stored against original item indexes, so it survives filtering otherwise.
-      if (!lastQuery.isEmpty()) {
-        selectedItems.retainAll(originalPositions);
-      }
+      // UI thread: apply the finished result and refresh, back to back, so the row count and the
+      // data never disagree.
+      model.commitFilter((ListDataModel.FilterResult) filterResults.values);
       notifyDataSetChanged();
-      // We store the original data in the originalItems variable
-      // We store the original item indexes in the originalPositions variable
-      // We have eliminated hiding/showing CardView to improve performance
     }
   };
 
-  public ListAdapterWithRecyclerView(ComponentContainer container, List<Object> data,
+  public ListAdapterWithRecyclerView(ComponentContainer container, ListDataModel model,
       int backgroundColor, int selectionColor, float radius) {
     this.container = container;
+    this.model = model;
     this.backgroundColor = backgroundColor;
     this.radius = radius;
     this.selectionColor = selectionColor;
-    updateData(data);
-}
-
-  public void updateData(List<Object> newItems) {
-    this.originalItems = newItems;
-    if (originalPositions.isEmpty()) {
-      this.items = new ArrayList<>(newItems);
-    } else {
-      filter.filter(lastQuery);
-    }
-    clearSelections();
   }
 
   protected CardView createCardView(ViewGroup parent) {
@@ -132,41 +80,18 @@ public abstract class ListAdapterWithRecyclerView
   }
 
   /**
-   * Returns the display row showing the given original item index, or -1 when that item is
-   * currently filtered out.
-   */
-  protected int toDisplayPosition(int originalPosition) {
-    return lastQuery.isEmpty() ? originalPosition : originalPositions.indexOf(originalPosition);
-  }
-
-  /**
-   * Returns the original item index behind the given display row.
-   */
-  protected int toOriginalPosition(int displayPosition) {
-    return lastQuery.isEmpty() ? displayPosition : originalPositions.get(displayPosition);
-  }
-
-  /**
-   * Returns whether the item at the given original index is currently shown, that is, whether it
-   * survives the active filter. With no filter every item is shown.
-   */
-  public boolean isVisible(int originalPosition) {
-    return lastQuery.isEmpty() || originalPositions.contains(originalPosition);
-  }
-
-  /**
    * Refreshes the row showing the given original item index, if it is currently visible.
    */
   private void notifyOriginalChanged(int originalPosition) {
-    int displayPosition = toDisplayPosition(originalPosition);
+    int displayPosition = model.toDisplayPosition(originalPosition);
     if (displayPosition >= 0) {
       notifyItemChanged(displayPosition);
     }
   }
 
   protected void updateCardViewColor(CardView cardView, int position) {
-    // Selection is stored against original item indexes, so map the display row first.
-    if (selectedItems.contains(toOriginalPosition(position))) {
+    // position is a display row; map it back to the original index the selection is keyed by.
+    if (model.isSelected(model.toOriginalPosition(position))) {
       cardView.setCardBackgroundColor(selectionColor);
     } else {
       cardView.setCardBackgroundColor(backgroundColor);
@@ -175,22 +100,21 @@ public abstract class ListAdapterWithRecyclerView
 
   @Override
   public int getItemCount() {
-    return items.size();
+    return model.visibleSize();
   }
 
   /**
    * Selects the item at the given original index, replacing any previous selection.
    */
   public void toggleSelection(int position) {
-    if (selectedItems.contains(position)) {
+    if (model.isSelected(position)) {
       return;
     }
-    if (!selectedItems.isEmpty()) {
-      int oldPosition = selectedItems.get(0);
-      selectedItems.clear();
+    int oldPosition = model.firstSelection();
+    model.selectSingle(position);
+    if (oldPosition >= 0) {
       notifyOriginalChanged(oldPosition);
     }
-    selectedItems.add(position);
     notifyOriginalChanged(position);
   }
 
@@ -198,16 +122,12 @@ public abstract class ListAdapterWithRecyclerView
    * Toggles the item at the given original index, used when MultiSelect is enabled.
    */
   public void changeSelections(int position) {
-    if (selectedItems.contains(position)) {
-      selectedItems.remove(Integer.valueOf(position));
-    } else {
-      selectedItems.add(position);
-    }
+    model.toggleSelection(position);
     notifyOriginalChanged(position);
   }
 
   public void clearSelections() {
-    selectedItems.clear();
+    model.clearSelection();
   }
 
   abstract class RvViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
@@ -218,7 +138,7 @@ public abstract class ListAdapterWithRecyclerView
 
     @Override
     public void onClick(View v) {
-      clickListener.onItemClick(toOriginalPosition(getAdapterPosition()), v);
+      clickListener.onItemClick(model.toOriginalPosition(getAdapterPosition()), v);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListDataModel.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListDataModel.java
@@ -5,24 +5,38 @@
 
 package com.google.appinventor.components.runtime;
 
+import com.google.appinventor.components.runtime.util.YailDictionary;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 /**
- * Single owner of the {@link ListView}'s non-visual list data.
+ * Single owner of the {@link ListView}'s non-visual state: the item list, the search filter,
+ * and the selection.
  *
- * <p>This is the first step of consolidating the ListView's scattered state into one
- * source of truth. In this step the model owns the canonical list of items and every
- * mutation to it; {@link ListView} and the row adapters read and mutate the list through
- * this model instead of each keeping their own copy.
+ * <p>The model holds the canonical list of items and every mutation to it; {@link ListView} and
+ * the row adapters read and mutate through this model instead of each keeping their own copy. It
+ * also owns the active search {@link #computeFilter query} and which rows survive it, plus the
+ * current {@link #selectSingle selection} (stored against original item indexes so it survives
+ * filtering).
  *
- * <p>Selection and filtering are still handled by the adapter for now and move into this
- * model in a later step, at which point the mutation methods below become the single place
- * where a data change also updates the filtered view and the selection.
+ * <p>Filtering is split into a pure {@link #computeFilter} that a background thread can run
+ * safely and a {@link #commitFilter} that the UI thread applies, so the filtered view is only
+ * ever swapped in on the UI thread and the row count never disagrees with the data — see the
+ * Filter in {@link ListAdapterWithRecyclerView}.
  */
 public class ListDataModel {
   private final List<Object> items = new ArrayList<>();
+
+  // Filtering. While lastQuery is empty the list is unfiltered and filteredItems/originalPositions
+  // are unused; getVisibleItems() then returns the full list directly.
+  private List<Object> filteredItems = new ArrayList<>();
+  private List<Integer> originalPositions = new ArrayList<>();
+  private String lastQuery = "";
+
+  // Selection, stored by ORIGINAL item index (a list so MultiSelect can hold several).
+  private final List<Integer> selectedItems = new ArrayList<>();
 
   /**
    * The live backing list. The adapter holds this same reference as its data source, so
@@ -72,5 +86,150 @@ public class ListDataModel {
 
   public void clear() {
     items.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filtering
+  // ---------------------------------------------------------------------------
+
+  /** The current lowercased search query, or the empty string when unfiltered. */
+  public String getLastQuery() {
+    return lastQuery;
+  }
+
+  /**
+   * Computes, but does not apply, the filtered view for the given query. Reads only the item
+   * list and returns a fresh, self-contained {@link FilterResult}, so it is safe to run off the
+   * UI thread; {@link #commitFilter} then applies the result on the UI thread.
+   */
+  public FilterResult computeFilter(String query) {
+    String normalized = query == null ? "" : query.toLowerCase();
+    List<Object> visible = new ArrayList<>();
+    List<Integer> positions = new ArrayList<>();
+    if (!normalized.isEmpty()) {
+      for (int index = 0; index < items.size(); index++) {
+        Object item = items.get(index);
+        if (filterTextOf(item).toLowerCase().contains(normalized)) {
+          visible.add(item);
+          positions.add(index);
+        }
+      }
+    }
+    return new FilterResult(normalized, visible, positions);
+  }
+
+  /**
+   * Applies a result from {@link #computeFilter}. Call on the UI thread: it swaps in the new
+   * filtered view and drops any selection the filter now hides, so the caller can notify the
+   * adapter immediately afterwards without the row count ever disagreeing with the data.
+   */
+  public void commitFilter(FilterResult result) {
+    lastQuery = result.query;
+    filteredItems = result.visibleItems;
+    originalPositions = result.originalPositions;
+    if (!lastQuery.isEmpty()) {
+      // Selection is kept by original index, so it survives filtering; only drop entries the
+      // filter now hides.
+      selectedItems.retainAll(originalPositions);
+    }
+  }
+
+  /** Re-runs the active filter against the current items, e.g. after the data changed. */
+  public void refreshFilter() {
+    commitFilter(computeFilter(lastQuery));
+  }
+
+  /** The text an item contributes to filtering: main text plus detail for dictionary rows. */
+  private static String filterTextOf(Object item) {
+    if (item instanceof YailDictionary
+        && ((YailDictionary) item).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {
+      YailDictionary dict = (YailDictionary) item;
+      String text = dict.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
+      Object detail = dict.get(Component.LISTVIEW_KEY_DESCRIPTION);
+      if (detail != null) {
+        text += " " + detail;
+      }
+      return text;
+    }
+    return item.toString();
+  }
+
+  /** The rows currently shown: the filtered subset while a filter is active, else every item. */
+  public List<Object> getVisibleItems() {
+    return lastQuery.isEmpty() ? items : filteredItems;
+  }
+
+  public Object getVisibleItem(int displayPosition) {
+    return getVisibleItems().get(displayPosition);
+  }
+
+  public int visibleSize() {
+    return getVisibleItems().size();
+  }
+
+  /** Display row showing the given original index, or -1 when that item is filtered out. */
+  public int toDisplayPosition(int originalPosition) {
+    return lastQuery.isEmpty() ? originalPosition : originalPositions.indexOf(originalPosition);
+  }
+
+  /** The original item index behind the given display row. */
+  public int toOriginalPosition(int displayPosition) {
+    return lastQuery.isEmpty() ? displayPosition : originalPositions.get(displayPosition);
+  }
+
+  /** Whether the item at the given original index survives the active filter. */
+  public boolean isVisible(int originalPosition) {
+    return lastQuery.isEmpty() || originalPositions.contains(originalPosition);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Selection (by original item index)
+  // ---------------------------------------------------------------------------
+
+  public boolean isSelected(int originalPosition) {
+    return selectedItems.contains(originalPosition);
+  }
+
+  /** The first selected original index, or -1 when nothing is selected. */
+  public int firstSelection() {
+    return selectedItems.isEmpty() ? -1 : selectedItems.get(0);
+  }
+
+  /** Selects only the given original index, replacing any previous selection. */
+  public void selectSingle(int originalPosition) {
+    selectedItems.clear();
+    selectedItems.add(originalPosition);
+  }
+
+  /** Adds or removes the given original index from the selection (used by MultiSelect). */
+  public void toggleSelection(int originalPosition) {
+    if (!selectedItems.remove(Integer.valueOf(originalPosition))) {
+      selectedItems.add(originalPosition);
+    }
+  }
+
+  public void clearSelection() {
+    selectedItems.clear();
+  }
+
+  /**
+   * A computed filtered view produced by {@link #computeFilter} and applied by
+   * {@link #commitFilter}. Immutable so it can pass safely from a background thread to the UI
+   * thread.
+   */
+  public static final class FilterResult {
+    private final String query;
+    private final List<Object> visibleItems;
+    private final List<Integer> originalPositions;
+
+    FilterResult(String query, List<Object> visibleItems, List<Integer> originalPositions) {
+      this.query = query;
+      this.visibleItems = visibleItems;
+      this.originalPositions = originalPositions;
+    }
+
+    int size() {
+      return visibleItems.size();
+    }
   }
 }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -200,7 +200,7 @@ public final class ListView extends AndroidViewComponent {
           public void onFilterComplete(int count) {
             // Keep the selection while the selected item is still on screen, and clear it only
             // when the filter hides it, so the user never has a selection they cannot see.
-            if (selectionIndex > 0 && !listAdapterWithRecyclerView.isVisible(selectionIndex - 1)) {
+            if (selectionIndex > 0 && !dataModel.isVisible(selectionIndex - 1)) {
               SelectionIndex(0);
             }
           }
@@ -1339,37 +1339,37 @@ public final class ListView extends AndroidViewComponent {
   public void setAdapterData() {
     switch (layout) {
       case LISTVIEW_LAYOUT_SINGLE_TEXT:
-        setListAdapter(new ListViewSingleTextAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewSingleTextAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT:
-        setListAdapter(new ListViewTwoTextAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewTwoTextAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT_LINEAR:
-        setListAdapter(new ListViewTwoTextLinearAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewTwoTextLinearAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT:
-        setListAdapter(new ListViewImageSingleTextAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewImageSingleTextAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TWO_TEXT:
-        setListAdapter(new ListViewImageTwoTextVerticalAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewImageTwoTextVerticalAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT:
-        setListAdapter(new ListViewImageTopTwoTextAdapter(container, dataModel.getItems(),
+        setListAdapter(new ListViewImageTopTwoTextAdapter(container, dataModel,
             textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
             elementColor, selectionColor, radius, imageWidth, imageHeight,
             textAlignmentMain, textAlignmentDetail));
@@ -1382,7 +1382,9 @@ public final class ListView extends AndroidViewComponent {
    */
   public void updateAdapterData() {
     SelectionIndex(0);
-    listAdapterWithRecyclerView.updateData(dataModel.getItems());
+    // Data changed, so rebuild the filtered view (a no-op when unfiltered) and refresh.
+    dataModel.refreshFilter();
+    listAdapterWithRecyclerView.notifyDataSetChanged();
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
@@ -22,7 +22,6 @@ import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
 import java.io.IOException;
-import java.util.List;
 
 public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView {
 
@@ -33,11 +32,11 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
   private int imageHeight;
   private int textMainAlignment;
 
-  public ListViewImageSingleTextAdapter(ComponentContainer container, List<Object> data,
+  public ListViewImageSingleTextAdapter(ComponentContainer container, ListDataModel model,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
       int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -88,7 +87,7 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     ImageSingleTextRvViewHolder imageSingleTextHolder = (ImageSingleTextRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
@@ -20,7 +20,6 @@ import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 import java.io.IOException;
-import java.util.List;
 
 public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView {
 
@@ -37,7 +36,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
 
   public ListViewImageTopTwoTextAdapter(
       ComponentContainer container,
-      List<Object> data,
+      ListDataModel model,
       int textMainColor,
       float textMainSize,
       String textMainFont,
@@ -51,7 +50,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
       int imageHeight,
       int textMainAlignment,
       int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -134,7 +133,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     ImageTopTwoTextRvViewHolder imageTwoTextHolder = (ImageTopTwoTextRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
@@ -22,7 +22,6 @@ import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
 import java.io.IOException;
-import java.util.List;
 
 public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecyclerView {
 
@@ -37,11 +36,11 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
   private int textMainAlignment;
   private int textDetailAlignment;
 
-  public ListViewImageTwoTextVerticalAdapter(ComponentContainer container, List<Object> data,
+  public ListViewImageTwoTextVerticalAdapter(ComponentContainer container, ListDataModel model,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
       int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -118,7 +117,7 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     ImageTwoTextRvViewHolder imageTwoTextHolder = (ImageTwoTextRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
@@ -15,8 +15,6 @@ import androidx.core.view.ViewCompat;
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
-import java.util.List;
-
 public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
 
   private int textMainColor;
@@ -24,11 +22,11 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
   private String textMainFont;
   private int textMainAlignment;
 
-  public ListViewSingleTextAdapter(ComponentContainer container, List<Object> data,
+  public ListViewSingleTextAdapter(ComponentContainer container, ListDataModel model,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
       int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -65,7 +63,7 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     SingleTextRvViewHolder singleTextHolder = (SingleTextRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
@@ -14,7 +14,6 @@ import androidx.core.view.ViewCompat;
 
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
-import java.util.List;
 
 public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
 
@@ -27,11 +26,11 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
   private int textMainAlignment;
   private int textDetailAlignment;
 
-  public ListViewTwoTextAdapter(ComponentContainer container, List<Object> data,
+  public ListViewTwoTextAdapter(ComponentContainer container, ListDataModel model,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
       int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -98,7 +97,7 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     TwoTextRvViewHolder twoTextHolder = (TwoTextRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
@@ -14,7 +14,6 @@ import androidx.core.view.ViewCompat;
 
 import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
-import java.util.List;
 
 public class ListViewTwoTextLinearAdapter extends ListAdapterWithRecyclerView {
 
@@ -27,11 +26,11 @@ public class ListViewTwoTextLinearAdapter extends ListAdapterWithRecyclerView {
   private int textMainAlignment;
   private int textDetailAlignment;
 
-  public ListViewTwoTextLinearAdapter(ComponentContainer container, List<Object> data,
+  public ListViewTwoTextLinearAdapter(ComponentContainer container, ListDataModel model,
       int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
       float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
       int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, data, backgroundColor, selectionColor, radius);
+    super(container, model, backgroundColor, selectionColor, radius);
     this.container = container;
     this.textMainColor = textMainColor;
     this.textMainSize = textMainSize;
@@ -85,7 +84,7 @@ public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
   @Override
   public void onBindViewHolder(RvViewHolder holder, int position) {
     TwoTextLinearRvViewHolder twoTextHolder = (TwoTextLinearRvViewHolder) holder;
-    Object o = items.get(position);
+    Object o = model.getVisibleItem(position);
     YailDictionary dictItem = new YailDictionary();
     if (o instanceof YailDictionary) {
       if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/ListDataModelTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/ListDataModelTest.java
@@ -1,0 +1,140 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.appinventor.components.runtime.util.YailDictionary;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ListDataModel}, the single owner of the ListView's data, filter, and
+ * selection. Because the model no longer lives inside the adapter, these exercise the
+ * filter-position mapping and the selection policy directly, without a RecyclerView. Filtering
+ * is applied synchronously here via {@link ListDataModel#computeFilter}/{@code commitFilter},
+ * the same two steps the adapter's Filter runs across its background and UI threads.
+ */
+public class ListDataModelTest extends RobolectricTestBase {
+
+  private static ListDataModel modelOf(Object... items) {
+    ListDataModel model = new ListDataModel();
+    model.setItems(Arrays.asList(items));
+    return model;
+  }
+
+  private static void applyFilter(ListDataModel model, String query) {
+    model.commitFilter(model.computeFilter(query));
+  }
+
+  private static YailDictionary dictItem(String main, String detail) {
+    YailDictionary dict = new YailDictionary();
+    dict.put(Component.LISTVIEW_KEY_MAIN_TEXT, main);
+    dict.put(Component.LISTVIEW_KEY_DESCRIPTION, detail);
+    return dict;
+  }
+
+  /** With no filter the visible view is the full list and positions map to themselves. */
+  @Test
+  public void testUnfilteredIsIdentity() {
+    ListDataModel model = modelOf("apple", "banana", "cantaloupe", "date");
+    assertEquals(4, model.visibleSize());
+    assertEquals("apple", model.getVisibleItem(0));
+    assertEquals(2, model.toOriginalPosition(2));
+    assertEquals(2, model.toDisplayPosition(2));
+    assertTrue(model.isVisible(3));
+  }
+
+  /** A filter narrows the visible view and maps display rows back to original indexes. */
+  @Test
+  public void testFilterMapsDisplayRowsToOriginalPositions() {
+    ListDataModel model = modelOf("apple", "banana", "cantaloupe", "date");
+    applyFilter(model, "an");  // matches banana (1) and cantaloupe (2)
+
+    assertEquals("an", model.getLastQuery());
+    assertEquals(2, model.visibleSize());
+    assertEquals("banana", model.getVisibleItem(0));
+    assertEquals("cantaloupe", model.getVisibleItem(1));
+    // display 0 -> original 1, display 1 -> original 2
+    assertEquals(1, model.toOriginalPosition(0));
+    assertEquals(2, model.toOriginalPosition(1));
+    // original 1 is shown at display 0; original 0 is hidden (-1)
+    assertEquals(0, model.toDisplayPosition(1));
+    assertEquals(-1, model.toDisplayPosition(0));
+    assertTrue(model.isVisible(1));
+    assertFalse(model.isVisible(0));
+  }
+
+  /** Clearing the filter restores the full list. */
+  @Test
+  public void testClearingFilterRestoresAllItems() {
+    ListDataModel model = modelOf("apple", "banana");
+    applyFilter(model, "ban");
+    assertEquals(1, model.visibleSize());
+    applyFilter(model, "");
+    assertEquals(2, model.visibleSize());
+    assertEquals("apple", model.getVisibleItem(0));
+  }
+
+  /** Filtering matches against both the main and the detail text of dictionary rows. */
+  @Test
+  public void testFilterMatchesMainAndDetailText() {
+    ListDataModel model = modelOf(
+        dictItem("apple", "red fruit"),
+        dictItem("banana", "yellow fruit"));
+
+    applyFilter(model, "red");  // only appears in the first row's detail text
+    assertEquals(1, model.visibleSize());
+    assertEquals("apple",
+        ((YailDictionary) model.getVisibleItem(0)).get(Component.LISTVIEW_KEY_MAIN_TEXT));
+
+    applyFilter(model, "fruit");  // appears in both details
+    assertEquals(2, model.visibleSize());
+  }
+
+  /**
+   * Selection is kept while its item stays visible under a filter and dropped only once the
+   * filter hides it — the policy agreed with the reviewer.
+   */
+  @Test
+  public void testSelectionKeptWhileVisibleAndPrunedWhenHidden() {
+    ListDataModel model = modelOf("apple", "banana", "cantaloupe", "date");
+    model.selectSingle(1);  // banana, by original index
+
+    applyFilter(model, "an");  // banana (1) still visible
+    assertTrue(model.isSelected(1));
+
+    applyFilter(model, "date");  // banana now hidden
+    assertFalse(model.isSelected(1));
+    assertEquals(-1, model.firstSelection());
+  }
+
+  /** Single-selection replaces; toggle adds/removes for MultiSelect; clear empties. */
+  @Test
+  public void testSelectionSemantics() {
+    ListDataModel model = modelOf("apple", "banana", "cantaloupe");
+
+    model.selectSingle(0);
+    assertEquals(0, model.firstSelection());
+    model.selectSingle(2);  // replaces the previous selection
+    assertFalse(model.isSelected(0));
+    assertTrue(model.isSelected(2));
+
+    model.toggleSelection(1);  // now 1 and 2 are selected
+    assertTrue(model.isSelected(1));
+    assertTrue(model.isSelected(2));
+    model.toggleSelection(2);  // removes 2
+    assertFalse(model.isSelected(2));
+
+    model.clearSelection();
+    assertFalse(model.isSelected(1));
+    assertEquals(-1, model.firstSelection());
+  }
+}


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

The ListView keeps three things that aren't visual: the list of items, the
search filter, and which row is selected. Until now those were split across
different classes — the item list lived in `ListDataModel` (added in #4037),
but the filter and the selection still lived inside the row adapter. This PR
finishes that consolidation by moving the filter and the selection into
`ListDataModel` too, so there is a single place that owns all of it. The
adapter is now just a thin view that reads from the model and draws the rows.

This is an internal cleanup, not a feature change. There are no new blocks or
properties, and filtering and selection behave the same as before: the search
bar narrows the list, tapping selects a row, and a selection is kept while its
item is still visible under a filter and cleared once the filter hides it.

There is one small, intentional improvement: the selected row's highlight now
stays put when a color or font is changed at runtime. Previously, changing a
property rebuilt the list and quietly dropped the highlight even though
`SelectionIndex` still reported the old value; now the highlight and the
reported value stay in agreement.

Because the filter and selection logic now live in one plain class instead of
inside the adapter, they can be tested on their own. This PR adds
`ListDataModelTest`, which checks the filter (including matching on both the
main and detail text), the mapping from a filtered row back to its real item,
and the "keep selection while visible, clear it when hidden" behavior. The
existing `ListViewTest` still passes unchanged.

*Testing Guidelines*

Automated: `ant tests` (the relevant classes are `ListDataModelTest` and
`ListViewTest`).

Manual (Android companion): add a ListView with several items, turn on the
filter bar, and set a Label to `ListView.Selection` in `AfterPicking`.
- Type in the filter bar → the list narrows to matching rows (matches anywhere
  in the main or detail text).
- Tap one of the filtered rows → the label shows that exact item.
- Select a row, then keep typing so it's filtered out → the highlight clears;
  delete back so it's shown again → it comes back unselected.
- Select a row, then change BackgroundColor or FontSize at runtime → the
  highlight stays.

**Context for the changes**

This changes code that runs on the device (the companion), so it is based on
`ucr`.

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

(No user-facing API changed — no new properties or blocks — so no version bump
or upgrader is needed.)

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/ (no user-facing change, so no docs update needed)
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
