### PR TITLE
Feature/listview Multiselect (Android + iOS)

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1669,6 +1669,11 @@ public final class YoungAndroidFormUpgrader {
       // Added TextAlignmentDetail property (default: 0 = left).
       srcCompVersion = 11;
     }
+    if (srcCompVersion < 12) {
+      // The MultiSelect property became visible in the designer and the blocks (default: False).
+      // Added SelectedItems property.
+      srcCompVersion = 12;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2526,7 +2526,12 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2:
     // - Added TextAlignmentMain property
     // - Added TextAlignmentDetail property
-    11: "noUpgrade"
+    11: "noUpgrade",
+
+    // AI2:
+    // - Made the MultiSelect property visible in the designer and the blocks
+    // - Added SelectedItems property
+    12: "noUpgrade"
 
   }, // End ListView upgraders
 

--- a/appinventor/components-ios/src/ListView.swift
+++ b/appinventor/components-ios/src/ListView.swift
@@ -89,17 +89,69 @@ class ListDataModel {
     return item(at: index)?["Text2"] as? String ?? ""
   }
 
+  // ---- Selection (stored by ORIGINAL item index, so it survives filtering) ----
+  /// The selected original indexes, in the order the items were picked. An array rather than a
+  /// single value so MultiSelect can hold several; UIKit's own selection state cannot be the
+  /// source of truth because `reloadData()` wipes it on every filter change.
+  private(set) var selectedIndices: [Int] = []
+
+  /// The first selected original index, or nil when nothing is selected.
+  var firstSelection: Int? { selectedIndices.first }
+
+  func isSelected(_ originalIndex: Int) -> Bool { selectedIndices.contains(originalIndex) }
+
+  /// Selects only the given original index, replacing any previous selection.
+  func selectOnly(_ originalIndex: Int) {
+    selectedIndices = [originalIndex]
+  }
+
+  /// Adds or removes the given original index from the selection (used by MultiSelect).
+  func toggleSelection(_ originalIndex: Int) {
+    if let position = selectedIndices.firstIndex(of: originalIndex) {
+      selectedIndices.remove(at: position)
+    } else {
+      selectedIndices.append(originalIndex)
+    }
+  }
+
+  func clearSelection() {
+    selectedIndices.removeAll()
+  }
+
+  /// Moves selected indexes up by `count` so they still point at the same items after rows are
+  /// inserted at `index`. Selections before the insert point are unaffected.
+  private func shiftSelectionForInsert(at index: Int, count: Int) {
+    selectedIndices = selectedIndices.map { $0 >= index ? $0 + count : $0 }
+  }
+
+  /// Drops the selection of the item removed at `index` and moves the ones after it down one, so
+  /// the remaining selections still point at the items the user picked.
+  private func dropAndShiftSelectionForRemove(at index: Int) {
+    selectedIndices = selectedIndices.compactMap { selected in
+      if selected == index {
+        return nil
+      }
+      return selected > index ? selected - 1 : selected
+    }
+  }
+
   // ---- Mutations (mirrors the Android ListDataModel's setItems/add/addAt/remove/clear) ----
   func clear() {
     elements.removeAll()
     items.removeAll()
+    // The old items are gone, so the indexes that referred to them mean nothing now.
+    selectedIndices.removeAll()
   }
 
   /// Replaces the list with rich rows, dropping any string rows (used by the ListData setter).
   func setItems(_ newItems: [[String: AnyObject]]) {
     elements.removeAll()
     items = newItems
+    selectedIndices.removeAll()
   }
