### PR TITLE
Fix iOS GetBackgroundPixelColor with sprites

### DIFF
--- a/appinventor/components-ios/src/Canvas.swift
+++ b/appinventor/components-ios/src/Canvas.swift
@@ -760,7 +760,17 @@ public class Canvas: ViewComponent, AbstractMethodsForViewComponent, UIGestureRe
 
     let colorSpace = CGColorSpaceCreateDeviceRGB()
     let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+    let wasHidden = _sprites.map { $0.DisplayLayer.isHidden }
 
+    for sprite in _sprites {
+      sprite.DisplayLayer.isHidden = true
+    }
+
+    defer {
+      for (index, sprite) in _sprites.enumerated() {
+        sprite.DisplayLayer.isHidden = wasHidden[index]
+      }
+    }
     if let context = CGContext(data: &pixel, width: 1, height: 1, bitsPerComponent: 8,
                                bytesPerRow: 4, space: colorSpace, bitmapInfo: bitmapInfo.rawValue) {
       context.translateBy(x: -CGFloat(x), y: -CGFloat(y))
@@ -811,6 +821,8 @@ public class Canvas: ViewComponent, AbstractMethodsForViewComponent, UIGestureRe
           }
         }
       }
+    } else if let ball = sprite as? Ball {
+      return ball.PaintColor
     }
     return GetBackgroundPixelColor(x, y)
   }


### PR DESCRIPTION
## Description

Fixes #4083.

On iOS, `GetBackgroundPixelColor` renders `_view.layer`, which also contains
sprite layers. As a result, a sprite could incorrectly affect the returned
background color.

This change temporarily hides sprite layers while sampling the background
and restores their previous visibility afterward.

`GetPixelColor` also handles `Ball` directly using its `PaintColor`, preserving
sprite color behavior after sprites are excluded from background sampling.

## Testing

- `git diff --check` passes.
- Verified the change is limited to `Canvas.swift`.
- iOS runtime testing is still required on macOS/Xcode.