### PR TITLE
Fix lexvar bug with globals declared as dicts

### DIFF
--- a/appinventor/blocklyeditor/src/warningHandler.js
+++ b/appinventor/blocklyeditor/src/warningHandler.js
@@ -834,7 +834,7 @@ Blockly.WarningHandler.keyCacheHelper = function(block) {
 
 Blockly.WarningHandler.prototype.getDictionaryKeyBlocks_ = function(block) {
   return block.inputList.map(function(input) {
-    var pair = input.connection.targetBlock();
+    var pair = input.connection && input.connection.targetBlock();
     if (pair) {
       return {
         pair: pair,


### PR DESCRIPTION
Change-Id: Icda2010621fd659087d8af71fa25d90bf4313c41

**What does this PR accomplish?**

Fixes the bug reported here: https://community.appinventor.mit.edu/t/blocks-editor-slow-to-recognize-local-variables-in-new-block-pulldowns/175322?u=ewpatton

*Description*

If a global decl block is set to an empty dictionary, an uncaught error prevents the lexical variable dropdown from populating correctly.

*Testing Guidelines*

ABG provides a test project to verify the bug.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine
