### PR TITLE
Add polling for TTS initialization before reporting error

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/TextToSpeech.java
@@ -8,12 +8,12 @@ package com.google.appinventor.components.runtime;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 
 import android.media.AudioManager;
+import android.os.Handler;
 import android.util.Log;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
@@ -76,6 +76,12 @@ public class TextToSpeech extends AndroidNonvisibleComponent
   private float pitch = 1.0f;
   private float speechRate = 1.0f;
   private static final String LOG_TAG = "TextToSpeech";
+
+  // Delay (ms) between retries while waiting for the TTS engine to finish initializing.
+  private static final int PREPARE_TTS_RETRY_DELAY = 100;
+  // Max number of retries before giving up and reporting ERROR_TTS_NOT_READY.
+  private static final int PREPARE_TTS_MAX_RETRIES = 120;
+  private final Handler prepareTtsHandler = new Handler();
 
   static {
     initLocaleMaps();
@@ -379,18 +385,26 @@ public class TextToSpeech extends AndroidNonvisibleComponent
   }
 
   public void prepareLanguageAndCountryProperties() {
-    if (!isTtsPrepared) {
-      if (!tts.isInitialized()) {
-        form.dispatchErrorOccurredEvent(this, "TextToSpeech",
-            ErrorMessages.ERROR_TTS_NOT_READY);
-        // Force the TTS engine to initialize by making it speak.
-        // If it's not ready the user will have to try again.
-        // Should we put a retry wait here?
-        Speak("");
-      } else {
-        getLanguageAndCountryLists();
-        isTtsPrepared = true;
-      }
+    prepareLanguageAndCountryProperties(0);
+  }
+
+  private void prepareLanguageAndCountryProperties(final int retries) {
+    if (isTtsPrepared) {
+      return;
+    }
+    if (tts.isInitialized()) {
+      getLanguageAndCountryLists();
+      isTtsPrepared = true;
+    } else if (retries >= PREPARE_TTS_MAX_RETRIES) {
+      form.dispatchErrorOccurredEvent(this, "TextToSpeech",
+          ErrorMessages.ERROR_TTS_NOT_READY);
+    } else {
+      prepareTtsHandler.postDelayed(new Runnable() {
+        @Override
+        public void run() {
+          prepareLanguageAndCountryProperties(retries + 1);
+        }
+      }, PREPARE_TTS_RETRY_DELAY);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to MIT App Inventor. Please answer the following questions to help us review your changes.
If an item does not apply to this PR, leave the check box unselected.
-->

**What does this PR accomplish?**
This PR fixes the bug mentioned in this community thread:
https://community.appinventor.mit.edu/t/text-to-speech-block-doesnt-work/175761/25
<!--
Please describe below why the PR is needed, what it adds/fixes, etc.
--->

*Description*
Function prepareLanguageAndCountryProperties() checked tts.isInitialized() only
once and immediately dispatched an error if the engine wasn't ready
yet, triggering false ERROR_TTS_NOT_READY (2701) reports. Now it retries with a short
delay (100ms, up to 120 times / ~12s) before giving up, matching the
retry budget already used by InternalTextToSpeech.speak().
<!--
Please describe below how to test the changes in the PR.
--->

*Testing Guidelines*

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes # .

<!--
If this resolves an enhancement/feature request issue, please note it here (otherwise, delete)
-->

Resolves # .

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [ ] I have made no changes that affect the companion

- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [x] I have made no changes that affect the master branch

- [ ] I branched from `master`
- [ ] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [ ] My code follows the:
    - [x] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [ ] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine
