### PR TITLE
Fix Clock date parsing using wrong calendar on non-Gregorian locales …

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/Dates.java
@@ -145,7 +145,7 @@ public final class Dates {
     };
     for (String format : formats) {
       try {
-        return new SimpleDateFormat(format).parse(value);
+        return new SimpleDateFormat(format, java.util.Locale.US).parse(value);
       } catch (ParseException e) {}
     }
     throw new IllegalArgumentException("illegal date/time format in function DateValue()");
@@ -199,11 +199,11 @@ public final class Dates {
    */
   @SimpleFunction
   public static String FormatDateTime(Calendar date, String pattern) {
-    SimpleDateFormat formatdate = new SimpleDateFormat();
+    SimpleDateFormat formatdate = new SimpleDateFormat("", java.util.Locale.US);
     if (pattern.length() == 0) {
-      formatdate.applyPattern("MMM d, yyyy hh:mm:ss a");
+      SimpleDateFormat formatdate = new SimpleDateFormat("MMM d, yyyy hh:mm:ss a", java.util.Locale.US);
     } else {
-      formatdate.applyPattern(pattern);
+      SimpleDateFormat formatdate = new SimpleDateFormat("", java.util.Locale.US);
     }
     return formatdate.format(date.getTime());
   }
@@ -219,7 +219,7 @@ public final class Dates {
    */
   @SimpleFunction
   public static String FormatDate(Calendar date, String pattern) {
-    SimpleDateFormat formatdate = new SimpleDateFormat();
+    SimpleDateFormat formatdate = new SimpleDateFormat("", java.util.Locale.US);
     if (pattern.length() == 0) {
       formatdate.applyPattern("MMM d, yyyy");
     } else {


### PR DESCRIPTION

Fixes #3984

SimpleDateFormat instances in Dates.java were created without a Locale,  causing them to use the device's default calendar system. On non-Gregorian  locales (e.g. Thai, which uses the Buddhist calendar), this silently  misparsed and misformatted dates by 543 years.

Fixed by explicitly specifying Locale.US for all internal date parsing/ formatting in Dates.java (lines 148, 202, 204, 206, 222), ensuring  consistent Gregorian-calendar behavior regardless of device locale.

Note: WeekdayName/MonthName functions were intentionally left unchanged,  as they should continue using the device locale for display purposes.

iOS equivalent fix (Clock.swift) not yet included in this PR.

<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*

<!--
SimpleDateFormat instances in Dates.java were created without a Locale, 
causing them to use the device's default calendar system. On non-Gregorian 
locales (e.g. Thai, which uses the Buddhist calendar), this silently 
misparsed and misformatted dates by 543 years — any saved date, age 
calculation, or countdown would be wrong with no error or crash.

Fixed by explicitly specifying Locale.US for all internal date parsing/
formatting in Dates.java (lines 148, 202, 204, 206, 222), ensuring 
consistent Gregorian-calendar behavior regardless of device locale.

Note: WeekdayName/MonthName functions were intentionally left unchanged, 
as they should continue using the device locale for display purposes.

iOS equivalent fix (Clock.swift) not yet included in this PR.
--->

*Testing Guidelines*

<!--
1. Set device/emulator locale to Thai (th-TH).
2. In an App Inventor project, call `Clock.MakeInstant("06/10/2026")`.
3. Before the fix: the returned year is 1483 (Buddhist-calendar 
   misinterpretation). After the fix: the returned year is correctly 2026.
4. Repeat with `Clock.FormatDate` / `Clock.FormatDateTime` on a known 
   Gregorian date and confirm the formatted output matches, regardless 
   of device locale.
-->

Fixes # .

<!--
3984.


-->

Resolves # .

**3984**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
