### PR TITLE
Include comment bubbles when downloading blocks as an image

### DIFF
--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -66,6 +66,52 @@ goog.provide('AI.Blockly.ExportBlocksImage');
     return css;
   }
 
+  var SVG_NS = 'http://www.w3.org/2000/svg';
+
+  /**
+   * Assembles the part of a workspace that belongs in an exported image: the
+   * block canvas plus the comment bubbles from the bubble canvas. The two
+   * canvases share one transform, so with it removed their children line up.
+   * Mutator bubbles, warning bubbles and the backpack flyout also live on the
+   * bubble canvas and are deliberately left out.
+   * @param {!Blockly.WorkspaceSvg} workspace The workspace to export.
+   * @return {{group: !Element, bbox: {x: number, y: number, width: number,
+   *     height: number}}} A detached group and its bounds in workspace units.
+   */
+  out$.workspaceExportGroup = function(workspace) {
+    var blockCanvas = workspace.getCanvas();
+    var bubbleCanvas = workspace.getBubbleCanvas();
+    var group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'blocklyBlockCanvas');
+    var blocks = blockCanvas.cloneNode(true);
+    blocks.removeAttribute('transform');
+    group.appendChild(blocks);
+
+    var box = blockCanvas.getBBox();
+    var bounds = {left: box.x, top: box.y, right: box.x + box.width,
+                  bottom: box.y + box.height};
+    var bubbles = bubbleCanvas ? bubbleCanvas.children : [];
+    for (var i = 0; i < bubbles.length; i++) {
+      var bubble = bubbles[i];
+      if (!bubble.classList || !bubble.classList.contains('blocklyTextInputBubble')) {
+        continue;
+      }
+      var bubbleBox = bubble.getBBox();
+      var xy = Blockly.utils.svgMath.getRelativeXY(bubble);
+      bounds.left = Math.min(bounds.left, xy.x + bubbleBox.x);
+      bounds.top = Math.min(bounds.top, xy.y + bubbleBox.y);
+      bounds.right = Math.max(bounds.right, xy.x + bubbleBox.x + bubbleBox.width);
+      bounds.bottom = Math.max(bounds.bottom, xy.y + bubbleBox.y + bubbleBox.height);
+      var bubbleClone = bubble.cloneNode(true);
+      group.appendChild(bubbleClone);
+    }
+    return {
+      group: group,
+      bbox: {x: bounds.left, y: bounds.top, width: bounds.right - bounds.left,
+             height: bounds.bottom - bounds.top}
+    };
+  };
+
   out$.svgAsDataUri = function(el, optmetrics, options, cb) {
     options = options || {};
     options.scale = options.scale || 1;
@@ -97,12 +143,16 @@ goog.provide('AI.Blockly.ExportBlocksImage');
       var bottom = (parseFloat(optmetrics.contentHeight)).toString();
       clone.setAttribute("viewBox", left + " " + top + " " + right + " " + bottom);
     } else {
-      var matrix = el.getScreenCTM();
-      clone.setAttribute('transform', clone.getAttribute('transform').replace(/translate\(.*?\)/, '')
-                         .replace(/scale\(.*?\)/, '').trim());
-      var box = el.getBBox();
-      //width = (box.x + box.width)/matrix.a;
-      //height = (box.y + box.height)/matrix.a;
+      var box;
+      if (options.bbox) {
+        // A group assembled for export (see workspaceExportGroup); it is not
+        // in the document, so its bounds are supplied by the caller.
+        box = options.bbox;
+      } else {
+        clone.setAttribute('transform', (clone.getAttribute('transform') || '')
+            .replace(/translate\(.*?\)/, '').replace(/scale\(.*?\)/, '').trim());
+        box = el.getBBox();
+      }
       width = box.width;
       height = box.height;
 
@@ -151,6 +201,14 @@ goog.provide('AI.Blockly.ExportBlocksImage');
 
     for (var i = 0; i < toHide.length; i++) {
       toHide[i].parentElement.removeChild(toHide[i]);
+    }
+
+    // Bubbles reference an emboss filter defined in the workspace's <defs>,
+    // which is not part of the export; a dangling filter reference makes
+    // browsers skip the element entirely.
+    var filtered = clone.querySelectorAll('[filter]');
+    for (var i = 0; i < filtered.length; i++) {
+      filtered[i].removeAttribute('filter');
     }
 
     var zelement = clone.getElementById("rectCorner");
@@ -218,7 +276,9 @@ goog.provide('AI.Blockly.ExportBlocksImage');
  *
  */
 AI.Blockly.ExportBlocksImage.onclickExportBlocks = function(metrics, opt_workspace) {
-  saveSvgAsPng((opt_workspace || Blockly.common.getMainWorkspace()).svgBlockCanvas_, "blocks.png", metrics);
+  var workspace = opt_workspace || Blockly.common.getMainWorkspace();
+  var exported = workspaceExportGroup(workspace);
+  saveSvgAsPng(exported.group, "blocks.png", metrics, {bbox: exported.bbox});
 }
 
 
@@ -233,7 +293,8 @@ AI.Blockly.ExportBlocksImage.getUri = function(callback, opt_workspace) {
   if (metrics == null || metrics.viewHeight == 0) {
     return null;
   }
-  svgAsDataUri(workspace.svgBlockCanvas_, metrics, {},
+  var exported = workspaceExportGroup(workspace);
+  svgAsDataUri(exported.group, metrics, {bbox: exported.bbox},
     function(uri) {
       var image = new Image();
       image.onload = function() {

--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -207,50 +207,108 @@ goog.provide('AI.Blockly.ExportBlocksImage');
   }
 
   /**
+   * Widens bounds to include an element, whose bbox is in its own coordinates
+   * and sits at offset within the export.
+   * @param {?{left: number, top: number, right: number, bottom: number}} bounds
+   *     The bounds so far, or null.
+   * @param {!Element} element A live SVG element.
+   * @param {{x: number, y: number}} offset Where the element sits.
+   * @return {{left: number, top: number, right: number, bottom: number}} The
+   *     widened bounds.
+   */
+  function includeBounds(bounds, element, offset) {
+    var box = element.getBBox();
+    var left = offset.x + box.x;
+    var top = offset.y + box.y;
+    if (!bounds) {
+      return {left: left, top: top, right: left + box.width, bottom: top + box.height};
+    }
+    bounds.left = Math.min(bounds.left, left);
+    bounds.top = Math.min(bounds.top, top);
+    bounds.right = Math.max(bounds.right, left + box.width);
+    bounds.bottom = Math.max(bounds.bottom, top + box.height);
+    return bounds;
+  }
+
+  /**
+   * Appends clones of the open comment bubbles of the given blocks to an
+   * export group. Bubbles live on the workspace's bubble canvas, positioned in
+   * the same coordinate space as the blocks.
+   * @param {!Element} group The export group.
+   * @param {!Array<!Blockly.BlockSvg>} blocks The blocks whose comments to add.
+   * @param {?Object} bounds The export bounds so far (see includeBounds).
+   * @param {{fill: string, border: string}} colours See commentColours.
+   * @return {?Object} The widened bounds.
+   */
+  function appendCommentBubbles(group, blocks, bounds, colours) {
+    for (var i = 0; i < blocks.length; i++) {
+      var icon = blocks[i].getIcon && blocks[i].getIcon('comment');
+      if (!icon || !icon.bubbleIsVisible()) {
+        continue;
+      }
+      // Blockly 11 has no public accessor for the icon's bubble.
+      var bubble = icon.textInputBubble;
+      if (!bubble || !bubble.getSvgRoot) {
+        continue;
+      }
+      var root = bubble.getSvgRoot();
+      var clone = root.cloneNode(true);
+      inlineCommentText(clone, root, colours);
+      group.appendChild(clone);
+      bounds = includeBounds(bounds, root, Blockly.utils.svgMath.getRelativeXY(root));
+    }
+    return bounds;
+  }
+
+  function toBBox(bounds) {
+    return {x: bounds.left, y: bounds.top, width: bounds.right - bounds.left,
+            height: bounds.bottom - bounds.top};
+  }
+
+  /**
    * Assembles the part of a workspace that belongs in an exported image: the
-   * block canvas plus the comment bubbles from the bubble canvas. The two
-   * canvases share one transform, so with it removed their children line up.
-   * Mutator bubbles, warning bubbles and the backpack flyout also live on the
-   * bubble canvas and are deliberately left out.
+   * block canvas plus the open comment bubbles of its blocks. The block and
+   * bubble canvases share one transform, so with it removed their children
+   * line up. Mutator bubbles, warning bubbles and the backpack flyout also
+   * live on the bubble canvas and are deliberately left out.
    * @param {!Blockly.WorkspaceSvg} workspace The workspace to export.
    * @return {{group: !Element, bbox: {x: number, y: number, width: number,
    *     height: number}}} A detached group and its bounds in workspace units.
    */
   out$.workspaceExportGroup = function(workspace) {
+    var colours = commentColours(workspace);
     var blockCanvas = workspace.getCanvas();
-    var bubbleCanvas = workspace.getBubbleCanvas();
     var group = document.createElementNS(SVG_NS, 'g');
     group.setAttribute('class', 'blocklyBlockCanvas');
     var blocks = blockCanvas.cloneNode(true);
     blocks.removeAttribute('transform');
-    var colours = commentColours(workspace);
     inlineCommentText(blocks, blockCanvas, colours);  // workspace comments
     group.appendChild(blocks);
+    var bounds = includeBounds(null, blockCanvas, {x: 0, y: 0});
+    bounds = appendCommentBubbles(group, workspace.getAllBlocks(false), bounds, colours);
+    return {group: group, bbox: toBBox(bounds)};
+  };
 
-    var box = blockCanvas.getBBox();
-    var bounds = {left: box.x, top: box.y, right: box.x + box.width,
-                  bottom: box.y + box.height};
-    var bubbles = bubbleCanvas ? bubbleCanvas.children : [];
-    for (var i = 0; i < bubbles.length; i++) {
-      var bubble = bubbles[i];
-      if (!bubble.classList || !bubble.classList.contains('blocklyTextInputBubble')) {
-        continue;
-      }
-      var bubbleBox = bubble.getBBox();
-      var xy = Blockly.utils.svgMath.getRelativeXY(bubble);
-      bounds.left = Math.min(bounds.left, xy.x + bubbleBox.x);
-      bounds.top = Math.min(bounds.top, xy.y + bubbleBox.y);
-      bounds.right = Math.max(bounds.right, xy.x + bubbleBox.x + bubbleBox.width);
-      bounds.bottom = Math.max(bounds.bottom, xy.y + bubbleBox.y + bubbleBox.height);
-      var bubbleClone = bubble.cloneNode(true);
-      inlineCommentText(bubbleClone, bubble, colours);
-      group.appendChild(bubbleClone);
-    }
-    return {
-      group: group,
-      bbox: {x: bounds.left, y: bounds.top, width: bounds.right - bounds.left,
-             height: bounds.bottom - bounds.top}
-    };
+  /**
+   * Assembles one block (with the blocks attached to it) and the open comment
+   * bubbles of those blocks, for the single-block PNG export.
+   * @param {!Blockly.BlockSvg} block The block to export.
+   * @return {{group: !Element, bbox: {x: number, y: number, width: number,
+   *     height: number}}} A detached group and its bounds in workspace units.
+   */
+  out$.blockExportGroup = function(block) {
+    var colours = commentColours(block.workspace);
+    var root = block.getSvgRoot();
+    var group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'blocklyBlockCanvas');
+    // The clone keeps its translate(x, y): that is the block's position in
+    // workspace units, the same space the bubbles are positioned in.
+    var clone = root.cloneNode(true);
+    inlineCommentText(clone, root, colours);
+    group.appendChild(clone);
+    var bounds = includeBounds(null, root, block.getRelativeToSurfaceXY());
+    bounds = appendCommentBubbles(group, block.getDescendants(false), bounds, colours);
+    return {group: group, bbox: toBBox(bounds)};
   };
 
   out$.svgAsDataUri = function(el, optmetrics, options, cb) {
@@ -659,7 +717,8 @@ Blockly.exportBlockAsPng = function(block) {
   var xml = document.createElement('xml');
   xml.appendChild(Blockly.Xml.blockToDom(block, true));
   var code = Blockly.Xml.domToText(xml);
-  svgAsDataUri(block.getSvgRoot(), block.workspace.getMetrics(), null, function(uri) {
+  var exported = blockExportGroup(block);
+  svgAsDataUri(exported.group, block.workspace.getMetrics(), {bbox: exported.bbox}, function(uri) {
     var img = new Image();
     img.src = uri;
     img.onload = function() {

--- a/appinventor/blocklyeditor/src/exportBlocksImage.js
+++ b/appinventor/blocklyeditor/src/exportBlocksImage.js
@@ -69,6 +69,144 @@ goog.provide('AI.Blockly.ExportBlocksImage');
   var SVG_NS = 'http://www.w3.org/2000/svg';
 
   /**
+   * The colours Blockly's theme gives comments. They are CSS custom
+   * properties on the injection div, so an exported SVG cannot see them.
+   * @param {Blockly.WorkspaceSvg} workspace The workspace.
+   * @return {{fill: string, border: string}} The colours.
+   */
+  function commentColours(workspace) {
+    var div = workspace && workspace.getInjectionDiv && workspace.getInjectionDiv();
+    var style = div ? window.getComputedStyle(div) : null;
+    var read = function(name, fallback) {
+      var value = style ? style.getPropertyValue(name).trim() : '';
+      return value || fallback;
+    };
+    return {
+      fill: read('--commentFillColour', '#FFFCC7'),
+      border: read('--commentBorderColour', '#F2E49B')
+    };
+  }
+
+  /**
+   * Comment text is edited in a <textarea> inside a <foreignObject>. Browsers
+   * do not reliably rasterise foreignObject content when an SVG is drawn onto
+   * a canvas (Safari refuses outright), so each one in the export is replaced
+   * with a background rect plus <text>/<tspan> lines wrapped to the same box.
+   * The text and font are read from the live textarea, since a cloned
+   * textarea has no value. Colours are set inline because the inlined
+   * stylesheet still refers to theme variables that do not exist in the
+   * export.
+   * @param {!Element} clone The export DOM being assembled.
+   * @param {!Element} original The live element the clone was made from.
+   * @param {{fill: string, border: string}} colours See commentColours.
+   */
+  function inlineCommentText(clone, original, colours) {
+    var topbars = clone.querySelectorAll('.blocklyCommentTopbarBackground');
+    for (var t = 0; t < topbars.length; t++) {
+      topbars[t].setAttribute('style', 'fill: ' + colours.border + ';');
+    }
+
+    var clonedObjects = clone.querySelectorAll('foreignObject');
+    var liveObjects = original.querySelectorAll('foreignObject');
+    if (clonedObjects.length !== liveObjects.length) {
+      return;  // Not a 1:1 clone; leave the export as it is.
+    }
+    for (var i = 0; i < clonedObjects.length; i++) {
+      var fo = clonedObjects[i];
+      var textarea = liveObjects[i].querySelector('textarea');
+      if (!textarea) {
+        continue;
+      }
+      var style = window.getComputedStyle(textarea);
+      var fontSize = parseFloat(style.fontSize) || 11;
+      var fontFamily = style.fontFamily || 'sans-serif';
+      var padding = parseFloat(style.paddingLeft) || 0;
+      var lineHeight = parseFloat(style.lineHeight) || fontSize * 1.2;
+      var boxX = parseFloat(fo.getAttribute('x')) || 0;
+      var boxY = parseFloat(fo.getAttribute('y')) || 0;
+      var boxWidth = parseFloat(fo.getAttribute('width')) || 0;
+      var boxHeight = parseFloat(fo.getAttribute('height')) || 0;
+
+      // The textarea's background: filled, and bordered for workspace
+      // comments (bubbles already sit on their own coloured rect).
+      var background = document.createElementNS(SVG_NS, 'rect');
+      background.setAttribute('x', boxX);
+      background.setAttribute('y', boxY);
+      background.setAttribute('width', boxWidth);
+      background.setAttribute('height', boxHeight);
+      var isWorkspaceComment = fo.classList.contains('blocklyCommentForeignObject');
+      background.setAttribute('style', 'fill: ' + colours.fill + ';' +
+          (isWorkspaceComment ? ' stroke: ' + colours.border + '; stroke-width: 1;' : ''));
+
+      // The font family is left to the blocklyText class: the export later
+      // rewrites 'sans-serif' into a quoted font list, which must not land
+      // inside an attribute value.
+      var text = document.createElementNS(SVG_NS, 'text');
+      text.setAttribute('class', 'blocklyText');
+      text.setAttribute('style', 'font-size: ' + fontSize + 'px; fill: ' +
+          (style.color || '#000') + ';');
+      text.setAttribute('xml:space', 'preserve');
+      var lines = wrapLines(textarea.value, boxWidth - 2 * padding,
+          fontSize + 'px ' + fontFamily);
+      var maxLines = Math.max(1, Math.floor((boxHeight - 2 * padding) / lineHeight));
+      for (var j = 0; j < lines.length && j < maxLines; j++) {
+        var tspan = document.createElementNS(SVG_NS, 'tspan');
+        tspan.setAttribute('x', boxX + padding);
+        tspan.setAttribute('y', boxY + padding + fontSize + j * lineHeight);
+        tspan.textContent = lines[j];
+        text.appendChild(tspan);
+      }
+      fo.parentNode.insertBefore(background, fo);
+      fo.parentNode.replaceChild(text, fo);
+    }
+  }
+
+  /**
+   * Breaks text into lines no wider than maxWidth, the way a textarea with
+   * white-space: pre-wrap does: explicit newlines are kept, and words that
+   * are too long for a line are split by character.
+   * @param {string} value The text.
+   * @param {number} maxWidth Available width in pixels.
+   * @param {string} font A CSS font shorthand used to measure.
+   * @return {!Array<string>} The lines.
+   */
+  function wrapLines(value, maxWidth, font) {
+    var context = document.createElement('canvas').getContext('2d');
+    context.font = font;
+    var measure = function(str) { return context.measureText(str).width; };
+    var lines = [];
+    var paragraphs = (value || '').split('\n');
+    for (var p = 0; p < paragraphs.length; p++) {
+      var words = paragraphs[p].split(' ');
+      var line = '';
+      for (var w = 0; w < words.length; w++) {
+        var word = words[w];
+        var candidate = line ? line + ' ' + word : word;
+        if (measure(candidate) <= maxWidth || !line && measure(word) <= maxWidth) {
+          line = candidate;
+          continue;
+        }
+        if (line) {
+          lines.push(line);
+          line = '';
+        }
+        // The word alone is wider than the box: split it by character.
+        while (measure(word) > maxWidth && word.length > 1) {
+          var cut = word.length;
+          while (cut > 1 && measure(word.slice(0, cut)) > maxWidth) {
+            cut--;
+          }
+          lines.push(word.slice(0, cut));
+          word = word.slice(cut);
+        }
+        line = word;
+      }
+      lines.push(line);
+    }
+    return lines;
+  }
+
+  /**
    * Assembles the part of a workspace that belongs in an exported image: the
    * block canvas plus the comment bubbles from the bubble canvas. The two
    * canvases share one transform, so with it removed their children line up.
@@ -85,6 +223,8 @@ goog.provide('AI.Blockly.ExportBlocksImage');
     group.setAttribute('class', 'blocklyBlockCanvas');
     var blocks = blockCanvas.cloneNode(true);
     blocks.removeAttribute('transform');
+    var colours = commentColours(workspace);
+    inlineCommentText(blocks, blockCanvas, colours);  // workspace comments
     group.appendChild(blocks);
 
     var box = blockCanvas.getBBox();
@@ -103,6 +243,7 @@ goog.provide('AI.Blockly.ExportBlocksImage');
       bounds.right = Math.max(bounds.right, xy.x + bubbleBox.x + bubbleBox.width);
       bounds.bottom = Math.max(bounds.bottom, xy.y + bubbleBox.y + bubbleBox.height);
       var bubbleClone = bubble.cloneNode(true);
+      inlineCommentText(bubbleClone, bubble, colours);
       group.appendChild(bubbleClone);
     }
     return {
@@ -117,13 +258,6 @@ goog.provide('AI.Blockly.ExportBlocksImage');
     options.scale = options.scale || 1;
     var xmlns = "http://www.w3.org/2000/xmlns/";
     var outer = document.createElement("div");
-
-    var textAreas = document.getElementsByTagName("textarea");
-
-    for (var i = 0; i < textAreas.length; i++)
-      {
-        textAreas[i].innerHTML = textAreas[i].value;
-      }
 
     var clone = el.cloneNode(true);
     var width, height;
@@ -202,6 +336,8 @@ goog.provide('AI.Blockly.ExportBlocksImage');
     for (var i = 0; i < toHide.length; i++) {
       toHide[i].parentElement.removeChild(toHide[i]);
     }
+
+    inlineCommentText(clone, el, commentColours(Blockly.common.getMainWorkspace()));
 
     // Bubbles reference an emboss filter defined in the workspace's <defs>,
     // which is not part of the export; a dangling filter reference makes

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/exportBlocksImage_tests.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/exportBlocksImage_tests.js
@@ -38,4 +38,124 @@ suite('ExportBlocksImage', function() {
     chai.assert.equal(add.getInputTargetBlock('NUM0').getFieldValue('NUM'), '5');
     chai.assert.equal(add.getInputTargetBlock('NUM1').getFieldValue('NUM'), '10');
   });
+
+  suite('comment bubbles', function() {
+    let block;
+
+    setup(async function() {
+      block = Blockly.serialization.blocks.append({
+        type: 'math_number', fields: { NUM: 42 }, x: 40, y: 40
+      }, workspace);
+      block.setCommentText('first line\nsecond line');
+      await act(() => block.getIcon('comment').setBubbleVisible(true));
+    });
+
+    function liveBubble() {
+      return workspace.getBubbleCanvas().querySelector('.blocklyTextInputBubble');
+    }
+
+    function decode(uri) {
+      return decodeURIComponent(escape(window.atob(uri.split(',')[1])));
+    }
+
+    test('the export group includes the comment bubble', function() {
+      chai.assert.isNotNull(liveBubble(), 'the bubble is shown on the workspace');
+      const exported = workspaceExportGroup(workspace);
+      chai.assert.isNotNull(exported.group.querySelector('.blocklyTextInputBubble'));
+      chai.assert.isNotNull(exported.group.querySelector('.blocklyBubbleTail'));
+      chai.assert.isNotNull(exported.group.querySelector('.blocklyBlockCanvas'));
+    });
+
+    test('comment text becomes SVG text, one tspan per line', function() {
+      const exported = workspaceExportGroup(workspace);
+      chai.assert.lengthOf(exported.group.querySelectorAll('foreignObject'), 0);
+      const text = exported.group.querySelector('.blocklyTextInputBubble text');
+      chai.assert.isNotNull(text);
+      const lines = Array.from(text.querySelectorAll('tspan')).map(t => t.textContent);
+      chai.assert.deepEqual(lines, ['first line', 'second line']);
+      // The textarea's background is drawn as a rect behind the text, with an
+      // inline fill (the theme colour is a CSS variable the export can't see).
+      const background = text.previousElementSibling;
+      chai.assert.equal(background.tagName.toLowerCase(), 'rect');
+      chai.assert.match(background.getAttribute('style'), /fill: #[0-9a-fA-F]{6}/);
+    });
+
+    test('long comment lines wrap to the bubble width', function() {
+      block.setCommentText('word '.repeat(40).trim());
+      const exported = workspaceExportGroup(workspace);
+      const tspans = exported.group.querySelectorAll('.blocklyTextInputBubble tspan');
+      chai.assert.isAbove(tspans.length, 1, 'the text was wrapped');
+      const fo = liveBubble().querySelector('foreignObject');
+      const width = parseFloat(fo.getAttribute('width'));
+      for (const tspan of tspans) {
+        chai.assert.isAtMost(tspan.getComputedTextLength(), width);
+      }
+    });
+
+    test('the export bounds cover the bubble and its tail', function() {
+      const exported = workspaceExportGroup(workspace);
+      const bubble = liveBubble();
+      const xy = Blockly.utils.svgMath.getRelativeXY(bubble);
+      const box = bubble.getBBox();
+      const blocks = workspace.getCanvas().getBBox();
+      chai.assert.isAtMost(exported.bbox.x, Math.min(blocks.x, xy.x + box.x));
+      chai.assert.isAtMost(exported.bbox.y, Math.min(blocks.y, xy.y + box.y));
+      chai.assert.isAtLeast(exported.bbox.x + exported.bbox.width,
+          Math.max(blocks.x + blocks.width, xy.x + box.x + box.width));
+      chai.assert.isAtLeast(exported.bbox.y + exported.bbox.height,
+          Math.max(blocks.y + blocks.height, xy.y + box.y + box.height));
+    });
+
+    test('other bubbles on the bubble canvas are left out', function() {
+      const stray = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      stray.setAttribute('class', 'blocklyBubble stray-mutator');
+      workspace.getBubbleCanvas().appendChild(stray);
+      try {
+        const exported = workspaceExportGroup(workspace);
+        chai.assert.isNull(exported.group.querySelector('.stray-mutator'));
+        chai.assert.isNotNull(exported.group.querySelector('.blocklyTextInputBubble'));
+      } finally {
+        stray.remove();
+      }
+    });
+
+    test('without comments the bounds are the block canvas bounds', async function() {
+      await act(() => block.setCommentText(null));
+      const exported = workspaceExportGroup(workspace);
+      chai.assert.isNull(exported.group.querySelector('.blocklyTextInputBubble'));
+      const blocks = workspace.getCanvas().getBBox();
+      chai.assert.closeTo(exported.bbox.x, blocks.x, 0.01);
+      chai.assert.closeTo(exported.bbox.y, blocks.y, 0.01);
+      chai.assert.closeTo(exported.bbox.width, blocks.width, 0.01);
+      chai.assert.closeTo(exported.bbox.height, blocks.height, 0.01);
+    });
+
+    test('the SVG data URI has the comment, no foreignObject and no dangling filter', function(done) {
+      const exported = workspaceExportGroup(workspace);
+      svgAsDataUri(exported.group, workspace.getMetrics(), { bbox: exported.bbox }, uri => {
+        const svg = decode(uri);
+        chai.assert.include(svg, 'second line');
+        chai.assert.notInclude(svg, '<foreignObject');
+        chai.assert.notInclude(svg, 'filter=');
+        chai.assert.include(svg, 'blocklyTextInputBubble');
+        done();
+      });
+    });
+
+    test('the exported SVG rasterizes to an image', function(done) {
+      // The reason foreignObject is replaced: an SVG containing one may not
+      // draw into an <img>/<canvas>, which is how the PNG is produced.
+      const exported = workspaceExportGroup(workspace);
+      svgAsDataUri(exported.group, workspace.getMetrics(), { bbox: exported.bbox }, uri => {
+        const image = new Image();
+        image.onload = () => {
+          chai.assert.isAbove(image.width, 0);
+          chai.assert.isAbove(image.height, 0);
+          done();
+        };
+        image.onerror = () => done(new Error('the exported SVG did not load as an image'));
+        image.src = uri;
+      });
+    });
+  });
 });

--- a/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/exportBlocksImage_tests.js
+++ b/appinventor/blocklyeditor/tests/com/google/appinventor/blocklyeditor/exportBlocksImage_tests.js
@@ -142,6 +142,40 @@ suite('ExportBlocksImage', function() {
       });
     });
 
+    test('a single block export includes the comment bubbles of the block and its children', function() {
+      const outer = Blockly.serialization.blocks.append({
+        type: 'math_add', x: 200, y: 200,
+        inputs: { NUM0: { block: { type: 'math_number', fields: { NUM: 1 } } } }
+      }, workspace);
+      const inner = outer.getInputTargetBlock('NUM0');
+      inner.setCommentText('child comment');
+      return act(() => inner.getIcon('comment').setBubbleVisible(true)).then(() => {
+        const exported = blockExportGroup(outer);
+        const bubbles = exported.group.querySelectorAll('.blocklyTextInputBubble');
+        chai.assert.lengthOf(bubbles, 1, "only the exported block's own bubbles, not the other block's");
+        chai.assert.include(bubbles[0].textContent, 'child comment');
+        chai.assert.lengthOf(exported.group.querySelectorAll('foreignObject'), 0);
+        const root = inner.getIcon('comment').textInputBubble.getSvgRoot();
+        const xy = Blockly.utils.svgMath.getRelativeXY(root);
+        const box = root.getBBox();
+        chai.assert.isAtMost(exported.bbox.x, xy.x + box.x);
+        chai.assert.isAtLeast(exported.bbox.x + exported.bbox.width, xy.x + box.x + box.width);
+        chai.assert.isAtLeast(exported.bbox.y + exported.bbox.height, xy.y + box.y + box.height);
+      });
+    });
+
+    test('a single block export without comments keeps the block bounds', function() {
+      const lone = Blockly.serialization.blocks.append({ type: 'math_number', x: 300, y: 300 }, workspace);
+      const exported = blockExportGroup(lone);
+      chai.assert.isNull(exported.group.querySelector('.blocklyTextInputBubble'));
+      const box = lone.getSvgRoot().getBBox();
+      const xy = lone.getRelativeToSurfaceXY();
+      chai.assert.closeTo(exported.bbox.x, xy.x + box.x, 0.01);
+      chai.assert.closeTo(exported.bbox.y, xy.y + box.y, 0.01);
+      chai.assert.closeTo(exported.bbox.width, box.width, 0.01);
+      chai.assert.closeTo(exported.bbox.height, box.height, 0.01);
+    });
+
     test('the exported SVG rasterizes to an image', function(done) {
       // The reason foreignObject is replaced: an SVG containing one may not
       // draw into an <img>/<canvas>, which is how the PNG is produced.


### PR DESCRIPTION
**What does this PR accomplish?**

*Description*

"Download Blocks as Image" only captured the block canvas. Since the Blockly update, comment bubbles live on a separate bubble canvas, so every comment was silently missing from the PNG (#892). Comment text is also an HTML `<textarea>` inside a `<foreignObject>`, which browsers do not reliably draw into a canvas (Safari refuses), so adding the bubble canvas alone would not have been enough.

| | Before | After |
|---|---|---|
| Block comment bubbles (Download Blocks as Image) | missing | included, with tail and text |
| Block comment bubbles (single block: right-click → Download Blocks as PNG, or drag out) | missing | included, for the block and the blocks attached to it |
| Workspace comments | box with a black top bar, no text | top bar, body and text in the theme colours |
| Image bounds | blocks only | grow to fit bubbles and tails |
| Mutator bubbles, warnings, backpack | not exported | still not exported |
| Comment text in the SVG | `<foreignObject>` | `<text>`/`<tspan>` lines wrapped to the box |

How it works:

- `workspaceExportGroup()` builds the export from the block canvas plus the comment bubbles from the bubble canvas. The two canvases share one transform, so their children line up once it is removed; the union of their bounds becomes the image size.
- Each `<foreignObject>` is replaced with a background rect in the theme's comment colour plus SVG text wrapped to the same width, measured with the textarea's real font. Colours are inlined because the theme exposes them as CSS variables the exported SVG cannot see.
- Dangling `filter` references are removed (a missing filter makes browsers skip the element).
- The old page-wide `textarea.innerHTML = value` workaround is gone.
- Comment bubbles are found through each block's comment icon, so the whole-workspace export and the single-block export (`exportBlockAsPng`) share one routine. The whole-workspace export includes every open bubble; the single-block export includes the bubbles of that block and its children only.
- All three callers use the new path: the download menu, the single-block PNG, and the project screenshot (`getUri`).

*Testing Guidelines*

1. Open a project, go to Blocks, add a comment to a block and keep the bubble open. Right-click the workspace → Download Blocks as Image. The PNG contains the bubble, its tail and the text.
2. Right-click the workspace → Add Comment and type a long line. Download again: the note appears with its top bar and wrapped text.
3. Right-click a block that has a comment → Download Blocks as PNG (or drag the block out to the desktop). The PNG contains the block and its bubble; a comment on a *different* block is not included. Dragging the PNG back onto the workspace still recreates the block.
4. Close the bubbles and download: blocks only, as before. Open a mutator and download: the mutator is not in the image.
5. `ant tests`: 10 new cases in `exportBlocksImage_tests.js` (bubble included, one tspan per line, wrapping stays inside the box, bounds cover the tail, stray bubbles excluded, no-comment bounds unchanged, no `foreignObject` or `filter` in the SVG, the SVG loads as an image, and the single-block export includes only that block's bubbles).

Fixes #892.

**Context for the changes**

Branched from `master`; no companion changes.

If your code changes how something works on the device (i.e., it affects the companion):

- [x] I have made no changes that affect the companion

For all other changes:

- [x] I branched from `master`
- [x] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under docs/ (not applicable: the image export has no page under docs/)
- [x] My code follows the:
    - [x] [Google JavaScript style guide](https://google.github.io/styleguide/jsguide.html) (for .js files)
    - [x] Indentation has been doubled checked
    - [x] This PR does not include unnecessary changes such as formatting or white space
- [x] `ant tests` passes on my machine

