### PR TITLE
Add resizeWarningToggle

### DIFF
--- a/appinventor/blocklyeditor/src/warningIndicator.js
+++ b/appinventor/blocklyeditor/src/warningIndicator.js
@@ -250,7 +250,28 @@ Blockly.WarningIndicator.prototype.updateWarningToggleText = function() {
   } else {
     this.warningToggleText_.textContent = Blockly.Msg.SHOW_WARNINGS;
   }
+  this.resizeWarningToggle_();
 }
+
+/**
+ * Resize the warning toggle to fit its current label.
+ *
+ * @private
+ */
+Blockly.WarningIndicator.prototype.resizeWarningToggle_ = function() {
+  var textWidth = this.warningToggleText_.getComputedTextLength();
+  if (textWidth === 0) {
+    requestAnimationFrame(this.resizeWarningToggle_.bind(this));
+    return;
+  }
+
+  var left = -15;
+  var horizontalPadding = 16;
+  var width = Math.ceil(textWidth + horizontalPadding);
+  this.warningToggle_.setAttribute('width', width);
+  this.warningToggleText_.setAttribute(
+      'transform', 'translate(' + (left + width / 2) + ', 35)');
+};
 
 /**
  * Call to change the current warning state on all screens.
@@ -291,10 +312,11 @@ Blockly.WarningIndicator.prototype.onclickErrorNavNext = function() {
  *     are already on the workspace.
  */
 Blockly.WarningIndicator.prototype.position = function(metrics, savedPositions) {
+  this.resizeWarningToggle_();
   this.position_(metrics);
 }
 
 Blockly.WarningIndicator.prototype.getBoundingRectangle = function() {
-  var width = 120;  // TODO: this is a guess
+  var width = Number(this.warningToggle_.getAttribute('width'));
   return new Blockly.utils.Rect(this.left_, this.left_ + width, this.top_, this.top_ + this.INDICATOR_HEIGHT_)
 }


### PR DESCRIPTION
**What does this PR accomplish?**
- Resize warning toggle to fit its current label, invoked when toggle text is updated (Show Warning/Hide Warning) and after dom creation.
- Refactor getBoundingRectangle code to always fetch the correct width of the warning toggle.

*Description*

_Issue_
<img width="595" height="184" alt="image" src="https://github.com/user-attachments/assets/3ed3f327-783d-4328-bbf0-e13ee34d609a" />

_Fixed now_
<img width="595" height="184" alt="image" src="https://github.com/user-attachments/assets/9a567fcc-ce85-4a94-9a2b-58512aafab88" />



*Testing Guidelines*
1. Change language from English to Magyar.
2. The warning toggle should now resize automatically.
3. Click on warning toggle to update its text, it will resize automatically now.

<!--
If this fixes a known issue, please note it here (otherwise, delete)
-->

Fixes #2484

**Context for the changes**

If this PR changes anything related to the companion make sure you have used the `ucr` branch. For all other changes use `master` or provide context for having used a different branch.
See a summary of git branches in the docs: [App Inventor Developer Overview](https://docs.google.com/document/u/1/d/1hIvAtbNx-eiIJcTA2LLPQOawctiGIpnnt0AvfgnKBok/pub#h.g4ai8y7wpbh6)

<!--
This section pertains to changes to the components module that affect the code running on the Android device.
-->

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

- [ ] I branched from `ucr`
- [ ] My pull request has `ucr` as the base

Further, if you've changed the blocks language or another user-facing designer/blocks API (added a SimpleProperty, etc.):

- [ ] I have updated the corresponding version number in appinventor/components/src/.../common/YaVersion.java
- [ ] I have updated the corresponding upgrader in appinventor/appengine/src/.../client/youngandroid/YoungAndroidFormUpgrader.java (components only)
- [ ] I have updated the corresponding entries in appinventor/blocklyeditor/src/versioning.js

<!--
This section pertains to changes that affect appengine, blocklyeditor (except changes to block semantics), buildserver, components (but not changes to runtime), and docs.
-->

For all other changes:

- [ ] I have made no changes that affect the master branch

- [x] I branched from `master`
- [x] My pull request has `master` as the base


**General items:**

- [ ] I have updated the relevant documentation files under docs/
- [x] My code follows the:
    - [ ] [Google Java style guide](https://google.github.io/styleguide/javaguide.html) (for .java files)
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [ ] [Swift style guide](https://google.github.io/swift/) (for .swift files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine