### PR TITLE
Speed up Android builds via parallel D8 dexing

### DIFF
--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunD8.java
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/tasks/android/RunD8.java
@@ -1,5 +1,5 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2023 MIT, All rights reserved
+// Copyright 2023-2026 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
@@ -23,11 +23,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @BuildType(aab = true, apk = true)
 public class RunD8 extends DexTask implements AndroidTask {
@@ -46,9 +49,18 @@ public class RunD8 extends DexTask implements AndroidTask {
 
       final Set<String> criticalJars = getCriticalJars(context);
 
-      for (String jar : criticalJars) {
-        inputs.add(preDexLibrary(context, recordForMainDex(
-            new File(context.getResource(jar)), mainDexClasses)));
+      try {
+        Set<File> parallelResults = criticalJars.parallelStream().map(jar -> {
+          try {
+            return preDexLibrary(context, recordForMainDex(new File(context.getResource(jar)), mainDexClasses));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }).collect(Collectors.toSet());
+        // Adding parallel results to existing list
+        inputs.addAll(parallelResults);
+      } catch (Exception e) {
+        throw new IOException(e);
       }
 
       // Only include ACRA for the companion app
@@ -57,29 +69,54 @@ public class RunD8 extends DexTask implements AndroidTask {
             new File(context.getResources().getAcraRuntime()), mainDexClasses)));
       }
 
-      for (String jar : context.getResources().getSupportJars()) {
-        if (criticalJars.contains(jar)) {  // already covered above
-          continue;
-        }
-        inputs.add(preDexLibrary(context, new File(context.getResource(jar))));
+      final List<String> supportJars = Arrays.asList(context.getResources().getSupportJars());
+      try {
+        Set<File> parallelResults = supportJars.parallelStream()
+            .filter(jar -> !criticalJars.contains(jar)) // already covered above
+            .map(jar -> {
+              try {
+                return preDexLibrary(context, new File(context.getResource(jar)));
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            })
+            .collect(Collectors.toSet());
+        // Adding parallel results to existing list
+        inputs.addAll(parallelResults);
+      } catch (Exception e) {
+        throw new IOException(e);
       }
 
       // Add the rest of the libraries in any order
-      for (String lib : context.getComponentInfo().getUniqueLibsNeeded()) {
-        inputs.add(preDexLibrary(context, new File(lib)));
+      try {
+        Set<File> parallelResults = context.getComponentInfo().getUniqueLibsNeeded().parallelStream().map(lib -> {
+          try {
+            return preDexLibrary(context, new File(lib));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }).collect(Collectors.toSet());
+        // Adding parallel results to existing list
+        inputs.addAll(parallelResults);
+      } catch (Exception e) {
+        throw new IOException(e);
       }
 
       // Add extension libraries
-      Set<String> addedExtJars = new HashSet<>();
-      for (String type : context.getExtCompTypes()) {
-        String sourcePath = ExecutorUtils.getExtCompDirPath(type, context.getProject(),
-            context.getExtTypePathCache())
-            + context.getResources().getSimpleAndroidRuntimeJarPath();
-        if (!addedExtJars.contains(sourcePath)) {
-          inputs.add(new File(sourcePath));
-          addedExtJars.add(sourcePath);
-        }
-      }
+      Set<String> addedExtJars = ConcurrentHashMap.newKeySet();
+      Set<File> parallelResults = context.getExtCompTypes().parallelStream()
+          .map(type -> {
+            String sourcePath = ExecutorUtils.getExtCompDirPath(type, context.getProject(),
+                context.getExtTypePathCache())
+                + context.getResources().getSimpleAndroidRuntimeJarPath();
+            if (addedExtJars.add(sourcePath)) {
+              return new File(sourcePath);
+            }
+            return null;
+          })
+          .filter(file -> file != null)
+          .collect(Collectors.toSet());
+      inputs.addAll(parallelResults);
 
       Files.walkFileTree(context.getPaths().getClassesDir().toPath(), new FileVisitor<Path>() {
         @Override


### PR DESCRIPTION
**What does this PR accomplish?**
This PR introduces Java parallel streams (.parallelStream()) to the D8 dexing process in the buildserver module. By running the D8 dexing tasks in parallel across available CPU cores, this optimization significantly speeds up the compilation/dexing phase during app builds.

*Testing Guidelines*
1. Build sample apps (both small projects and larger projects with multiple components/extensions) to verify that the D8 dexing phase executes without errors.
2. Observe and compare build duration times to verify performance improvements during the dexing phase.
3. Ensure the resulting APKs install and run correctly on a device or emulator.

Fixes # .

Resolves # .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion
- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch
- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine