### PR TITLE
Force CustomAlertView title color to be black on iOS

### DIFF
--- a/appinventor/components-ios/src/Notifier.swift
+++ b/appinventor/components-ios/src/Notifier.swift
@@ -169,6 +169,7 @@ fileprivate class CustomAlertView: UIView {
     let titleLabel = makeLabel()
     titleLabel.font = UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
     titleLabel.text = title
+    titleLabel.textColor = .black
     stack.spacing = kDefaultSpacing
     stack.alignment = .fill
     stack.axis = .vertical


### PR DESCRIPTION
Change-Id: I59e4d7db641d864facc455fc4b8cc26de6a098f5

As reported [via the community](https://community.appinventor.mit.edu/t/how-to-change-notifier-title-text-color-for-ios/174953?u=ewpatton): The title text of the Notifier is white on a light background. Specifically, I think this only occurs when the phone is in dark mode, since the default background color would be darker. We use a custom UIView hierarchy for our alert view, and that is always lighter in color. Now, it might be better to dynamically adjust the background based on the fact that the phone is in dark mode, but for the sake of simplicity I figured it was easier to force the title text to be reasonable.
