### PR TITLE
Do not send vestigial YAIL files to the buildserver

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -82,10 +82,13 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 
@@ -548,6 +551,18 @@ public final class YoungAndroidProjectService extends CommonProjectService {
     for (String buildOutputFile : buildOutputFiles) {
       storageIo.deleteFile(userId, projectId, buildOutputFile);
     }
+
+    // A partially failed screen deletion can leave behind a vestigial YAIL file
+    // with no corresponding .scm/.bky files. The client does not show such a
+    // screen, so the user has no way to remove the file, and sending it to the
+    // buildserver makes the build fail. Delete any orphaned YAIL files before
+    // packaging the project.
+    List<String> sourceFiles = storageIo.getProjectSourceFiles(userId, projectId);
+    for (String yailFile : findVestigialYailFiles(sourceFiles)) {
+      LOG.warning("Deleting vestigial YAIL file " + yailFile + " in project " + projectId);
+      storageIo.deleteFile(userId, projectId, yailFile);
+    }
+
     URL buildServerUrl = null;
     ProjectSourceZip zipFile = null;
     try {
@@ -664,6 +679,34 @@ public final class YoungAndroidProjectService extends CommonProjectService {
       return new RpcResult(false, "", wrappedException.getMessage());
     }
     return new RpcResult(true, "Building " + projectName, "");
+  }
+
+  /**
+   * Returns the YAIL files in {@code fileNames} that have neither a
+   * corresponding form (.scm) file nor a corresponding blocks (.bky) file.
+   *
+   * <p>A YAIL file can be orphaned by a partially failed screen deletion.
+   * The client does not show such a screen, so the user cannot remove the
+   * file, and the buildserver fails the build when it receives a YAIL file
+   * for a screen that does not otherwise exist.
+   *
+   * @param fileNames the names of the project's source files
+   * @return the names of the vestigial YAIL files, possibly empty
+   */
+  @VisibleForTesting
+  static List<String> findVestigialYailFiles(List<String> fileNames) {
+    Set<String> files = new HashSet<>(fileNames);
+    List<String> vestigialYailFiles = new ArrayList<>();
+    for (String fileName : fileNames) {
+      if (fileName.startsWith(SRC_FOLDER + "/") && fileName.endsWith(YAIL_FILE_EXTENSION)) {
+        String base = fileName.substring(0, fileName.length() - YAIL_FILE_EXTENSION.length());
+        if (!files.contains(base + FORM_PROPERTIES_EXTENSION)
+            && !files.contains(base + BLOCKLY_SOURCE_EXTENSION)) {
+          vestigialYailFiles.add(fileName);
+        }
+      }
+    }
+    return vestigialYailFiles;
   }
 
   public RpcResult loginToGallery(String userId) {

--- a/appinventor/appengine/tests/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectServiceTest.java
+++ b/appinventor/appengine/tests/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectServiceTest.java
@@ -5,15 +5,65 @@
 
 package com.google.appinventor.server.project.youngandroid;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import junit.framework.TestCase;
 import org.junit.Test;
 
 public class YoungAndroidProjectServiceTest extends TestCase {
-	
+
+  private static final String SCREEN1 = "src/appinventor/ai_test/TestProject/Screen1";
+  private static final String SCREEN2 = "src/appinventor/ai_test/TestProject/Screen2";
+
   /* Testing the case of a null build URL */
   @Test
   public void testBuildErrorMsgDoesntThrowNPE() {
     YoungAndroidProjectService obj = new YoungAndroidProjectService(null);
-    obj.buildErrorMsg("TestException", null, "userID", 0); 
+    obj.buildErrorMsg("TestException", null, "userID", 0);
+  }
+
+  @Test
+  public void testFindVestigialYailFilesFlagsYailWithoutScmOrBky() {
+    List<String> files = Arrays.asList(
+        "youngandroidproject/project.properties",
+        SCREEN1 + ".scm", SCREEN1 + ".bky", SCREEN1 + ".yail",
+        SCREEN2 + ".yail");
+    assertEquals(Collections.singletonList(SCREEN2 + ".yail"),
+        YoungAndroidProjectService.findVestigialYailFiles(files));
+  }
+
+  @Test
+  public void testFindVestigialYailFilesKeepsCompleteScreens() {
+    List<String> files = Arrays.asList(
+        "youngandroidproject/project.properties",
+        SCREEN1 + ".scm", SCREEN1 + ".bky", SCREEN1 + ".yail",
+        SCREEN2 + ".scm", SCREEN2 + ".bky", SCREEN2 + ".yail");
+    assertTrue(YoungAndroidProjectService.findVestigialYailFiles(files).isEmpty());
+  }
+
+  @Test
+  public void testFindVestigialYailFilesKeepsYailWithOnlyScm() {
+    List<String> files = Arrays.asList(SCREEN1 + ".scm", SCREEN1 + ".yail");
+    assertTrue(YoungAndroidProjectService.findVestigialYailFiles(files).isEmpty());
+  }
+
+  @Test
+  public void testFindVestigialYailFilesKeepsYailWithOnlyBky() {
+    List<String> files = Arrays.asList(SCREEN1 + ".bky", SCREEN1 + ".yail");
+    assertTrue(YoungAndroidProjectService.findVestigialYailFiles(files).isEmpty());
+  }
+
+  @Test
+  public void testFindVestigialYailFilesIgnoresFilesOutsideSrc() {
+    List<String> files = Arrays.asList("assets/external_comps/comp/comp.yail");
+    assertTrue(YoungAndroidProjectService.findVestigialYailFiles(files).isEmpty());
+  }
+
+  @Test
+  public void testFindVestigialYailFilesEmptyProject() {
+    assertTrue(YoungAndroidProjectService.findVestigialYailFiles(
+        Collections.<String>emptyList()).isEmpty());
   }
 }


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

A partially failed screen deletion can leave a project with a vestigial `.yail` file whose corresponding `.scm`/`.bky` files are gone. The client does not show such a screen, so the user has no way to remove the file, and the build fails because the buildserver receives a YAIL file for a screen that does not otherwise exist (see the forum thread linked in #3939).

Following the approach suggested in the issue discussion, `YoungAndroidProjectService.build()` now checks, before packaging the project for the buildserver, that each `src/**/*.yail` file still has a corresponding `.scm` or `.bky` file. Vestigial YAIL files are deleted (with a log warning) before the export:

- Because the check runs at `build()` time, it protects every `StorageIo` implementation. (`ObjectifyStorageIo.exportProjectSourceZip` already filters incomplete screen file sets for buildserver exports, but that logic is not shared by other storage backends.)
- Deleting the file, rather than only filtering it out of the ZIP, also cleans up the vestigial YAIL files left over from before, per the cost-savings note in the issue.
- A YAIL file is only treated as vestigial when *both* the `.scm` and the `.bky` files are missing — the "(or .bky)" reading of the suggestion in the issue — so a screen that still has either of its editable files is never touched. This is deliberately narrower than the screen-count filter in `ObjectifyStorageIo`.

*Testing Guidelines*

- `ant AiServerLibTests` — new unit tests in `YoungAndroidProjectServiceTest` cover the helper: an orphaned YAIL file is flagged; complete screens are kept; a YAIL file is kept when either an `.scm` or a `.bky` file still exists; files outside `src/` are ignored.
- Manual: remove `ScreenX.scm` and `ScreenX.bky` from a project at the storage level while leaving `ScreenX.yail` (the failure mode @ewpatton describes in the issue). Building the project previously failed; with this change the build succeeds and the vestigial `ScreenX.yail` is deleted from the project.
- Local `ant tests` note (macOS): every suite passes except the GWT client test `OdeTest.testCompareLocales`, which fails identically on unmodified `master` in my environment (JDK 11 and 17), so it is unrelated to this change.

Fixes #3939.

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine (1533 JUnit + 140 Karma tests, `BUILD SUCCESSFUL`; the only exception is the pre-existing `OdeTest` environment error noted above, which is identical on unmodified `master`)
