### PR TITLE
Fix Circular Progress Color property not working on iOS

### DIFF
--- a/appinventor/components-ios/src/CircularProgress.swift
+++ b/appinventor/components-ios/src/CircularProgress.swift
@@ -5,8 +5,11 @@
 
 import Foundation
 
+fileprivate let kCircularProgressDefaultColor = Color.blue.int32
+
 public class CircularProgress: ViewComponent, AbstractMethodsForViewComponent {
   private let _view: CircularProgressView
+  private var _color: Int32 = kCircularProgressDefaultColor
   
   public override init(_ parent: ComponentContainer) {
     _view = CircularProgressView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
@@ -25,10 +28,11 @@ public class CircularProgress: ViewComponent, AbstractMethodsForViewComponent {
   
   @objc open var Color: Int32 {
     get {
-      return _view.progressLayer.strokeColor as! Int32
+      return _color
     }
     set(argb) {
-      _view.progressLayer.strokeColor = argbToColor(argb).cgColor
+      _color = argb
+      _view.progressColor = argbToColor(argb == AIComponentKit.Color.default.int32 ? kCircularProgressDefaultColor : argb)
     }
   }
 
@@ -48,6 +52,12 @@ public class CircularProgress: ViewComponent, AbstractMethodsForViewComponent {
 class CircularProgressView: UIView {
   let progressLayer = CAShapeLayer()
   let backgroundLayer = CAShapeLayer()
+  
+  var progressColor: UIColor = Color.blue.uiColor {
+    didSet {
+      progressLayer.strokeColor = progressColor.cgColor
+    }
+  }
   
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -96,7 +106,7 @@ class CircularProgressView: UIView {
     
     progressLayer.path = progressPath.cgPath
     progressLayer.lineWidth = lineWidth
-    progressLayer.strokeColor = Color.blue.uiColor.cgColor
+    progressLayer.strokeColor = progressColor.cgColor
     progressLayer.fillColor = UIColor.clear.cgColor
     progressLayer.strokeEnd = 0
     


### PR DESCRIPTION
## What does this PR accomplish?

Fixes #4021

On iOS, the `Color` property of the `CircularProgress` component did not work correctly. Custom colors selected in the Designer or set through blocks were reset to the default blue during subsequent layout updates.

The issue was caused by two problems in `appinventor/components-ios/src/CircularProgress.swift`:

1. `updateViews()` hardcoded the progress layer's `strokeColor` to blue. Since `updateViews()` is called during layout updates, any custom color set by the `Color` setter could be overwritten.
2. The `Color` getter attempted to cast the layer's `CGColor` directly to `Int32`, which could cause a runtime crash when the property was read.

### Changes made

- Store the selected color as an ARGB `Int32` in the component.
- Return the stored value from the `Color` getter.
- Add a `progressColor` property to `CircularProgressView`.
- Use `progressColor` when updating the progress layer instead of hardcoding blue.
- Preserve the default blue color when `Color.Default` is used.

The implementation follows the existing color-handling pattern used by `LinearProgress` in the iOS component code.

No Android code was changed, and no new API or property was introduced.

### Testing

I verified the logic by reviewing the color setter/getter and layout update flow:

- Default `Color` → blue.
- Custom color → applied to the progress indicator.
- Custom color remains after subsequent layout passes.
- Setting the color back to `Color.Default` → blue.
- Reading the `Color` property returns the stored ARGB value without the previous invalid cast.


### Checklist


- [x] No Android files were modified.
- [x] No new user-facing API was introduced.
- [x] No documentation update is required.
- [x] No unnecessary formatting or whitespace changes were made.