+
+  // The append methods leave every existing index where it was, so the selection needs no
+  // adjustment; only the insert and remove methods move rows around.
 
   func append(_ text: String) {
     elements.append(text)
@@ -115,18 +167,22 @@ class ListDataModel {
 
   func insert(_ text: String, at index: Int) {
     elements.insert(text, at: index)
+    shiftSelectionForInsert(at: index, count: 1)
   }
 
   func insert(_ item: [String: AnyObject], at index: Int) {
     items.insert(item, at: index)
+    shiftSelectionForInsert(at: index, count: 1)
   }
 
   func insert(contentsOf texts: [String], at index: Int) {
     elements.insert(contentsOf: texts, at: index)
+    shiftSelectionForInsert(at: index, count: texts.count)
   }
 
   func insert(contentsOf newItems: [[String: AnyObject]], at index: Int) {
     items.insert(contentsOf: newItems, at: index)
+    shiftSelectionForInsert(at: index, count: newItems.count)
   }
 
   /// Removes the row at a real (unfiltered) position from whichever array holds it.
@@ -137,6 +193,7 @@ class ListDataModel {
     if elements.count > index {
       elements.remove(at: index)
     }
+    dropAndShiftSelectionForRemove(at: index)
   }
 }
 
@@ -162,6 +219,7 @@ fileprivate final class ListViewRootView: UIView {
   fileprivate var _selectionDetailText = ""
   fileprivate var _selectionColor = kListViewDefaultSelectionColor
   fileprivate var _selectionIndex = Int32(0)
+  fileprivate var _multiSelect = false
   fileprivate var _showFilter = false
   fileprivate var _textColor = kListViewDefaultTextColor
   fileprivate var _textColorDetail = kListViewDefaultTextColor
@@ -358,11 +416,16 @@ fileprivate final class ListViewRootView: UIView {
   func elementsCount() {
     _automaticHeightConstraint?.constant = preferredTableHeight
     if let searchBar = _view.tableHeaderView as? UISearchBar {
+      // Re-running the filter also re-applies the selection to the reloaded rows.
       self.searchBar(searchBar, textDidChange: searchBar.text ?? "")
+      _collectionView.reloadData()
     } else {
       _view.reloadData()
+      _collectionView.reloadData()
+      // reloadData drops UIKit's selection state, so without a filter bar to do it for us the
+      // highlight has to be put back or it vanishes every time the data changes.
+      restoreSelectedRows()
     }
-    _collectionView.reloadData()
     _collectionView.collectionViewLayout.invalidateLayout()
     invalidateListViewSize()
   }
@@ -582,32 +645,67 @@ fileprivate final class ListViewRootView: UIView {
   /// and moves the highlight to the row that item is drawn on. `index` is 1-based; 0 clears.
   /// Mirrors Android, where SelectionIndex(int) is likewise the single derivation point.
   fileprivate func applySelection(_ index: Int32, scroll: Bool) {
-    // Drop the old highlight first: the newly selected item may be hidden by the filter, in which
-    // case there is no row to move the highlight to.
-    if let selectedRow = _view.indexPathForSelectedRow {
-      _view.deselectRow(at: selectedRow, animated: false)
+    guard index > 0, _model.item(at: Int(index) - 1) != nil else {
+      // An index outside the list selects nothing, so report nothing rather than keeping a number
+      // that points at no row.
+      _model.clearSelection()
+      clearSelectionInfo()
+      restoreSelectedRows()
+      return
+    }
+    let originalIndex = Int(index) - 1
+    if _multiSelect {
+      // Setting the index picks that row. Unlike a tap it never un-picks one, so that setting the
+      // same index twice does not quietly undo itself.
+      if !_model.isSelected(originalIndex) {
+        _model.toggleSelection(originalIndex)
+      }
+    } else {
+      _model.selectOnly(originalIndex)
+    }
+    readSelectionInfo(from: originalIndex)
+    restoreSelectedRows(scrollTo: scroll ? originalIndex : nil)
+  }
+
+  /// Points what the Selection blocks report at the item at the given original index.
+  /// Does not change which rows are selected.
+  fileprivate func readSelectionInfo(from originalIndex: Int) {
+    _selectionIndex = Int32(originalIndex) + 1
+    _selection = _model.mainText(at: originalIndex)
+    _selectionDetailText = _model.detailText(at: originalIndex)
+  }
+
+  /// Clears what the Selection blocks report, without touching the selection the model holds, so
+  /// that MultiSelect keeps the rest of the set the user built up.
+  fileprivate func clearSelectionInfo() {
+    _selectionIndex = 0
+    _selection = ""
+    _selectionDetailText = ""
+  }
+
+  /// Re-applies the model's selection to UIKit, which is the one place the highlight can live but
+  /// cannot be trusted to remember it: `reloadData()` wipes UIKit's selection, and it only ever
+  /// tracks rows that are currently on screen. Rows the filter hides are skipped — they stay
+  /// selected in the model and light up again when the query clears. Pass an original index to
+  /// scroll that row into view.
+  fileprivate func restoreSelectedRows(scrollTo originalIndex: Int? = nil) {
+    for path in _view.indexPathsForSelectedRows ?? [] {
+      _view.deselectRow(at: path, animated: false)
     }
     for path in _collectionView.indexPathsForSelectedItems ?? [] {
       _collectionView.deselectItem(at: path, animated: false)
     }
-    guard index > 0, let item = _model.item(at: Int(index) - 1) else {
-      _selectionIndex = 0
-      _selection = ""
-      _selectionDetailText = ""
-      return
+    for selected in _model.selectedIndices {
+      guard let displayRow = _model.toDisplayPosition(selected) else {
+        continue
+      }
+      let path = IndexPath(row: displayRow, section: 0)
+      let scrollToThisRow = selected == originalIndex
+      _view.selectRow(at: path, animated: scrollToThisRow,
+                      scrollPosition: scrollToThisRow ? .middle : .none)
+      _collectionView.selectItem(at: path, animated: scrollToThisRow,
+                                 scrollPosition: scrollToThisRow ? .centeredHorizontally : [])
     }
-    _selectionIndex = index
-    _selection = item["Text1"] as? String ?? ""
-    _selectionDetailText = item["Text2"] as? String ?? ""
-    // The highlight belongs to the visible row, which differs from the item's real position while a
-    // filter is active. A nil position means the filter currently hides the selected item.
-    guard let displayRow = _model.toDisplayPosition(Int(index) - 1) else {
-      return
-    }
-    let path = IndexPath(row: displayRow, section: 0)
-    _view.selectRow(at: path, animated: true, scrollPosition: scroll ? .middle : .none)
-    _collectionView.selectItem(at: path, animated: true,
-                               scrollPosition: scroll ? .centeredHorizontally : [])
   }
 
   @objc open var Selection: String {
@@ -631,6 +729,33 @@ fileprivate final class ListViewRootView: UIView {
         : nil
       applySelection(index.map { Int32($0) + 1 } ?? 0, scroll: false)
     }
+  }
+
+  /// Whether the user can select more than one element at a time. While this is on, a tap adds a
+  /// row to or removes it from `SelectedItems`, and `Selection` / `SelectionIndex` report the row
+  /// touched last.
+  @objc open var MultiSelect: Bool {
+    get {
+      return _multiSelect
+    }
+    set(multiSelect) {
+      _multiSelect = multiSelect
+      _view.allowsMultipleSelection = multiSelect
+      _collectionView.allowsMultipleSelection = multiSelect
+      // Switching modes starts from a clean slate: a set built up in one mode has no meaning in
+      // the other, and a leftover highlight would outlive what the Selection blocks report.
+      _model.clearSelection()
+      clearSelectionInfo()
+      _view.reloadData()
+      _collectionView.reloadData()
+    }
+  }
+
+  /// Every element the user has selected, in the order they were picked. Unless `MultiSelect` is
+  /// enabled this holds at most one element, since selecting a row replaces the previous selection.
+  @objc open var SelectedItems: [AnyObject] {
+    return _model.selectedIndices.compactMap { _model.item(at: $0) }
+      .map { _model.isDataMode ? $0 as AnyObject : ($0["Text1"] as? String ?? "") as AnyObject }
   }
 
   @objc open var SelectionColor: Int32 {
@@ -806,6 +931,10 @@ fileprivate final class ListViewRootView: UIView {
       _model.insert(ListDataModel.makeItem(text1: mainText, text2: detailText, image: imageName),
                     at: index)
     }
+    if _selectionIndex >= addIndex {
+      // The new row pushed the selected item down one.
+      _selectionIndex += 1
+    }
     elementsCount()
   }
 
@@ -831,6 +960,10 @@ fileprivate final class ListViewRootView: UIView {
     let index = Int(addIndex - 1)
     let newItems = elements.map { normalizedListItem(from: $0) }
     _model.insert(contentsOf: newItems, at: index)
+    if _selectionIndex >= addIndex {
+      // The new rows pushed the selected item down by however many went in.
+      _selectionIndex += Int32(newItems.count)
+    }
     elementsCount()
   }
 
@@ -869,6 +1002,13 @@ fileprivate final class ListViewRootView: UIView {
       return
     }
     _model.remove(at: Int(index - 1))
+    if _selectionIndex == index {
+      // The item the blocks are reporting is the one that just went away.
+      clearSelectionInfo()
+    } else if _selectionIndex > index {
+      // Everything after the hole moved down one, so follow the item that is still selected.
+      _selectionIndex -= 1
+    }
     elementsCount()
   }
 
@@ -1217,7 +1357,35 @@ fileprivate final class ListViewRootView: UIView {
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
       // Map the tapped visible row back to its real position, so selection is correct while filtering.
       // Tapping must not scroll the list — the row is already where the user is looking.
-      applySelection(Int32(_model.originalIndex(indexPath.row)) + 1, scroll: false)
+      handleTap(onOriginalIndex: _model.originalIndex(indexPath.row), selected: true)
+    }
+
+    /// With `allowsMultipleSelection` on, UIKit reports a tap on an already selected row here
+    /// rather than through `didSelectRowAt`, so the deselecting half of a MultiSelect tap only
+    /// arrives via this method. Programmatic `deselectRow` calls do not reach it, and in
+    /// single-select mode UIKit uses it to retire the previous row, which is bookkeeping the model
+    /// has already done — hence the guard.
+    open func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+      guard _multiSelect else {
+        return
+      }
+      handleTap(onOriginalIndex: _model.originalIndex(indexPath.row), selected: false)
+    }
+
+    /// The one place a tap is turned into a selection change, for both the table and the
+    /// collection view. MultiSelect toggles the tapped row and leaves the rest of the set alone;
+    /// otherwise the tap replaces the selection. Either way the row just touched is what the
+    /// Selection blocks go on to report, including when the touch was the one that un-picked it.
+    fileprivate func handleTap(onOriginalIndex originalIndex: Int, selected: Bool) {
+      if _multiSelect {
+        // UIKit has already moved its own highlight, so only the model needs syncing.
+        if _model.isSelected(originalIndex) != selected {
+          _model.toggleSelection(originalIndex)
+        }
+        readSelectionInfo(from: originalIndex)
+      } else {
+        applySelection(Int32(originalIndex) + 1, scroll: false)
+      }
       AfterPicking()
     }
     
@@ -1227,17 +1395,16 @@ fileprivate final class ListViewRootView: UIView {
     _model.setFilter(searchText)
     _view.reloadData()
     _collectionView.reloadData()
-    // reloadData drops UIKit's selection state, so the highlight is lost on every filter change.
-    // Selection is stored against the original index, so re-highlight the selected item's new
-    // visible row while it survives the filter, and clear it only when the filter hides it, so the
-    // user never ends up with a selection they cannot see.
-    if _selectionIndex > 0 {
-      if let displayRow = _model.toDisplayPosition(Int(_selectionIndex) - 1) {
-        _view.selectRow(at: IndexPath(row: displayRow, section: 0), animated: false, scrollPosition: .none)
-        _collectionView.selectItem(at: IndexPath(item: displayRow, section: 0), animated: false, scrollPosition: [])
-      } else {
-        applySelection(0, scroll: false)
-      }
+    // reloadData drops UIKit's selection state, so every highlight is lost on each filter change.
+    // Selection is stored against original indexes, so re-highlight whichever selected rows the
+    // filter still shows.
+    restoreSelectedRows()
+    // A single selection is the one thing Selection reports, so a hidden one would be a selection
+    // the user cannot see: drop it once the filter hides it. MultiSelect is a set the user is
+    // building up instead, so searching again must not throw away what they already picked.
+    if !_multiSelect && _selectionIndex > 0
+        && _model.toDisplayPosition(Int(_selectionIndex) - 1) == nil {
+      applySelection(0, scroll: false)
     }
   }
 
@@ -1441,8 +1608,16 @@ fileprivate final class ListViewRootView: UIView {
   // UICollectionViewDelegate (selection → AfterPicking)
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     // Map the tapped visible item back to its real position, so selection is correct while filtering.
-    applySelection(Int32(_model.originalIndex(indexPath.item)) + 1, scroll: false)
-    AfterPicking()
+    handleTap(onOriginalIndex: _model.originalIndex(indexPath.item), selected: true)
+  }
+
+  /// The collection view's half of the MultiSelect tap, for the same reason as the table's
+  /// `didDeselectRowAt`: un-picking an already selected item is only reported here.
+  public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    guard _multiSelect else {
+      return
+    }
+    handleTap(onOriginalIndex: _model.originalIndex(indexPath.item), selected: false)
   }
 
   // UICollectionViewDelegateFlowLayout (optional sizing)

--- a/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
+++ b/appinventor/components-ios/tests/Unit Tests/components/visible/ListViewTests.swift
@@ -468,6 +468,68 @@ class ListViewTests: AppInventorTestCase {
     XCTAssertEqual("", testList.Selection)
   }
 
+  func testSingleSelectReplacesTheSelection() {
+    testList.Elements = ["apple", "banana", "cherry"] as [AnyObject]
+    let tableView = visibleTableView(for: testList)
+
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
+
+    XCTAssertEqual(["cherry"], testList.SelectedItems as? [String])
+    XCTAssertEqual(3, testList.SelectionIndex)
+  }
+
+  func testMultiSelectAccumulatesTappedRows() {
+    testList.Elements = ["apple", "banana", "cherry"] as [AnyObject]
+    testList.MultiSelect = true
+    let tableView = visibleTableView(for: testList)
+
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
+
+    XCTAssertEqual(["apple", "cherry"], testList.SelectedItems as? [String])
+    // The last row touched is what the singular properties report.
+    XCTAssertEqual(3, testList.SelectionIndex)
+    XCTAssertEqual("cherry", testList.Selection)
+
+    // With allowsMultipleSelection on, UIKit reports a tap on an already selected row through
+    // didDeselectRowAt rather than didSelectRowAt, so that is how the un-picking tap arrives.
+    testList.tableView(tableView, didDeselectRowAt: IndexPath(row: 0, section: 0))
+
+    XCTAssertEqual(["cherry"], testList.SelectedItems as? [String])
+    XCTAssertEqual(1, testList.SelectionIndex)
+    XCTAssertEqual("apple", testList.Selection)
+  }
+
+  func testMultiSelectKeepsSelectionThroughFiltering() {
+    testList.Elements = ["apple", "banana", "cherry"] as [AnyObject]
+    testList.MultiSelect = true
+    let tableView = visibleTableView(for: testList)
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+    testList.tableView(tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
+
+    // "ban" hides both of the picked rows, but a set the user is building must survive a search.
+    testList.searchBar(UISearchBar(), textDidChange: "ban")
+    XCTAssertEqual(["apple", "cherry"], testList.SelectedItems as? [String])
+
+    testList.searchBar(UISearchBar(), textDidChange: "")
+    XCTAssertEqual(["apple", "cherry"], testList.SelectedItems as? [String])
+  }
+
+  func testRemoveItemKeepsSelectionOnTheSameItem() {
+    testList.Elements = ["apple", "banana", "cherry", "date"] as [AnyObject]
+    testList.SelectionIndex = 4  // date
+
+    testList.RemoveItemAtIndex(2)  // banana goes, so date slides from 4 to 3
+
+    XCTAssertEqual(3, testList.SelectionIndex)
+    XCTAssertEqual("date", testList.Selection)
+
+    testList.RemoveItemAtIndex(3)  // removing date itself clears what the blocks report
+    XCTAssertEqual(0, testList.SelectionIndex)
+    XCTAssertEqual("", testList.Selection)
+  }
+
   // MARK: Events
 
   func testAfterPicking() {

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1280,7 +1280,10 @@ public class YaVersion {
   // For LISTVIEW_COMPONENT_VERSION 11:
   // - Added TextAlignmentMain property
   // - Added TextAlignmentDetail property
-  public static final int LISTVIEW_COMPONENT_VERSION = 11;
+  // For LISTVIEW_COMPONENT_VERSION 12:
+  // - Made the MultiSelect property visible in the designer and the blocks
+  // - Added SelectedItems property
+  public static final int LISTVIEW_COMPONENT_VERSION = 12;
 
   // For LOCATIONSENSOR_COMPONENT_VERSION 2:
   // - The TimeInterval and DistanceInterval properties were added.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListAdapterWithRecyclerView.java
@@ -106,7 +106,7 @@ public abstract class ListAdapterWithRecyclerView
   /**
    * Selects the item at the given original index, replacing any previous selection.
    */
-  public void toggleSelection(int position) {
+  public void selectOnly(int position) {
     if (model.isSelected(position)) {
       return;
     }
@@ -119,9 +119,9 @@ public abstract class ListAdapterWithRecyclerView
   }
 
   /**
-   * Toggles the item at the given original index, used when MultiSelect is enabled.
+   * Adds or removes the item at the given original index, used when MultiSelect is enabled.
    */
-  public void changeSelections(int position) {
+  public void toggleSelection(int position) {
     model.toggleSelection(position);
     notifyOriginalChanged(position);
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListDataModel.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListDataModel.java
@@ -9,7 +9,9 @@ import com.google.appinventor.components.runtime.util.YailDictionary;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.ListIterator;
 
 /**
  * Single owner of the {@link ListView}'s non-visual state: the item list, the search filter,
@@ -62,7 +64,11 @@ public class ListDataModel {
   public void setItems(Collection<?> newItems) {
     items.clear();
     items.addAll(newItems);
+    // The old items are gone, so the indexes that referred to them mean nothing now.
+    selectedItems.clear();
   }
+
+  // add and addAll append, so no existing index moves and the selection needs no adjustment.
 
   public void add(Object item) {
     items.add(item);
@@ -70,6 +76,7 @@ public class ListDataModel {
 
   public void addAt(int index, Object item) {
     items.add(index, item);
+    shiftSelectionForInsert(index, 1);
   }
 
   public void addAll(Collection<?> newItems) {
@@ -78,14 +85,46 @@ public class ListDataModel {
 
   public void addAllAt(int index, Collection<?> newItems) {
     items.addAll(index, newItems);
+    shiftSelectionForInsert(index, newItems.size());
   }
 
   public void remove(int index) {
     items.remove(index);
+    dropAndShiftSelectionForRemove(index);
   }
 
   public void clear() {
     items.clear();
+    selectedItems.clear();
+  }
+
+  /**
+   * Moves selected indexes up by {@code count} so they still point at the same items after rows
+   * are inserted at {@code index}. Selections before the insert point are unaffected.
+   */
+  private void shiftSelectionForInsert(int index, int count) {
+    for (int i = 0; i < selectedItems.size(); i++) {
+      int selected = selectedItems.get(i);
+      if (selected >= index) {
+        selectedItems.set(i, selected + count);
+      }
+    }
+  }
+
+  /**
+   * Drops the selection of the item removed at {@code index} and moves the indexes after it down
+   * one, so the remaining selections still point at the items the user picked.
+   */
+  private void dropAndShiftSelectionForRemove(int index) {
+    ListIterator<Integer> iterator = selectedItems.listIterator();
+    while (iterator.hasNext()) {
+      int selected = iterator.next();
+      if (selected == index) {
+        iterator.remove();
+      } else if (selected > index) {
+        iterator.set(selected - 1);
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -120,18 +159,19 @@ public class ListDataModel {
 
   /**
    * Applies a result from {@link #computeFilter}. Call on the UI thread: it swaps in the new
-   * filtered view and drops any selection the filter now hides, so the caller can notify the
-   * adapter immediately afterwards without the row count ever disagreeing with the data.
+   * filtered view, so the caller can notify the adapter immediately afterwards without the row
+   * count ever disagreeing with the data.
+   *
+   * <p>Filtering deliberately leaves the selection alone. Selections are held by original index
+   * and the filter only changes which rows are on screen, so a hidden item is still the item the
+   * user picked and comes back when the query is cleared. Whether a selection the user can no
+   * longer see should be dropped is a policy call, and it belongs to {@link ListView}, which
+   * clears it for a single selection but keeps it when MultiSelect is building up a set.
    */
   public void commitFilter(FilterResult result) {
     lastQuery = result.query;
     filteredItems = result.visibleItems;
     originalPositions = result.originalPositions;
-    if (!lastQuery.isEmpty()) {
-      // Selection is kept by original index, so it survives filtering; only drop entries the
-      // filter now hides.
-      selectedItems.retainAll(originalPositions);
-    }
   }
 
   /** Re-runs the active filter against the current items, e.g. after the data changed. */
@@ -193,6 +233,11 @@ public class ListDataModel {
   /** The first selected original index, or -1 when nothing is selected. */
   public int firstSelection() {
     return selectedItems.isEmpty() ? -1 : selectedItems.get(0);
+  }
+
+  /** Every selected original index, in the order the items were picked. */
+  public List<Integer> getSelectedIndexes() {
+    return Collections.unmodifiableList(selectedItems);
   }
 
   /** Selects only the given original index, replacing any previous selection. */

--- a/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/ListView.java
@@ -43,6 +43,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import android.graphics.Canvas;
@@ -198,9 +199,11 @@ public final class ListView extends AndroidViewComponent {
         listAdapterWithRecyclerView.getFilter().filter(cs, new Filter.FilterListener() {
           @Override
           public void onFilterComplete(int count) {
-            // Keep the selection while the selected item is still on screen, and clear it only
-            // when the filter hides it, so the user never has a selection they cannot see.
-            if (selectionIndex > 0 && !dataModel.isVisible(selectionIndex - 1)) {
+            // A single selection is the one thing Selection reports, so a hidden one would be a
+            // selection the user cannot see: keep it while its row is on screen and drop it once
+            // the filter hides it. MultiSelect is a set the user is building up instead, so
+            // searching again must not throw away what they already picked.
+            if (!multiSelect && selectionIndex > 0 && !dataModel.isVisible(selectionIndex - 1)) {
               SelectionIndex(0);
             }
           }
@@ -349,8 +352,10 @@ public final class ListView extends AndroidViewComponent {
   @SimpleProperty
   public void Elements(List<Object> itemsList) {
     dataModel.setItems(itemsList);
+    // Every item was replaced, so nothing that was selected is still there to point at. The
+    // model dropped the selection with the items; this clears what the blocks read.
+    clearSelectionInfo();
     updateAdapterData();
-    listAdapterWithRecyclerView.notifyDataSetChanged();
   }
 
   /**
@@ -380,8 +385,10 @@ public final class ListView extends AndroidViewComponent {
       category = PropertyCategory.BEHAVIOR)
   public void ElementsFromString(String itemstring) {
     dataModel.setItems(ElementsUtil.elementsListFromString(itemstring));
+    // Every item was replaced, so nothing that was selected is still there to point at. The
+    // model dropped the selection with the items; this clears what the blocks read.
+    clearSelectionInfo();
     updateAdapterData();
-    listAdapterWithRecyclerView.notifyDataSetChanged();
   }
 
   /**
@@ -389,11 +396,16 @@ public final class ListView extends AndroidViewComponent {
    * will be `0`. If an attempt is made to set this to a number less than `1` or greater than the
    * number of items in the `ListView`, `SelectionIndex` will be set to `0`, and
    * {@link #Selection(String)} will be set to the empty text.
+   *
+   * While {@link #MultiSelect(boolean)} is enabled this is the row the user touched last, which
+   * may have been touched to deselect it. Read {@link #SelectedItems()} for what is selected now.
    */
   @SimpleProperty(description = "The index of the currently selected item, starting at 1. "
                                     + "If no item is selected, the value will be 0. If an attempt is made to set this "
                                     + "to a number less than 1 or greater than the number of stringItems in the ListView, "
-                                    + "SelectionIndex will be set to 0, and Selection will be set to the empty text.",
+                                    + "SelectionIndex will be set to 0, and Selection will be set to the empty text. "
+                                    + "While MultiSelect is enabled this is the row the user touched last, which may "
+                                    + "have been touched to deselect it; read SelectedItems for what is selected now.",
       category = PropertyCategory.BEHAVIOR)
   public int SelectionIndex() {
     return selectionIndex;
@@ -407,27 +419,22 @@ public final class ListView extends AndroidViewComponent {
    */
   @SimpleProperty
   public void SelectionIndex(int index) {
-    selectionIndex = index;
     if (index > 0 && index <= dataModel.size()) {
-      Object o = dataModel.get(index - 1);
-      if (o instanceof YailDictionary) {
-        if (((YailDictionary) o).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {
-          selection = ((YailDictionary) o).get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
-          selectionDetailText = ElementsUtil.toStringEmptyIfNull(((YailDictionary) o)
-              .get(Component.LISTVIEW_KEY_DESCRIPTION));
-        } else {
-          selection = o.toString();
+      selectionIndex = index;
+      readSelectionTextFrom(index);
+      if (multiSelect) {
+        // Setting the index picks that row. Unlike a tap it never un-picks one, so that setting
+        // the same index twice does not quietly undo itself.
+        if (!dataModel.isSelected(index - 1)) {
+          listAdapterWithRecyclerView.toggleSelection(index - 1);
         }
       } else {
-        selection = o.toString();
-      }
-      if (multiSelect) {
-        listAdapterWithRecyclerView.changeSelections(selectionIndex - 1);
-      } else {
-        listAdapterWithRecyclerView.toggleSelection(selectionIndex - 1);
+        listAdapterWithRecyclerView.selectOnly(index - 1);
       }
     } else {
-      selection = "";
+      // An index outside the list selects nothing, so report nothing rather than keeping a number
+      // that points at no row.
+      clearSelectionInfo();
       listAdapterWithRecyclerView.clearSelections();
       listAdapterWithRecyclerView.notifyDataSetChanged();
     }
@@ -435,8 +442,14 @@ public final class ListView extends AndroidViewComponent {
 
   /**
    * Returns the text in the `ListView` at the position of {@link #SelectionIndex(int)}.
+   *
+   * While {@link #MultiSelect(boolean)} is enabled this is the text of the row the user touched
+   * last. Read {@link #SelectedItems()} for every element that is selected now.
    */
-  @SimpleProperty(description = "The text value of the most recently selected item in the ListView.",
+  @SimpleProperty(description = "The text value of the most recently selected item in the "
+                                    + "ListView. While MultiSelect is enabled this is the row the "
+                                    + "user touched last; read SelectedItems for every element "
+                                    + "that is selected now.",
       category = PropertyCategory.BEHAVIOR)
   public String Selection() {
     return selection;
@@ -487,6 +500,34 @@ public final class ListView extends AndroidViewComponent {
   }
 
   /**
+   * Points what the Selection blocks report at the item at the given 1-based index, reading the
+   * main and detail text out of it. Does not change which rows are selected.
+   */
+  private void readSelectionTextFrom(int index) {
+    Object item = dataModel.get(index - 1);
+    if (item instanceof YailDictionary
+        && ((YailDictionary) item).containsKey(Component.LISTVIEW_KEY_MAIN_TEXT)) {
+      selection = ((YailDictionary) item).get(Component.LISTVIEW_KEY_MAIN_TEXT).toString();
+      selectionDetailText = ElementsUtil.toStringEmptyIfNull(((YailDictionary) item)
+          .get(Component.LISTVIEW_KEY_DESCRIPTION));
+    } else {
+      selection = item.toString();
+    }
+  }
+
+  /**
+   * Clears what the Selection blocks report, without touching the selection the model holds.
+   *
+   * <p>Callers that removed or replaced items use this so that MultiSelect keeps the rest of the
+   * set the user built up; the model has already dropped the entries whose items are gone.
+   */
+  private void clearSelectionInfo() {
+    selectionIndex = 0;
+    selection = "";
+    selectionDetailText = "";
+  }
+
+  /**
    * Returns the Secondary or Detail text in the ListView at the position set by SelectionIndex
    */
   @SimpleProperty(description = "Returns the secondary text of the selected row in the ListView.",
@@ -496,11 +537,37 @@ public final class ListView extends AndroidViewComponent {
   }
 
   /**
+   * Returns every element the user has selected, in the order they were picked. Unless
+   * {@link #MultiSelect(boolean)} is enabled this holds at most one element, since selecting a
+   * row replaces the previous selection.
+   *
+   * @return the selected elements, as strings or as dictionaries depending on the layout
+   */
+  @SimpleProperty(description = "The elements the user has selected, in the order they were "
+                                    + "picked. Unless MultiSelect is enabled this holds at most "
+                                    + "one element. Use GetMainText or GetDetailText to read an "
+                                    + "element from the list.",
+      category = PropertyCategory.BEHAVIOR)
+  public YailList SelectedItems() {
+    List<Object> selectedItems = new ArrayList<>();
+    for (int index : dataModel.getSelectedIndexes()) {
+      selectedItems.add(dataModel.get(index));
+    }
+    return YailList.makeList(selectedItems);
+  }
+
+  /**
    * Simple event to be raised after the an element has been chosen in the list.
    * The selected element is available in the {@link #Selection(String)} property.
+   *
+   * While {@link #MultiSelect(boolean)} is enabled this is raised for every tap, including a tap
+   * that takes a row back out of {@link #SelectedItems()}.
    */
   @SimpleEvent(description = "Simple event to be raised after the an element has been chosen in the"
-                                 + " list. The selected element is available in the Selection property.")
+                                 + " list. The selected element is available in the Selection"
+                                 + " property. While MultiSelect is enabled this is raised for"
+                                 + " every tap, including one that takes a row back out of"
+                                 + " SelectedItems.")
   public void AfterPicking() {
     EventDispatcher.dispatchEvent(this, "AfterPicking");
   }
@@ -943,30 +1010,37 @@ public final class ListView extends AndroidViewComponent {
    * @return true or false (is multiselect)
    * @suppressdoc
    */
-  // See https://github.com/mit-cml/appinventor-sources/pull/3235#issuecomment-2435573318
-//  @SimpleProperty(description = "A function that allows you to select multiple elements. "
-//                                    + "True - function enabled, false - disabled.",
-//      category = PropertyCategory.BEHAVIOR)
+  @SimpleProperty(description = "Whether the user can select more than one element at a time. "
+                                    + "While this is enabled, tapping a row adds it to or removes "
+                                    + "it from SelectedItems, and Selection and SelectionIndex "
+                                    + "report the row that was tapped last.",
+      category = PropertyCategory.BEHAVIOR)
   public boolean MultiSelect() {
     return multiSelect;
   }
 
   /**
-   * Sets the multiselect function. `true`{:.logic.block} will enable the function,
-   * `false`{:.logic.block} will disable.
+   * Whether the user can select more than one element at a time. `true`{:.logic.block} makes a tap
+   * add a row to, or remove it from, {@link #SelectedItems()}; `false`{:.logic.block} makes each
+   * tap replace the previous selection.
    *
-   * @param multiSelect sets the function according to this input
+   * Turning this on or off clears whatever is selected at the time, since a set built up in one
+   * mode has no meaning in the other.
+   *
+   * @param multi whether more than one element can be selected at a time
    */
-  // See https://github.com/mit-cml/appinventor-sources/pull/3235#issuecomment-2435573318
-//  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
-//      defaultValue = "False")
-//  @SimpleProperty
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_BOOLEAN,
+      defaultValue = "False")
+  @SimpleProperty
   public void MultiSelect(boolean multi) {
-    if (selectionIndex > 0) {
-      listAdapterWithRecyclerView.clearSelections();
+    this.multiSelect = multi;
+    // Switching modes starts from a clean slate: a set built up in one mode has no meaning in the
+    // other, and a leftover highlight would outlive what the Selection blocks report.
+    dataModel.clearSelection();
+    clearSelectionInfo();
+    if (listAdapterWithRecyclerView != null) {
       listAdapterWithRecyclerView.notifyDataSetChanged();
     }
-    this.multiSelect = multi;
   }
 
   /**
@@ -1049,8 +1123,10 @@ public final class ListView extends AndroidViewComponent {
         Log.e(LOG_TAG, "Malformed JSON in ListView.ListData", e);
         container.$form().dispatchErrorOccurredEvent(this, "ListView.ListData", ErrorMessages.ERROR_DEFAULT, e.getMessage());
       }
+      // Every item was replaced, so nothing that was selected is still there to point at. The
+      // model dropped the selection with the items; this clears what the blocks read.
+      clearSelectionInfo();
       updateAdapterData();
-      listAdapterWithRecyclerView.notifyDataSetChanged();
     }
   }
 
@@ -1237,8 +1313,14 @@ public final class ListView extends AndroidViewComponent {
       return;
     }
     dataModel.remove(index - 1);
+    if (selectionIndex == index) {
+      // The item the blocks are reporting is the one that just went away.
+      clearSelectionInfo();
+    } else if (selectionIndex > index) {
+      // Everything after the hole moved down one, so follow the item that is still selected.
+      selectionIndex--;
+    }
     updateAdapterData();
-    listAdapterWithRecyclerView.notifyItemRemoved(index - 1);
   }
 
   /**
@@ -1264,8 +1346,8 @@ public final class ListView extends AndroidViewComponent {
         dataModel.add(CreateElement(mainText, detailText, imageName));
       }
     }
+    // Appending leaves every existing index where it was, so the selection needs no adjustment.
     updateAdapterData();
-    listAdapterWithRecyclerView.notifyItemChanged(listAdapterWithRecyclerView.getItemCount() - 1);
   }
 
   /**
@@ -1274,11 +1356,9 @@ public final class ListView extends AndroidViewComponent {
   @SimpleFunction(description = "Add new Items to list at the end.")
   public void AddItems(List<Object> itemsList) {
     if (!itemsList.isEmpty()) {
-      int positionStart = dataModel.size();
-      int itemCount = itemsList.size();
       dataModel.addAll(itemsList);
+      // Appending leaves every existing index where it was, so the selection needs no adjustment.
       updateAdapterData();
-      listAdapterWithRecyclerView.notifyItemRangeChanged(positionStart, itemCount);
     }
   }
 
@@ -1310,8 +1390,11 @@ public final class ListView extends AndroidViewComponent {
         dataModel.addAt(index - 1, CreateElement(mainText, detailText, imageName));
       }
     }
+    if (selectionIndex >= index) {
+      // The new row pushed the selected item down one.
+      selectionIndex++;
+    }
     updateAdapterData();
-    listAdapterWithRecyclerView.notifyItemInserted(index - 1);
   }
 
   /**
@@ -1325,11 +1408,12 @@ public final class ListView extends AndroidViewComponent {
       return;
     }
     if (!itemsList.isEmpty()) {
-      int positionStart = index - 1;
-      int itemCount = itemsList.size();
-      dataModel.addAllAt(positionStart, itemsList);
+      dataModel.addAllAt(index - 1, itemsList);
+      if (selectionIndex >= index) {
+        // The new rows pushed the selected item down by however many went in.
+        selectionIndex += itemsList.size();
+      }
       updateAdapterData();
-      listAdapterWithRecyclerView.notifyItemRangeChanged(positionStart, itemCount);
     }
   }
 
@@ -1378,10 +1462,12 @@ public final class ListView extends AndroidViewComponent {
   }
 
   /**
-   * Deselect the item and update the data in adapter.
+   * Rebuilds the filtered view after the data changed and redraws the rows.
+   *
+   * <p>The selection is left alone: callers that change the item list adjust the selected index
+   * themselves, since only they know which rows moved and by how much.
    */
   public void updateAdapterData() {
-    SelectionIndex(0);
     // Data changed, so rebuild the filtered view (a no-op when unfiltered) and refresh.
     dataModel.refreshFilter();
     listAdapterWithRecyclerView.notifyDataSetChanged();
@@ -1407,7 +1493,15 @@ public final class ListView extends AndroidViewComponent {
     listAdapterWithRecyclerView.setOnItemClickListener(new ListAdapterWithRecyclerView.ClickListener() {
       @Override
       public void onItemClick(int position, View v) {
-        SelectionIndex(position + 1);
+        if (multiSelect) {
+          // A tap toggles: touching a row that is already picked takes it back out of the set.
+          // Either way the row just touched is what the Selection blocks go on to report.
+          listAdapterWithRecyclerView.toggleSelection(position);
+          selectionIndex = position + 1;
+          readSelectionTextFrom(position + 1);
+        } else {
+          SelectionIndex(position + 1);
+        }
         AfterPicking();
       }
     });

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/ListDataModelTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/ListDataModelTest.java
@@ -100,19 +100,81 @@ public class ListDataModelTest extends RobolectricTestBase {
   }
 
   /**
-   * Selection is kept while its item stays visible under a filter and dropped only once the
-   * filter hides it — the policy agreed with the reviewer.
+   * Filtering never changes the selection. It only decides which rows are on screen, so an item
+   * the filter hides is still the item the user picked and is still selected once the query is
+   * cleared. Whether to drop a selection the user can no longer see is {@link ListView}'s policy
+   * call, not the model's.
    */
   @Test
-  public void testSelectionKeptWhileVisibleAndPrunedWhenHidden() {
+  public void testFilteringLeavesTheSelectionAlone() {
     ListDataModel model = modelOf("apple", "banana", "cantaloupe", "date");
     model.selectSingle(1);  // banana, by original index
 
     applyFilter(model, "an");  // banana (1) still visible
     assertTrue(model.isSelected(1));
 
-    applyFilter(model, "date");  // banana now hidden
+    applyFilter(model, "date");  // banana is hidden now, but still the user's pick
+    assertFalse(model.isVisible(1));
+    assertTrue(model.isSelected(1));
+
+    applyFilter(model, "");  // and it is still there when the filter clears
+    assertTrue(model.isSelected(1));
+    assertEquals(1, model.firstSelection());
+  }
+
+  /** Removing an item drops its selection and moves the later ones down with their rows. */
+  @Test
+  public void testRemoveKeepsSelectionOnTheSameItems() {
+    ListDataModel model = modelOf("apple", "banana", "cantaloupe", "date");
+    model.toggleSelection(1);  // banana
+    model.toggleSelection(3);  // date
+
+    model.remove(1);  // banana goes, so date slides from index 3 to index 2
+
     assertFalse(model.isSelected(1));
+    assertTrue(model.isSelected(2));
+    assertEquals("date", model.get(2));
+  }
+
+  /** Inserting ahead of a selected item carries the selection along with it. */
+  @Test
+  public void testInsertShiftsSelectionThatMovedDown() {
+    ListDataModel model = modelOf("apple", "banana");
+    model.toggleSelection(1);  // banana
+
+    model.addAt(0, "apricot");  // banana slides from 1 to 2
+    assertTrue(model.isSelected(2));
+    assertEquals("banana", model.get(2));
+
+    model.addAllAt(0, Arrays.asList("acai", "almond"));  // and down another two
+    assertTrue(model.isSelected(4));
+    assertEquals("banana", model.get(4));
+  }
+
+  /** Appending leaves existing rows where they are, so the selection does not move. */
+  @Test
+  public void testAppendLeavesSelectionInPlace() {
+    ListDataModel model = modelOf("apple", "banana");
+    model.toggleSelection(0);
+
+    model.add("cantaloupe");
+    model.addAll(Arrays.asList("date", "elderberry"));
+
+    assertTrue(model.isSelected(0));
+    assertEquals(0, model.firstSelection());
+  }
+
+  /** Replacing or emptying the items drops the selection, because those items are gone. */
+  @Test
+  public void testReplacingItemsClearsSelection() {
+    ListDataModel model = modelOf("apple", "banana");
+    model.toggleSelection(1);
+
+    model.setItems(Arrays.asList("cherry", "damson"));
+    assertEquals(-1, model.firstSelection());
+
+    model.toggleSelection(0);
+    model.clear();
     assertEquals(-1, model.firstSelection());
   }
 

--- a/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
+++ b/appinventor/components/tests/com/google/appinventor/components/runtime/ListViewTest.java
@@ -119,6 +119,129 @@ public class ListViewTest extends RobolectricTestBase {
     assertEquals(0, listView1.SelectionIndex());
   }
 
+  /**
+   * With MultiSelect enabled, tapping rows builds up SelectedItems instead of replacing it, and
+   * tapping a selected row again removes it. Selection and SelectionIndex report the row that was
+   * touched last either way, including when that touch was the one that deselected it.
+   */
+  @Test
+  public void testMultiSelectAccumulatesTappedRows() {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe");
+    listView.Height(200);
+    listView.Width(320);
+    listView.MultiSelect(true);
+    initialize(listView);
+
+    assertTrue(getViewForPosition(listView, 0).performClick());
+    assertTrue(getViewForPosition(listView, 2).performClick());
+
+    assertEquals(2, listView.SelectedItems().size());
+    assertEquals("apple", listView.SelectedItems().getObject(0));
+    assertEquals("cantaloupe", listView.SelectedItems().getObject(1));
+    // The last row touched is what the singular blocks report.
+    assertEquals(3, listView.SelectionIndex());
+    assertEquals("cantaloupe", listView.Selection());
+
+    // Tapping an already selected row takes it back out of the set.
+    assertTrue(getViewForPosition(listView, 0).performClick());
+    assertEquals(1, listView.SelectedItems().size());
+    assertEquals("cantaloupe", listView.SelectedItems().getObject(0));
+    assertEquals(1, listView.SelectionIndex());
+  }
+
+  /**
+   * Without MultiSelect, each tap replaces the previous selection, so SelectedItems never holds
+   * more than the one element the user last picked.
+   */
+  @Test
+  public void testSingleSelectReplacesTheSelection() {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe");
+    listView.Height(200);
+    listView.Width(320);
+    initialize(listView);
+
+    assertTrue(getViewForPosition(listView, 0).performClick());
+    assertTrue(getViewForPosition(listView, 2).performClick());
+
+    assertEquals(1, listView.SelectedItems().size());
+    assertEquals("cantaloupe", listView.SelectedItems().getObject(0));
+    assertEquals(3, listView.SelectionIndex());
+  }
+
+  /**
+   * Filtering must not throw away a set the user is building with MultiSelect: an item the filter
+   * hides stays selected and is still there once the query is cleared.
+   */
+  @Test
+  public void testMultiSelectKeepsSelectionThroughFiltering() throws InterruptedException {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe,date");
+    listView.Height(200);
+    listView.Width(320);
+    listView.MultiSelect(true);
+    initialize(listView);
+
+    assertTrue(getViewForPosition(listView, 0).performClick());  // apple
+    assertTrue(getViewForPosition(listView, 3).performClick());  // date
+    assertEquals(2, listView.SelectedItems().size());
+
+    EditText filterBox = (EditText) ((LinearLayout) listView.getView()).getChildAt(0);
+    filterBox.setText("an");  // hides both apple and date
+    Thread.sleep(100);  // Filtering runs on a separate thread for performance reasons
+    runAllEvents();
+    assertEquals(2, listView.SelectedItems().size());
+
+    filterBox.setText("");
+    Thread.sleep(100);
+    runAllEvents();
+    assertEquals(2, listView.SelectedItems().size());
+    assertEquals("apple", listView.SelectedItems().getObject(0));
+    assertEquals("date", listView.SelectedItems().getObject(1));
+  }
+
+  /**
+   * Removing an item above the selected one keeps the selection on the item the user picked,
+   * rather than leaving the index pointing at whatever slid into its place.
+   */
+  @Test
+  public void testRemoveItemKeepsSelectionOnTheSameItem() {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe,date");
+    listView.Height(200);
+    listView.Width(320);
+
+    listView.SelectionIndex(4);  // date
+    listView.RemoveItemAtIndex(2);  // banana goes, so date moves from 4 to 3
+
+    assertEquals(3, listView.SelectionIndex());
+    assertEquals("date", listView.Selection());
+
+    listView.RemoveItemAtIndex(3);  // removing date itself clears what the blocks report
+    assertEquals(0, listView.SelectionIndex());
+    assertEquals("", listView.Selection());
+  }
+
+  /**
+   * An index outside the list selects nothing, so SelectionIndex reports 0 rather than keeping a
+   * number that points at no row — which is what its documentation has always promised.
+   */
+  @Test
+  public void testOutOfRangeSelectionIndexReportsNothingSelected() {
+    ListView listView = new ListView(getForm());
+    listView.ElementsFromString("apple,banana,cantaloupe");
+    listView.Height(200);
+    listView.Width(320);
+
+    listView.SelectionIndex(2);
+    listView.SelectionIndex(99);
+
+    assertEquals(0, listView.SelectionIndex());
+    assertEquals("", listView.Selection());
+    assertEquals(0, listView.SelectedItems().size());
+  }
+
   private View getViewForPosition(ListView listView, int position) {
     LinearLayout listLayout = (LinearLayout) ((LinearLayout) listView.getView()).getChildAt(1);
     RecyclerView rv = (RecyclerView) listLayout.getChildAt(0);

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -913,13 +913,29 @@ This is a visible component that displays a list of text and image elements in y
 {:id="ListView.ListViewLayout" .number} *ListViewLayout*
 : Specifies type of layout for ListView row.
 
+{:id="ListView.MultiSelect" .boolean} *MultiSelect*
+: Whether the user can select more than one element at a time. `true`{:.logic.block} makes a tap
+ add a row to, or remove it from, [`SelectedItems`](#ListView.SelectedItems); `false`{:.logic.block} makes each
+ tap replace the previous selection.
+
+ Turning this on or off clears whatever is selected at the time, since a set built up in one
+ mode has no meaning in the other.
+
 {:id="ListView.Orientation" .number} *Orientation*
 : Specifies the layout's orientation. This may be: `Vertical`, which displays elements
  in rows one after the other; or `Horizontal`, which displays one element at a time and
  allows the user to swipe left or right to brows the elements.
 
+{:id="ListView.SelectedItems" .list .ro .bo} *SelectedItems*
+: Returns every element the user has selected, in the order they were picked. Unless
+ [`MultiSelect`](#ListView.MultiSelect) is enabled this holds at most one element, since selecting a
+ row replaces the previous selection.
+
 {:id="ListView.Selection" .text} *Selection*
 : Returns the text in the `ListView` at the position of [`SelectionIndex`](#ListView.SelectionIndex).
+
+ While [`MultiSelect`](#ListView.MultiSelect) is enabled this is the text of the row the user touched
+ last. Read [`SelectedItems`](#ListView.SelectedItems) for every element that is selected now.
 
 {:id="ListView.SelectionColor" .color} *SelectionColor*
 : The color of the item when it is selected.
@@ -932,6 +948,9 @@ This is a visible component that displays a list of text and image elements in y
  will be `0`. If an attempt is made to set this to a number less than `1` or greater than the
  number of items in the `ListView`, `SelectionIndex` will be set to `0`, and
  [`Selection`](#ListView.Selection) will be set to the empty text.
+
+ While [`MultiSelect`](#ListView.MultiSelect) is enabled this is the row the user touched last, which
+ may have been touched to deselect it. Read [`SelectedItems`](#ListView.SelectedItems) for what is selected now.
 
 {:id="ListView.ShowFilterBar" .boolean} *ShowFilterBar*
 : Sets visibility of the filter bar. `true`{:.logic.block} will show the bar,
@@ -975,6 +994,9 @@ This is a visible component that displays a list of text and image elements in y
 {:id="ListView.AfterPicking"} AfterPicking()
 : Simple event to be raised after the an element has been chosen in the list.
  The selected element is available in the [`Selection`](#ListView.Selection) property.
+
+ While [`MultiSelect`](#ListView.MultiSelect) is enabled this is raised for every tap, including a tap
+ that takes a row back out of [`SelectedItems`](#ListView.SelectedItems).
 
 ### Methods  {#ListView-Methods}
 


### PR DESCRIPTION
**What does this PR accomplish?**

**PR #4062 should be merged before this PR**


*Description*

Makes the ListView's `MultiSelect` property visible in the designer and the blocks
on both Android and iOS, and adds a `SelectedItems` property so an app can read
everything the user picked.


**Context for the changes**

This changes component runtime code that runs on the device on both platforms, so
it is based on `ucr`.

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [x] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [x] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [x] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [x] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
