### PR TITLE
Set kCFStreamSSLPeerName to support SNI in CloudDB

### DIFF
--- a/appinventor/components-ios/src/CloudDB.swift
+++ b/appinventor/components-ios/src/CloudDB.swift
@@ -104,9 +104,11 @@ public class CloudDB: NonvisibleComponent, RedisManagerDelegate {
   fileprivate func getRedis() {
     _redisQueue.sync {
       if _redis == nil {
+        let serverName = _useDefault ? _defaultRedisServer: _redisServer
         var sslConfig: [String: NSObject] = [:]
         if _useSSL {
-          sslConfig = [GCDAsyncSocketManuallyEvaluateTrust as String: true as NSObject]
+          sslConfig = [GCDAsyncSocketManuallyEvaluateTrust as String: true as NSObject,
+                       kCFStreamSSLPeerName as String: serverName as NSObject]
         }
         var jToken: String = _token
         if _token.hasPrefix("%") {
@@ -115,8 +117,8 @@ public class CloudDB: NonvisibleComponent, RedisManagerDelegate {
         
         _redis = RedisClient(delegate: self, queue: _redisQueue, sslConfig: sslConfig)
         _subscriptionManager = RedisClient(delegate: self, queue: _redisQueue, sslConfig: sslConfig)
-        _redis?.connect(host: _useDefault ? _defaultRedisServer: _redisServer, port: Int(_redisPort), pwd: jToken)
-        _subscriptionManager?.connect(host: _useDefault ? _defaultRedisServer: _redisServer, port: Int(_redisPort), pwd: jToken)
+        _redis?.connect(host: serverName, port: Int(_redisPort), pwd: jToken)
+        _subscriptionManager?.connect(host: serverName, port: Int(_redisPort), pwd: jToken)
       }
     }
   }


### PR DESCRIPTION
Change-Id: I19d39d949640d3d8bdc57c1c38f5dbcdd99183ee

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**

This change adds support for SNI to CloudDB. This is needed in the case where there are multiple CloudDB servers at a single IP address being served over TLS.

*Description*

Changes the CloudDB logic to also assert the hostname in SNI.

*Testing Guidelines*

I made a test project to read/write a tag on CloudDB and report changes to the user via a label. In a copy of the project, I changed the RedisServer property to the test server. Running both in the production iOS companion and a companion built with this PR, I confirmed that changes did not propagate between the two versions (had SNI failed, they'd get routed to the same server).

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
