### PR TITLE
Fix iOS GetBackgroundPixelColor with sprites #4083

### DIFF
--- a/appinventor/components-ios/src/Canvas.swift
+++ b/appinventor/components-ios/src/Canvas.swift
@@ -760,7 +760,17 @@ public class Canvas: ViewComponent, AbstractMethodsForViewComponent, UIGestureRe
 
     let colorSpace = CGColorSpaceCreateDeviceRGB()
     let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+    let wasHidden = _sprites.map { $0.DisplayLayer.isHidden }
 
+    for sprite in _sprites {
+      sprite.DisplayLayer.isHidden = true
+    }
+
+    defer {
+      for (index, sprite) in _sprites.enumerated() {
+        sprite.DisplayLayer.isHidden = wasHidden[index]
+      }
+    }
     if let context = CGContext(data: &pixel, width: 1, height: 1, bitsPerComponent: 8,
                                bytesPerRow: 4, space: colorSpace, bitmapInfo: bitmapInfo.rawValue) {
       context.translateBy(x: -CGFloat(x), y: -CGFloat(y))
@@ -811,6 +821,8 @@ public class Canvas: ViewComponent, AbstractMethodsForViewComponent, UIGestureRe
           }
         }
       }
+    } else if let ball = sprite as? Ball {
+      return ball.PaintColor
     }
     return GetBackgroundPixelColor(x, y)
   }


### PR DESCRIPTION
**What does this PR accomplish?**

Fix iOS GetBackgroundPixelColor with sprites.

**Description**

Fixes #4083.

On iOS, `GetBackgroundPixelColor` renders `_view.layer`, which also contains
sprite layers. As a result, a sprite could incorrectly affect the returned
background color.

This change temporarily hides sprite layers while sampling the background
and restores their previous visibility afterward.

`GetPixelColor` also handles `Ball` directly using its `PaintColor`, preserving
sprite color behavior after sprites are excluded from background sampling.

**Testing Guidelines**

- `git diff --check` passes.
- Verified the change is limited to `Canvas.swift`.
- iOS runtime testing is still required on macOS/Xcode.

**Fixes #4083**

**Resolves #**

**Context for the changes**

This PR changes iOS Companion behavior, so the `ucr` branch is used.

- [ ] I have made no changes that affect the companion
- [x] I branched from `ucr`
- [x] My pull request has `ucr` as the base

**Further, if you've changed the blocks language or another user-facing designer/blocks API:**

- [ ] I have updated the corresponding version number in YaVersion.java
- [ ] I have updated the corresponding upgrader
- [ ] I have updated the corresponding entries in versioning.js

**For all other changes:**

- [ ] I have made no changes that affect the master branch
- [ ] I branched from `master`
- [ ] My pull request has `master` as the base

**General items:**

- [ ] I have updated the relevant documentation files under `docs/`
- [ ] My code follows the:
  - [ ] Google Java style guide
  - [ ] Google JavaScript style guide
  - [x] Swift style guide
  - [x] Indentation has been double checked
  - [x] This PR does not include unnecessary changes such as formatting or white space
- [ ] `ant tests` passes on my machine