### PR TITLE
Stop rebuilding the ListView adapter on Android, and let iOS rows size themselves

### DIFF
--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -129,6 +129,8 @@ fileprivate final class ListViewRootView: UIView {
     _view.tableFooterView = UIView()
     _view.backgroundView = nil
     _view.backgroundColor = argbToColor(_backgroundColor)
+    // Rows size themselves from their own constraints, whatever the layout mode.
+    _view.rowHeight = UITableView.automaticDimension
 
     // Auto height for the table (existing)
     _automaticHeightConstraint = _view.heightAnchor.constraint(equalToConstant: kDefaultTableCellHeight)
@@ -834,16 +836,12 @@ fileprivate final class ListViewRootView: UIView {
       let origRow = _model.originalIndex(indexPath.row)
       let item = listItem(at: origRow) ?? makeListItem()
       cell.imageView?.image = nil
-      tableView.rowHeight = UITableView.automaticDimension
 
       if _listViewLayoutMode == 0 {
         cell.textLabel?.text = item["Text1"] as? String
         cell.detailTextLabel?.text = ""
-        tableView.estimatedRowHeight = 44
       } else {
         if _listViewLayoutMode == 1 {
-          tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 44
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = item["Text2"] as? String
 
@@ -876,8 +874,6 @@ fileprivate final class ListViewRootView: UIView {
             stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
           ])
         } else if _listViewLayoutMode == 2 {
-          tableView.rowHeight = UITableView.automaticDimension
-          tableView.estimatedRowHeight = 60
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = item["Text2"] as? String
 
@@ -913,7 +909,6 @@ fileprivate final class ListViewRootView: UIView {
             stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
           ])
         } else if _listViewLayoutMode == 3 {
-          tableView.estimatedRowHeight = preferredRowHeight
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
@@ -953,7 +948,6 @@ fileprivate final class ListViewRootView: UIView {
             ])
           }
         } else if _listViewLayoutMode == 4 {
-          tableView.estimatedRowHeight = 60
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
@@ -1005,7 +999,6 @@ fileprivate final class ListViewRootView: UIView {
             ])
           }
         } else if _listViewLayoutMode == 5 {
-          tableView.estimatedRowHeight = 120
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
@@ -1054,7 +1047,6 @@ fileprivate final class ListViewRootView: UIView {
             ])
           }
         } else {
-          tableView.estimatedRowHeight = 44
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = ""
         }
@@ -1152,10 +1144,11 @@ fileprivate final class ListViewRootView: UIView {
 
     // MARK: UITableViewDelegate
 
-    open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-      return preferredRowHeight
-    }
-
+    // Deliberately no heightForRowAt. Implementing it makes UIKit ignore rowHeight,
+    // automaticDimension included, so a font-derived number would override the cell's
+    // own constraints. Every layout pins its content to the contentView's top and
+    // bottom, so Auto Layout already knows the real height, image and wrapped text
+    // included. This stays an estimate, and an estimate is allowed to be approximate.
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
       return preferredRowHeight
     }

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -395,6 +395,10 @@ fileprivate final class ListViewRootView: UIView {
     set(height) {
       _imageHeight = height
       _view.reloadData()
+      // A row in the image layouts is as tall as its image, so the ListView's own automatic
+      // height has to follow the image size the same way it follows the row count.
+      _automaticHeightConstraint?.constant = preferredTableHeight
+      invalidateListViewSize()
     }
 }
 
@@ -836,6 +840,13 @@ fileprivate final class ListViewRootView: UIView {
       let origRow = _model.originalIndex(indexPath.row)
       let item = listItem(at: origRow) ?? makeListItem()
       cell.imageView?.image = nil
+      // This method rebuilds a cell's subviews every time it binds, so drop the previous build
+      // first. A stack left behind by an earlier bind keeps its pins to the contentView's top and
+      // bottom, and since rows size themselves those stale pins fight the live stack over the
+      // row's height. Only stacks are removed: the layouts that do not build one (mode 0 and the
+      // fallback) leave their system labels where UIKit put them, and the reuse identifier is per
+      // layout mode, so a cell never crosses over from a layout that does build one.
+      cell.contentView.subviews.filter { $0 is UIStackView }.forEach { $0.removeFromSuperview() }
 
       if _listViewLayoutMode == 0 {
         cell.textLabel?.text = item["Text1"] as? String
@@ -911,141 +922,158 @@ fileprivate final class ListViewRootView: UIView {
         } else if _listViewLayoutMode == 3 {
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = ""
+
+          // Configure the layout
+          cell.layoutMargins = UIEdgeInsets.zero
+          cell.separatorInset = UIEdgeInsets.zero
+          cell.preservesSuperviewLayoutMargins = true
+
+          // Create a stack view to hold the labels horizontally
+          let stackView = UIStackView()
+          stackView.axis = .horizontal
+          stackView.alignment = .leading
+          stackView.distribution = .fill
+          stackView.spacing = 8.0
+
+          // The image is optional, the stack is not: it is what pins the row's content to the
+          // contentView, and without it a self-sizing row has nothing to take its height from.
+          var imageConstraints: [NSLayoutConstraint] = []
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
              let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-
-            // Configure the layout
-            cell.layoutMargins = UIEdgeInsets.zero
-            cell.separatorInset = UIEdgeInsets.zero
-            cell.preservesSuperviewLayoutMargins = true
-
-            // Create a stack view to hold the labels horizontally
-            let stackView = UIStackView()
-            stackView.axis = .horizontal
-            stackView.alignment = .leading
-            stackView.distribution = .fill
-            stackView.spacing = 8.0
-
-            // Add the labels to the stack view
             stackView.addArrangedSubview(cell.imageView!)
-            stackView.addArrangedSubview(cell.textLabel!)
-
-            // Add the stack view to the cell's content view
-            cell.contentView.addSubview(stackView)
-
-            // Set up constraints
-            stackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-
-              stackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
-              stackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
-              stackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
-              stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0),
+            imageConstraints = [
               cell.imageView!.widthAnchor.constraint(equalToConstant: CGFloat(_imageWidth / 4)),
               cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4))
-            ])
+            ]
           }
+
+          // Add the labels to the stack view
+          stackView.addArrangedSubview(cell.textLabel!)
+
+          // Add the stack view to the cell's content view
+          cell.contentView.addSubview(stackView)
+
+          // Set up constraints
+          stackView.translatesAutoresizingMaskIntoConstraints = false
+          NSLayoutConstraint.activate(imageConstraints + [
+            stackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
+            stackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
+            stackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
+            stackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
+          ])
         } else if _listViewLayoutMode == 4 {
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
+
+          // Configure the layout
+          cell.layoutMargins = UIEdgeInsets.zero
+          cell.separatorInset = UIEdgeInsets.zero
+          cell.preservesSuperviewLayoutMargins = true
+
+          // Create a horizontal stack view to hold the imageView and a nested vertical stack view
+          let horizontalStackView = UIStackView()
+          horizontalStackView.axis = .horizontal
+          horizontalStackView.alignment = .center
+          horizontalStackView.distribution = .fill
+          horizontalStackView.spacing = 8.0
+
+          // Create a vertical stack view to hold the textLabel and detailTextLabel.
+          // Use .fill so labels span the inner stack width and textAlignment is
+          // visible regardless of text length.
+          let verticalStackView = UIStackView()
+          verticalStackView.axis = .vertical
+          verticalStackView.alignment = .fill
+          verticalStackView.distribution = .fill
+          verticalStackView.spacing = 8.0
+
+          // The image is optional, the stack is not: it is what pins the row's content to the
+          // contentView, and without it a self-sizing row has nothing to take its height from.
+          var imageConstraints: [NSLayoutConstraint] = []
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
              let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-
-            // Configure the layout
-            cell.layoutMargins = UIEdgeInsets.zero
-            cell.separatorInset = UIEdgeInsets.zero
-            cell.preservesSuperviewLayoutMargins = true
-
-            // Create a horizontal stack view to hold the imageView and a nested vertical stack view
-            let horizontalStackView = UIStackView()
-            horizontalStackView.axis = .horizontal
-            horizontalStackView.alignment = .center
-            horizontalStackView.distribution = .fill
-            horizontalStackView.spacing = 8.0
-
-            // Create a vertical stack view to hold the textLabel and detailTextLabel.
-            // Use .fill so labels span the inner stack width and textAlignment is
-            // visible regardless of text length.
-            let verticalStackView = UIStackView()
-            verticalStackView.axis = .vertical
-            verticalStackView.alignment = .fill
-            verticalStackView.distribution = .fill
-            verticalStackView.spacing = 8.0
-
-            // Add the imageView and nested vertical stack view to the horizontal stack view
             horizontalStackView.addArrangedSubview(cell.imageView!)
-            horizontalStackView.addArrangedSubview(verticalStackView)
-
-            // Add the textLabel and detailTextLabel to the vertical stack view
-            verticalStackView.addArrangedSubview(cell.textLabel!)
-            verticalStackView.addArrangedSubview(cell.detailTextLabel!)
-
-            // Add the horizontal stack view to the cell's content view
-            cell.contentView.addSubview(horizontalStackView)
-
-            // Set up constraints
-            horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-              horizontalStackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
-              horizontalStackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
-              horizontalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
-              horizontalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0),
+            imageConstraints = [
               cell.imageView!.widthAnchor.constraint(equalToConstant: CGFloat(_imageWidth / 4)),
               cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4))
-            ])
+            ]
           }
+
+          // Add the nested vertical stack view to the horizontal stack view
+          horizontalStackView.addArrangedSubview(verticalStackView)
+
+          // Add the textLabel and detailTextLabel to the vertical stack view
+          verticalStackView.addArrangedSubview(cell.textLabel!)
+          verticalStackView.addArrangedSubview(cell.detailTextLabel!)
+
+          // Add the horizontal stack view to the cell's content view
+          cell.contentView.addSubview(horizontalStackView)
+
+          // Set up constraints
+          horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
+          NSLayoutConstraint.activate(imageConstraints + [
+            horizontalStackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
+            horizontalStackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
+            horizontalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
+            horizontalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
+          ])
         } else if _listViewLayoutMode == 5 {
           cell.textLabel?.text = item["Text1"] as? String ?? ""
           cell.detailTextLabel?.text = item["Text2"] as? String ?? ""
+
+          // Configure the layout
+          cell.layoutMargins = UIEdgeInsets.zero
+          cell.separatorInset = UIEdgeInsets.zero
+          cell.preservesSuperviewLayoutMargins = true
+
+          // Inner stack: labels with .fill so they span the full label-stack
+          // width, making textAlignment visible regardless of text length.
+          let labelsStackView = UIStackView()
+          labelsStackView.axis = .vertical
+          labelsStackView.alignment = .fill
+          labelsStackView.distribution = .fill
+          labelsStackView.spacing = 8.0
+          labelsStackView.addArrangedSubview(cell.textLabel!)
+          labelsStackView.addArrangedSubview(cell.detailTextLabel!)
+
+          // Outer stack: image (centered) + labels stack
+          let verticalStackView = UIStackView()
+          verticalStackView.axis = .vertical
+          verticalStackView.alignment = .center
+          verticalStackView.distribution = .fill
+          verticalStackView.spacing = 8.0
+
+          // The image is optional, the stack is not: it is what pins the row's content to the
+          // contentView, and without it a self-sizing row has nothing to take its height from.
+          var imageConstraints: [NSLayoutConstraint] = []
           if let imagePath = item["Image"] as? String, !imagePath.isEmpty,
              let image = AssetManager.shared.imageFromPath(path: imagePath) {
             cell.imageView?.image = image
             cell.imageView?.contentMode = .scaleAspectFit
-
-            // Configure the layout
-            cell.layoutMargins = UIEdgeInsets.zero
-            cell.separatorInset = UIEdgeInsets.zero
-            cell.preservesSuperviewLayoutMargins = true
-
-            // Inner stack: labels with .fill so they span the full label-stack
-            // width, making textAlignment visible regardless of text length.
-            let labelsStackView = UIStackView()
-            labelsStackView.axis = .vertical
-            labelsStackView.alignment = .fill
-            labelsStackView.distribution = .fill
-            labelsStackView.spacing = 8.0
-            labelsStackView.addArrangedSubview(cell.textLabel!)
-            labelsStackView.addArrangedSubview(cell.detailTextLabel!)
-
-            // Outer stack: image (centered) + labels stack
-            let verticalStackView = UIStackView()
-            verticalStackView.axis = .vertical
-            verticalStackView.alignment = .center
-            verticalStackView.distribution = .fill
-            verticalStackView.spacing = 8.0
             verticalStackView.addArrangedSubview(cell.imageView!)
-            verticalStackView.addArrangedSubview(labelsStackView)
-
-            // Add the outer stack to the cell's content view
-            cell.contentView.addSubview(verticalStackView)
-
-            // Set up constraints. The labelsStackView width is pinned to the
-            // outer stack so labels span full row width while the image stays
-            // centered at its intrinsic / explicit size.
-            verticalStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-              verticalStackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
-              verticalStackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
-              verticalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
-              verticalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0),
+            imageConstraints = [
               cell.imageView!.widthAnchor.constraint(equalToConstant: CGFloat(_imageWidth / 4)),
               cell.imageView!.heightAnchor.constraint(equalToConstant: CGFloat(_imageHeight / 4))
-            ])
+            ]
           }
