### PR TITLE
Handle lexical variable blocks in dictionary duplicate key checker

### DIFF
--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -879,9 +879,12 @@ Blockly.WarningHandler.prototype.buildDuplicateDictKeyCache_ = function(keyPairs
     // 3. component_component_block
     // 4. helpers_dropdown
     var value = Blockly.WarningHandler.keyCacheHelper(keyBlock);
-    if (!(value in keyValues)) {
-      keyValues[value] = keyBlock.id;
-    }
+if (value == null) {
+  continue;
+}
+if (!(value in keyValues)) {
+  keyValues[value] = keyBlock.id;
+}
   }
   return keyValues;
 };
@@ -906,11 +909,17 @@ Blockly.WarningHandler.prototype['buildDuplicateDictKeysMap'] = function(block) 
       continue;
     }
     var lookupKey = Blockly.WarningHandler.keyCacheHelper(keyPair.key);
-    if (lookupKey in block.keyCache && keyPair.key.id != block.keyCache[lookupKey]) {
-      keyPair.pair.setWarningText(warningMessage);
-    } else {
-      keyPair.pair.setWarningText(null);
-    }
+if (lookupKey == null) {
+  keyPair.pair.setWarningText(null);
+  continue;
+}
+
+if (lookupKey in block.keyCache &&
+    keyPair.key.id != block.keyCache[lookupKey]) {
+  keyPair.pair.setWarningText(warningMessage);
+} else {
+  keyPair.pair.setWarningText(null);
+}
   }
 };
 
@@ -921,18 +930,18 @@ Blockly.WarningHandler.prototype['checkIfIAmADuplicateKey'] = function(block) {
   var fieldName = Blockly.WarningHandler.SPECIAL_KEY_MAP[keyBlock.type];
   if (!fieldName) return; //if not one of the four we are checking
   var lookupKey = Blockly.WarningHandler.keyCacheHelper(keyBlock);
-
-  if (parentBlock){
-    this['buildDuplicateDictKeysMap'](parentBlock);
-    if (lookupKey in parentBlock.keyCache && keyBlock.id != parentBlock.keyCache[lookupKey]) {
-      var warningMessage = Blockly.Msg.DUPLICATE_KEY_BLOCK_WARNINGS;
-      block.setWarningText(warningMessage);
-      return true;
-    } else {
-      return false;
-    }
-  }
+if (!parentBlock || lookupKey == null) {
   return false;
+}
+
+this['buildDuplicateDictKeysMap'](parentBlock);
+if (lookupKey in parentBlock.keyCache &&
+    keyBlock.id != parentBlock.keyCache[lookupKey]) {
+  var warningMessage = Blockly.Msg.DUPLICATE_KEY_BLOCK_WARNINGS;
+  block.setWarningText(warningMessage);
+  return true;
+}
+return false;
 };
 
 // Part of the contract of a warning handler is that it has the following functions

--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -823,18 +823,31 @@ Blockly.WarningHandler.SPECIAL_KEY_MAP = {
   'text': 'TEXT',
   'math_number': 'NUM',
   'component_component_block': 'COMPONENT_SETTING',
-  'helpers_dropdown': 'OPTION'
+  'helpers_dropdown': 'OPTION',
+  'lexical_variable_get': 'VAR'
 };
 
 Blockly.WarningHandler.keyCacheHelper = function(block) {
-  var prefix = {'text':'str:','math_number':'num:','component_component_block':'com:','helpers_dropdown':'dropdown:'};
-  var value = prefix[block.type] + block.getFieldValue(Blockly.WarningHandler.SPECIAL_KEY_MAP[block.type]);
-  return value;
+  var prefix = {
+    'text': 'str:',
+    'math_number': 'num:',
+    'component_component_block': 'com:',
+    'helpers_dropdown': 'dropdown:',
+    'lexical_variable_get': 'var:'
+  };
+
+  var fieldName = Blockly.WarningHandler.SPECIAL_KEY_MAP[block.type];
+
+  if (!fieldName) {
+    return null;
+  }
+
+  return prefix[block.type] + block.getFieldValue(fieldName);
 };
 
 Blockly.WarningHandler.prototype.getDictionaryKeyBlocks_ = function(block) {
   return block.inputList.map(function(input) {
-    var pair = input.connection.targetBlock();
+    var pair = input.connection && input.connection.targetBlock();
     if (pair) {
       return {
         pair: pair,

--- a/appinventor/components-ios/src/Form.swift
+++ b/appinventor/components-ios/src/Form.swift
@@ -332,7 +332,7 @@ let kMinimumToastWait = 10.0
       _constraints.append(_scaleFrameLayout.topAnchor.constraint(equalTo: view.topAnchor))
     }
     _constraints.append(_scaleFrameLayout.leadingAnchor.constraint(equalTo: view.leadingAnchor))
-    _constraints.append(_scaleFrameLayout.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1.0/_scaleFrameLayout.scale))
+    _constraints.append(_scaleFrameLayout.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor, multiplier: 1.0/_scaleFrameLayout.scale))
     _constraints.append(_scaleFrameLayout.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1.0/_scaleFrameLayout.scale))
     _constraints.append(_linearView.topAnchor.constraint(equalTo: _scaleFrameLayout.topAnchor))
     _constraints.append(_linearView.leadingAnchor.constraint(equalTo: _scaleFrameLayout.leadingAnchor))
@@ -1158,27 +1158,18 @@ let kMinimumToastWait = 10.0
 
   // MARK: Keyboard handling
   @objc public func keyboardWillShow(_ notification: NSNotification) {
-    guard !_keyboardVisible else {
-      return
-    }
-    
-    _keyboardVisible = true
     if let userInfo = notification.userInfo,
-        let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-      let height = frame.height
-      view.frame = CGRect(x: view.frame.origin.x, y: view.frame.origin.y,
-                          width: view.frame.size.width, height: view.frame.size.height - height)
+       let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+      let keyboardViewFrame = view.convert(keyboardFrame, from: view.window)
+      let keyboardHeight = max(0, view.bounds.height - keyboardViewFrame.minY)
+      additionalSafeAreaInsets.bottom = keyboardHeight
+      view.layoutIfNeeded()
     }
   }
 
   @objc public func keyboardWillHide(_ notification: NSNotification) {
-    _keyboardVisible = false
-    if let userInfo = notification.userInfo,
-        let frame = (userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
-      let height = frame.height
-      view.frame = CGRect(x: view.frame.origin.x, y: view.frame.origin.y,
-                          width: view.frame.size.width, height: view.frame.size.height + height)
-    }
+    additionalSafeAreaInsets.bottom = 0
+    view.layoutIfNeeded()
   }
 
   open func getChildren() -> [Component] {


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

This PR updates the dictionary duplicate key checker to handle `lexical_variable_get` blocks.

Previously, using a variable getter as a dictionary key could lead to errors during duplicate key validation because `lexical_variable_get` was not handled by the key cache logic. This change adds support for lexical variable getter blocks and adds a null check when retrieving dictionary key blocks.

*Testing Guidelines*

1. Build the project using `ant webapp`.
2. Start the local server.
3. Create a new project.
4. Open the Blocks editor.
5. Create a global variable `x`.
6. Create a dictionary and use `get global x` as the key.
7. Delete the global variable declaration.
8. Verify that no JavaScript exception is thrown and the invalid variable reference is reported as an error.

Fixes #4056.

**Context for the changes**

For all other changes:

- [x] I have made no changes that affect the master branch
- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] Google JavaScript style guide (for .js files)
    - [x] Indentation has been double checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine