### PR TITLE
Add a Submit to LMS menu item and track pending editor saves so a submission waits for them

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/Ode.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/Ode.java
@@ -475,6 +475,7 @@ public class Ode implements EntryPoint {
     hideChaff();
     hideTutorials();
     currentView = TRASHCAN;
+    getTopToolbar().updateSubmitToLmsMenuItem();
     ProjectListBox.getProjectListBox().loadTrashList();
     projectToolbar.enableStartButton();
     projectToolbar.setProjectTabButtonsVisible(false);
@@ -490,6 +491,7 @@ public class Ode implements EntryPoint {
     hideChaff();
     hideTutorials();
     currentView = USERADMIN;
+    getTopToolbar().updateSubmitToLmsMenuItem();
     deckPanel.showWidget(userAdminTabIndex);
   }
 
@@ -1289,6 +1291,7 @@ public class Ode implements EntryPoint {
    */
   public void setCurrentFileEditor(FileEditor fileEditor) {
     currentFileEditor = fileEditor;
+    getTopToolbar().updateSubmitToLmsMenuItem();
     if (currentFileEditor == null) {
       // nothing more we can do
       LOG.info("Setting current file editor to null");

--- a/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/OdeMessages.java
@@ -543,6 +543,22 @@ public interface OdeMessages extends Messages, ComponentTranslations {
   @Description("Name of Export Project menuitem")
   String exportProjectMenuItem();
 
+  @DefaultMessage("Submit to LMS")
+  @Description("Menu item for submitting the current work to the LMS that launched it over LTI.")
+  String submitToLmsMenuItem();
+
+  @DefaultMessage("Submitting to your LMS...")
+  @Description("Shown while a submission to the LMS over LTI is in progress.")
+  String submittingToLms();
+
+  @DefaultMessage("Submitted to your LMS. Your teacher will grade it there.")
+  @Description("Shown after the current work is submitted to the LMS over LTI.")
+  String submitToLmsSuccess();
+
+  @DefaultMessage("Could not submit to your LMS. Open the assignment from your LMS and try again.")
+  @Description("Shown when a submission to the LMS over LTI does not succeed.")
+  String submitToLmsFailed();
+
   @DefaultMessage("Export")
   @Description("Export button title")
   String exportButton();

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.java
@@ -14,6 +14,8 @@ import com.google.appinventor.client.boxes.ProjectListBox;
 import com.google.appinventor.client.editor.youngandroid.DesignToolbar.DesignProject;
 import com.google.appinventor.client.editor.youngandroid.DesignToolbar.Screen;
 import com.google.appinventor.client.editor.youngandroid.YaBlocksEditor;
+import com.google.appinventor.client.explorer.project.Project;
+import com.google.appinventor.client.settings.project.ProjectSettings;
 import com.google.appinventor.client.widgets.DropDownButton;
 import com.google.appinventor.common.version.AppInventorFeatures;
 import com.google.appinventor.shared.storage.StorageUtil;
@@ -69,6 +71,7 @@ public class TopToolbar extends Composite {
   private static final String WIDGET_NAME_IMPORTPROJECT = "ImportProject";
   private static final String WIDGET_NAME_IMPORTTEMPLATE = "ImportTemplate";
   private static final String WIDGET_NAME_EXPORTPROJECT = "ExportProject";
+  private static final String WIDGET_NAME_SUBMIT_TO_LMS = "SubmitToLms";
   private static final String WIDGET_NAME_PROJECTPROPERTIES = "ProjectProperties";
 
   private static final String WIDGET_NAME_ADMIN = "Admin";
@@ -131,6 +134,8 @@ public class TopToolbar extends Composite {
     }
 
     fileDropDown.removeUnneededSeparators();
+    // Separator cleanup removes hidden items, so apply dynamic visibility only after it.
+    updateSubmitToLmsMenuItem();
 
     // Second Buildserver Menu Items
     //
@@ -210,6 +215,17 @@ public class TopToolbar extends Composite {
     fileDropDown.setItemHtmlById(WIDGET_NAME_EXPORTPROJECT, exportProjectLabel);
     fileDropDown.setItemEnabledById(WIDGET_NAME_EXPORTPROJECT, allowExport);
     fileDropDown.setItemEnabled(MESSAGES.exportAllProjectsMenuItem(), allowExportAll);
+  }
+
+  /**
+   * Shows Submit to LMS only while a writable project carrying the LTI launch marker is open.
+   */
+  public void updateSubmitToLmsMenuItem() {
+    Project project = Ode.getCurrentProject();
+    ProjectSettings settings = project == null ? null : project.getSettings();
+    boolean visible = hasWriteAccess && Ode.getInstance().getCurrentView() == Ode.DESIGNER
+        && settings != null && settings.isLtiLaunched();
+    fileDropDown.setItemVisibleById(WIDGET_NAME_SUBMIT_TO_LMS, visible);
   }
 
   public void updateKeystoreStatus(boolean present) {
@@ -316,6 +332,7 @@ public class TopToolbar extends Composite {
    * of "Delete" and "Download Source").
    */
   public void updateFileMenuButtons(int view) {
+    updateSubmitToLmsMenuItem();
     if (readOnly) {
       // This may be too simple
       return;

--- a/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/TopToolbar.ui.xml
@@ -52,6 +52,9 @@
       <ai:DropDownItem name="ExportProject" caption="{messages.exportProjectMenuItem}">
         <actions:ExportProjectAction/>
       </ai:DropDownItem>
+      <ai:DropDownItem name="SubmitToLms" caption="{messages.submitToLmsMenuItem}">
+        <actions:SubmitToLmsAction/>
+      </ai:DropDownItem>
       <ai:DropDownItem name="ExportAllProjects" caption="{messages.exportAllProjectsMenuItem}">
         <actions:ExportAllProjectsAction/>
       </ai:DropDownItem>

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
@@ -1,0 +1,65 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.actions;
+
+import static com.google.appinventor.client.Ode.MESSAGES;
+
+import com.google.appinventor.client.ErrorReporter;
+import com.google.appinventor.client.Ode;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.Command;
+
+/**
+ * Submits the current project to the LMS that launched App Inventor over LTI, by
+ * posting to the same origin /lti/submit endpoint. No separate LMS login is
+ * needed, because the LTI launch already established the session.
+ */
+public class SubmitToLmsAction implements Command {
+
+  // Guards against a double click sending two submissions.
+  private static boolean submitting = false;
+
+  @Override
+  public void execute() {
+    if (submitting) {
+      return;
+    }
+    submitting = true;
+    ErrorReporter.reportInfo(MESSAGES.submittingToLms());
+    RequestBuilder builder = new RequestBuilder(RequestBuilder.POST, "/lti/submit");
+    // A custom header the server requires. A cross site page cannot set it, so
+    // only a submission started from within App Inventor is accepted.
+    builder.setHeader("X-AppInventor-LTI", "1");
+    builder.setHeader("Content-Type", "application/x-www-form-urlencoded");
+    long projectId = Ode.getInstance().getCurrentYoungAndroidProjectId();
+    try {
+      builder.sendRequest("projectId=" + projectId, new RequestCallback() {
+        @Override
+        public void onResponseReceived(Request request, Response response) {
+          submitting = false;
+          if (response.getStatusCode() / 100 == 2) {
+            ErrorReporter.reportInfo(MESSAGES.submitToLmsSuccess());
+          } else {
+            ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
+          }
+        }
+
+        @Override
+        public void onError(Request request, Throwable exception) {
+          submitting = false;
+          ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
+        }
+      });
+    } catch (RequestException e) {
+      submitting = false;
+      ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
+    }
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
@@ -9,22 +9,53 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.appinventor.client.ErrorReporter;
 import com.google.appinventor.client.Ode;
+import com.google.appinventor.client.editor.EditorManager;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 
 /**
  * Submits the current project to the LMS that launched App Inventor over LTI, by
  * posting to the same origin /lti/submit endpoint. No separate LMS login is
  * needed, because the LTI launch already established the session.
+ *
+ * <p>Work in an open editor reaches the server on a timer rather than on every
+ * keystroke, so the editors are saved first and the submission is only sent once
+ * that save has finished. Otherwise a learner who edits and submits straight away
+ * would hand in whatever the last automatic save happened to catch.
+ *
+ * <p>Every attempt carries a number, and a callback that arrives after its own
+ * attempt has ended is ignored. A late answer from an attempt that already timed
+ * out therefore cannot report over a newer attempt or release its guard.
  */
 public class SubmitToLmsAction implements Command {
 
-  // Guards against a double click sending two submissions.
+  /**
+   * How long to wait for the submit request. The server freezes a copy of the
+   * project and then reaches the platform over the network, so this is generous.
+   * It is here so a request that never answers cannot leave the menu item unusable
+   * until the page is reloaded, rather than as a limit on a healthy submission.
+   */
+  private static final int REQUEST_TIMEOUT_MILLIS = 60000;
+
+  /**
+   * A backstop for the save that runs before the request. The request carries its
+   * own timeout, so this only matters if saving never finishes.
+   */
+  private static final int OVERALL_TIMEOUT_MILLIS = 90000;
+
+  /** Guards against a double click sending two submissions. */
   private static boolean submitting = false;
+
+  /** Identifies the attempt in flight, so a late callback knows it is stale. */
+  private static int attempt = 0;
+
+  /** Releases the guard if neither the save nor the request ever comes back. */
+  private static Timer deadline;
 
   @Override
   public void execute() {
@@ -32,8 +63,42 @@ public class SubmitToLmsAction implements Command {
       return;
     }
     submitting = true;
+    final int thisAttempt = ++attempt;
+    deadline = new Timer() {
+      @Override
+      public void run() {
+        finish(thisAttempt, false);
+      }
+    };
+    deadline.schedule(OVERALL_TIMEOUT_MILLIS);
     ErrorReporter.reportInfo(MESSAGES.submittingToLms());
+
+    final EditorManager editorManager = Ode.getInstance().getEditorManager();
+    editorManager.saveDirtyEditors(new Command() {
+      @Override
+      public void execute() {
+        if (!isCurrent(thisAttempt)) {
+          return;
+        }
+        if (editorManager.hasUnsavedChanges()) {
+          // The save reported back, but something is still dirty, which is how a
+          // failed save shows up. Submitting now would hand in older content than
+          // the learner is looking at.
+          finish(thisAttempt, false);
+          return;
+        }
+        send(thisAttempt);
+      }
+    });
+  }
+
+  /** Posts the saved project, once every editor is known to be on the server. */
+  private static void send(final int thisAttempt) {
+    if (!isCurrent(thisAttempt)) {
+      return;
+    }
     RequestBuilder builder = new RequestBuilder(RequestBuilder.POST, "/lti/submit");
+    builder.setTimeoutMillis(REQUEST_TIMEOUT_MILLIS);
     // A custom header the server requires. A cross site page cannot set it, so
     // only a submission started from within App Inventor is accepted.
     builder.setHeader("X-AppInventor-LTI", "1");
@@ -43,22 +108,42 @@ public class SubmitToLmsAction implements Command {
       builder.sendRequest("projectId=" + projectId, new RequestCallback() {
         @Override
         public void onResponseReceived(Request request, Response response) {
-          submitting = false;
-          if (response.getStatusCode() / 100 == 2) {
-            ErrorReporter.reportInfo(MESSAGES.submitToLmsSuccess());
-          } else {
-            ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
-          }
+          finish(thisAttempt, response.getStatusCode() / 100 == 2);
         }
 
         @Override
         public void onError(Request request, Throwable exception) {
-          submitting = false;
-          ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
+          finish(thisAttempt, false);
         }
       });
     } catch (RequestException e) {
-      submitting = false;
+      finish(thisAttempt, false);
+    }
+  }
+
+  /** Whether the given attempt is still the one in flight. */
+  private static boolean isCurrent(int thisAttempt) {
+    return submitting && thisAttempt == attempt;
+  }
+
+  /**
+   * Ends the submission, releases the guard, and reports once. Every path that can
+   * stop the submission comes through here, and a call from an attempt that has
+   * already ended does nothing, so the deadline and a late answer cannot both
+   * report to the learner.
+   */
+  private static void finish(int thisAttempt, boolean succeeded) {
+    if (!isCurrent(thisAttempt)) {
+      return;
+    }
+    submitting = false;
+    if (deadline != null) {
+      deadline.cancel();
+      deadline = null;
+    }
+    if (succeeded) {
+      ErrorReporter.reportInfo(MESSAGES.submitToLmsSuccess());
+    } else {
       ErrorReporter.reportError(MESSAGES.submitToLmsFailed());
     }
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/actions/SubmitToLmsAction.java
@@ -9,7 +9,6 @@ import static com.google.appinventor.client.Ode.MESSAGES;
 
 import com.google.appinventor.client.ErrorReporter;
 import com.google.appinventor.client.Ode;
-import com.google.appinventor.client.editor.EditorManager;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -25,8 +24,11 @@ import com.google.gwt.user.client.Timer;
  *
  * <p>Work in an open editor reaches the server on a timer rather than on every
  * keystroke, so the editors are saved first and the submission is only sent once
- * that save has finished. Otherwise a learner who edits and submits straight away
- * would hand in whatever the last automatic save happened to catch.
+ * nothing is left waiting to reach the server. Otherwise a learner who edits and
+ * submits straight away would hand in whatever the last automatic save happened to
+ * catch. An automatic save may already have been running when the learner chose to
+ * submit, so what is still outstanding decides, rather than the fact that a save
+ * answered.
  *
  * <p>Every attempt carries a number, and a callback that arrives after its own
  * attempt has ended is ignored. A late answer from an attempt that already timed
@@ -54,12 +56,22 @@ public class SubmitToLmsAction implements Command {
   /** Identifies the attempt in flight, so a late callback knows it is stale. */
   private static int attempt = 0;
 
+  /** How long to leave between looks at whether everything has reached the server. */
+  private static final int SETTLE_POLL_MILLIS = 250;
+
   /** Releases the guard if neither the save nor the request ever comes back. */
   private static Timer deadline;
+
+  /** The request in flight, held so that ending the attempt also ends the request. */
+  private static Request inFlight;
 
   @Override
   public void execute() {
     if (submitting) {
+      return;
+    }
+    final long projectId = Ode.getInstance().getCurrentYoungAndroidProjectId();
+    if (projectId == 0) {
       return;
     }
     submitting = true;
@@ -73,27 +85,43 @@ public class SubmitToLmsAction implements Command {
     deadline.schedule(OVERALL_TIMEOUT_MILLIS);
     ErrorReporter.reportInfo(MESSAGES.submittingToLms());
 
-    final EditorManager editorManager = Ode.getInstance().getEditorManager();
-    editorManager.saveDirtyEditors(new Command() {
+    // The project is fixed at the click, so a learner who switches project while the save
+    // runs cannot have one project saved and another submitted.
+    Ode.getInstance().getEditorManager().saveDirtyEditors(new Command() {
       @Override
       public void execute() {
-        if (!isCurrent(thisAttempt)) {
-          return;
-        }
-        if (editorManager.hasUnsavedChanges()) {
-          // The save reported back, but something is still dirty, which is how a
-          // failed save shows up. Submitting now would hand in older content than
-          // the learner is looking at.
-          finish(thisAttempt, false);
-          return;
-        }
-        send(thisAttempt);
+        settleThenSend(thisAttempt, projectId);
       }
     });
   }
 
+  /**
+   * Sends once nothing is waiting to reach the server, and gives up when the deadline says so.
+   *
+   * <p>The command a save reports back with covers that save, and an automatic save may have
+   * been running before this one began, so it is what is still outstanding that decides,
+   * not the fact that a save answered. A save that has genuinely failed leaves its editor
+   * waiting, and the deadline is what ends the wait, since retrying it here would be the
+   * thundering herd the editor deliberately avoids.
+   */
+  private static void settleThenSend(final int thisAttempt, final long projectId) {
+    if (!isCurrent(thisAttempt)) {
+      return;
+    }
+    if (Ode.getInstance().getEditorManager().hasUnsavedChanges()) {
+      new Timer() {
+        @Override
+        public void run() {
+          settleThenSend(thisAttempt, projectId);
+        }
+      }.schedule(SETTLE_POLL_MILLIS);
+      return;
+    }
+    send(thisAttempt, projectId);
+  }
+
   /** Posts the saved project, once every editor is known to be on the server. */
-  private static void send(final int thisAttempt) {
+  private static void send(final int thisAttempt, long projectId) {
     if (!isCurrent(thisAttempt)) {
       return;
     }
@@ -103,9 +131,8 @@ public class SubmitToLmsAction implements Command {
     // only a submission started from within App Inventor is accepted.
     builder.setHeader("X-AppInventor-LTI", "1");
     builder.setHeader("Content-Type", "application/x-www-form-urlencoded");
-    long projectId = Ode.getInstance().getCurrentYoungAndroidProjectId();
     try {
-      builder.sendRequest("projectId=" + projectId, new RequestCallback() {
+      inFlight = builder.sendRequest("projectId=" + projectId, new RequestCallback() {
         @Override
         public void onResponseReceived(Request request, Response response) {
           finish(thisAttempt, response.getStatusCode() / 100 == 2);
@@ -140,6 +167,13 @@ public class SubmitToLmsAction implements Command {
     if (deadline != null) {
       deadline.cancel();
       deadline = null;
+    }
+    if (inFlight != null) {
+      // The deadline can end the attempt while the request is still running, and a retry
+      // must not race a request that is already on the server. Ending the attempt ends the
+      // request with it, so at most one submission is ever in flight.
+      inFlight.cancel();
+      inFlight = null;
     }
     if (succeeded) {
       ErrorReporter.reportInfo(MESSAGES.submitToLmsSuccess());

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
@@ -221,16 +221,6 @@ public final class EditorManager {
   }
 
   /**
-   * Check whether any editor or project setting still holds changes that are not on the server.
-   *
-   * <p>The command given to {@link #saveDirtyEditors(Command)} runs once every save has finished,
-   * whether it succeeded or not, and a file whose save failed is put back in the dirty set. Asking
-   * this from that command is therefore how a caller tells a completed save apart from a failed
-   * one before it acts on the saved content.
-   *
-   * @return true if something is still unsaved, otherwise false
-   */
-  /**
    * Puts settings whose save did not do what it was asked back in the queue.
    *
    * <p>The next save takes them, the way a failed file save is retried, and no timer is
@@ -260,6 +250,16 @@ public final class EditorManager {
     return settingsCount + (fileCount == 0 ? 1 : fileCount);
   }
 
+  /**
+   * Check whether any editor or project setting still holds changes that are not on the server.
+   *
+   * <p>The command given to {@link #saveDirtyEditors(Command)} runs once every save has finished,
+   * whether it succeeded or not, and a file whose save failed is put back in the dirty set. Asking
+   * this from that command is therefore how a caller tells a completed save apart from a failed
+   * one before it acts on the saved content.
+   *
+   * @return true if something is still unsaved, otherwise false
+   */
   public boolean hasUnsavedChanges() {
     return !files.isEmpty() || !settings.isEmpty();
   }
@@ -308,9 +308,14 @@ public final class EditorManager {
 
     // Take everything that can be sent now. Anything whose previous save has not answered yet
     // is held back, because two saves of one thing can land in either order and the older one
-    // landing last would undo the newer one.
-    List<FileEditor> editorsToSave = files.take();
-    final List<ProjectSettings> projectSettingsToSave = settings.take();
+    // landing last would undo the newer one. A closing window is the one exception. No later
+    // save could ever come for what was held back there, so holding it would drop it, and
+    // sending it beside the unanswered save is the lesser risk.
+    boolean windowClosing = Ode.isWindowClosing();
+    List<FileEditor> editorsToSave =
+        windowClosing ? files.takeEvenInFlight() : files.take();
+    final List<ProjectSettings> projectSettingsToSave =
+        windowClosing ? settings.takeEvenInFlight() : settings.take();
     List<FileDescriptorWithContent> filesToSave = new ArrayList<FileDescriptorWithContent>();
     for (FileEditor fileEditor : editorsToSave) {
       filesToSave.add(new FileDescriptorWithContent(

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
@@ -18,16 +18,15 @@ import com.google.appinventor.client.settings.project.ProjectSettings;
 import com.google.appinventor.shared.rpc.BlocksTruncatedException;
 import com.google.appinventor.shared.rpc.project.FileDescriptorWithContent;
 import com.google.appinventor.shared.rpc.project.ProjectRootNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
@@ -55,9 +54,11 @@ public final class EditorManager {
   private static final int AUTO_SAVE_FORCED_TIMEOUT = 30000;
 
   // Fields used for saving and auto-saving.
-  private final Set<ProjectSettings> dirtyProjectSettings;
-  private final Set<FileEditor> dirtyFileEditors;
-  private final HashMap<String,FileEditor> pendingFileEditors;
+  /** Files waiting to be saved and files whose save has not answered yet. */
+  private final PendingSaves<FileEditor> files;
+
+  /** Project settings waiting to be saved and settings whose save has not answered yet. */
+  private final PendingSaves<ProjectSettings> settings;
   private final Timer autoSaveTimer;
   private boolean autoSaveIsScheduled;
   private long autoSaveRequestTime;
@@ -73,15 +74,23 @@ public final class EditorManager {
   public EditorManager() {
     openProjectEditors = Maps.newHashMap();
 
-    dirtyProjectSettings = new HashSet<ProjectSettings>();
-    dirtyFileEditors = new HashSet<FileEditor>();
-    pendingFileEditors = new HashMap<String,FileEditor>();
+    files = new PendingSaves<FileEditor>(new PendingSaves.Key<FileEditor>() {
+      @Override
+      public Object of(FileEditor fileEditor) {
+        return fileEditor.getFileId();
+      }
+    });
+    settings = new PendingSaves<ProjectSettings>(new PendingSaves.Key<ProjectSettings>() {
+      @Override
+      public Object of(ProjectSettings projectSettings) {
+        return projectSettings;
+      }
+    });
 
     autoSaveTimer = new Timer() {
       @Override
       public void run() {
-        // When the timer goes off, save all dirtyProjectSettings and
-        // dirtyFileEditors.
+        // When the timer goes off, save everything that is waiting.
         Ode.getInstance().lockScreens(true); // Lock out changes
         saveDirtyEditors(new Command() {
             @Override
@@ -151,7 +160,7 @@ public final class EditorManager {
         // in case the file is not open in an editor (possible?) check 
         // the FileEditors for null. 
         if (fileEditor != null) {
-          dirtyFileEditors.remove(fileEditor);
+          files.discard(fileEditor);
         }
       }
       projectEditor.closeFileEditors(fileIds);
@@ -170,7 +179,7 @@ public final class EditorManager {
     // memory even after we've removed them.
     Project project = Ode.getInstance().getProjectManager().getProject(projectId);
     ProjectSettings projectSettings = project.getSettings();
-    dirtyProjectSettings.remove(projectSettings);
+    settings.discard(projectSettings);
     openProjectEditors.remove(projectId);
   }
 
@@ -181,8 +190,8 @@ public final class EditorManager {
    * @param projectSettings the project settings for which to schedule auto-save
    */
   public void scheduleAutoSave(ProjectSettings projectSettings) {
-    // Add the project settings to the dirtyProjectSettings list.
-    dirtyProjectSettings.add(projectSettings);
+    // Note that the project settings need saving.
+    settings.add(projectSettings);
     scheduleAutoSaveTimer();
   }
 
@@ -193,9 +202,9 @@ public final class EditorManager {
    * @param fileEditor the file editor for which to schedule auto-save
    */
   public void scheduleAutoSave(FileEditor fileEditor) {
-    // Add the file editor to the dirtyFileEditors list.
+    // Note that the file editor needs saving.
     if (!fileEditor.isDamaged()) { // Don't save damaged files
-      dirtyFileEditors.add(fileEditor);
+      files.add(fileEditor);
     } else {
       LOG.info("Not saving blocks for " + fileEditor.getFileId() + " because it is damaged.");
     }
@@ -221,8 +230,38 @@ public final class EditorManager {
    *
    * @return true if something is still unsaved, otherwise false
    */
+  /**
+   * Puts settings whose save did not do what it was asked back in the queue.
+   *
+   * <p>The next save takes them, the way a failed file save is retried, and no timer is
+   * started for them. Retrying a failure on a clock of its own would hammer a server that is
+   * already in trouble, which the file path deliberately avoids, so the settings path avoids
+   * it the same way.
+   */
+  public void settingsSaveFailed(ProjectSettings projectSettings) {
+    settings.failed(projectSettings);
+  }
+
+  /**
+   * How many completions {@link #saveDirtyEditors} waits for before it reports back.
+   *
+   * <p>Each project settings save is its own operation, and so is each file, because
+   * {@link #saveMultipleFilesAtOnce} sends one request per file and answers the command once
+   * for each of them. With no files to save it still answers once. Counting the files as a
+   * single operation would report back while the rest were still in flight, and would clear
+   * anything still waiting before a later failure could put its editor back.
+   *
+   * @param settingsCount how many project settings are being saved
+   * @param fileCount how many files are being saved
+   * @return the number of completions to wait for
+   */
+  @VisibleForTesting
+  static int pendingSaveOperationCount(int settingsCount, int fileCount) {
+    return settingsCount + (fileCount == 0 ? 1 : fileCount);
+  }
+
   public boolean hasUnsavedChanges() {
-    return !dirtyFileEditors.isEmpty() || !dirtyProjectSettings.isEmpty();
+    return !files.isEmpty() || !settings.isEmpty();
   }
 
   /**
@@ -249,56 +288,57 @@ public final class EditorManager {
   }
 
   /**
-   * Saves all modified files and project settings and calls the afterSaving
-   * command after they have all been saved successfully.
-   *
-   * If any errors occur while saving, the afterSaving command will not be
-   * executed.
-   * If nothing needs to be saved, the afterSavingFiles command is called
+   * Saves what needs saving and runs the afterSaving command once every save it
+   * sent has answered, whether it succeeded or not. What is still unsaved
+   * afterwards is what {@link #hasUnsavedChanges} reports, which is how a
+   * caller tells the two apart. With nothing to send it runs the command
    * immediately, not asynchronously.
    *
-   * @param afterSaving  optional command to be executed after project
-   *                     settings and file editors are saved successfully
+   * @param afterSaving  optional command to be executed once every save this
+   *                     call sent has answered
    */
   public void saveDirtyEditors(final Command afterSaving) {
     // Note, We don't do any saving if we are in read only mode
     if (Ode.getInstance().isReadOnly()) {
-      afterSaving.execute();
+      if (afterSaving != null) {
+        afterSaving.execute();
+      }
       return;
     }
 
-    // Collect the files that need to be saved.
+    // Take everything that can be sent now. Anything whose previous save has not answered yet
+    // is held back, because two saves of one thing can land in either order and the older one
+    // landing last would undo the newer one.
+    List<FileEditor> editorsToSave = files.take();
+    final List<ProjectSettings> projectSettingsToSave = settings.take();
     List<FileDescriptorWithContent> filesToSave = new ArrayList<FileDescriptorWithContent>();
-    for (FileEditor fileEditor : dirtyFileEditors) {
-      FileDescriptorWithContent fileContent = new FileDescriptorWithContent(
-          fileEditor.getProjectId(), fileEditor.getFileId(), fileEditor.getRawFileContent());
-      filesToSave.add(fileContent);
-      pendingFileEditors.put(fileEditor.getFileId(), fileEditor); // pending save
+    for (FileEditor fileEditor : editorsToSave) {
+      filesToSave.add(new FileDescriptorWithContent(
+          fileEditor.getProjectId(), fileEditor.getFileId(), fileEditor.getRawFileContent()));
     }
-    dirtyFileEditors.clear();
-
-    // Collect the project settings that need to be saved.
-    List<ProjectSettings> projectSettingsToSave = new ArrayList<ProjectSettings>();
-    projectSettingsToSave.addAll(dirtyProjectSettings);
-    dirtyProjectSettings.clear();
 
     autoSaveTimer.cancel();
     autoSaveIsScheduled = false;
+    if (files.heldBack() || settings.heldBack()) {
+      // Something is waiting for a save that has not answered yet. Nothing else would come
+      // back for it, since the timer only starts again when the learner types, so it is
+      // started here and the next save takes what is waiting.
+      scheduleAutoSaveTimer();
+    }
 
     // Keep count as each save operation finishes so we can set the projects' modified date and
     // call the afterSaving command after everything has been saved.
-    // Each project settings is saved as a separate operation, but all files are saved as a single
-    // save operation. So the initial value of pendingSaveOperations is the size of
-    // projectSettingsToSave plus 1.
-    final AtomicInteger pendingSaveOperations = new AtomicInteger(projectSettingsToSave.size() + 1);
+    final AtomicInteger pendingSaveOperations = new AtomicInteger(
+        pendingSaveOperationCount(projectSettingsToSave.size(), filesToSave.size()));
     final DateHolder dateHolder = new DateHolder();
     Command callAfterSavingCommand = new Command() {
       @Override
       public void execute() {
         if (pendingSaveOperations.decrementAndGet() == 0) {
           // We get here when all save operations have completed, either
-          // with success or not.
-          pendingFileEditors.clear(); // Failed I/O will be back in dirtyFileEditors
+          // with success or not. Each one has already said so for itself as it
+          // finished, since clearing the whole map here would also drop the files of a save
+          // that is still running, and a save started while another is in flight is ordinary.
           // Execute the afterSaving command if one was given.
           if (afterSaving != null) {
             afterSaving.execute();
@@ -313,11 +353,14 @@ public final class EditorManager {
     };
 
     // Save all files at once (asynchronously).
-    saveMultipleFilesAtOnce(filesToSave, callAfterSavingCommand, dateHolder);
+    saveMultipleFilesAtOnce(editorsToSave, filesToSave, callAfterSavingCommand, dateHolder);
 
-    // Save project settings one at a time (asynchronously).
+    // Save project settings one at a time (asynchronously). Each completion first marks its
+    // own save answered, or the settings would count as on their way forever and everything
+    // waiting for the last save to finish would wait for good.
     for (ProjectSettings projectSettings : projectSettingsToSave) {
-      projectSettings.saveSettings(callAfterSavingCommand);
+      projectSettings.saveSettings(
+          PendingSaves.answering(settings, projectSettings, callAfterSavingCommand));
     }
   }
   
@@ -386,17 +429,22 @@ public final class EditorManager {
    * a trivial blocks workspace is attempting to be written over a non-trivial
    * file.
    *
-   * If any unhandled errors occur while saving, the afterSavingFiles
-   * command will not be executed.  If filesWithContent is empty, the
-   * afterSavingFiles command is called immediately, not
-   * asynchronously.
+   * The afterSavingFiles command is executed once for every file, whether its
+   * save succeeded or not, which is how the caller counts the batch down. If
+   * filesWithContent is empty, the afterSavingFiles command is called
+   * immediately, not asynchronously.
    *
    * @param filesWithContent  the files that need to be saved
    * @param afterSavingFiles  optional command to be executed after file
    *                          editors are saved.
    */
-  private void saveMultipleFilesAtOnce(
-      final List<FileDescriptorWithContent> filesWithContent, final Command afterSavingFiles, final DateHolder dateHolder) {
+  private void saveMultipleFilesAtOnce(final List<FileEditor> editorsBeingSaved,
+      final List<FileDescriptorWithContent> filesWithContent, final Command afterSavingFiles,
+      final DateHolder dateHolder) {
+    final Map<String, String> contentById = new HashMap<String, String>();
+    for (FileDescriptorWithContent fileDescriptor : filesWithContent) {
+      contentById.put(fileDescriptor.getFileId(), fileDescriptor.getContent());
+    }
     if (filesWithContent.isEmpty()) {
       // No files needed saving.
       // Execute the afterSavingFiles command if one was given.
@@ -405,15 +453,16 @@ public final class EditorManager {
       }
 
     } else {
-      for (FileDescriptorWithContent fileDescriptor : filesWithContent ) {
-        final long projectId = fileDescriptor.getProjectId();
-        final String fileId = fileDescriptor.getFileId();
-        final String content = fileDescriptor.getContent();
+      for (final FileEditor fileEditor : editorsBeingSaved) {
+        final long projectId = fileEditor.getProjectId();
+        final String fileId = fileEditor.getFileId();
+        final String content = contentById.get(fileId);
         Ode.CLog("Saving fileId " + fileId + " for projectId " + projectId);
         Ode.getInstance().getProjectService().save2(Ode.getInstance().getSessionId(),
           projectId, fileId, false, content, new OdeAsyncCallback<Long>(MESSAGES.saveErrorMultipleFiles()) {
             @Override
             public void onSuccess(Long date) {
+              files.answered(fileEditor);
               if (dateHolder.date != 0) {
                 // This sets the project modification time to that of one of
                 // the successful file saves. It doesn't really matter which
@@ -432,7 +481,12 @@ public final class EditorManager {
             public void onFailure(Throwable caught) {
               // Here is where we handle BlocksTruncatedException
               if (caught instanceof BlocksTruncatedException) {
+                // The learner is being asked whether to save truncated blocks, and this same
+                // callback answers again once they decide, so the attempt is not finished.
+                // Counting it as finished here would let a submission go out while the
+                // question is still on the screen, and would count this file twice.
                 Ode.getInstance().blocksTruncatedDialog(projectId, fileId, content, this);
+                return;
               } else {
                 // We mark the file editor as dirty again because the save failed.
                 //
@@ -443,9 +497,7 @@ public final class EditorManager {
                 // we mark the editors as dirty, so the next update by the user to any
                 // file will retry all of the non-saved files. The "Save Project" menu
                 // item will also re-attempt the failed I/O
-                if (pendingFileEditors.containsKey(fileId)) {
-                  dirtyFileEditors.add(pendingFileEditors.get(fileId));
-                }
+                files.failed(fileEditor);
                 super.onFailure(caught);
               }
               if (afterSavingFiles != null) { // Need to call this to decrement the count

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/EditorManager.java
@@ -212,6 +212,20 @@ public final class EditorManager {
   }
 
   /**
+   * Check whether any editor or project setting still holds changes that are not on the server.
+   *
+   * <p>The command given to {@link #saveDirtyEditors(Command)} runs once every save has finished,
+   * whether it succeeded or not, and a file whose save failed is put back in the dirty set. Asking
+   * this from that command is therefore how a caller tells a completed save apart from a failed
+   * one before it acts on the saved content.
+   *
+   * @return true if something is still unsaved, otherwise false
+   */
+  public boolean hasUnsavedChanges() {
+    return !dirtyFileEditors.isEmpty() || !dirtyProjectSettings.isEmpty();
+  }
+
+  /**
    * Schedules the auto-save timer.
    */
   private void scheduleAutoSaveTimer() {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/PendingSaves.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/PendingSaves.java
@@ -91,6 +91,23 @@ class PendingSaves<T> {
   }
 
   /**
+   * Takes everything waiting, even what an unanswered save would normally hold back.
+   *
+   * <p>Only for a window that is closing. No later save could ever come for held back work
+   * there, so holding it would drop it, and sending it beside the unanswered save is the
+   * lesser risk. The newer send takes the slot, and the identity checks in {@link #answered}
+   * and {@link #failed} keep a late answer from the older save from clearing it.
+   */
+  List<T> takeEvenInFlight() {
+    List<T> sending = new ArrayList<T>(waiting.values());
+    for (Map.Entry<Object, T> entry : waiting.entrySet()) {
+      inFlight.put(entry.getKey(), entry.getValue());
+    }
+    waiting.clear();
+    return sending;
+  }
+
+  /**
    * Notes that a save answered and did what it was asked.
    *
    * <p>Only the save that owns the slot may clear it. After a discard, a newer save of the
@@ -144,6 +161,7 @@ class PendingSaves<T> {
   }
 
   /** How many are on their way, which is how many answers a caller is waiting for. */
+  @VisibleForTesting
   int inFlightCount() {
     return inFlight.size();
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/PendingSaves.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/PendingSaves.java
@@ -1,0 +1,150 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracks what still has to reach the server and what is already on its way.
+ *
+ * <p>Two saves of one thing must not run at the same time. They are separate requests, they
+ * can land in either order, and the older one landing last would undo the newer one. So
+ * something that is already on its way is held back rather than sent again, and it is sent by
+ * the next save instead.
+ *
+ * <p>Holding something back means a save can finish while work is still waiting, which is why
+ * {@link #heldBack()} exists. A caller that stops its timer when it starts saving has to look
+ * at that and start the timer again, or the held back work would sit there with nothing
+ * coming for it.
+ *
+ * <p>This holds no reference to a browser, a timer, or a request, so what it decides can be
+ * read and tested on its own. The editor manager owns the requests and asks this what to send.
+ *
+ * @param <T> what is being saved, a file editor or a project settings
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+@VisibleForTesting
+class PendingSaves<T> {
+
+  /** How two saves of one thing are recognised as being of one thing. */
+  interface Key<T> {
+    Object of(T item);
+  }
+
+  private final Key<T> key;
+
+  /** Waiting to be sent, in the order it became dirty. */
+  private final Map<Object, T> waiting = new LinkedHashMap<Object, T>();
+
+  /** Sent and not answered yet. */
+  private final Map<Object, T> inFlight = new LinkedHashMap<Object, T>();
+
+  PendingSaves(Key<T> key) {
+    this.key = key;
+  }
+
+  /** Notes that this needs saving, replacing any earlier note of the same thing. */
+  void add(T item) {
+    waiting.put(key.of(item), item);
+  }
+
+  /** Forgets about this entirely, for something that is going away rather than being saved. */
+  void discard(T item) {
+    Object id = key.of(item);
+    waiting.remove(id);
+    inFlight.remove(id);
+  }
+
+  /**
+   * Takes everything that can be sent now and records it as on its way.
+   *
+   * @return what to send, which is everything waiting that is not already on its way
+   */
+  List<T> take() {
+    List<T> sending = new ArrayList<T>();
+    Iterator<Map.Entry<Object, T>> entries = waiting.entrySet().iterator();
+    while (entries.hasNext()) {
+      Map.Entry<Object, T> entry = entries.next();
+      if (inFlight.containsKey(entry.getKey())) {
+        continue;
+      }
+      inFlight.put(entry.getKey(), entry.getValue());
+      sending.add(entry.getValue());
+      entries.remove();
+    }
+    return sending;
+  }
+
+  /** Whether anything was held back because it is already on its way. */
+  boolean heldBack() {
+    return !waiting.isEmpty();
+  }
+
+  /**
+   * Notes that a save answered and did what it was asked.
+   *
+   * <p>Only the save that owns the slot may clear it. After a discard, a newer save of the
+   * same thing can be on its way, and a late answer from the discarded one must not take the
+   * newer save's place out from under it.
+   */
+  void answered(T item) {
+    Object id = key.of(item);
+    if (inFlight.get(id) == item) {
+      inFlight.remove(id);
+    }
+  }
+
+  /**
+   * Notes that a save answered and did not do what it was asked, so it waits to be sent again.
+   * Anything that became dirty while it was on its way is newer and is left as it is, and a
+   * late answer from a save that was discarded changes nothing.
+   */
+  void failed(T item) {
+    Object id = key.of(item);
+    if (inFlight.get(id) != item) {
+      return;
+    }
+    inFlight.remove(id);
+    if (!waiting.containsKey(id)) {
+      waiting.put(id, item);
+    }
+  }
+
+  /**
+   * Wraps a completion so the save it belongs to is marked answered before anything else runs.
+   *
+   * <p>A save that is never marked answered stays on its way forever, and everything that asks
+   * whether work is outstanding would wait on it for good. Wrapping the completion here rather
+   * than at each call site keeps that promise in one tested place.
+   */
+  static <T> com.google.gwt.user.client.Command answering(final PendingSaves<T> queue,
+      final T item, final com.google.gwt.user.client.Command then) {
+    return new com.google.gwt.user.client.Command() {
+      @Override
+      public void execute() {
+        queue.answered(item);
+        then.execute();
+      }
+    };
+  }
+
+  /** Whether anything at all is unfinished, whether waiting or already on its way. */
+  boolean isEmpty() {
+    return waiting.isEmpty() && inFlight.isEmpty();
+  }
+
+  /** How many are on their way, which is how many answers a caller is waiting for. */
+  int inFlightCount() {
+    return inFlight.size();
+  }
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/ProjectSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/ProjectSettings.java
@@ -73,25 +73,50 @@ public final class ProjectSettings extends CommonSettings implements SettingsAcc
         });
   }
 
+  /**
+   * Saves the settings, and answers the given command once, whatever happens.
+   *
+   * <p>The caller counts the answer, so a path that returned without answering would leave a
+   * save looking unfinished forever. A failure also puts the settings back in the queue, since
+   * the caller has already taken them out of it and would otherwise never try them again.
+   */
   @Override
   public void saveSettings(final Command command) {
-    if (Ode.getInstance().isReadOnly()) {
-      return;                   // No changes when in read only mode
-    } else if (!changed) {
-      // Do not save project settings if they haven't changed.
+    if (Ode.getInstance().isReadOnly() || !changed) {
+      // Nothing to write, either because the session may not write or because nothing moved.
+      if (command != null) {
+        command.execute();
+      }
       return;
     }
-    String s = encodeSettings();
-    LOG.info("Saving project settings: " + s);
+    final String sent = encodeSettings();
+    LOG.info("Saving project settings: " + sent);
     Ode.getInstance().getProjectService().storeProjectSettings(
         Ode.getInstance().getSessionId(),
-        project.getProjectId(), s,
+        project.getProjectId(), sent,
         new OdeAsyncCallback<Void>(
             // failure message
             MESSAGES.settingsSaveError()) {
           @Override
           public void onSuccess(Void result) {
-            changed = false;
+            // Only what was sent is on the server. A setting the learner moved while this was
+            // in flight is not, so saying nothing has changed would lose it.
+            if (sent.equals(encodeSettings())) {
+              changed = false;
+            }
+            if (command != null) {
+              command.execute();
+            }
+          }
+
+          @Override
+          public void onFailure(Throwable caught) {
+            // Put them back the way a failed file save is put back, so the next save retries
+            // them and anything asking what is still unsaved is told the truth. No timer is
+            // started for them, since retrying a failure on a clock of its own would hammer
+            // a server that is already in trouble.
+            Ode.getInstance().getEditorManager().settingsSaveFailed(ProjectSettings.this);
+            super.onFailure(caught);
             if (command != null) {
               command.execute();
             }

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/ProjectSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/ProjectSettings.java
@@ -13,6 +13,7 @@ import com.google.appinventor.client.Ode;
 import com.google.appinventor.client.OdeAsyncCallback;
 import com.google.appinventor.client.explorer.project.Project;
 import com.google.appinventor.client.settings.CommonSettings;
+import com.google.appinventor.client.settings.Settings;
 import com.google.appinventor.client.settings.SettingsAccessProvider;
 import com.google.appinventor.client.utils.Promise;
 import com.google.appinventor.shared.rpc.project.youngandroid.YoungAndroidProjectNode;
@@ -48,6 +49,15 @@ public final class ProjectSettings extends CommonSettings implements SettingsAcc
     return project.getProjectId();
   }
 
+  /**
+   * Returns whether this project carries the marker set by an LTI launch.
+   */
+  public boolean isLtiLaunched() {
+    Settings settings = getSettings(SettingsConstants.PROJECT_YOUNG_ANDROID_SETTINGS);
+    return settings != null && "true".equals(settings.getPropertyValue(
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_LTI_LAUNCHED));
+  }
+
   // SettingsAccessProvider implementation
 
   @Override
@@ -58,6 +68,7 @@ public final class ProjectSettings extends CommonSettings implements SettingsAcc
           LOG.info("Loaded project settings: " + result);
           decodeSettings(result);
           changed = false;
+          Ode.getInstance().getTopToolbar().updateSubmitToLmsMenuItem();
           return resolve(ProjectSettings.this);
         });
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/settings/project/YoungAndroidSettings.java
@@ -95,6 +95,9 @@ public final class YoungAndroidSettings extends Settings {
         SettingsConstants.YOUNG_ANDROID_SETTINGS_LAST_OPENED, "Screen1",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,
+        SettingsConstants.YOUNG_ANDROID_SETTINGS_LTI_LAUNCHED, "",
+        EditableProperty.TYPE_INVISIBLE));
+    addProperty(new EditableProperty(this,
         SettingsConstants.YOUNG_ANDROID_SETTINGS_AIVERSIONING, YOUNG_ANDROID_VERSION + "",
         EditableProperty.TYPE_INVISIBLE));
     addProperty(new EditableProperty(this,

--- a/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
+++ b/appinventor/appengine/src/com/google/appinventor/client/style/neo/TopToolbarNeo.ui.xml
@@ -47,6 +47,9 @@
       <ai:DropDownItem name="ExportProject" caption="{messages.exportButton}">
         <actions:ExportProjectAction/>
       </ai:DropDownItem>
+      <ai:DropDownItem name="SubmitToLms" caption="{messages.submitToLmsMenuItem}">
+        <actions:SubmitToLmsAction/>
+      </ai:DropDownItem>
       <ai:DropDownItem name="ExportAllProjects" caption="{messages.exportAllProjectsMenuItem}"
                        visible="false">
         <actions:ExportAllProjectsAction/>

--- a/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
+++ b/appinventor/appengine/src/com/google/appinventor/shared/settings/SettingsConstants.java
@@ -71,6 +71,7 @@ public class SettingsConstants {
   public static final String YOUNG_ANDROID_SETTINGS_PROJECT_COLORS = "ProjectColors";
   public static final String YOUNG_ANDROID_SETTINGS_AIVERSIONING = "AIVersioning";
   public static final String YOUNG_ANDROID_SETTINGS_LAST_OPENED = "LastOpened";
+  public static final String YOUNG_ANDROID_SETTINGS_LTI_LAUNCHED = "LtiLaunched";
   public static final String YOUNG_ANDROID_SETTINGS_BUILDNUMBER = "BuildNumber";
   public static final String YOUNG_ANDROID_SETTINGS_NSBTALWAYSUSAGE = "NSBluetoothAlwaysUsageDescription";
   public static final String YOUNG_ANDROID_SETTINGS_NSBTPERIPHERALUSAGE = "NSBluetoothPeripheralUsageDescription";

--- a/appinventor/appengine/tests/com/google/appinventor/client/editor/EditorManagerTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/editor/EditorManagerTest.java
@@ -1,0 +1,54 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests how many completions a save waits for before it reports back.
+ *
+ * <p>This is the arithmetic behind Submit to LMS. The menu item saves the open editors and
+ * only sends the submission once nothing is left unsaved, so a count that reports back early
+ * would hand in whatever had reached the server by then. Saving a screen's designer and its
+ * blocks is two files, which is the ordinary case rather than an unusual one.
+ *
+ * <p>This covers the arithmetic alone. What is sent, held back, retried, and still
+ * outstanding is decided by {@code PendingSaves} and covered by its own tests. Driving the
+ * save itself would need {@code Ode}, which cannot load outside a GWT client, so the lines
+ * that hand these pieces to each other are covered by reading them and by the end to end run.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class EditorManagerTest extends TestCase {
+
+  /** Each file is answered separately, so each file is one thing to wait for. */
+  public void testEachFileIsCounted() {
+    assertEquals(2, EditorManager.pendingSaveOperationCount(0, 2));
+    assertEquals(5, EditorManager.pendingSaveOperationCount(0, 5));
+  }
+
+  /**
+   * A screen's designer and its blocks are separate files, so editing both and then
+   * submitting has to wait for two answers rather than one.
+   */
+  public void testASavedScreenWaitsForBothOfItsFiles() {
+    assertEquals(2, EditorManager.pendingSaveOperationCount(0, 2));
+    assertFalse("counting the files as one operation reports back too early",
+        EditorManager.pendingSaveOperationCount(0, 2) == 1);
+  }
+
+  /** With nothing to save the file step still answers once, so the count is never zero. */
+  public void testNoFilesStillCountsOnce() {
+    assertEquals(1, EditorManager.pendingSaveOperationCount(0, 0));
+    assertEquals(4, EditorManager.pendingSaveOperationCount(3, 0));
+  }
+
+  /** Project settings are saved one at a time alongside the files. */
+  public void testSettingsAndFilesAddUp() {
+    assertEquals(5, EditorManager.pendingSaveOperationCount(3, 2));
+    assertEquals(1, EditorManager.pendingSaveOperationCount(0, 1));
+  }
+}

--- a/appinventor/appengine/tests/com/google/appinventor/client/editor/PendingSavesTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/editor/PendingSavesTest.java
@@ -247,4 +247,40 @@ public class PendingSavesTest extends TestCase {
 
     assertEquals(1, q.take().size());
   }
+
+  /**
+   * A closing window sends held back work instead of dropping it. No later save could come
+   * for it there, so takeEvenInFlight hands out everything waiting, and the newer send takes
+   * the slot so a late answer from the older save cannot clear it.
+   */
+  public void testAClosingWindowSendsWhatWasHeldBack() {
+    PendingSaves<Note> q = noteQueue();
+    Note older = new Note("Screen1.bky", 1);
+    Note newer = new Note("Screen1.bky", 2);
+    q.add(older);
+    q.take();
+    q.add(newer);
+    assertEquals("an ordinary save holds the newer one back", 0, q.take().size());
+
+    List<Note> sent = q.takeEvenInFlight();
+
+    assertEquals("the closing window sends it anyway", 1, sent.size());
+    assertSame(newer, sent.get(0));
+    assertFalse("nothing is left waiting", q.heldBack());
+    q.answered(older);
+    assertEquals("the newer send owns the slot, so a late answer cannot clear it",
+        1, q.inFlightCount());
+    q.answered(newer);
+    assertTrue("its own answer clears it", q.isEmpty());
+  }
+
+  /** With nothing waiting, a closing window has nothing to send. */
+  public void testTakeEvenInFlightWithNothingWaitingSendsNothing() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+
+    assertEquals(0, q.takeEvenInFlight().size());
+    assertEquals("the earlier save still owns its slot", 1, q.inFlightCount());
+  }
 }

--- a/appinventor/appengine/tests/com/google/appinventor/client/editor/PendingSavesTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/client/editor/PendingSavesTest.java
@@ -1,0 +1,250 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2026 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.editor;
+
+import java.util.List;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests what a save sends and what is left outstanding.
+ *
+ * <p>This is what Submit to LMS rests on. The menu item saves the open editors and sends the
+ * submission only once nothing is outstanding, so anything wrong here hands in work that is
+ * not what the learner is looking at, or waits for something that is never coming.
+ *
+ * @author zikun@stanford.edu (Zikun Zhu)
+ */
+public class PendingSavesTest extends TestCase {
+
+  /** Two notes of one file, so a test can tell the newer edit from the older one. */
+  private static final class Note {
+    private final String fileId;
+    private final int version;
+
+    Note(String fileId, int version) {
+      this.fileId = fileId;
+      this.version = version;
+    }
+  }
+
+  /** Names a note by its file, which is what the file side does. */
+  private static PendingSaves<Note> noteQueue() {
+    return new PendingSaves<Note>(new PendingSaves.Key<Note>() {
+      @Override
+      public Object of(Note note) {
+        return note.fileId;
+      }
+    });
+  }
+
+  /** Names each item by itself, which is what the settings side does. */
+  private static PendingSaves<String> queue() {
+    return new PendingSaves<String>(new PendingSaves.Key<String>() {
+      @Override
+      public Object of(String item) {
+        return item;
+      }
+    });
+  }
+
+  /** Nothing to do means nothing outstanding, which is what lets a submission go out. */
+  public void testAnEmptyQueueHasNothingOutstanding() {
+    assertTrue(queue().isEmpty());
+    assertFalse(queue().heldBack());
+  }
+
+  /** Something waiting to be saved is outstanding, so a submission must not go out. */
+  public void testSomethingWaitingIsOutstanding() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+
+    assertFalse("a file waiting to be saved is unfinished work", q.isEmpty());
+  }
+
+  /** Something sent and not answered is still outstanding, even though nothing is waiting. */
+  public void testSomethingOnItsWayIsStillOutstanding() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    assertEquals(1, q.take().size());
+
+    assertFalse("a save that has not answered is still unfinished work", q.isEmpty());
+    assertFalse("nothing is waiting, it is on its way", q.heldBack());
+    assertEquals(1, q.inFlightCount());
+  }
+
+  /** Once every save has answered there is nothing outstanding. */
+  public void testAnsweringClearsIt() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+
+    q.answered("Screen1.bky");
+
+    assertTrue(q.isEmpty());
+    assertEquals(0, q.inFlightCount());
+  }
+
+  /**
+   * Two saves of one file must not run at the same time. They are separate requests and can
+   * land in either order, and the older one landing last would undo the newer one.
+   */
+  public void testTheSameFileIsNeverSentTwiceAtOnce() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    assertEquals(1, q.take().size());
+
+    q.add("Screen1.bky");
+    List<String> second = q.take();
+
+    assertTrue("the second save has to wait for the first to answer", second.isEmpty());
+    assertTrue("and it is held back rather than forgotten", q.heldBack());
+  }
+
+  /** The held back save goes out as soon as the one before it has answered. */
+  public void testTheHeldBackSaveGoesOutNext() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+    q.add("Screen1.bky");
+    q.take();
+
+    q.answered("Screen1.bky");
+    List<String> third = q.take();
+
+    assertEquals(1, third.size());
+    assertEquals("Screen1.bky", third.get(0));
+  }
+
+  /** A file with nothing outstanding is sent straight away even while another one is waiting. */
+  public void testAnotherFileIsNotHeldUpByTheFirst() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+    q.add("Screen1.bky");
+    q.add("Screen2.bky");
+
+    List<String> sending = q.take();
+
+    assertEquals(1, sending.size());
+    assertEquals("Screen2.bky", sending.get(0));
+    assertTrue("Screen1 is still held back", q.heldBack());
+  }
+
+  /** A save that failed goes back to waiting, so the next save tries it again. */
+  public void testAFailedSaveGoesBackToWaiting() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+
+    q.failed("Screen1.bky");
+
+    assertFalse("a file whose save failed is unfinished work", q.isEmpty());
+    assertEquals(1, q.take().size());
+  }
+
+  /**
+   * A failure must not undo an edit made while the save was on its way. What is waiting is
+   * newer than what was sent, so it is what goes next.
+   */
+  public void testAFailureDoesNotUndoANewerEdit() {
+    PendingSaves<Note> q = noteQueue();
+    Note older = new Note("Screen1.bky", 1);
+    Note newer = new Note("Screen1.bky", 2);
+    q.add(older);
+    q.take();
+    q.add(newer);
+
+    q.failed(older);
+
+    List<Note> sending = q.take();
+    assertEquals(1, sending.size());
+    assertEquals("the newer edit goes, not the one whose save failed", 2, sending.get(0).version);
+  }
+
+  /**
+   * One save answering must not clear another save of a different file, which is what a map
+   * keyed only by file cannot express when both are outstanding.
+   */
+  public void testOneAnswerDoesNotClearAnother() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.add("Screen2.bky");
+    assertEquals(2, q.take().size());
+
+    q.answered("Screen1.bky");
+
+    assertFalse("Screen2 is still on its way", q.isEmpty());
+    assertEquals(1, q.inFlightCount());
+  }
+
+  /** Something being closed rather than saved is forgotten entirely. */
+  public void testDiscardForgetsIt() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.take();
+    q.add("Screen1.bky");
+
+    q.discard("Screen1.bky");
+
+    assertTrue(q.isEmpty());
+    assertFalse(q.heldBack());
+  }
+
+  /**
+   * The wrapped completion marks its save answered before anything else runs. A completion
+   * that did not would leave the save counting as on its way forever, and a submission would
+   * wait on it until its deadline.
+   */
+  public void testAnsweringMarksTheSaveAnsweredFirst() {
+    final PendingSaves<String> q = queue();
+    q.add("settings");
+    q.take();
+    final boolean[] sawItAnswered = {false};
+
+    PendingSaves.answering(q, "settings", new com.google.gwt.user.client.Command() {
+      @Override
+      public void execute() {
+        sawItAnswered[0] = q.isEmpty();
+      }
+    }).execute();
+
+    assertTrue("the completion runs", sawItAnswered[0]);
+    assertTrue("and nothing is left outstanding", q.isEmpty());
+  }
+
+  /**
+   * A late answer from a save that was discarded must not clear a newer save of the same
+   * thing. The newer save owns the slot, and losing it would let a second save of that thing
+   * go out while the newer one is still on its way.
+   */
+  public void testAStaleAnswerCannotClearANewerSave() {
+    PendingSaves<Note> q = noteQueue();
+    Note older = new Note("Screen1.bky", 1);
+    Note newer = new Note("Screen1.bky", 2);
+    q.add(older);
+    q.take();
+    q.discard(older);
+    q.add(newer);
+    assertEquals(1, q.take().size());
+
+    q.answered(older);
+
+    assertEquals("the newer save still owns its slot", 1, q.inFlightCount());
+    q.failed(older);
+    assertEquals("a stale failure changes nothing either", 1, q.inFlightCount());
+    assertFalse("and the discarded save is not requeued", q.heldBack());
+  }
+
+  /** Noting the same thing twice before it is sent sends it once. */
+  public void testNotingTwiceSendsOnce() {
+    PendingSaves<String> q = queue();
+    q.add("Screen1.bky");
+    q.add("Screen1.bky");
+
+    assertEquals(1, q.take().size());
+  }
+}


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

This adds a Submit to LMS item to the Project menu, together with the machinery that decides when it is allowed to appear. It is the client half of submitting an assignment from inside App Inventor, split out of the design branch #4031 so it can be taken on its own.

The item fixes the project at the click, saves the open editors, and posts that project id to a server submit endpoint only once nothing at all is still on its way to the server. Saving first matters because work in an open editor reaches the server on a timer, five seconds after the learner stops typing and within about thirty five seconds of the first change, so posting straight away would hand in whatever the last automatic save had caught rather than what the learner is looking at.

What still has to reach the server and what is already on its way now lives in a small browser free coordinator, PendingSaves, that the editor manager delegates to. It sends one save per file at a time, because two saves of one file can land in either order and the older one landing last would undo the newer one. It holds a file back while an earlier save of it is still running and restarts the idle timer, and the next save pass sends the held back save once the earlier one has answered. A closing window is the one exception, where everything waiting goes out beside the unanswered save, because no later pass can come for it there. It puts a failed save back in the queue without a clock of its own, the way the file path has always retried, and it ignores a completion that arrives after its save was discarded, so a late answer cannot clear a newer save of the same file. Settings saves answer their completion on every path, including failure and read only, and a settings edit made while a save is in flight is no longer lost when that save succeeds.

The request carries a custom header that a page on another site cannot set without a preflight, which the server side work refuses to grant, so once that work lands only a submission started from inside App Inventor is accepted, and a guard keeps a double click from sending two submissions. The request carries a timeout, which the underlying builder leaves off by default, a longer deadline covers the save that runs before it, and ending an attempt also ends its request, so a call that never answers cannot leave the item unusable and a retry can never overlap a request this client still holds open. Every path that can end a submission goes through one place that releases the guard and reports exactly once, and each attempt carries a number so a late answer from an attempt that already ended cannot report over a newer one.

The user sees a short progress message and then success or failure, reported through the existing ErrorReporter.

The item is gated on an invisible per project setting, LtiLaunched, that the server side assignment work writes on the project it creates for a learner at launch. The gate requires a writable project carrying that marker to be open in the designer, and it is refreshed when a project loads, when the file menu updates, and when the view or the open editor changes. Nothing in this change writes the marker, so the item stays hidden on every project until the server side work lands. The save path it goes through does change for everyone, which is where review is most useful, and the behaviour it changes is described above.

Splitting the client half out also gives the classroom portal work a base to reuse. The item, the gate, and the request guard stay the same whatever sits behind the endpoint, so a different server side flow only needs to point the same item at its own address.

*Testing Guidelines*

The full build passes with this change applied, including the GWT compile and link of the client module. The server suite reads ninety three tests, the shared suite twenty two, and the client suite forty four, with no failure and no error in any of them, and sixteen of the client tests cover the coordinator. The coordinator tests are mutation tested, meaning each rule was removed or inverted in a copy of the code and the suite went red each time, so the tests hold the behaviour rather than mirror the code. The lines that hand the coordinator to the editor and the menu run only inside the GWT client, which no unit test here can start, so those lines are verified by reading and by the end to end run, and the test javadocs say which is which. The touched files carry no checkstyle warning that master does not already have. On a build that includes the server work, the item appears only on the project a launch created, which was exercised end to end against a real Moodle on the design branch.

**Context for the changes**

This is exploration split out of #4031. The endpoint the item posts to arrives with the server side work, and until then the menu item is invisible everywhere, so this change has no user visible effect on its own.

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine (the server, shared, and client suites pass, the blockly suite needs a browser this machine does not have)

**Update.** A review pass found that the first version posted before the open editors were saved, and that the request had no timeout. Both are fixed in the second commit. A further pass found holes in how the second commit waited. A submission could go out while an automatic save that began earlier was still running, two saves of one file could land in either order and let the older content arrive last, and a failed settings save never answered its completion. The third commit moves the bookkeeping into the coordinator described above and closes each of these. One residual is worth naming rather than hiding. If the deadline expires while the server is still working, the learner is told the submission failed even though it may yet succeed, and a retry then produces a second frozen copy. The attempt now cancels its own request when it ends, which narrows that window, the deadline is generous enough that it should only follow a genuine fault, and the server side work treats a later submission as superseding an earlier one.

A late review pass found one more hole worth naming. The window closing save went through the same hold back, and a closing page has no later save pass, so an edit held back at that moment was never sent at all, where the old code would still have issued its racy request. Saving on a closing window now takes everything, held back or not, since no later pass exists there and the identity checks already keep a late answer from an older save from clearing the newer one. Two coordinator tests cover it, and the moved javadoc that had drifted from its method was put back where it belongs.