+          verticalStackView.addArrangedSubview(labelsStackView)
+
+          // Add the outer stack to the cell's content view
+          cell.contentView.addSubview(verticalStackView)
+
+          // Set up constraints. The labelsStackView width is pinned to the
+          // outer stack so labels span full row width while the image stays
+          // centered at its intrinsic / explicit size.
+          verticalStackView.translatesAutoresizingMaskIntoConstraints = false
+          NSLayoutConstraint.activate(imageConstraints + [
+            verticalStackView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 8.0),
+            verticalStackView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -8.0),
+            verticalStackView.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 8.0),
+            verticalStackView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -8.0)
+          ])
         } else {
           cell.textLabel?.text = item["Text1"] as? String
           cell.detailTextLabel?.text = ""
@@ -1221,17 +1249,26 @@ fileprivate final class ListViewRootView: UIView {
     let twoTextVerticalHeight = mainTextHeight + detailTextHeight + kDefaultTableCellVerticalPadding
     let twoTextHorizontalHeight = max(mainTextHeight, detailTextHeight) + kDefaultTableCellVerticalPadding
 
+    // The image layouts pin the image to a quarter of its set size — keep this in step with the
+    // height anchors in cellForRowAt. The 60 and 120 floors below are what a default 200px image
+    // works out to, so without this term a taller image gives correct rows inside a ListView that
+    // is still sized as though every image were 200px.
+    let imageHeight = CGFloat(_imageHeight / 4)
+
     switch _listViewLayoutMode {
     case 1:
       return max(kDefaultTableCellHeight, twoTextVerticalHeight)
     case 2:
       return max(kDefaultTableCellHeight, twoTextHorizontalHeight)
     case 3:
-      return max(60.0, singleTextHeight)
+      // Image beside the text, so the row is as tall as the taller of the two.
+      return max(60.0, singleTextHeight, imageHeight + kDefaultTableCellVerticalPadding)
     case 4:
-      return max(60.0, twoTextVerticalHeight)
+      // Image beside both labels, so again the taller of the two.
+      return max(60.0, twoTextVerticalHeight, imageHeight + kDefaultTableCellVerticalPadding)
     case 5:
-      return max(120.0, twoTextVerticalHeight)
+      // Image above both labels, so here they add up.
+      return max(120.0, imageHeight + twoTextVerticalHeight)
     default:
       return max(kDefaultTableCellHeight, singleTextHeight)
     }

--- a/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
@@ -95,7 +95,24 @@ class ListViewTests: AppInventorTestCase {
       XCTFail("Expected ListView to contain a table view")
       return
     }
-    XCTAssertGreaterThan(listView.tableView(tableView, heightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+    XCTAssertGreaterThan(
+      listView.tableView(tableView, estimatedHeightForRowAt: IndexPath(row: 0, section: 0)), 44.0)
+  }
+
+  func testRowsSizeFromTheirOwnConstraints() {
+    form.clear()
+    let listView = ListView(form)
+    form.onAttach()
+
+    guard let tableView = listView.view.subviews.first(where: { $0 is UITableView }) as? UITableView else {
+      XCTFail("Expected ListView to contain a table view")
+      return
+    }
+    XCTAssertEqual(tableView.rowHeight, UITableView.automaticDimension)
+    // Implementing heightForRowAt makes UIKit ignore rowHeight, so a row would be pinned to a
+    // height that knows nothing about ImageHeight and a tall image would squeeze out the labels.
+    XCTAssertFalse(
+      listView.responds(to: #selector(UITableViewDelegate.tableView(_:heightForRowAt:))))
   }
   
   func testElementAsDictItems() {

--- a/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
@@ -114,7 +114,64 @@ class ListViewTests: AppInventorTestCase {
     XCTAssertFalse(
       listView.responds(to: #selector(UITableViewDelegate.tableView(_:heightForRowAt:))))
   }
-  
+
+  func testAutomaticHeightFollowsImageHeight() {
+    testList.ListViewLayout = 5
+    testList.Elements = ["apple", "banana"] as [AnyObject]
+
+    let atDefaultImageSize = testList.view.intrinsicContentSize.height
+    testList.ImageHeight = 500
+
+    // A row is pinned to ImageHeight / 4, so rows grow with the image. The ListView's automatic
+    // height has to grow with them, or tall images render correctly inside a container still
+    // sized for the default 200px image.
+    XCTAssertGreaterThan(testList.view.intrinsicContentSize.height, atDefaultImageSize)
+  }
+
+  func testImagelessRowStillGetsItsStackView() {
+    testList.ListViewLayout = 3
+    testList.Elements = ["apple", "banana"] as [AnyObject]
+
+    let tableView = visibleTableView(for: testList)
+    let cell = testList.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+
+    // The image layouts build their stack whether or not an image loaded. The stack is what pins
+    // the row's content to the contentView, and now that rows size themselves, a row with nothing
+    // pinned has no height to compute.
+    XCTAssertEqual(1, cell.contentView.subviews.filter { $0 is UIStackView }.count)
+  }
+
+  func testReusedRowsDoNotStackUpTheirSubviews() {
+    testList.ListViewLayout = 2
+    testList.Height = 88
+    testList.Elements = (1...40).map { "item \($0)" } as [AnyObject]
+
+    form.view.frame = CGRect(x: 0, y: 0, width: 393, height: 852)
+    form.onAttach()
+    form.view.setNeedsLayout()
+    form.view.layoutIfNeeded()
+
+    let tableView = visibleTableView(for: testList)
+    tableView.reloadData()
+    tableView.layoutIfNeeded()
+    tableView.contentOffset = CGPoint(x: 0, y: 600)
+    tableView.layoutIfNeeded()
+    // Scrolling back up is what forces reuse. On the way down every row is new, so UIKit builds
+    // fresh cells and nothing is recycled; coming back up binds the top rows into the cells the
+    // bottom rows just released.
+    tableView.contentOffset = .zero
+    tableView.layoutIfNeeded()
+
+    // Guard against the assertion below passing because nothing was laid out at all.
+    XCTAssertFalse(tableView.visibleCells.isEmpty)
+    // A recycled cell must not keep the stack from its previous bind: a stale stack holds on to
+    // its pins to the contentView's top and bottom and fights the live one over the row's height.
+    for cell in tableView.visibleCells {
+      XCTAssertEqual(1, cell.contentView.subviews.filter { $0 is UIStackView }.count)
+    }
+  }
+
+
   func testElementAsDictItems() {
     testList.Elements = [["Text1": "MainText","Text2": "DetailText", "Image": "Image"] as YailDictionary]
     XCTAssertEqual(1, testList.Elements.count)

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -116,9 +116,13 @@ public abstract class ListAdapterWithRecyclerView
    */
   protected void styleImage(ImageView imageView) {
     ViewGroup.LayoutParams params = imageView.getLayoutParams();
-    params.width = style.imageWidth;
-    params.height = style.imageHeight;
-    imageView.setLayoutParams(params);
+    // setLayoutParams requests a layout pass, and this runs on every bind, so only pay for it
+    // when the dimensions actually changed.
+    if (params.width != style.imageWidth || params.height != style.imageHeight) {
+      params.width = style.imageWidth;
+      params.height = style.imageHeight;
+      imageView.setLayoutParams(params);
+    }
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 
 import android.widget.Filter;
 import android.widget.Filterable;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.cardview.widget.CardView;
 
@@ -17,17 +19,20 @@ import androidx.core.view.ViewCompat;
 
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.appinventor.components.runtime.util.TextViewUtil;
+
 public abstract class ListAdapterWithRecyclerView
     extends RecyclerView.Adapter<ListAdapterWithRecyclerView.RvViewHolder> implements Filterable {
   protected static final String LOG_TAG = ListView.LOG_TAG;
 
   protected ClickListener clickListener;
 
-  protected int backgroundColor;
-  protected int selectionColor;
-  protected float radius;
   // The model owns the data, the filter, and the selection; this adapter is only a view over it.
   protected final ListDataModel model;
+  // The ListView owns the style and mutates it in place, so re-binding a row is enough to pick up
+  // an appearance change. Subclasses must therefore apply style when they bind a row, never when
+  // they create one: onCreateViewHolder runs only once per recycled view.
+  protected final ListViewStyle style;
   protected ComponentContainer container;
 
   protected final Filter filter = new Filter() {
@@ -51,12 +56,10 @@ public abstract class ListAdapterWithRecyclerView
   };
 
   public ListAdapterWithRecyclerView(ComponentContainer container, ListDataModel model,
-      int backgroundColor, int selectionColor, float radius) {
+      ListViewStyle style) {
     this.container = container;
     this.model = model;
-    this.backgroundColor = backgroundColor;
-    this.radius = radius;
-    this.selectionColor = selectionColor;
+    this.style = style;
   }
 
   protected CardView createCardView(ViewGroup parent) {
@@ -64,8 +67,6 @@ public abstract class ListAdapterWithRecyclerView
     cardView.setContentPadding(15, 15, 15, 15);
     cardView.setPreventCornerOverlap(false);
     cardView.setMaxCardElevation(3f);
-    cardView.setCardBackgroundColor(backgroundColor);
-    cardView.setRadius(radius);
     cardView.setCardElevation(0.0f);
     ViewCompat.setElevation(cardView, 0);
 
@@ -89,12 +90,48 @@ public abstract class ListAdapterWithRecyclerView
     }
   }
 
-  protected void updateCardViewColor(CardView cardView, int position) {
+  /**
+   * Applies the current style to a row's main text. Call this while binding, so that changing an
+   * appearance property only has to re-bind the visible rows.
+   */
+  protected void styleMainText(TextView textView) {
+    textView.setTextSize(style.fontSizeMain);
+    textView.setTextColor(style.textColor);
+    TextViewUtil.setFontTypeface(container.$form(), textView, style.fontTypeface, false, false);
+    TextViewUtil.setAlignment(textView, style.textAlignmentMain, false);
+  }
+
+  /**
+   * Applies the current style to a row's detail text. See {@link #styleMainText}.
+   */
+  protected void styleDetailText(TextView textView) {
+    textView.setTextSize(style.fontSizeDetail);
+    textView.setTextColor(style.detailTextColor);
+    TextViewUtil.setFontTypeface(container.$form(), textView, style.fontTypeDetail, false, false);
+    TextViewUtil.setAlignment(textView, style.textAlignmentDetail, false);
+  }
+
+  /**
+   * Applies the current image dimensions to a row's image. See {@link #styleMainText}.
+   */
+  protected void styleImage(ImageView imageView) {
+    ViewGroup.LayoutParams params = imageView.getLayoutParams();
+    params.width = style.imageWidth;
+    params.height = style.imageHeight;
+    imageView.setLayoutParams(params);
+  }
+
+  /**
+   * Applies the current style to a row's card, including the selection highlight. See
+   * {@link #styleMainText}.
+   */
+  protected void styleCardView(CardView cardView, int position) {
+    cardView.setRadius(style.radius);
     // position is a display row; map it back to the original index the selection is keyed by.
     if (model.isSelected(model.toOriginalPosition(position))) {
-      cardView.setCardBackgroundColor(selectionColor);
+      cardView.setCardBackgroundColor(style.selectionColor);
     } else {
-      cardView.setCardBackgroundColor(backgroundColor);
+      cardView.setCardBackgroundColor(style.elementColor);
     }
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -1381,6 +1381,23 @@ public final class ListView extends AndroidViewComponent {
     recyclerView.addItemDecoration(new DividerItemDecoration());
   }
 
+  /**
+   * Returns the model holding this ListView's items, filter and selection. Extensions need it to
+   * build an adapter to pass to {@link #setListAdapter}.
+   */
+  public ListDataModel getDataModel() {
+    return dataModel;
+  }
+
+  /**
+   * Returns this ListView's appearance. The ListView mutates it in place, so an adapter holding on
+   * to it picks up appearance changes when its rows re-bind. Extensions need it to build an adapter
+   * to pass to {@link #setListAdapter}.
+   */
+  public ListViewStyle getStyle() {
+    return style;
+  }
+
   public void setListAdapter(ListAdapterWithRecyclerView adapter) {
     listAdapterWithRecyclerView = adapter;
     listAdapterWithRecyclerView.setOnItemClickListener(new ListAdapterWithRecyclerView.ClickListener() {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -100,33 +100,20 @@ public final class ListView extends AndroidViewComponent {
   private int backgroundColor;
   private static final int DEFAULT_BACKGROUND_COLOR = Component.COLOR_BLACK;
 
-  private int elementColor = COLOR_NONE;
-
-  private int textColor;
-  private int detailTextColor;
-
-  private int selectionColor;
-
-  private float fontSizeMain;
-  private float fontSizeDetail;
-  private String fontTypeface;
-  private String fontTypeDetail;
+  // The row appearance. The adapter holds this same instance, so changing a value here and
+  // re-binding the rows is enough — no new adapter needed.
+  private final ListViewStyle style = new ListViewStyle();
 
   private String hint;
 
   /* for backward compatibility */
   private static final float DEFAULT_TEXT_SIZE = 22;
 
-  private int imageWidth;
-  private int imageHeight;
   private static final int DEFAULT_IMAGE_WIDTH = 200;
 
   // variable for ListView layout types
   private int layout;
   private String propertyValue;  // JSON string representing data entered through the Designer
-
-  private int textAlignmentMain;
-  private int textAlignmentDetail;
 
   private boolean multiSelect;
   private Paint dividerPaint;
@@ -135,7 +122,6 @@ public final class ListView extends AndroidViewComponent {
   private static final int DEFAULT_DIVIDER_SIZE = 0;
   private int margins;
   private static final int DEFAULT_RADIUS = 0;
-  private int radius;
   private RecyclerView.EdgeEffectFactory edgeEffectFactory;
   private ListBounceEdgeEffectFactory bounceEdgeEffectFactory;
   private boolean bounceEffect;
@@ -163,6 +149,10 @@ public final class ListView extends AndroidViewComponent {
 
     layoutManager = new LinearLayoutManager(container.$context(), LinearLayoutManager.VERTICAL, false);
     recyclerView.setLayoutManager(layoutManager);
+
+    // Build the adapter up front. The property setters below only mutate the style and re-bind, so
+    // an adapter has to exist by the time the first of them runs.
+    setAdapterData();
 
     listLayout = new LinearLayout(container.$context());
     LinearLayout.LayoutParams paramsList = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
@@ -225,9 +215,6 @@ public final class ListView extends AndroidViewComponent {
     }
 
     // set the colors and initialize the elements
-    // note that the TextColor and ElementsFromString setters
-    // need to have the textColor set first, since they reset the
-    // adapter
     BackgroundColor(DEFAULT_BACKGROUND_COLOR);
     SelectionColor(Component.COLOR_LTGRAY);
     TextColor(Component.COLOR_WHITE);
@@ -256,7 +243,6 @@ public final class ListView extends AndroidViewComponent {
     linearLayout.requestLayout();
     container.$add(this);
     Width(Component.LENGTH_FILL_PARENT);
-    ListViewLayout(ComponentConstants.LISTVIEW_LAYOUT_SINGLE_TEXT);
     // initialize selectionIndex which also sets selection
     SelectionIndex(0);
   }
@@ -536,7 +522,6 @@ public final class ListView extends AndroidViewComponent {
     backgroundColor = argb;
     recyclerView.setBackgroundColor(backgroundColor);
     linearLayout.setBackgroundColor(backgroundColor);
-    setAdapterData();
   }
 
   /**
@@ -551,7 +536,7 @@ public final class ListView extends AndroidViewComponent {
       category = PropertyCategory.APPEARANCE)
   @IsColor
   public int ElementColor() {
-    return elementColor;
+    return style.elementColor;
   }
 
   /**
@@ -567,8 +552,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.DEFAULT_VALUE_COLOR_NONE)
   @SimpleProperty
   public void ElementColor(int argb) {
-    elementColor = argb;
-    setAdapterData();
+    style.elementColor = argb;
+    refreshStyle();
   }
 
   /**
@@ -584,7 +569,7 @@ public final class ListView extends AndroidViewComponent {
       category = PropertyCategory.APPEARANCE)
   @IsColor
   public int SelectionColor() {
-    return selectionColor;
+    return style.selectionColor;
   }
 
   /**
@@ -601,8 +586,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.DEFAULT_VALUE_COLOR_LTGRAY)
   @SimpleProperty
   public void SelectionColor(int argb) {
-    selectionColor = argb;
-    setAdapterData();
+    style.selectionColor = argb;
+    refreshStyle();
   }
 
   /**
@@ -617,7 +602,7 @@ public final class ListView extends AndroidViewComponent {
       category = PropertyCategory.APPEARANCE)
   @IsColor
   public int TextColor() {
-    return textColor;
+    return style.textColor;
   }
 
   /**
@@ -633,8 +618,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.DEFAULT_VALUE_COLOR_WHITE)
   @SimpleProperty
   public void TextColor(int argb) {
-    textColor = argb;
-    setAdapterData();
+    style.textColor = argb;
+    refreshStyle();
   }
 
   /**
@@ -645,7 +630,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "The color of the detail text of ListView elements. ",
       category = PropertyCategory.APPEARANCE)
   public int TextColorDetail() {
-    return detailTextColor;
+    return style.detailTextColor;
   }
 
   /**
@@ -658,8 +643,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.DEFAULT_VALUE_COLOR_WHITE)
   @SimpleProperty
   public void TextColorDetail(int argb) {
-    detailTextColor = argb;
-    setAdapterData();
+    style.detailTextColor = argb;
+    refreshStyle();
   }
 
   /**
@@ -668,7 +653,7 @@ public final class ListView extends AndroidViewComponent {
   @Deprecated
   @SimpleProperty
   public int TextSize() {
-    return Math.round(fontSizeMain);
+    return Math.round(style.fontSizeMain);
   }
 
   /**
@@ -691,7 +676,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "The font size of the main text.",
       category = PropertyCategory.APPEARANCE)
   public float FontSize() {
-    return fontSizeMain;
+    return style.fontSizeMain;
   }
 
   /**
@@ -704,10 +689,10 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty
   public void FontSize(float fontSize) {
     if (fontSize > 1000 || fontSize < 1)
-      fontSizeMain = 999;
+      style.fontSizeMain = 999;
     else
-      fontSizeMain = fontSize;
-    setAdapterData();
+      style.fontSizeMain = fontSize;
+    refreshStyle();
   }
 
    /**
@@ -718,7 +703,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "The font size of the detail text.",
       category = PropertyCategory.APPEARANCE)
   public float FontSizeDetail() {
-    return fontSizeDetail;
+    return style.fontSizeDetail;
   }
 
   /**
@@ -731,10 +716,10 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty
   public void FontSizeDetail(float fontSize) {
     if (fontSize > 1000 || fontSize < 1)
-      fontSizeDetail = 999;
+      style.fontSizeDetail = 999;
     else
-      fontSizeDetail = fontSize;
-    setAdapterData();
+      style.fontSizeDetail = fontSize;
+    refreshStyle();
   }
 
   /**
@@ -749,7 +734,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       userVisible = false)
   public @Options(FontTypeface.class) String FontTypeface() {
-    return fontTypeface;
+    return style.fontTypeface;
   }
 
   /**
@@ -765,8 +750,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.TYPEFACE_DEFAULT + "")
   @SimpleProperty(userVisible = false)
   public void FontTypeface(@Options(FontTypeface.class) String typeface) {
-    fontTypeface = typeface;
-    setAdapterData();
+    style.fontTypeface = typeface;
+    refreshStyle();
   }
 
   /**
@@ -781,7 +766,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
       userVisible = false)
   public @Options(FontTypeface.class) String FontTypefaceDetail() {
-    return fontTypeDetail;
+    return style.fontTypeDetail;
   }
 
   /**
@@ -797,8 +782,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.TYPEFACE_DEFAULT + "")
   @SimpleProperty(userVisible = false)
   public void FontTypefaceDetail(@Options(FontTypeface.class) String typeface) {
-    fontTypeDetail = typeface;
-    setAdapterData();
+    style.fontTypeDetail = typeface;
+    refreshStyle();
   }
 
   /**
@@ -813,7 +798,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "Specifies the alignment of the main text in ListView elements.",
       category = PropertyCategory.APPEARANCE)
   public int TextAlignmentMain() {
-    return textAlignmentMain;
+    return style.textAlignmentMain;
   }
 
   /**
@@ -829,8 +814,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.ALIGNMENT_NORMAL + "")
   @SimpleProperty
   public void TextAlignmentMain(int alignment) {
-    textAlignmentMain = alignment;
-    setAdapterData();
+    style.textAlignmentMain = alignment;
+    refreshStyle();
   }
 
   /**
@@ -845,7 +830,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "Specifies the alignment of the detail text in ListView elements.",
       category = PropertyCategory.APPEARANCE)
   public int TextAlignmentDetail() {
-    return textAlignmentDetail;
+    return style.textAlignmentDetail;
   }
 
   /**
@@ -861,8 +846,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = Component.ALIGNMENT_NORMAL + "")
   @SimpleProperty
   public void TextAlignmentDetail(int alignment) {
-    textAlignmentDetail = alignment;
-    setAdapterData();
+    style.textAlignmentDetail = alignment;
+    refreshStyle();
   }
 
   /**
@@ -873,7 +858,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "Image width of ListView elements.",
       category = PropertyCategory.APPEARANCE)
   public int ImageWidth() {
-    return imageWidth;
+    return style.imageWidth;
   }
 
   /**
@@ -885,8 +870,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = DEFAULT_IMAGE_WIDTH + "")
   @SimpleProperty
   public void ImageWidth(int width) {
-    imageWidth = width;
-    setAdapterData();
+    style.imageWidth = width;
+    refreshStyle();
   }
 
   /**
@@ -897,7 +882,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "Image height of ListView elements.",
       category = PropertyCategory.APPEARANCE)
   public int ImageHeight() {
-    return imageHeight;
+    return style.imageHeight;
   }
 
   /**
@@ -909,8 +894,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = DEFAULT_IMAGE_WIDTH + "")
   @SimpleProperty
   public void ImageHeight(int height) {
-    imageHeight = height;
-    setAdapterData();
+    style.imageHeight = height;
+    refreshStyle();
   }
 
   /**
@@ -1179,7 +1164,7 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty(description = "The radius of the rounded corners of a list view element.",
       category = PropertyCategory.APPEARANCE)
   public int ElementCornerRadius() {
-    return radius;
+    return style.radius;
   }
 
   /**
@@ -1191,8 +1176,8 @@ public final class ListView extends AndroidViewComponent {
       defaultValue = DEFAULT_RADIUS + "")
   @SimpleProperty
   public void ElementCornerRadius(int radius) {
-    this.radius = radius;
-    setAdapterData();
+    style.radius = radius;
+    refreshStyle();
   }
 
   /**
@@ -1334,45 +1319,39 @@ public final class ListView extends AndroidViewComponent {
   }
 
   /**
-   * Create a new adapter and apply visual changes, load data if it exists.
+   * Re-applies the current appearance to the rows on screen.
+   *
+   * <p>The adapter reads the style as it binds each row, so an appearance change only has to
+   * re-bind. Building a new adapter would work too, but it drops every row view and sends the
+   * user's scroll position back to the top of the list.
+   */
+  private void refreshStyle() {
+    listAdapterWithRecyclerView.notifyItemRangeChanged(0,
+        listAdapterWithRecyclerView.getItemCount());
+  }
+
+  /**
+   * Create a new adapter for the current layout, load data if it exists.
    */
   public void setAdapterData() {
     switch (layout) {
       case LISTVIEW_LAYOUT_SINGLE_TEXT:
-        setListAdapter(new ListViewSingleTextAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewSingleTextAdapter(container, dataModel, style));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT:
-        setListAdapter(new ListViewTwoTextAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewTwoTextAdapter(container, dataModel, style));
         break;
       case LISTVIEW_LAYOUT_TWO_TEXT_LINEAR:
-        setListAdapter(new ListViewTwoTextLinearAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewTwoTextLinearAdapter(container, dataModel, style));
         break;
       case LISTVIEW_LAYOUT_IMAGE_SINGLE_TEXT:
-        setListAdapter(new ListViewImageSingleTextAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewImageSingleTextAdapter(container, dataModel, style));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TWO_TEXT:
-        setListAdapter(new ListViewImageTwoTextVerticalAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewImageTwoTextVerticalAdapter(container, dataModel, style));
         break;
       case LISTVIEW_LAYOUT_IMAGE_TOP_TWO_TEXT:
-        setListAdapter(new ListViewImageTopTwoTextAdapter(container, dataModel,
-            textColor, fontSizeMain, fontTypeface, detailTextColor, fontSizeDetail, fontTypeDetail,
-            elementColor, selectionColor, radius, imageWidth, imageHeight,
-            textAlignmentMain, textAlignmentDetail));
+        setListAdapter(new ListViewImageTopTwoTextAdapter(container, dataModel, style));
         break;
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageSingleTextAdapter.java
@@ -17,7 +17,6 @@ import androidx.core.view.ViewCompat;
 import android.util.Log;
 
 import com.google.appinventor.components.runtime.util.MediaUtil;
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
@@ -25,26 +24,10 @@ import java.io.IOException;
 
 public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int imageWidth;
-  private int imageHeight;
-  private int textMainAlignment;
-
   public ListViewImageSingleTextAdapter(ComponentContainer container, ListDataModel model,
-      int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
-      float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.imageWidth = imageWidth;
-    this.imageHeight = imageHeight;
-    this.textMainAlignment = textMainAlignment;
-  }  
+      ListViewStyle style) {
+    super(container, model, style);
+  }
 
   @Override
   public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -56,7 +39,7 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     final int idImage = ViewCompat.generateViewId();
     imageView.setId(idImage);
     LinearLayout.LayoutParams layoutParamsImage =
-            new LinearLayout.LayoutParams(imageWidth, imageHeight);
+            new LinearLayout.LayoutParams(style.imageWidth, style.imageHeight);
     layoutParamsImage.setMargins(0, 0, 15, 0);
     imageView.setLayoutParams(layoutParamsImage);
 
@@ -66,10 +49,6 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -110,7 +89,10 @@ public class ListViewImageSingleTextAdapter extends ListAdapterWithRecyclerView 
     } catch (IOException ioe) {
       Log.e(LOG_TAG, "onBindViewHolder Unable to load image " + imageName + ": " + ioe.getMessage());
     }
-    updateCardViewColor(imageSingleTextHolder.cardView, position);
+
+    styleMainText(imageSingleTextHolder.textViewFirst);
+    styleImage(imageSingleTextHolder.imageView);
+    styleCardView(imageSingleTextHolder.cardView, position);
   }
  
   public class ImageSingleTextRvViewHolder extends RvViewHolder {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTopTwoTextAdapter.java
@@ -16,52 +16,15 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 import com.google.appinventor.components.runtime.util.MediaUtil;
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 import java.io.IOException;
 
 public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int textDetailColor;
-  private float textDetailSize;
-  private String textDetailFont;
-  private int imageWidth;
-  private int imageHeight;
-  private int textMainAlignment;
-  private int textDetailAlignment;
-
   public ListViewImageTopTwoTextAdapter(
-      ComponentContainer container,
-      ListDataModel model,
-      int textMainColor,
-      float textMainSize,
-      String textMainFont,
-      int textDetailColor,
-      float textDetailSize,
-      String textDetailFont,
-      int backgroundColor,
-      int selectionColor,
-      int radius,
-      int imageWidth,
-      int imageHeight,
-      int textMainAlignment,
-      int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.textDetailColor = textDetailColor;
-    this.textDetailSize = textDetailSize;
-    this.textDetailFont = textDetailFont;
-    this.imageWidth = imageWidth;
-    this.imageHeight = imageHeight;
-    this.textMainAlignment = textMainAlignment;
-    this.textDetailAlignment = textDetailAlignment;
+      ComponentContainer container, ListDataModel model, ListViewStyle style) {
+    super(container, model, style);
   }
 
   @Override
@@ -74,7 +37,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     final int idImage = ViewCompat.generateViewId();
     imageView.setId(idImage);
     LinearLayout.LayoutParams layoutParamsImage =
-        new LinearLayout.LayoutParams(imageWidth, imageHeight);
+        new LinearLayout.LayoutParams(style.imageWidth, style.imageHeight);
     layoutParamsImage.setMargins(0, 0, 0, 15);
     imageView.setLayoutParams(layoutParamsImage);
 
@@ -86,10 +49,6 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
         new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -98,11 +57,7 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
     LinearLayout.LayoutParams layoutParams2 =
         new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-    textViewSecond.setTextSize(textDetailSize);
-    TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
-    textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
-    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayoutTexts = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinearTexts =
@@ -162,7 +117,11 @@ public class ListViewImageTopTwoTextAdapter extends ListAdapterWithRecyclerView 
       Log.e(
           LOG_TAG, "onBindViewHolder Unable to load image " + imageName + ": " + ioe.getMessage());
     }
-    updateCardViewColor(imageTwoTextHolder.cardView, position);
+
+    styleMainText(imageTwoTextHolder.textViewFirst);
+    styleDetailText(imageTwoTextHolder.textViewSecond);
+    styleImage(imageTwoTextHolder.imageView);
+    styleCardView(imageTwoTextHolder.cardView, position);
   }
 
   public class ImageTopTwoTextRvViewHolder extends RvViewHolder {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewImageTwoTextVerticalAdapter.java
@@ -17,7 +17,6 @@ import androidx.core.view.ViewCompat;
 import android.util.Log;
 
 import com.google.appinventor.components.runtime.util.MediaUtil;
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.ViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
@@ -25,34 +24,10 @@ import java.io.IOException;
 
 public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int textDetailColor;
-  private float textDetailSize;
-  private String textDetailFont;
-  private int imageWidth;
-  private int imageHeight;
-  private int textMainAlignment;
-  private int textDetailAlignment;
-
   public ListViewImageTwoTextVerticalAdapter(ComponentContainer container, ListDataModel model,
-      int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
-      float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.textDetailColor = textDetailColor;
-    this.textDetailSize = textDetailSize;
-    this.textDetailFont = textDetailFont;
-    this.imageWidth = imageWidth;
-    this.imageHeight = imageHeight;
-    this.textMainAlignment = textMainAlignment;
-    this.textDetailAlignment = textDetailAlignment;
-  }  
+      ListViewStyle style) {
+    super(container, model, style);
+  }
 
   @Override
   public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -64,7 +39,7 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     final int idImage = ViewCompat.generateViewId();
     imageView.setId(idImage);
     LinearLayout.LayoutParams layoutParamsImage =
-            new LinearLayout.LayoutParams(imageWidth, imageHeight);
+            new LinearLayout.LayoutParams(style.imageWidth, style.imageHeight);
     layoutParamsImage.setMargins(0, 0, 15, 0);
     imageView.setLayoutParams(layoutParamsImage);
 
@@ -74,10 +49,6 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -86,11 +57,7 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     LinearLayout.LayoutParams layoutParams2 =
             new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-    textViewSecond.setTextSize(textDetailSize);
-    TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
-    textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
-    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout2 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear2 =
@@ -145,7 +112,11 @@ public class ListViewImageTwoTextVerticalAdapter extends ListAdapterWithRecycler
     } catch (IOException ioe) {
       Log.e(LOG_TAG, "onBindViewHolder Unable to load image " + imageName + ": " + ioe.getMessage());
     }
-    updateCardViewColor(imageTwoTextHolder.cardView, position);
+
+    styleMainText(imageTwoTextHolder.textViewFirst);
+    styleDetailText(imageTwoTextHolder.textViewSecond);
+    styleImage(imageTwoTextHolder.imageView);
+    styleCardView(imageTwoTextHolder.cardView, position);
   }
  
   public class ImageTwoTextRvViewHolder extends RvViewHolder {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewSingleTextAdapter.java
@@ -12,28 +12,15 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
 public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int textMainAlignment;
-
   public ListViewSingleTextAdapter(ComponentContainer container, ListDataModel model,
-      int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
-      float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.textMainAlignment = textMainAlignment;
+      ListViewStyle style) {
+    super(container, model, style);
   }
-  
+
 
   @Override
   public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -46,10 +33,6 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     linearLayout1.setLayoutParams(layoutParamslinear1);
@@ -77,7 +60,8 @@ public class ListViewSingleTextAdapter extends ListAdapterWithRecyclerView {
     String first = dictItem.get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
     singleTextHolder.textViewFirst.setText(first);
 
-    updateCardViewColor(singleTextHolder.cardView, position);
+    styleMainText(singleTextHolder.textViewFirst);
+    styleCardView(singleTextHolder.cardView, position);
   }
  
   public class SingleTextRvViewHolder extends RvViewHolder {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewStyle.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewStyle.java
@@ -1,0 +1,40 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2025 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime;
+
+/**
+ * The visual state of a {@link ListView}'s rows: colors, fonts, sizes, alignments and image
+ * dimensions.
+ *
+ * <p>{@link ListView} owns one instance and the row adapters hold a reference to it rather than
+ * copies of its values, so an appearance change is picked up the next time a row is bound. That is
+ * what lets the appearance setters refresh the visible rows in place instead of building a whole
+ * new adapter, which used to reset the user's scroll position.
+ *
+ * <p>Deliberately a plain holder with no behaviour: it must not know about the RecyclerView, and
+ * the non-visual state (items, filter, selection) stays in {@link ListDataModel}.
+ */
+public class ListViewStyle {
+  // Unlike the other properties, ElementColor has no setter call in the ListView constructor, so
+  // its default has to live here.
+  public int elementColor = Component.COLOR_NONE;
+  public int selectionColor;
+  public int radius;
+
+  public int textColor;
+  public int detailTextColor;
+
+  public float fontSizeMain;
+  public float fontSizeDetail;
+  public String fontTypeface;
+  public String fontTypeDetail;
+
+  public int textAlignmentMain;
+  public int textAlignmentDetail;
+
+  public int imageWidth;
+  public int imageHeight;
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextAdapter.java
@@ -12,34 +12,13 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
 public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int textDetailColor;
-  private float textDetailSize;
-  private String textDetailFont;
-  private int textMainAlignment;
-  private int textDetailAlignment;
-
   public ListViewTwoTextAdapter(ComponentContainer container, ListDataModel model,
-      int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
-      float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.textDetailColor = textDetailColor;
-    this.textDetailSize = textDetailSize;
-    this.textDetailFont = textDetailFont;
-    this.textMainAlignment = textMainAlignment;
-    this.textDetailAlignment = textDetailAlignment;
+      ListViewStyle style) {
+    super(container, model, style);
   }
 
   @Override
@@ -55,10 +34,6 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
         new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText
     TextView textViewSecond = new TextView(container.$context());
@@ -67,11 +42,7 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
     LinearLayout.LayoutParams layoutParams2 =
         new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-    textViewSecond.setTextSize(textDetailSize);
-    TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
-    textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
-    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout2 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear2 =
@@ -115,8 +86,10 @@ public class ListViewTwoTextAdapter extends ListAdapterWithRecyclerView {
     }
     twoTextHolder.textViewFirst.setText(first);
     twoTextHolder.textViewSecond.setText(second);
-    
-    updateCardViewColor(twoTextHolder.cardView, position);
+
+    styleMainText(twoTextHolder.textViewFirst);
+    styleDetailText(twoTextHolder.textViewSecond);
+    styleCardView(twoTextHolder.cardView, position);
   }
 
   public class TwoTextRvViewHolder extends RvViewHolder {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListViewTwoTextLinearAdapter.java
@@ -12,34 +12,13 @@ import android.widget.TextView;
 import androidx.cardview.widget.CardView;
 import androidx.core.view.ViewCompat;
 
-import com.google.appinventor.components.runtime.util.TextViewUtil;
 import com.google.appinventor.components.runtime.util.YailDictionary;
 
 public class ListViewTwoTextLinearAdapter extends ListAdapterWithRecyclerView {
 
-  private int textMainColor;
-  private float textMainSize;
-  private String textMainFont;
-  private int textDetailColor;
-  private float textDetailSize;
-  private String textDetailFont;
-  private int textMainAlignment;
-  private int textDetailAlignment;
-
   public ListViewTwoTextLinearAdapter(ComponentContainer container, ListDataModel model,
-      int textMainColor, float textMainSize, String textMainFont, int textDetailColor,
-      float textDetailSize, String textDetailFont, int backgroundColor, int selectionColor,
-      int radius, int imageWidth, int imageHeight, int textMainAlignment, int textDetailAlignment) {
-    super(container, model, backgroundColor, selectionColor, radius);
-    this.container = container;
-    this.textMainColor = textMainColor;
-    this.textMainSize = textMainSize;
-    this.textMainFont = textMainFont;
-    this.textDetailColor = textDetailColor;
-    this.textDetailSize = textDetailSize;
-    this.textDetailFont = textDetailFont;
-    this.textMainAlignment = textMainAlignment;
-    this.textDetailAlignment = textDetailAlignment;
+      ListViewStyle style) {
+    super(container, model, style);
   }
 
   @Override
@@ -53,21 +32,13 @@ public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     textViewFirst.setId(idFirst);
     LinearLayout.LayoutParams layoutParams1 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
     textViewFirst.setLayoutParams(layoutParams1);
-    textViewFirst.setTextSize(textMainSize);
-    textViewFirst.setTextColor(textMainColor);
-    TextViewUtil.setFontTypeface(container.$form(), textViewFirst, textMainFont, false, false);
-    TextViewUtil.setAlignment(textViewFirst, textMainAlignment, false);
 
     // DetailText — weight=1 gives it the remaining 50%, so it can never be pushed off-screen
     TextView textViewSecond = new TextView(container.$context());
     final int idSecond = ViewCompat.generateViewId();
     textViewSecond.setId(idSecond);
     LinearLayout.LayoutParams layoutParams2 = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1);
-    textViewSecond.setTextSize(textDetailSize);
-    TextViewUtil.setFontTypeface(container.$form(), textViewSecond, textDetailFont, false, false);
-    textViewSecond.setTextColor(textDetailColor);
     textViewSecond.setLayoutParams(layoutParams2);
-    TextViewUtil.setAlignment(textViewSecond, textDetailAlignment, false);
 
     LinearLayout linearLayout1 = new LinearLayout(container.$context());
     LinearLayout.LayoutParams layoutParamslinear1 = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -102,8 +73,10 @@ public RvViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     }
     twoTextHolder.textViewFirst.setText(first);
     twoTextHolder.textViewSecond.setText(second);
-    
-    updateCardViewColor(twoTextHolder.cardView, position);
+
+    styleMainText(twoTextHolder.textViewFirst);
+    styleDetailText(twoTextHolder.textViewSecond);
+    styleCardView(twoTextHolder.cardView, position);
   }
 
   public class TwoTextLinearRvViewHolder extends RvViewHolder {

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
@@ -7,16 +7,21 @@ package com.google.appinventor.components.runtime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import android.os.Looper;
 import android.view.View;
+import android.view.ViewGroup;
 
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.runtime.shadows.ShadowEventDispatcher;
 import com.google.appinventor.components.runtime.util.YailList;
 
@@ -119,9 +124,60 @@ public class ListViewTest extends RobolectricTestBase {
     assertEquals(0, listView1.SelectionIndex());
   }
 
-  private View getViewForPosition(ListView listView, int position) {
+  /**
+   * Test that changing an appearance property restyles the rows already on screen rather than
+   * building a new adapter, which would drop every row view and send the user's scroll position
+   * back to the top of the list.
+   */
+  @Test
+  public void testAppearanceChangeReusesAdapter() {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe");
+    listView.Height(200);
+    listView.Width(320);
+    initialize(listView);
+
+    RecyclerView.Adapter<?> before = getRecyclerView(listView).getAdapter();
+    listView.TextColor(Component.COLOR_RED);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    assertSame(before, getRecyclerView(listView).getAdapter());
+    assertEquals(Component.COLOR_RED, listView.TextColor());
+    // The new color must actually reach the row, not just the property.
+    assertEquals(Component.COLOR_RED, getMainTextView(listView, 0).getCurrentTextColor());
+
+  }
+
+  /**
+   * Test that changing the layout still builds a new adapter: each layout is a different adapter
+   * class, so it is the one appearance property that cannot be handled by re-binding.
+   */
+  @Test
+  public void testLayoutChangeRebuildsAdapter() {
+    // Left empty on purpose: swapping the adapter while rows are on screen makes RecyclerView
+    // re-bind the old layout's view holders with the new layout's adapter, which throws. That is
+    // pre-existing behaviour of ListViewLayout, not something this test is about.
+    ListView listView = new ListView(getForm());
+
+    RecyclerView.Adapter<?> before = getRecyclerView(listView).getAdapter();
+    listView.ListViewLayout(ComponentConstants.LISTVIEW_LAYOUT_TWO_TEXT);
+
+    assertNotSame(before, getRecyclerView(listView).getAdapter());
+  }
+
+  private RecyclerView getRecyclerView(ListView listView) {
     LinearLayout listLayout = (LinearLayout) ((LinearLayout) listView.getView()).getChildAt(1);
-    RecyclerView rv = (RecyclerView) listLayout.getChildAt(0);
+    return (RecyclerView) listLayout.getChildAt(0);
+  }
+
+  /** The main text of a row: the card holds a LinearLayout whose first child is that TextView. */
+  private TextView getMainTextView(ListView listView, int position) {
+    ViewGroup cardView = (ViewGroup) getViewForPosition(listView, position);
+    return (TextView) ((ViewGroup) cardView.getChildAt(0)).getChildAt(0);
+  }
+
+  private View getViewForPosition(ListView listView, int position) {
+    RecyclerView rv = getRecyclerView(listView);
     rv.scrollToPosition(position);
     shadowOf(Looper.getMainLooper()).idle();
     RecyclerView.ViewHolder vh = rv.findViewHolderForAdapterPosition(position);

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
@@ -145,7 +145,6 @@ public class ListViewTest extends RobolectricTestBase {
     assertEquals(Component.COLOR_RED, listView.TextColor());
     // The new color must actually reach the row, not just the property.
     assertEquals(Component.COLOR_RED, getMainTextView(listView, 0).getCurrentTextColor());
-
   }
 
   /**
@@ -154,9 +153,9 @@ public class ListViewTest extends RobolectricTestBase {
    */
   @Test
   public void testLayoutChangeRebuildsAdapter() {
-    // Left empty on purpose: swapping the adapter while rows are on screen makes RecyclerView
-    // re-bind the old layout's view holders with the new layout's adapter, which throws. That is
-    // pre-existing behaviour of ListViewLayout, not something this test is about.
+    // The list is left with no elements on purpose: swapping the adapter while rows are on screen
+    // makes RecyclerView re-bind the old layout's view holders with the new layout's adapter,
+    // which throws. That is pre-existing behaviour of ListViewLayout, not what this test is about.
     ListView listView = new ListView(getForm());
 
     RecyclerView.Adapter<?> before = getRecyclerView(listView).getAdapter();


### PR DESCRIPTION
**What does this PR accomplish?**

PR #4064 should be merged before this PR.

*Description*

Two fixes to the same component, one per platform. Both are about view state being
thrown away or ignored when it did not need to be.

**Android — an appearance change no longer rebuilds the adapter**

Right now, changing any appearance property of a ListView (TextColor, FontSize,
ElementColor, and so on) throws away the whole adapter and builds a new one. The
RecyclerView loses every row view and starts drawing again from the first item,
so the user's scroll position jumps back to the top of the list. If you are 30
rows down and a block changes the text color, you end up back at row 1.

The reason is where the styling happens. Each of the six row adapters sets the
colors, fonts and alignments inside `onCreateViewHolder`. RecyclerView only calls
that about ten times in total, because it reuses row views as you scroll. So
there was no way to restyle the rows that already exist, and replacing the whole
adapter was the only thing that worked.

This PR moves the styling to `onBindViewHolder`, which runs every time a row is
drawn. The appearance values now live in a small new class, `ListViewStyle`. The
ListView owns one of them and the adapter keeps a reference to that same object,
so changing a value and asking RecyclerView to re-bind the rows is enough. No new
adapter, and the scroll position stays where the user left it.

**iOS — rows size themselves from their own content**

The iOS list pinned every row to a height derived from the font size, through
`heightForRowAt`. A row's own content had no say, so a tall image or wrapped text
was squeezed into a fixed box instead of making the row taller. Rows now size
themselves: `rowHeight` is `UITableView.automaticDimension` and `heightForRowAt`
is gone, because implementing it makes UIKit ignore `rowHeight` entirely. Every
layout already pins its content to the contentView's top and bottom, so Auto
Layout has what it needs. `estimatedHeightForRowAt` stays — an estimate is
allowed to be approximate.


**Context for the changes**

This changes component runtime code that runs on the device, so it is based on
`ucr`.

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

(No properties were added, removed or changed, so no version bump or upgrader is
needed.)

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine

(The component runtime suite is green — `ListViewTest` 5/5 and the iOS
`ListViewTests` 31/31. The appengine and buildserver suites fail locally for
setup reasons unrelated to this change, and `MapTest.testLoadFromURL` needs
network.)
